### PR TITLE
fix: CI-repair scope guard false positive (test artifacts + stale cumulative base)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -2495,13 +2495,20 @@ class GitHubOps:
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     def git_add_all(self) -> None:
-        """Stage all changes.
+        """Stage all changes, excluding test-pollution artifacts.
 
         After staging, remove any ``.worktrees/`` gitlinks that ``git add -A``
         may have picked up from nested worktree directories. These appear as
         160000-mode submodule references but have no ``.gitmodules`` entry,
         which breaks CI (``git submodule foreach`` fails with "No url found
         for submodule path") and pollutes schema-sync diffs.
+
+        Additionally filter test-pollution artifacts that the dev agent's
+        pytest run can create: empty files whose names are ``repr()`` of
+        MagicMock objects (mocks passed to ``Path(...)``/``open(...)``), plus
+        the standard test caches (``__pycache__``, ``.pytest_cache``). These
+        are not legitimate source files; committing them inflates the scope
+        guard's file count and blocks CI-repair pushes.
         """
         self._run_git(["add", "-A"])
         try:
@@ -2511,6 +2518,57 @@ class GitHubOps:
             )
         except Exception:
             pass
+        self._unstage_test_artifacts()
+
+    @staticmethod
+    def _is_test_artifact_path(path: str) -> bool:
+        """Return True for test-pollution paths that must not be committed.
+
+        These are files created by pytest side-effects when the dev agent runs
+        tests in its worktree: ``repr()`` of MagicMock objects passed to
+        ``Path(...)``/``open(...)`` (e.g. ``<MagicMock id='...'>``), and the
+        standard Python/pytest caches. Also rejects any path that isn't a sane
+        relative filename (contains ``<``/``>``, is absolute, or is empty).
+        """
+        if not path:
+            return True
+        # MagicMock repr and angle-bracket garbage: ``<MagicMock ...>`` etc.
+        if "<" in path or ">" in path:
+            return True
+        # Absolute paths are never valid repo-relative filenames.
+        if path.startswith("/"):
+            return True
+        # Standard test caches that pytest/cpython create as side-effects.
+        parts = path.split("/")
+        if "__pycache__" in parts:
+            return True
+        if parts and parts[0] == ".pytest_cache":
+            return True
+        return False
+
+    def _unstage_test_artifacts(self) -> None:
+        """Unstage test-pollution artifacts from the git index.
+
+        Reads the staged file list, identifies test artifacts via
+        ``_is_test_artifact_path``, and unstages each with
+        ``git reset HEAD -- <path>``. Fail-soft: a transient git error leaves
+        the original staging intact (legitimate files stay staged).
+        """
+        try:
+            result = self._run_git(["diff", "--cached", "--name-only"], check=False)
+            if result.returncode != 0:
+                return
+            staged = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        except Exception:
+            return
+
+        artifacts = [p for p in staged if self._is_test_artifact_path(p)]
+        for path in artifacts:
+            try:
+                self._run_git(["reset", "-q", "HEAD", "--", path], check=False)
+            except Exception:
+                # Best-effort: continue unstaging the remaining artifacts.
+                pass
 
     def git_commit(self, message: str, no_verify: bool = False) -> dict:
         """Create a git commit.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3539,6 +3539,38 @@ class AutonomousOrchestrator:
 
         ranges = [("current round", commit_before)]
         cumulative_base = (wf.get("base_commit_sha") or "").strip()
+        # Bug B: When the cumulative range spans a prior merge of upstream
+        # main (even if ``commit_after`` itself is not the merge commit), the
+        # persisted ``base_commit_sha`` is the stale branch-creation point.
+        # The CI-repair push path calls this validator with the stale ``wf``
+        # after a prior round merged main, so the cumulative diff would count
+        # every merged upstream file -> a false "scope exceeded". Re-derive via
+        # merge-base so the cumulative range excludes upstream merge files,
+        # mirroring the merge-commit reduction above and the pre-merge logic.
+        if cumulative_base:
+            try:
+                mb_result = gh._run_git(["merge-base", commit_after, "origin/main"], check=False)
+                effective_cumulative_base = (
+                    mb_result.stdout.strip() if mb_result.returncode == 0 else ""
+                )
+            except Exception as exc:
+                logger.warning("Failed to re-derive cumulative merge-base: %s", exc)
+                effective_cumulative_base = ""
+            if effective_cumulative_base and effective_cumulative_base != cumulative_base:
+                # The merge-base is a closer (more recent) ancestor than the
+                # stale persisted base. Use it so upstream files merged into
+                # the branch are excluded from the cumulative count. The
+                # merge-base can only be equal to or a descendant of the true
+                # branch point, so this only NARROWS the base — it never
+                # widens it past the original branch-creation point.
+                logger.info(
+                    "Cumulative base re-derived via merge-base %s (was stale %s)",
+                    effective_cumulative_base[:12],
+                    cumulative_base[:12],
+                )
+                cumulative_base = effective_cumulative_base
+                wf = dict(wf)
+                wf["base_commit_sha"] = effective_cumulative_base
         if not cumulative_base:
             # Legacy workflows (or a batch whose initial rev-parse failed) can
             # have no persisted base. Never compare them with the *moving*

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -332,10 +332,12 @@ class TestGitHubOpsGit:
     def test_git_add_all(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         self.gh.git_add_all()
-        cmd = mock_run.call_args[0][0]
-        assert "git" in cmd
-        assert "add" in cmd
-        assert "-A" in cmd
+        # git_add_all issues multiple commands (add -A, rm .worktrees, diff
+        # --cached, reset artifacts). Find the ``add -A`` call among them.
+        all_cmds = [call.args[0] for call in mock_run.call_args_list]
+        add_cmd = next((c for c in all_cmds if "add" in c), None)
+        assert add_cmd is not None, f"git add not found in calls: {all_cmds}"
+        assert "-A" in add_cmd
 
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     def test_git_commit(self, mock_run):

--- a/tests/unit/test_autonomous_scope_cumulative_merge.py
+++ b/tests/unit/test_autonomous_scope_cumulative_merge.py
@@ -149,3 +149,72 @@ def test_non_merge_round_keeps_cumulative_base_unchanged(monkeypatch):
     # Cumulative range still uses the persisted base_commit_sha unchanged.
     used_bases = [call.args[0] for call in gh.get_changed_files.call_args_list]
     assert used_bases == ["round-base", cumulative_base]
+
+
+def test_ci_repair_plain_commit_after_merge_uses_merge_base_for_cumulative(monkeypatch):
+    """CI-repair's plain commit following a prior merge must not count upstream files.
+
+    Bug B: ``_run_merge_ci_repair`` calls ``_validate_autonomous_change_scope``
+    with the stale ``wf`` (its ``base_commit_sha`` is the branch-creation
+    point). When the CI-repair commit (``commit_after``) is a *plain* commit
+    following a prior upstream merge, the merge-commit reduction is skipped,
+    so the cumulative range counts every merged upstream file -> a false
+    "scope exceeded". The cumulative base must be re-derived via merge-base
+    in this case too.
+    """
+    import app.modules.workspace.autonomous.orchestrator as orchestrator_module
+
+    monkeypatch.setattr(orchestrator_module, "MAX_AUTONOMOUS_CHANGED_FILES", 60)
+
+    orch = _make_orchestrator()
+    gh = MagicMock()
+
+    # The workflow merged upstream main in a prior round. Its persisted
+    # base_commit_sha is still the original branch-creation point (stale).
+    stale_branch_creation_base = "stale-base-aaa"
+    wf = {"base_commit_sha": stale_branch_creation_base}
+
+    # The merge-base of the CI-repair head and main is the real branch point.
+    effective_merge_base = "merge-base-bbb"
+
+    def fake_run_git(args, check=True, **kwargs):
+        if args[0] == "merge-base":
+            return MagicMock(returncode=0, stdout=f"{effective_merge_base}\n")
+        if args[0] == "fetch":
+            return MagicMock(returncode=0, stdout="")
+        return MagicMock(returncode=0, stdout="")
+
+    gh._run_git.side_effect = fake_run_git
+    gh.resolve_commit.return_value = "fetched-main-head"
+
+    def fake_changed_files(base, after):
+        # The current round (CI-repair round base) has a small real delta.
+        if base == "ci-repair-round-base":
+            return [f"app/real_{i}.py" for i in range(12)]
+        # Against the effective merge-base, the real autonomous delta is small.
+        if base == effective_merge_base:
+            return [f"app/real_{i}.py" for i in range(12)]
+        # Against the stale branch-creation base, the upstream merge's 181 files
+        # would be counted (the false positive).
+        if base == stale_branch_creation_base:
+            return [f"upstream/file_{i}.py" for i in range(181)]
+        raise AssertionError(f"unexpected base passed to get_changed_files: {base!r}")
+
+    gh.get_changed_files.side_effect = fake_changed_files
+
+    # commit_after is NOT a merge commit — it is a plain CI-repair commit.
+    # But the cumulative range spans a prior merge of main.
+    with patch.object(orch, "_is_merge_commit", return_value=False):
+        reason = orch._validate_autonomous_change_scope(
+            gh, wf, "ci-repair-round-base", "ci-repair-plain-head"
+        )
+
+    # The guard must not flag upstream files as scope exceeded.
+    assert reason == "", f"expected no scope violation, got: {reason}"
+    # The cumulative range must NOT use the stale branch-creation base.
+    used_bases = [call.args[0] for call in gh.get_changed_files.call_args_list]
+    assert stale_branch_creation_base not in used_bases, (
+        "cumulative range used the stale branch-creation base; upstream merge "
+        "files would be mis-counted"
+    )
+    assert effective_merge_base in used_bases

--- a/tests/unit/test_git_add_all_artifacts.py
+++ b/tests/unit/test_git_add_all_artifacts.py
@@ -1,0 +1,86 @@
+"""Bug A: git_add_all must not stage test-pollution artifacts.
+
+When the dev agent runs pytest in its worktree, test side-effects create
+empty files whose names are repr() of MagicMock objects (mocks passed to
+Path(...)/open(...)), plus the usual __pycache__/.pytest_cache. These are
+not legitimate source files and must not be committed.
+"""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+
+def _make_git_ops():
+    """Construct a GitHubOps whose _run_git is a controllable mock."""
+    gh = GitHubOps.__new__(GitHubOps)
+    gh.repo_path = "/tmp/test-repo"
+    return gh
+
+
+def test_git_add_all_filters_magicmock_and_pycache_artifacts():
+    """git_add_all must unstage MagicMock-named files and __pycache__.
+
+    After git_add_all(), only legitimate source files should remain staged.
+    """
+    gh = _make_git_ops()
+
+    # The set of staged paths as seen by ``git diff --cached --name-only``.
+    # This mirrors what prod sees: ``git add -A`` stages everything including
+    # the MagicMock repr files and __pycache__.
+    staged_after_add = [
+        "app/real_file.py",  # legitimate
+        "<MagicMock id='1234567890'>",  # test pollution (MagicMock repr)
+        "<MagicMock name='mock.obj' id='9876543210'>",
+        "__pycache__/something.cpython-311.pyc",  # test cache
+        ".pytest_cache/v/cache/lastfailed",  # pytest cache
+        "tests/test_real.py",  # legitimate
+    ]
+
+    call_log = []
+
+    def fake_run_git(args, check=True):
+        call_log.append(list(args))
+        if args[0] == "add" and "-A" in args:
+            return MagicMock(returncode=0, stdout="")
+        if args[0] == "rm" and "--cached" in args:
+            return MagicMock(returncode=0, stdout="")
+        if args[0] == "diff" and "--cached" in args:
+            return MagicMock(returncode=0, stdout="\n".join(staged_after_add) + "\n")
+        if args[0] == "reset":
+            # Simulate un-staging: remove the path from staged_after_add.
+            path = args[-1]
+            if path in staged_after_add:
+                staged_after_add.remove(path)
+            return MagicMock(returncode=0, stdout="")
+        return MagicMock(returncode=0, stdout="")
+
+    gh._run_git = MagicMock(side_effect=fake_run_git)
+
+    gh.git_add_all()
+
+    # The legitimate files must still be staged.
+    assert "app/real_file.py" in staged_after_add, "legitimate file was wrongly unstaged"
+    assert "tests/test_real.py" in staged_after_add, "legitimate test file was wrongly unstaged"
+
+    # The MagicMock repr files must have been unstaged.
+    assert (
+        "<MagicMock id='1234567890'>" not in staged_after_add
+    ), "MagicMock-named test artifact was not filtered"
+    assert (
+        "<MagicMock name='mock.obj' id='9876543210'>" not in staged_after_add
+    ), "MagicMock-named test artifact was not filtered"
+
+    # The standard test caches must have been unstaged.
+    assert (
+        "__pycache__/something.cpython-311.pyc" not in staged_after_add
+    ), "__pycache__ artifact was not filtered"
+    assert (
+        ".pytest_cache/v/cache/lastfailed" not in staged_after_add
+    ), ".pytest_cache artifact was not filtered"
+
+    # Verify a reset HEAD -- was issued for each offending path.
+    reset_calls = [c for c in call_log if c[0] == "reset"]
+    assert (
+        len(reset_calls) >= 4
+    ), f"expected at least 4 reset calls for artifact paths, got {len(reset_calls)}: {reset_calls}"


### PR DESCRIPTION
## Summary

Autonomous workflow CI-repair pushes were blocked by a false-positive scope guard ("Cumulative branch Autonomous change scope exceeded: 224 files changed (limit 60)"). Two independent bugs combine to cause this.

### Bug A — \`git_add_all()\` commits test-pollution artifacts

When the dev agent runs pytest in its worktree, test side-effects create empty files whose names are \`repr()\` of MagicMock objects (mocks passed to \`Path(...)\`/\`open(...)\`), plus the usual \`__pycache__\`/\`.pytest_cache\`. \`git_add_all()\` only stripped \`.worktrees/\` gitlinks — it did not filter these test artifacts, so they got committed as 0-add/0-del ghost files (prod: 43 MagicMock-named files committed to a branch). These are real changed files the scope guard then counts.

**Fix A** (\`github_ops.py git_add_all\`): after staging, read the staged paths via \`git diff --cached --name-only\` and unstage any path that isn't a sane repo-relative filename. Specifically rejects:
- Paths containing \`<\` or \`>\` (MagicMock reprs like \`<MagicMock id='...'>\`)
- Absolute paths (never valid repo-relative)
- \`__pycache__/\` segments and \`.pytest_cache/\` prefixes

Additive only — filters MORE, never changes what legitimate files get staged.

### Bug B — CI-repair push path uses a stale cumulative base

\`_validate_autonomous_change_scope\` only applies its merge-base reduction when \`commit_after\` IS a merge commit. The CI-repair push path (\`_run_merge_ci_repair\` -> \`_detect_and_push_ci_repair_changes\` -> scope validator) calls the validator with the STALE \`wf\` (its \`base_commit_sha\` is the branch-creation point) AFTER the branch has merged main. When the CI-repair commit is a plain commit following a prior merge, the merge-base reduction was skipped, so the cumulative diff counts every merged upstream file (~181).

**Fix B** (\`orchestrator.py _validate_autonomous_change_scope\`): when the cumulative range has a persisted base, re-derive the merge-base of \`commit_after\` and \`origin/main\`. If the merge-base is a closer (more recent) ancestor than the persisted base, use it — mirroring the established pre-merge logic (\`_validate_pre_merge_change_scope\`). The merge-base can only be a descendant of the true branch point, so this only NARROWS the base. Never weakens the 60-file cap.

## TDD evidence

### Bug A (red -> green)
**RED** (before fix): \`MagicMock-named test artifact was not filtered\`
\`\`\`
FAILED tests/unit/test_git_add_all_artifacts.py::test_git_add_all_filters_magicmock_and_pycache_artifacts
AssertionError: MagicMock-named test artifact was not filtered
\`\`\`
**GREEN** (after fix): 1 passed

### Bug B (red -> green)
**RED** (before fix): \`Cumulative branch Autonomous change scope exceeded: 181 files changed (limit 60)\`
\`\`\`
FAILED tests/unit/test_autonomous_scope_cumulative_merge.py::test_ci_repair_plain_commit_after_merge_uses_merge_base_for_cumulative
AssertionError: expected no scope violation, got: Cumulative branch Autonomous change scope exceeded: 181 files changed (limit 60)
\`\`\`
**GREEN** (after fix): 1 passed

### Guard preserved
\`test_genuinely_oversized_autonomous_change_is_still_blocked\` — PASS (80 real files > 60 cap still blocked)

## No-regression

\`\`\`
python -m pytest tests/unit/test_autonomous_ci_guardrails.py tests/unit/test_autonomous_scope_cumulative_merge.py tests/unit/test_git_add_all_artifacts.py tests/issues/716/test_github_ops.py --deselect tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_delete_branch
131 passed, 1 deselected
\`\`\`
(\`test_delete_branch\` is a pre-existing failure on main — \`delete_branch\` was refactored to add existence probes, now 4 subprocess calls vs the test's expected 2. Unrelated to this PR.)

## #2189 scanner

\`\`\`
python scripts/scan_test_false_positives.py tests --exclude-dirs tests/issues --baseline .false-positive-baseline.json
P0 (must fix): 0, P1 (review needed): 0, P2 (low priority): 0
EXIT: 0
\`\`\`

## Edge cases for reviewers

1. **Fix A angle-bracket check**: rejects ALL paths containing \`<\`/\`>\`, not just MagicMock reprs. Safe because legitimate filenames never contain these on any git-supported filesystem. \`__pycache__\`/\`.pytest_cache\` checks are segment-based so they won't false-positive on e.g. \`app/cache_helper.py\`.
2. **Fix B narrowing**: the re-derivation only NARROWS the cumulative base (merge-base can only be equal to or a descendant of the true branch point). A genuinely oversized change (>60 non-merge files) is still blocked — verified by existing guard test.
3. **Fix B fail-soft**: if merge-base derivation fails (\`returncode != 0\` or exception), the validator falls through to the original logic (uses the persisted base). Same fail-soft pattern as the existing merge-commit block.
4. **Fix B \`origin/main\` freshness**: uses the local \`origin/main\` ref — same mechanism as the existing legacy-base backfill. No worse than existing behavior.

## Test plan
- [x] Bug A test (RED -> GREEN)
- [x] Bug B test (RED -> GREEN)
- [x] Guard test (genuinely oversized still blocked)
- [x] No-regression suite (131 passed)
- [x] #2189 scanner exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)