### PR TITLE
fix(tests): provide tenant context in session-write tests (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -2,46 +2,6 @@
   "entries": [
     {
       "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1003",
-      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_autonomous_count_usage_false_leaves_counters",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1003",
-      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_legacy_count_usage_true_still_accumulates",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1003",
-      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_accumulates_across_calls",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1003",
-      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_starts_from_existing_value",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1003",
-      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestMilestoneSessionInvariant::test_session_equals_sum_of_per_call_deltas",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
       "exception_type": "TimeoutError",
       "issue_number": "1006",
       "nodeid": "tests/issues/1006/e2e_conversation_history_default_dates.py::test_default_dates",
@@ -95,38 +55,6 @@
       "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_list_sessions_hides_autonomous_tracking_wrappers",
       "outcome": "failure",
       "summary": "AssertionError: assert ['track-123',...l-claude-123'] == ['actual-claude-123']"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1128",
-      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_merges_duplicate_message_id_without_double_count",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1128",
-      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_persists_structured_session_message_columns",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "1128",
-      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_append_transcript_message_is_summary_side_effect_free",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1128",
-      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_llm_proxy_records_transcript_without_double_count",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 0 == 1"
     },
     {
       "category": "assertion_failure",
@@ -711,214 +639,6 @@
       "nodeid": "tests/issues/241/test_pagination_migration_head.py::test_single_migration_head",
       "outcome": "failure",
       "summary": "AssertionError: assert '20260809_001...il_dev_rounds' == '20260715_001...lure_head_sha'"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_include_messages_returns_recent_page_and_metadata",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_milestone_total_uses_conditional_count",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_without_include_messages_has_no_pagination_envelope",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_cursor_walk_through_endpoint",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_limit_clamped_to_max_via_endpoint",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_lone_before_timestamp_is_ignored",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_admin_bypasses_owner_check",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_404_for_unknown_session",
-      "outcome": "failure",
-      "summary": "assert 500 == 404"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_enforces_ownership_before_load",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_non_owner_gets_403",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_same_owner_wrong_tenant_gets_403",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_unknown_session_returns_404",
-      "outcome": "failure",
-      "summary": "assert 500 == 404"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_full_walk_no_overlap_no_gap",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_has_more_flag_and_cursor_only_when_older_page_exists",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestDescReverseAdjacency::test_second_page_is_adjacent_not_oldest",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_default_limit_used_when_none",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_empty_session_returns_empty_page",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_full_history_when_requested",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_no_messages_by_default",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_max_boundary_returns_exactly_max",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_over_max_clamped_to_max",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_zero_or_negative_falls_back_to_default",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_count_messages_total_and_milestone_scoped",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_get_messages_page_respects_milestone_filter",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestNullTimestampSafetyNet::test_schema_rejects_null_timestamp",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "241",
-      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestSameTimestampTiebreak::test_identical_timestamps_ordered_by_id",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
       "category": "test_body_exception",
@@ -1628,14 +1348,6 @@
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "716",
-      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_add_all",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 'add' in ['git', '-c', 'core.hooksPath=/dev/null', '-c', 'core.fsmonitor=false', '-c', ...]"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_blocked_state_triggers_ci_repair",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'mock' to have been called once. Called 0 times."
@@ -1823,14 +1535,6 @@
       "nodeid": "tests/issues/720/test_model_gateway_handler.py::TestGatewaySuccess::test_gateway_forward_success",
       "outcome": "failure",
       "summary": "assert 502 == 200"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "723",
-      "nodeid": "tests/issues/723/test_mtime_fallback.py::TestListCliSessionIdsForProject::test_returns_distinct_nonempty_ids",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
       "category": "assertion_failure",
@@ -2143,38 +1847,6 @@
       "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_planning_timeout_constant",
       "outcome": "failure",
       "summary": "assert 1800 == 600"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "764",
-      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_defaults_to_local",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "764",
-      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_includes_workspace_in_insert",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "764",
-      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_type_error_fixed",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TenantResolutionError",
-      "issue_number": "764",
-      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_with_workspace_type",
-      "outcome": "failure",
-      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
       "category": "assertion_failure",
@@ -2531,8 +2203,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-13 prune 2 resolved: tests/issues/814 worktree-selfheal tests, stale vs #1573 branch-consistency + #23 node_modules-shim + #2565 trusted-context-refresh additions to ensure_worktree; fixed by tenant-correcting the GitHubOps fake. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31704317996",
+    "prune_note": "2026-08-13 prune 37+3+1 resolved: TenantResolutionError session-write cluster plus 3 same-file baseline entries resolved by the tenant-context test fixes, plus 716 test_git_add_all resolved on main by #2601 (fb9c5128, observed passing in run 31709302597). Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31709302597",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/1003/test_session_usage_accounting.py
+++ b/tests/issues/1003/test_session_usage_accounting.py
@@ -44,7 +44,11 @@ def sqlite_sm(tmp_path, monkeypatch):
 
 
 def _create(sm, sid="sess-1"):
-    return sm.create_session(tool_name="test", session_id=sid, user_id=1)
+    # Session writes resolve tenant fail-closed (#1789 lineage); the fixture DB
+    # seeds no users row to look up, so pass the tenant explicitly. Counter
+    # updates below must pass the same tenant (require_tenant=True matches
+    # nothing when tenant_id is unresolved).
+    return sm.create_session(tool_name="test", session_id=sid, user_id=1, tenant_id=1)
 
 
 # ── increment_session_usage ──────────────────────────────────────────────
@@ -56,6 +60,7 @@ class TestIncrementSessionUsage:
         _create(sm)
         sm.increment_session_usage(
             "sess-1",
+            tenant_id=1,
             message_delta=2,
             request_delta=3,
             total_tokens_delta=100,
@@ -64,6 +69,7 @@ class TestIncrementSessionUsage:
         )
         sm.increment_session_usage(
             "sess-1",
+            tenant_id=1,
             message_delta=1,
             request_delta=2,
             total_tokens_delta=50,
@@ -81,8 +87,8 @@ class TestIncrementSessionUsage:
         # simulate a session that already has counts (e.g. resumed)
         sm = sqlite_sm
         _create(sm)
-        sm.increment_session_usage("sess-1", request_delta=10, total_tokens_delta=1000)
-        sm.increment_session_usage("sess-1", request_delta=3, total_tokens_delta=150)
+        sm.increment_session_usage("sess-1", tenant_id=1, request_delta=10, total_tokens_delta=1000)
+        sm.increment_session_usage("sess-1", tenant_id=1, request_delta=3, total_tokens_delta=150)
         s = sm.get_session("sess-1")
         assert s.request_count == 13
         assert s.total_tokens == 1150
@@ -104,7 +110,7 @@ class TestAddMessageCountUsageGate:
         session summary."""
         sm = sqlite_sm
         _create(sm)
-        sm.increment_session_usage("sess-1", request_delta=5, total_tokens_delta=500)
+        sm.increment_session_usage("sess-1", tenant_id=1, request_delta=5, total_tokens_delta=500)
         sm.add_message(session_id="sess-1", role="assistant", content="hi", count_usage=False)
         sm.add_message(session_id="sess-1", role="tool", content="result", count_usage=False)
         s = sm.get_session("sess-1")
@@ -186,6 +192,7 @@ class TestMilestoneSessionInvariant:
             # agent_runner finish path: increment session by this call's counts
             sm.increment_session_usage(
                 "sess-1",
+                tenant_id=1,
                 message_delta=1,
                 request_delta=rc,
                 total_tokens_delta=tk,

--- a/tests/issues/1128/test_session_message_transcript_contract.py
+++ b/tests/issues/1128/test_session_message_transcript_contract.py
@@ -29,7 +29,9 @@ def sqlite_sm(tmp_path, monkeypatch):
 
 
 def _create_session(sm: SessionManager, session_id: str = "sess-1128") -> AgentSession:
-    return sm.create_session(tool_name="claude", session_id=session_id, user_id=1)
+    # Session writes resolve tenant fail-closed (#1789 lineage); the fixture DB
+    # seeds no users row to look up, so pass the tenant explicitly.
+    return sm.create_session(tool_name="claude", session_id=session_id, user_id=1, tenant_id=1)
 
 
 def test_add_message_merges_duplicate_message_id_without_double_count(sqlite_sm):
@@ -194,8 +196,11 @@ def test_llm_proxy_records_transcript_without_double_count(monkeypatch):
         def get_session(self, session_id, include_messages=False):
             return self.session
 
-        def update_session(self, updated_session):
-            self.session = updated_session
+        def update_session_fields(self, session_id, fields, tenant_id=None, require_tenant=False):
+            # Mirror the real SessionManager interface (llm_proxy writes the
+            # session model via update_session_fields with a tenant kwarg).
+            for key, value in fields.items():
+                setattr(self.session, key, value)
             return True
 
         def increment_session_usage(
@@ -206,7 +211,16 @@ def test_llm_proxy_records_transcript_without_double_count(monkeypatch):
             total_tokens_delta=0,
             total_input_delta=0,
             total_output_delta=0,
+            total_cache_read_delta=0,
+            total_cache_write_delta=0,
+            tenant_id=None,
+            require_tenant=True,
         ):
+            # tenant_id/require_tenant/cache deltas mirror the real
+            # SessionManager signature (usage_sink passes tenant_id=... and the
+            # cache kwargs); without them the call raises TypeError and the
+            # sink's except swallows it, silently zeroing the counters this
+            # test asserts on.
             self.session.message_count = (self.session.message_count or 0) + message_delta
             self.session.request_count = (self.session.request_count or 0) + request_delta
             self.session.total_tokens = (self.session.total_tokens or 0) + total_tokens_delta

--- a/tests/issues/241/test_pagination_routes.py
+++ b/tests/issues/241/test_pagination_routes.py
@@ -59,9 +59,12 @@ def app_and_manager(monkeypatch):
 
 
 def _make_session(mgr, user_id=1, session_id="sess-route"):
+    # Session writes resolve tenant fail-closed (#1789 lineage); the fixture DB
+    # seeds no users row to look up, so pass the tenant explicitly.
     s = mgr.create_session(
         tool_name="qwen",
         user_id=user_id,
+        tenant_id=1,
         session_type="chat",
         title="route test",
         session_id=session_id,
@@ -103,7 +106,7 @@ class TestOwnershipAnd404:
     def test_unknown_session_returns_404(self, app_and_manager):
         app, _ = app_and_manager
         with app.test_request_context("/api/workspace/sessions/does-not-exist"):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session("does-not-exist")
         assert _status(resp) == 404
 
@@ -111,7 +114,11 @@ class TestOwnershipAnd404:
         app, mgr = app_and_manager
         sid = _make_session(mgr, user_id=1)
         with app.test_request_context(f"/api/workspace/sessions/{sid}"):
-            g.user = {"id": 999, "role": "user"}  # different user
+            # Same-tenant non-owner (a null-tenant user is denied earlier by
+            # _session_lookup_tenant_id's fail-closed abort, which the view's
+            # error handler surfaces as 500; tenant-correct the caller so this
+            # test exercises the ownership check it is named for).
+            g.user = {"id": 999, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session(sid)
         assert _status(resp) == 403
 
@@ -121,14 +128,15 @@ class TestOwnershipAnd404:
         sid = _make_session(mgr, user_id=1)
         _add(mgr, sid, 0)
         with app.test_request_context(f"/api/workspace/sessions/{sid}/messages"):
-            g.user = {"id": 999, "role": "user"}
+            # Same-tenant non-owner (see test_non_owner_gets_403 note).
+            g.user = {"id": 999, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session_messages(sid)
         assert _status(resp) == 403
 
     def test_messages_endpoint_404_for_unknown_session(self, app_and_manager):
         app, _ = app_and_manager
         with app.test_request_context("/api/workspace/sessions/ghost/messages"):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session_messages("ghost")
         assert _status(resp) == 404
 
@@ -152,7 +160,10 @@ class TestOwnershipAnd404:
         with app.test_request_context(f"/api/workspace/sessions/{sid}"):
             g.user = {"id": 1, "role": "user", "tenant_id": 3}
             resp = workspace_route.get_session(sid)
-        assert _status(resp) == 403
+        # Issue #2538: cross-tenant access returns 404 (not 403) so the caller
+        # cannot learn the session exists. The property under test — a
+        # tenant-mismatched owner is denied — is preserved.
+        assert _status(resp) == 404
 
 
 # =================== get_session pagination envelope ========================
@@ -168,7 +179,7 @@ class TestGetSessionEnvelope:
         with app.test_request_context(
             f"/api/workspace/sessions/{sid}?include_messages=true&message_limit=2"
         ):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session(sid)
 
         assert _status(resp) == 200
@@ -185,7 +196,7 @@ class TestGetSessionEnvelope:
         sid = _make_session(mgr, user_id=1)
         _add(mgr, sid, 0)
         with app.test_request_context(f"/api/workspace/sessions/{sid}"):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session(sid)
         data = _json(resp)["data"]
         assert "messages_total" not in data
@@ -204,7 +215,7 @@ class TestGetSessionEnvelope:
         with app.test_request_context(
             f"/api/workspace/sessions/{sid}?include_messages=true&milestone_id=M1"
         ):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session(sid)
         data = _json(resp)["data"]
         # session.message_count == 5, but milestone M1 has only 3.
@@ -229,7 +240,7 @@ class TestMessagesEndpointWalk:
             if before_ts is not None:
                 qs += f"&before_timestamp={before_ts}&before_id={before_id}"
             with app.test_request_context(qs):
-                g.user = {"id": 1, "role": "user"}
+                g.user = {"id": 1, "role": "user", "tenant_id": 1}
                 resp = workspace_route.get_session_messages(sid)
             assert _status(resp) == 200
             payload = _json(resp)["data"]
@@ -255,7 +266,7 @@ class TestMessagesEndpointWalk:
         with app.test_request_context(
             f"/api/workspace/sessions/{sid}/messages?before_timestamp=2026-07-04T12:00:03"
         ):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session_messages(sid)
         data = _json(resp)["data"]
         # No before_id => cursor dropped => most-recent page (5 rows, has_more False).
@@ -269,7 +280,7 @@ class TestMessagesEndpointWalk:
             _add(mgr, sid, n, count_usage=False)
 
         with app.test_request_context(f"/api/workspace/sessions/{sid}/messages?limit=99999"):
-            g.user = {"id": 1, "role": "user"}
+            g.user = {"id": 1, "role": "user", "tenant_id": 1}
             resp = workspace_route.get_session_messages(sid)
         assert _status(resp) == 200
         # Clamped to MAX (500) but only 3 rows exist.

--- a/tests/issues/241/test_session_messages_pagination.py
+++ b/tests/issues/241/test_session_messages_pagination.py
@@ -66,11 +66,16 @@ def manager(monkeypatch):
         pass
 
 
-def _create_session(mgr, session_id="sess-pagination", user_id=1):
-    """Create a session and return its session_id string."""
+def _create_session(mgr, session_id="sess-pagination", user_id=1, tenant_id=1):
+    """Create a session and return its session_id string.
+
+    Session writes resolve tenant fail-closed (#1789 lineage): an explicit
+    tenant_id is required because the fixture DB seeds no users row to look up.
+    """
     session = mgr.create_session(
         tool_name="qwen",
         user_id=user_id,
+        tenant_id=tenant_id,
         session_type="chat",
         title="pagination test",
         session_id=session_id,

--- a/tests/issues/723/test_mtime_fallback.py
+++ b/tests/issues/723/test_mtime_fallback.py
@@ -160,6 +160,7 @@ class TestListCliSessionIdsForProject:
         ]:
             sm.create_session(
                 session_id=sid,
+                tenant_id=1,
                 session_type="workflow",
                 title="t",
                 tool_name="claude-code",

--- a/tests/issues/764/test_session_create_params.py
+++ b/tests/issues/764/test_session_create_params.py
@@ -27,6 +27,7 @@ class TestCreateSessionAcceptsWorkspaceParams:
         sm = self._make_session_manager()
         session = sm.create_session(
             tool_name="claude-code",
+            tenant_id=1,
             title="Autonomous: test",
             project_path="/tmp/test",
             workspace_type="remote",
@@ -38,7 +39,7 @@ class TestCreateSessionAcceptsWorkspaceParams:
 
     def test_create_session_defaults_to_local(self):
         sm = self._make_session_manager()
-        session = sm.create_session(tool_name="claude-code", title="Test session")
+        session = sm.create_session(tool_name="claude-code", tenant_id=1, title="Test session")
         assert session.workspace_type == "local"
         assert session.remote_machine_id is None
 
@@ -46,12 +47,19 @@ class TestCreateSessionAcceptsWorkspaceParams:
         sm = self._make_session_manager()
         sm.create_session(
             tool_name="qwen-code-cli",
+            tenant_id=1,
             workspace_type="remote",
             remote_machine_id="abc-def",
         )
         mock_cursor = sm._get_connection.return_value.cursor.return_value
-        mock_cursor.execute.assert_called_once()
-        call_args = mock_cursor.execute.call_args
+        # create_session also probes the schema (tenant column introspection)
+        # via cursor.execute before the INSERT, so select the INSERT call
+        # instead of asserting exactly one execute.
+        insert_calls = [
+            c for c in mock_cursor.execute.call_args_list if "INSERT INTO agent_sessions" in c[0][0]
+        ]
+        assert len(insert_calls) == 1
+        call_args = insert_calls[0]
         sql = call_args[0][0]
         params = list(call_args[0][1])
         assert "workspace_type" in sql
@@ -64,6 +72,7 @@ class TestCreateSessionAcceptsWorkspaceParams:
         try:
             sm.create_session(
                 session_id="test-session-id",
+                tenant_id=1,
                 session_type="chat",
                 title="Autonomous: abc12345",
                 tool_name="claude-code",


### PR DESCRIPTION
## What

Resolves the **TenantResolutionError session-write cluster** — the largest deferred #2457 group — and prunes it plus same-fix collateral (**316 → 275**, shrink-only = 41 entries: 37 TenantResolutionError + 3 same-file baseline entries + 1 resolved on main by #2601). Test-only.

## Root cause

Session writes resolve the tenant fail-closed (#1789 lineage): explicit `tenant_id`, else a `users`-row lookup, else `TenantResolutionError` (or an unsatisfiable `1=0` tenant predicate for counter updates). These tests wrote sessions/counters with no tenant context against fixture DBs that seed no users row.

## Per-file fixes

- **241 ×2 / 1003 / 764 / 723**: pass `tenant_id=1` at session creation; 1003's `increment_session_usage` calls pass the same tenant (`require_tenant=True` matches nothing when unresolved). 241 routes: tenant-correct the `g.user` dicts (owners get `tenant_id: 1`); the cross-tenant test now expects **404** per #2538's don't-leak semantics (property — mismatched owner denied — preserved).
- **764**: the INSERT assertion selects the `worktree`-of-no-wait, the `INSERT INTO agent_sessions` call instead of `assert_called_once` (create_session also probes the schema via `cursor.execute` now).
- **1128**: the FakeSessionManager mirrors the real interface — `increment_session_usage` gains `tenant_id`/`require_tenant`/cache-delta kwargs (usage_sink passes them; the stale fake raised TypeError which the sink's except swallowed, silently zeroing the asserted counters) and `update_session_fields` replaces the stale `update_session` name (its AttributeError aborted `_record_llm_usage` before the sink ran).

## Composition notes

- Rebased on main incl. #2606 (814) — the prune conflict was recomposed on main's 316-entry baseline.
- `716::test_git_add_all` pruned because #2601 (`fb9c5128`) resolved it on main mid-stream (observed passing in run 31709302597).
- 723's `test_empty_project_path_returns_empty_set` hangs locally (macOS-only, CI-clean); 241's `test_single_migration_head` is a separate baseline-known entry — both untouched.

## Verification

- Local: 86/86 across the touched files (incl. 814).
- CI (dispatch `category=issues`, 4 shards): run 31711515489 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=275`.
- pre-commit clean (black / isort / ruff / mypy).

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)