### PR TITLE
fix(tests): align 814 worktree-selfheal tests with ensure_worktree additions (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -2282,22 +2282,6 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "GitHubOpsError",
-      "issue_number": "814",
-      "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
-      "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140600398512272'> != auto-dev/1390d553) with uncommitted changes.…"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "GitHubOpsError",
-      "issue_number": "814",
-      "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
-      "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140600663599696'> != auto-dev/1390d553) with uncommitted changes.…"
-    },
-    {
-      "category": "test_body_exception",
       "exception_type": "TimeoutError",
       "issue_number": "82",
       "nodeid": "tests/issues/82/test_sidebar_collapse.py::test_sidebar_collapse",
@@ -2547,8 +2531,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-13 prune 6 resolved: tests/issues/673/test_session_filter_params.py cluster (5 x setup_error from ambient-Database fixture hitting dev PG / empty isolated-home SQLite, 1 x assertion_failure from unauthenticated live-server request), fixed by self-contained load_schema_from_file fixtures + Flask test_client conversion. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31694625293",
+    "prune_note": "2026-08-13 prune 2 resolved: tests/issues/814 worktree-selfheal tests, stale vs #1573 branch-consistency + #23 node_modules-shim + #2565 trusted-context-refresh additions to ensure_worktree; fixed by tenant-correcting the GitHubOps fake. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31704317996",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -125,10 +125,22 @@ class TestEnsureWorktreeSelfHeal:
         # _ensure_worktree now checks validity via main_gh.path_exists_as_user
         # (cross-user safe; replaced the old os.path.isfile probe, Issue #1395).
         fake_gh = MagicMock()
-        fake_gh.path_exists_as_user.return_value = True
+        # Only the worktree's .git marker "exists": the #23 node_modules shim
+        # (later in ensure_worktree) probes the main clone's frontend and must
+        # find no install, else it runs _run_as_account on the mock and records
+        # a fail-soft milestone this test asserts never happens.
+        fake_gh.path_exists_as_user.side_effect = lambda p, **_kw: str(p).endswith("/.git")
+        # #1573 branch consistency: the worktree's actual branch must match
+        # branch_name, else the fake's MagicMock branch trips the mismatch
+        # guard (with a truthy has_uncommitted_changes → GitHubOpsError).
+        fake_gh.get_current_branch.return_value = wf["branch_name"]
+        # A class-like fake: constructing it yields fake_gh, and classmethod
+        # access (GitHubOps.clear_trusted_git_context, added by #2565's
+        # _refresh_trusted_git_context) works — a bare lambda has no attributes.
+        fake_gh_cls = MagicMock(return_value=fake_gh)
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path, **_kw: fake_gh,
+            fake_gh_cls,
         )
         o = _make_orchestrator(wf)
 
@@ -145,10 +157,22 @@ class TestEnsureWorktreeSelfHeal:
         canonical = wf["worktree_path"]
 
         fake_gh = MagicMock()
-        fake_gh.path_exists_as_user.return_value = True
+        # Only the worktree's .git marker "exists": the #23 node_modules shim
+        # (later in ensure_worktree) probes the main clone's frontend and must
+        # find no install, else it runs _run_as_account on the mock and records
+        # a fail-soft milestone this test asserts never happens.
+        fake_gh.path_exists_as_user.side_effect = lambda p, **_kw: str(p).endswith("/.git")
+        # #1573 branch consistency: the worktree's actual branch must match
+        # branch_name, else the fake's MagicMock branch trips the mismatch
+        # guard (with a truthy has_uncommitted_changes → GitHubOpsError).
+        fake_gh.get_current_branch.return_value = wf["branch_name"]
+        # A class-like fake: constructing it yields fake_gh, and classmethod
+        # access (GitHubOps.clear_trusted_git_context, added by #2565's
+        # _refresh_trusted_git_context) works — a bare lambda has no attributes.
+        fake_gh_cls = MagicMock(return_value=fake_gh)
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path, **_kw: fake_gh,
+            fake_gh_cls,
         )
         o = _make_orchestrator(wf)
 
@@ -176,17 +200,27 @@ class TestEnsureWorktreeSelfHeal:
             # worktree add <path> <existing-branch>  (NO -b)
             MagicMock(),
         ]
+        # A class-like fake: constructing it yields fake_gh, and classmethod
+        # access (GitHubOps.clear_trusted_git_context, added by #2565's
+        # _refresh_trusted_git_context) works — a bare lambda has no attributes.
+        fake_gh_cls = MagicMock(return_value=fake_gh)
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path, **_kw: fake_gh,
+            fake_gh_cls,
         )
 
         result = o._ensure_worktree(wf)
 
         assert result == canonical
-        # Last git call reattaches the existing branch (no -b flag).
-        last_call = fake_gh._run_git.call_args_list[-1].args[0]
-        assert last_call == ["worktree", "add", canonical, wf["branch_name"]]
+        # The reattach call (no -b flag). Selected by command prefix rather
+        # than position: #2565's post-add trusted-context refresh appends a
+        # rev-parse probe after it (absorbed by the refresh's error path).
+        add_calls = [
+            c.args[0]
+            for c in fake_gh._run_git.call_args_list
+            if c.args[0][:2] == ["worktree", "add"]
+        ]
+        assert add_calls == [["worktree", "add", canonical, wf["branch_name"]]]
         o._create_milestone.assert_called_once()
 
     def test_recreates_missing_worktree_and_branch_from_origin(self, monkeypatch):
@@ -224,22 +258,32 @@ class TestEnsureWorktreeSelfHeal:
             # worktree add -b <branch> <path> <base-sha-verified>
             MagicMock(),
         ]
+        # A class-like fake: constructing it yields fake_gh, and classmethod
+        # access (GitHubOps.clear_trusted_git_context, added by #2565's
+        # _refresh_trusted_git_context) works — a bare lambda has no attributes.
+        fake_gh_cls = MagicMock(return_value=fake_gh)
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path, **_kw: fake_gh,
+            fake_gh_cls,
         )
 
         result = o._ensure_worktree(wf)
 
         assert result == canonical
-        last_call = fake_gh._run_git.call_args_list[-1].args[0]
-        assert last_call == [
-            "worktree",
-            "add",
-            "-b",
-            wf["branch_name"],
-            canonical,
-            "base-sha-verified",
+        add_calls = [
+            c.args[0]
+            for c in fake_gh._run_git.call_args_list
+            if c.args[0][:2] == ["worktree", "add"]
+        ]
+        assert add_calls == [
+            [
+                "worktree",
+                "add",
+                "-b",
+                wf["branch_name"],
+                canonical,
+                "base-sha-verified",
+            ]
         ]
 
     def test_noop_for_new_branch_strategy(self, monkeypatch):


### PR DESCRIPTION
## What

Resolves the 4 `tests/issues/814/test_worktree_path_selfheal.py` failures (2 baseline entries + 2 newly failing since #2565), and prunes the 2 known entries (**318 → 316**, shrink-only). Test-only.

The 814 tests were stale against three later `ensure_worktree` features:

1. **#1573 branch consistency** — the fake's `get_current_branch()` returned a MagicMock ≠ `branch_name`, and truthy `has_uncommitted_changes()` tripped the mismatch guard → `GitHubOpsError` (the 2 baseline entries). Now configured to the expected branch.
2. **#23 node_modules shim** — blanket-True `path_exists_as_user` let the shim's main-clone frontend probe proceed to `_run_as_account` on the mock, recording the fail-soft `frontend_node_modules_shim_failed` milestone the valid-path tests forbid. Now the fake answers True only for the worktree's `.git` marker, so the shim no-ops (no frontend install to reuse).
3. **#2565 trusted-context refresh** — `GitHubOps` was replaced with a bare lambda, which has no classmethod attributes: `GitHubOps.clear_trusted_git_context(...)` raised `AttributeError` (the 2 new failures). Replaced with a class-like `MagicMock(return_value=fake_gh)`. The post-add refresh's rev-parse probe then exhausts `_run_git` side_effect and is absorbed by the refresh's `except`, so the reattach assertions select the `worktree add` call by prefix instead of `call_args_list[-1]`.

Each failure mode was observed and cleared incrementally while fixing (branch mismatch → shim milestone → AttributeError → last-call drift, in that order).

## Verification

- Local: `tests/issues/814/` 14/14 passed.
- CI (dispatch `category=issues`, 4 shards): run 31706274372 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=316`.
- Baseline prune shrink-only (2 nodeids removed, provenance updated).
- pre-commit clean (black / isort / ruff / mypy).

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)