### PR TITLE
orchestrator: fresh-retry resumed-agent empty result (#2618)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6708,7 +6708,7 @@ class AutonomousOrchestrator:
             **kwargs,
         )
         if not self._is_context_overflow(result):
-            # Resume-noop backstop (#2529, system layer). A --resumed stream-json
+            # Resume-noop backstop (#2618, system layer). A --resumed stream-json
             # agent whose stale background shell re-injects a <status>stopped</status>
             # notification can terminally report success with 0 tokens and empty
             # artifact text (the provider emits a result event with no assistant

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6708,6 +6708,45 @@ class AutonomousOrchestrator:
             **kwargs,
         )
         if not self._is_context_overflow(result):
+            # Resume-noop backstop (#2529, system layer). A --resumed stream-json
+            # agent whose stale background shell re-injects a <status>stopped</status>
+            # notification can terminally report success with 0 tokens and empty
+            # artifact text (the provider emits a result event with no assistant
+            # turn). The per-agent backstops in pr_review.py (#2570) and
+            # _apply_pr_review_fix (#2611) cover only two call sites; this lower-
+            # level guard covers EVERY resumed line. Retry ONCE on a fresh
+            # transcript (same prompt/line id) so the real prompt is actually
+            # processed. Guards: only when resumed (named line, not already
+            # force_fresh), only for success-but-empty with no tokens, and at
+            # most once (force_fresh=True on the retry prevents re-entry).
+            line_field = SESSION_LINE_FIELDS.get(session_line)
+            if (
+                line_field
+                and not kwargs.get("force_fresh")
+                and result.success
+                and not self._artifact_text(result).strip()
+                and int(result.total_tokens or 0) == 0
+            ):
+                self._accumulate_tokens(result)
+                logger.warning(
+                    "Workflow %s: resumed session line %s returned success with "
+                    "no artifact (resume no-op); retrying once on a fresh session",
+                    self._workflow_id[:8],
+                    session_line,
+                )
+                return self._run_agent(
+                    wf=wf,
+                    session_line=session_line,
+                    milestone_id=milestone_id,
+                    force_fresh=True,
+                    prior_usage={
+                        "total_tokens": int(result.total_tokens or 0),
+                        "total_input_tokens": int(result.total_input_tokens or 0),
+                        "total_output_tokens": int(result.total_output_tokens or 0),
+                        "request_count": int(result.request_count or 0),
+                    },
+                    **{k: v for k, v in kwargs.items() if k not in ("force_fresh", "prior_usage")},
+                )
             return result
 
         field = SESSION_LINE_FIELDS.get(session_line)

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -2623,3 +2623,140 @@ def test_review_fix_genuine_failure_does_not_trigger_fresh_retry():
     assert orch._run_agent_with_context_recovery.call_count == 1
     milestone_update = orch.repo.update_milestone.call_args.args[1]
     assert "agent failed" in milestone_update["error_message"]
+
+
+# ── #2529: system-layer resume-noop fresh-retry ──────────────────────────
+#
+# Root cause (confirmed): a --resumed stream-json agent whose stale background
+# shell re-injects a <status>stopped</status> notification causes the provider
+# to emit a terminal result event WITHOUT an assistant turn. The controller
+# sees success=True, 0 tokens, empty artifact_text. The per-agent backstops
+# (#2570 summary / #2611 pr_review fix) only cover two call sites; this backstop
+# lives in _run_agent_with_context_recovery so EVERY resumed agent line is
+# covered. When a resumed (non-fresh) line returns success-but-empty, retry
+# ONCE on a fresh session. Guards: retry once only, never retry genuine
+# failures/overflow/integrity.
+
+
+def _make_recovery_orchestrator():
+    """Minimal AutonomousOrchestrator for _run_agent_with_context_recovery
+    resume-noop tests: _run_agent behaviour is set per-test via side_effect."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2529"
+    orch.repo = MagicMock()
+    orch.repo.get_workflow.return_value = {}
+    orch._accumulate_tokens = MagicMock()
+    orch._is_context_overflow = MagicMock(return_value=False)
+    orch._update_workflow = MagicMock()
+    orch._runner = MagicMock()
+    return orch
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2529)
+def test_resumed_empty_success_retries_fresh_and_returns_nonempty():
+    """#2529: a resumed main line that returns success+empty (0 tokens) is a
+    resume-noop. _run_agent_with_context_recovery retries ONCE on a fresh
+    session; the fresh run's non-empty result is returned."""
+    orch = _make_recovery_orchestrator()
+    empty_resume = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    fresh_ok = AgentTaskResult(success=True, response_text="did the work", total_tokens=42)
+    orch._run_agent = MagicMock(side_effect=[empty_resume, fresh_ok])
+
+    result = orch._run_agent_with_context_recovery(
+        wf={"main_session_id": "track-main"},
+        session_line="main",
+        prompt="do X",
+    )
+
+    assert result.success is True
+    assert result.response_text == "did the work"
+    # Agent ran twice: resumed main (empty) + fresh (non-empty).
+    assert orch._run_agent.call_count == 2
+    # The retry (2nd call) must start a fresh provider transcript.
+    retry_kwargs = orch._run_agent.call_args_list[1].kwargs
+    assert retry_kwargs.get("force_fresh") is True
+    # Same line id / prompt (not a different task).
+    first_kwargs = orch._run_agent.call_args_list[0].kwargs
+    assert retry_kwargs.get("prompt") == first_kwargs.get("prompt")
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2529)
+def test_resumed_empty_success_retries_once_even_if_still_empty():
+    """#2529 guard: the fresh retry happens at most ONCE. If the retry also
+    returns empty, return that empty result (do NOT loop)."""
+    orch = _make_recovery_orchestrator()
+    empty_resume = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    empty_fresh = AgentTaskResult(success=True, response_text="   ", total_tokens=0)
+    orch._run_agent = MagicMock(side_effect=[empty_resume, empty_fresh])
+
+    result = orch._run_agent_with_context_recovery(
+        wf={"main_session_id": "track-main"},
+        session_line="main",
+        prompt="do X",
+    )
+
+    # Only two runs (resumed + one fresh retry) — no third attempt.
+    assert orch._run_agent.call_count == 2
+    assert result.success is True
+    assert result.response_text.strip() == ""
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2529)
+def test_genuine_failure_not_retried():
+    """#2529 guard: a real failure (success=False) is NOT retried. The existing
+    failure path handles it; the backstop is reserved for success-but-empty."""
+    orch = _make_recovery_orchestrator()
+    failed = AgentTaskResult(success=False, error="agent exited 1")
+    orch._run_agent = MagicMock(return_value=failed)
+
+    result = orch._run_agent_with_context_recovery(
+        wf={"main_session_id": "track-main"},
+        session_line="main",
+        prompt="do X",
+    )
+
+    assert result.success is False
+    assert orch._run_agent.call_count == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2529)
+def test_already_fresh_empty_not_retried():
+    """#2529 guard: a session_line="fresh" run that returns empty is not
+    retried again — there is no resume to no-op on, so retrying would loop."""
+    orch = _make_recovery_orchestrator()
+    empty_fresh = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    orch._run_agent = MagicMock(return_value=empty_fresh)
+
+    result = orch._run_agent_with_context_recovery(
+        wf={},
+        session_line="fresh",
+        prompt="do X",
+    )
+
+    assert result.response_text == ""
+    assert orch._run_agent.call_count == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2529)
+def test_resumed_nonempty_success_not_retried():
+    """#2529 guard: a resumed line that returns NON-empty success is a normal
+    run — no retry."""
+    orch = _make_recovery_orchestrator()
+    ok = AgentTaskResult(success=True, response_text="real work done", total_tokens=100)
+    orch._run_agent = MagicMock(return_value=ok)
+
+    result = orch._run_agent_with_context_recovery(
+        wf={"review_session_id": "track-review"},
+        session_line="review",
+        prompt="do X",
+    )
+
+    assert result.response_text == "real work done"
+    assert orch._run_agent.call_count == 1


### PR DESCRIPTION
## What

System-layer backstop for the resume-noop bug class (#2618). A `--resumed` stream-json agent whose stale background shell re-injects a `<status>stopped</status>` notification can terminally report `success=True` with **0 tokens** and **empty artifact_text** (the provider emits a result event with no assistant turn). The real prompt is never processed, yet the phase counts as a success.

The per-agent backstops only cover two call sites:
- `pr_review.py` summary agent (#2570)
- `orchestrator._apply_pr_review_fix` (#2611)

Every other resumed agent line (main/review/test/verification) had no backstop. This PR adds the backstop in `_run_agent_with_context_recovery` (the lowest shared run wrapper) so **every** resumed line is covered.

## Change

`app/modules/workspace/autonomous/orchestrator.py` — `_run_agent_with_context_recovery`, after the context-overflow check:

- **Condition**: resumed named line (`session_line ∈ {main,review,test,verification}`) **and** not already `force_fresh` **and** `result.success` **and** empty artifact text **and** `total_tokens == 0`.
- **Action**: retry once via `_run_agent(..., force_fresh=True, prior_usage=<rejected attempt>)`; accumulate the rejected attempt's tokens; return the retry result.
- **Guards**:
  - Retry **once** only — `force_fresh=True` on the retry prevents re-entry.
  - Never retry genuine failures (`success=False`), context overflow, or integrity violations — all handled by existing paths before this backstop.
  - Retry-still-empty → return the empty result so the caller's empty handling applies (e.g. #2570/#2611 fail-closed).

## Relationship to #2570 / #2611

Those per-agent backstops become **redundant** (they receive the non-empty result from this retry) but are **kept** as defense-in-depth. Their tests mock `_run_agent_with_context_recovery` (replace the whole method), so this internal change does not affect their mock behavior — confirmed: all 92 tests in `test_autonomous_ci_guardrails.py` pass, including the 3 #2550 tests.

## TDD (red → green)

`tests/unit/test_autonomous_ci_guardrails.py` — 5 new regression tests (`@pytest.mark.regression @pytest.mark.issue(2618)`):
1. `test_resumed_empty_success_retries_fresh_and_returns_nonempty` — happy path: resumed main line empty → fresh retry non-empty → returned.
2. `test_resumed_empty_success_retries_once_even_if_still_empty` — retry once only; no infinite loop.
3. `test_genuine_failure_not_retried` — `success=False` runs exactly once.
4. `test_already_fresh_empty_not_retried` — `session_line="fresh"` empty → no retry.
5. `test_resumed_nonempty_success_not_retried` — non-empty success → no retry.

RED confirmed before the change (tests 1 & 2 failed: empty result returned without retry / only 1 run). GREEN after: all 5 pass.

## Verification

- `#2189 scanner` (`scripts/scan_test_false_positives.py tests --exclude-dirs tests/issues`): **0 findings** (P0/P1/P2).
- `pre-commit run --files <changed>`: all pass (black/isort/ruff/mypy/bandit/pydocstyle).
- Full `test_autonomous_ci_guardrails.py`: 92 passed.
- Related orchestrator unit tests (`test_orchestrator_verification_agent.py`, `test_upstream_quota_pause.py`, `test_test_evidence_requirer.py`): 54 passed.
- Pre-existing `tests/issues/1816` & `tests/issues/1897` failures confirmed identical on clean `origin/main` (mock-arg drift in the quarantined tree; not executed by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)