### PR TITLE
fix(tests): self-contained fixtures for 673 session-filter tests (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -1611,54 +1611,6 @@
     {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_api_endpoint_integration",
-      "outcome": "failure",
-      "summary": "AssertionError: API 返回 401"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "OperationalError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_combined_filter",
-      "outcome": "error",
-      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "OperationalError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_session_type_filter",
-      "outcome": "error",
-      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "OperationalError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_status_filter",
-      "outcome": "error",
-      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "OperationalError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_session_type_filter",
-      "outcome": "error",
-      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "OperationalError",
-      "issue_number": "673",
-      "nodeid": "tests/issues/673/test_session_filter_params.py::test_status_filter",
-      "outcome": "error",
-      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_agent_runner.py::TestStopSession::test_shutdown_during_remote_creation_stops_actual_before_prompt",
       "outcome": "failure",
@@ -2595,8 +2547,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-13 prune 9 resolved: tests/issues/212/test_hostname_dedup.py no-such-table: registration_tokens cluster, fixed by adding the registration_tokens table to make_manager() (mirrors schema-sqlite.sql). Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31662464134",
+    "prune_note": "2026-08-13 prune 6 resolved: tests/issues/673/test_session_filter_params.py cluster (5 x setup_error from ambient-Database fixture hitting dev PG / empty isolated-home SQLite, 1 x assertion_failure from unauthenticated live-server request), fixed by self-contained load_schema_from_file fixtures + Flask test_client conversion. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31694625293",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/673/test_session_filter_params.py
+++ b/tests/issues/673/test_session_filter_params.py
@@ -4,17 +4,24 @@
 验证 /api/workspace/sessions API 正确处理 status 和 session_type 过滤参数。
 
 测试方法：
-1. 使用 fixture 创建独立测试数据（不同 status 和 session_type 的会话）
+1. 使用 fixture 在独立的临时 SQLite 库（权威 schema）创建测试数据
 2. 分别测试 status 过滤、session_type 过滤、组合过滤
 3. 验证返回结果符合预期
-4. 测试后清理测试数据
+4. API 集成测试通过 Flask test client（补丁鉴权）验证真实路由行为
 
+历史问题（#2457 baseline 6 条）：
+- 旧 fixture 直接 ``Database()``：本地解析到 dev Postgres（``users.name`` 列不
+  存在），CI 的 isolated-home 下解析到无表的空 SQLite（``no such table: users``）
+  → 5 条 setup_error。现改为 load_schema_from_file 的临时库 + DATABASE_URL 指向。
+- 旧 API 集成测试请求真实服务器且不带 token（401）→ 1 条 assertion_failure。
+  现改为注册 workspace_bp 的 test client + 补丁 _load_user_from_token。
 """
 
 import os
 import sys
 import time
 import uuid
+from unittest.mock import patch
 
 import pytest
 
@@ -22,11 +29,22 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
 
 from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+
+_AUTH_PATH = "app.routes.workspace._load_user_from_token"
+_EXTRACT_PATH = "app.routes.workspace._extract_token"
 
 
 @pytest.fixture
-def db():
-    """Database fixture"""
+def db(tmp_path, monkeypatch):
+    """独立临时 SQLite 库（权威 schema），不依赖环境/服务器数据库。
+
+    路由内 ``Database()`` 按 DATABASE_URL 解析，monkeypatch 指向本库后测试进程
+    与被测路由共享同一份数据；用例结束自动还原环境变量与临时文件。
+    """
+    db_url = f"sqlite:///{tmp_path / 'issue673.db'}"
+    load_schema_from_file(db_url=db_url, dialect="sqlite")
+    monkeypatch.setenv("DATABASE_URL", db_url)
     return Database()
 
 
@@ -35,16 +53,15 @@ def test_user_id(db):
     """Create a test user and return its ID"""
     test_email = f"test_filter_{uuid.uuid4().hex[:8]}@test.com"
 
-    # Create test user
+    # Create test user (users 表列为 username；无 updated_at 列 —— 旧代码两处均误写)
     db.execute(
         """
-        INSERT INTO users (email, name, password_hash, is_active, created_at, updated_at)
-        VALUES (?, ?, 'test_hash', 1, ?, ?)
+        INSERT INTO users (email, username, password_hash, is_active, created_at)
+        VALUES (?, ?, 'test_hash', 1, ?)
         """,
         (
             test_email,
             "Test Filter User",
-            time.strftime("%Y-%m-%d %H:%M:%S"),
             time.strftime("%Y-%m-%d %H:%M:%S"),
         ),
     )
@@ -113,7 +130,7 @@ def test_status_filter(db, test_user_id, test_sessions):
     for s in sessions:
         assert s["status"] == "active", f"Expected status='active', got '{s['status']}'"
 
-    # 验证找到预期的 active 会话（应该是 2 个）
+    # 验证找到预期的 active 会话（应该是 1 个）
     active_count = len([sid for sid in test_sessions if "active" in sid])
     assert (
         len(sessions) == active_count
@@ -140,7 +157,7 @@ def test_session_type_filter(db, test_user_id, test_sessions):
             s["session_type"] == "chat"
         ), f"Expected session_type='chat', got '{s['session_type']}'"
 
-    # 验证找到预期的 chat 会话（应该是 3 个）
+    # 验证找到预期的 chat 会话（应该是 2 个）
     chat_count = len([sid for sid in test_sessions if "chat" in sid])
     assert len(sessions) == chat_count, f"Expected {chat_count} chat sessions, got {len(sessions)}"
 
@@ -211,150 +228,90 @@ def test_invalid_session_type_filter(db, test_user_id, test_sessions):
     print("[PASS] 无效 session_type 过滤: 返回 0 个结果（符合预期）")
 
 
-def test_api_endpoint_integration():
+@pytest.fixture
+def client(db):
+    """Flask test client with the workspace blueprint (no live server needed)."""
+    from flask import Flask
+
+    from app.routes.workspace import workspace_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(workspace_bp, url_prefix="/api/workspace")
+    return app.test_client()
+
+
+def _authed_get(client, url, user_id):
+    """GET with auth patched to the seeded user (604-style blueprint test)."""
+    user = {
+        "id": user_id,
+        "username": "Test Filter User",
+        "role": "user",
+        "tenant_id": None,
+    }
+    with patch(_AUTH_PATH, return_value=user), patch(_EXTRACT_PATH, return_value="tok"):
+        return client.get(url)
+
+
+def test_api_endpoint_integration(client, db, test_user_id, test_sessions):
     """
-    集成测试: 通过 HTTP API 测试过滤参数
+    集成测试: 通过 API 测试过滤参数（Flask test client + 补丁鉴权）
 
-    需要服务器运行，使用 requests 测试
+    旧版直接 requests 打真实服务器且无 token（CI 401）。现在注册 workspace_bp
+    的 test client 上走真实路由/查询构建逻辑，鉴权指向 seeded 用户。
     """
-    import requests
-
-    BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
-
     # 测试 status 过滤
-    resp = requests.get(f"{BASE_URL}/api/workspace/sessions", params={"status": "active"})
+    resp = _authed_get(client, "/api/workspace/sessions?status=active", test_user_id)
     assert resp.status_code == 200, f"API 返回 {resp.status_code}"
-    data = resp.json()
-    if data.get("success") and data.get("data", {}).get("sessions"):
-        for s in data["data"]["sessions"]:
-            assert s["status"] == "active", f"Expected status='active', got '{s['status']}'"
-        print(f"[PASS] API status 过滤: 找到 {len(data['data']['sessions'])} 个 active 会话")
+    data = resp.get_json()
+    assert data.get("success") is True
+    sessions = data.get("data", {}).get("sessions", [])
+    for s in sessions:
+        assert s["status"] == "active", f"Expected status='active', got '{s['status']}'"
+    assert len(sessions) == 1, f"Expected 1 active session, got {len(sessions)}"
+    print(f"[PASS] API status 过滤: 找到 {len(sessions)} 个 active 会话")
 
     # 测试 session_type 过滤
-    resp = requests.get(f"{BASE_URL}/api/workspace/sessions", params={"session_type": "chat"})
+    resp = _authed_get(client, "/api/workspace/sessions?session_type=chat", test_user_id)
     assert resp.status_code == 200, f"API 返回 {resp.status_code}"
-    data = resp.json()
-    if data.get("success") and data.get("data", {}).get("sessions"):
-        for s in data["data"]["sessions"]:
-            assert (
-                s["session_type"] == "chat"
-            ), f"Expected session_type='chat', got '{s['session_type']}'"
-        print(f"[PASS] API session_type 过滤: 找到 {len(data['data']['sessions'])} 个 chat 会话")
+    data = resp.get_json()
+    assert data.get("success") is True
+    sessions = data.get("data", {}).get("sessions", [])
+    for s in sessions:
+        assert (
+            s["session_type"] == "chat"
+        ), f"Expected session_type='chat', got '{s['session_type']}'"
+    assert len(sessions) == 2, f"Expected 2 chat sessions, got {len(sessions)}"
+    print(f"[PASS] API session_type 过滤: 找到 {len(sessions)} 个 chat 会话")
 
     # 测试组合过滤
-    resp = requests.get(
-        f"{BASE_URL}/api/workspace/sessions", params={"status": "active", "session_type": "chat"}
+    resp = _authed_get(
+        client, "/api/workspace/sessions?status=active&session_type=chat", test_user_id
     )
     assert resp.status_code == 200, f"API 返回 {resp.status_code}"
-    data = resp.json()
-    if data.get("success") and data.get("data", {}).get("sessions"):
-        for s in data["data"]["sessions"]:
-            assert s["status"] == "active", f"Expected status='active', got '{s['status']}'"
-            assert (
-                s["session_type"] == "chat"
-            ), f"Expected session_type='chat', got '{s['session_type']}'"
-        print(f"[PASS] API 组合过滤: 找到 {len(data['data']['sessions'])} 个 active+chat 会话")
+    data = resp.get_json()
+    assert data.get("success") is True
+    sessions = data.get("data", {}).get("sessions", [])
+    for s in sessions:
+        assert s["status"] == "active", f"Expected status='active', got '{s['status']}'"
+        assert (
+            s["session_type"] == "chat"
+        ), f"Expected session_type='chat', got '{s['session_type']}'"
+    assert len(sessions) == 1, f"Expected 1 active+chat session, got {len(sessions)}"
+    print(f"[PASS] API 组合过滤: 找到 {len(sessions)} 个 active+chat 会话")
 
-    # 测试无效参数（API 应忽略无效值）
-    resp = requests.get(f"{BASE_URL}/api/workspace/sessions", params={"status": "invalid_status"})
+    # 测试无效参数（API 应忽略无效值并返回 200 + 未过滤列表）
+    resp = _authed_get(client, "/api/workspace/sessions?status=invalid_status", test_user_id)
     assert resp.status_code == 200, f"API 返回 {resp.status_code}"
-    print("[PASS] API 无效参数处理: 返回 200")
+    data = resp.get_json()
+    assert data.get("success") is True
+    sessions = data.get("data", {}).get("sessions", [])
+    assert len(sessions) == len(
+        test_sessions
+    ), f"Expected all {len(test_sessions)} sessions (invalid filter ignored), got {len(sessions)}"
+    print("[PASS] API 无效参数处理: 返回 200 且忽略无效过滤")
 
 
 if __name__ == "__main__":
-    # 直接运行测试（不通过 pytest）
-    print("=" * 60)
-    print("Issue #673: 会话过滤参数测试")
-    print("=" * 60)
-
-    db = Database()
-
-    print("\n[!] 注意: 直接运行模式使用硬编码测试数据，建议使用 pytest 运行")
-    print("\n运行 pytest 命令:")
-    print("  pytest tests/issues/673/test_session_filter_params.py -v")
-
-    # 简化测试（使用硬编码测试数据）
-    test_email = "test_filter_direct@test.com"
-
-    # 创建测试用户
-    try:
-        db.execute(
-            """
-            INSERT OR IGNORE INTO users (email, name, password_hash, is_active, created_at, updated_at)
-            VALUES (?, ?, 'test_hash', 1, ?, ?)
-            """,
-            (
-                test_email,
-                "Test Filter User Direct",
-                time.strftime("%Y-%m-%d %H:%M:%S"),
-                time.strftime("%Y-%m-%d %H:%M:%S"),
-            ),
-        )
-    except Exception:
-        pass  # SQLite 使用 INSERT OR IGNORE
-
-    user = db.fetch_one("SELECT id FROM users WHERE email = ?", (test_email,))
-    if not user:
-        # PostgreSQL
-        db.execute(
-            """
-            INSERT INTO users (email, name, password_hash, is_active, created_at, updated_at)
-            VALUES (?, ?, 'test_hash', 1, ?, ?)
-            ON CONFLICT (email) DO NOTHING
-            """,
-            (
-                test_email,
-                "Test Filter User Direct",
-                time.strftime("%Y-%m-%d %H:%M:%S"),
-                time.strftime("%Y-%m-%d %H:%M:%S"),
-            ),
-        )
-        user = db.fetch_one("SELECT id FROM users WHERE email = ?", (test_email,))
-
-    user_id = user["id"] if user else 1
-
-    print(f"\n使用测试用户 ID: {user_id}")
-
-    # 创建测试会话
-    test_session_id = f"test_direct_{uuid.uuid4().hex}"
-    now = time.strftime("%Y-%m-%d %H:%M:%S")
-    try:
-        db.execute(
-            """
-            INSERT INTO agent_sessions
-            (session_id, user_id, status, session_type, title, tool_name, host_name,
-             total_tokens, message_count, created_at, updated_at)
-            VALUES (?, ?, 'active', 'chat', 'Direct Test', 'qwen', 'test-host', 100, 5, ?, ?)
-            """,
-            (test_session_id, user_id, now, now),
-        )
-    except Exception as e:
-        print(f"[WARN] 创建测试会话失败: {e}")
-
-    print("\n[1] 测试 status 过滤...")
-    sessions = db.fetch_all(
-        "SELECT session_id, status FROM agent_sessions WHERE user_id = ? AND status = ?",
-        (user_id, "active"),
-    )
-    print(f"  找到 {len(sessions)} 个 active 会话")
-
-    print("\n[2] 测试 session_type 过滤...")
-    sessions = db.fetch_all(
-        "SELECT session_id, session_type FROM agent_sessions WHERE user_id = ? AND session_type = ?",
-        (user_id, "chat"),
-    )
-    print(f"  找到 {len(sessions)} 个 chat 会话")
-
-    print("\n[3] 测试组合过滤...")
-    sessions = db.fetch_all(
-        "SELECT session_id, status, session_type FROM agent_sessions WHERE user_id = ? AND status = ? AND session_type = ?",
-        (user_id, "active", "chat"),
-    )
-    print(f"  找到 {len(sessions)} 个 active+chat 会话")
-
-    # 清理
-    db.execute("DELETE FROM agent_sessions WHERE session_id = ?", (test_session_id,))
-
-    print("\n" + "=" * 60)
-    print("测试完成")
-    print("=" * 60)
+    # 直接运行委托给 pytest（fixture 化后不再支持硬编码直跑模式）
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Resolves the 6 `tests/issues/673/test_session_filter_params.py` entries tracked by the #2457 legacy-failure baseline, and prunes them (**324 → 318**, shrink-only).

Two failure modes, both from depending on the ambient environment:

1. **5 × setup_error** — the `db` fixtures used a bare `Database()`, which resolves via `DATABASE_URL`/config defaults: locally that is the **dev Postgres** (INSERT hits nonexistent `users.name` / `users.updated_at` columns); in CI's `--isolated-home` shard it resolved to an **empty SQLite path** (`no such table: users`).
2. **1 × assertion_failure** — `test_api_endpoint_integration` sent unauthenticated `requests` to the live server (401 in CI).

## Fix (test-only)

- Fixtures now build a throwaway SQLite DB from the authoritative schema (`load_schema_from_file`) and point `DATABASE_URL` at it — the established 1789/716 pattern — so tests and the route under test share one isolated DB. The INSERT uses the real `users` columns (`username`; no `updated_at`).
- The API test registers `workspace_bp` on a Flask test client and patches `_load_user_from_token`/`_extract_token` (the established 604 pattern), exercising the real route + auth `before_request` + query building deterministically. Assertions upgraded from per-item consistency to exact counts (1 active / 2 chat / 1 active+chat / all 4 when the filter is invalid-and-ignored).
- The legacy `__main__` direct-run block (hardcoded data, same broken columns) is replaced with a pytest delegation.
- Test names unchanged → the 6 baseline entries prune 1:1.

## Verification

- Local: `tests/issues/673/` 6/6 passed.
- CI (dispatch `category=issues`, 4 shards): run 31698041174 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=318`.
- Baseline prune is shrink-only (6 nodeids removed, 2 provenance lines added); `Baseline.from_json` loader validates 318 entries.
- pre-commit clean (black / isort / ruff / mypy).

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)