### PR TITLE
Carry forward prior test milestone verdict on retry (#2590 Option A)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6215,6 +6215,81 @@ class AutonomousOrchestrator:
             logger.debug("structured test verdict computation failed: %s", e)
             return ExecutionVerdict.NOT_RUN, [], f"compute failed: {e}"
 
+    def _carry_forward_prior_test_verdict(
+        self,
+        workflow_id: str,
+        current_milestone_id: str,
+        test_retries: int,
+    ) -> tuple[ExecutionVerdict, str]:
+        """Recompute the prior test milestone's structured verdict (#2590).
+
+        On a test-phase retry the agent session is reused (#2390), so the
+        current milestone has no stamped evidence — the agent saw the full
+        prior context and summarized the old results instead of re-running.
+        The #2390 milestone-scoped filter correctly yields NOT_RUN for the
+        current milestone, but the gate's heuristic fallback then reads the
+        *entire* session text (including the prior round's stale output) and
+        misclassifies the run — promoting a FAILED retry to inconclusive or
+        even pr_review.
+
+        This helper re-reads the prior test milestone's persisted
+        ``test_execution_evidence`` rows and recomputes its run verdict, so the
+        gate can carry that *real* verdict forward instead of trusting stale
+        prose. Only fires on an actual retry (``test_retries > 0``) and only
+        when a prior ``tests_run`` milestone with a decisive verdict exists.
+
+        Returns ``(verdict, reason)``. NOT_RUN means no usable prior verdict;
+        the caller falls through to the unchanged heuristic.
+        """
+        if test_retries <= 0 or not workflow_id or not current_milestone_id:
+            return ExecutionVerdict.NOT_RUN, "carry-forward skipped (no retry / no ids)"
+
+        try:
+            milestones = self.repo.list_milestones(workflow_id, phase="development")
+        except Exception:
+            milestones = []
+
+        # Only ``tests_run`` milestones, excluding the current one, newest-first.
+        test_milestones = [
+            ms
+            for ms in milestones
+            if ms.get("milestone_type") == "tests_run"
+            and (ms.get("milestone_id") or "") != current_milestone_id
+        ]
+        if not test_milestones:
+            return ExecutionVerdict.NOT_RUN, "no prior tests_run milestone"
+
+        # list_milestones returns ``created_at ASC, id ASC``; the prior milestone
+        # for THIS dev round is the one immediately before the current one. Take
+        # the latest prior test milestone (highest id) — a retry within the same
+        # dev round creates a chain of test milestones and the last one holds
+        # the real verdict the agent saw before this retry.
+        try:
+            prior_ms = max(test_milestones, key=lambda m: int(m.get("id") or 0))
+        except (ValueError, TypeError):
+            prior_ms = test_milestones[-1]
+        prior_milestone_id = prior_ms.get("milestone_id") or ""
+        if not prior_milestone_id:
+            return ExecutionVerdict.NOT_RUN, "prior milestone has no id"
+
+        try:
+            from app.modules.workspace.autonomous.command_evidence.test_verdict import (
+                compute_run_verdict,
+            )
+            from app.repositories.test_evidence_repo import TestExecutionEvidenceRepository
+
+            prior_evidences = TestExecutionEvidenceRepository().query_by_milestone(
+                workflow_id, prior_milestone_id
+            )
+            if not prior_evidences:
+                return ExecutionVerdict.NOT_RUN, "prior milestone has no test evidence"
+
+            verdict = compute_run_verdict(prior_evidences)
+            return verdict, f"carried forward from milestone {prior_milestone_id}"
+        except Exception as e:
+            logger.debug("prior verdict carry-forward failed: %s", e)
+            return ExecutionVerdict.NOT_RUN, f"carry-forward failed: {e}"
+
     def _emit_structured_test_fallback(
         self,
         verdict: ExecutionVerdict,
@@ -10401,6 +10476,29 @@ class AutonomousOrchestrator:
         structured_verdict, _structured_evidences, structured_reason = (
             self._compute_structured_test_verdict(test_result, framework_type, test_ms)
         )
+        # #2590 Option A: carry forward the prior test milestone's verdict on a
+        # retry. On a test retry the agent session is reused (#2390), so the
+        # current milestone has no stamped evidence and the structured layer
+        # correctly defers NOT_RUN. But the heuristic fallback then reads the
+        # *entire* session text (the prior round's stale output) and
+        # misclassifies the run — promoting a real FAILED to inconclusive or
+        # even pr_review. When this is a retry (test_retries > 0) and the prior
+        # test milestone had a decisive verdict, carry it forward instead of
+        # trusting stale prose. No prior milestone / prior NOT_RUN / not a
+        # retry falls through unchanged.
+        if structured_verdict == ExecutionVerdict.NOT_RUN:
+            _retry_count = int(wf.get("test_retries", 0) or 0)
+            if _retry_count > 0:
+                _prior_verdict, _prior_reason = self._carry_forward_prior_test_verdict(
+                    self._workflow_id,
+                    test_ms.get("milestone_id", ""),
+                    _retry_count,
+                )
+                if _prior_verdict in (ExecutionVerdict.FAILED, ExecutionVerdict.PASSED):
+                    structured_verdict = _prior_verdict
+                    structured_reason = (
+                        f"carried forward from prior test milestone: {_prior_reason}"
+                    )
         # Only PASSED is authoritative (#2376 D2). A structured FAILED used to
         # set this too, which zeroed BOTH test_result_inconclusive and
         # tests_actually_skipped — and since nothing downstream reads

--- a/tests/unit/test_prior_milestone_verdict_carryforward.py
+++ b/tests/unit/test_prior_milestone_verdict_carryforward.py
@@ -1,0 +1,324 @@
+"""Carry forward the prior test milestone's structured verdict (#2590, Option A).
+
+On a test-phase retry, the agent session is reused (same ``session_id``). The
+#2390 milestone-scoped filter correctly yields ``NOT_RUN`` for the current
+milestone — the agent saw the full prior context and *summarized* the old
+results instead of re-running the tests, so no command evidence was stamped
+for this round. But the gate then falls back to the legacy heuristic, which
+reads the *entire* session text (including the prior round's "N passed")
+and misclassifies the run as ``inconclusive`` instead of carrying forward the
+prior round's real FAILED verdict.
+
+The fix: when the current milestone's structured verdict is ``NOT_RUN`` and
+this is a retry (``test_retries > 0``), recompute the prior test milestone's
+verdict from its persisted ``test_execution_evidence`` rows and carry it
+forward — FAILED stays FAILED (keeps retrying), PASSED proceeds. No prior
+milestone or prior NOT_RUN falls through to the unchanged heuristic.
+
+These tests drive ``_run_test_phase`` (gate behaviour, not just verdict
+behaviour) so the assertion pins the routing, not merely a return value.
+Mirrors tests/issues/2376/test_gate_flags.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2590)]
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import TestExecutionEvidence
+from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+_STRUCTURED = (
+    "app.modules.workspace.autonomous.orchestrator."
+    "AutonomousOrchestrator._compute_structured_test_verdict"
+)
+_PASSING_TOOL = "app.modules.workspace.autonomous.orchestrator._has_passing_test_tool_result"
+_COMPUTE_RUN = "app.modules.workspace.autonomous.command_evidence.test_verdict.compute_run_verdict"
+_TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
+
+
+def _workflow(**overrides):
+    base = {
+        "workflow_id": "wf-2590",
+        "user_id": 1,
+        "title": "T",
+        "status": "developing",
+        "requirements_text": "r",
+        "project_path": "/tmp/p",
+        "worktree_path": "/tmp/p",
+        "workspace_type": "local",
+        "cli_tool": "claude-code",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "new-branch",
+        "current_phase": "development",
+        "dev_round": 1,
+        "current_round": 1,
+        "github_issue_number": 2590,
+        "test_retries": 0,
+        "skip_retries": 0,
+        "dev_retries_on_test_fail": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _orchestrator(wf):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as repo_cls,
+    ):
+        repo = MagicMock()
+        repo.get_workflow.return_value = wf
+        repo.list_milestones.return_value = []
+        repo.create_milestone.return_value = {"milestone_id": "ms-cur", "workflow_id": "wf-2590"}
+        repo.update_workflow.return_value = wf
+        repo.update_milestone.return_value = {}
+        repo.create_event.return_value = {"id": 1}
+        repo_cls.return_value = repo
+        orch = AutonomousOrchestrator("wf-2590")
+        orch.repo = repo
+        orch.emitter = MagicMock()
+        orch._gh = MagicMock()
+        orch._gh.has_uncommitted_changes.return_value = False
+        return orch, repo
+
+
+def _run(orch, wf, *, verdict, text, tool_pass, prior_evidences=None, prior_milestones=None):
+    """Drive _run_test_phase with a scripted structured verdict + agent output.
+
+    ``prior_evidences`` sets what the prior milestone's test-evidence repo
+    returns (used by carry-forward). ``prior_milestones`` sets what
+    ``list_milestones`` returns so the carry-forward can find the prior test
+    milestone.
+    """
+    result = AgentTaskResult(
+        session_id="sess",
+        response_text=text,
+        visible_response_text=text,
+        success=True,
+        tool_calls=[{"tool": {"name": "Bash", "input": {"command": "python -m pytest tests/ -q"}}}],
+    )
+    patches = []
+    orch._update_workflow = lambda p: patches.append(p)
+    orch._post_github_comment = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-cur"})
+    orch._find_or_create_milestone = MagicMock(return_value={"milestone_id": "ms-cur"})
+    orch._run_agent = MagicMock(return_value=result)
+    orch._runtime_environment_gate = MagicMock(return_value="")
+    orch._build_test_execution_context = MagicMock(return_value=("", []))
+    orch._project_runtime_contract = MagicMock(return_value="")
+    orch._artifact_visible_text = MagicMock(return_value=text)
+    orch._artifact_text = MagicMock(return_value=text)
+    orch._shadow_compare_evidence = MagicMock()
+    orch._emit_structured_test_fallback = MagicMock()
+    orch._validate_test_report_format = MagicMock(return_value=(True, ""))
+
+    orch.repo.list_milestones.return_value = prior_milestones or []
+
+    with (
+        patch(_STRUCTURED, return_value=(verdict, [], "scripted")),
+        patch(_PASSING_TOOL, return_value=tool_pass),
+        patch(_TEST_REPO) as _test_repo_cls,
+    ):
+        # Default: no prior evidence; caller overrides.
+        _test_repo_cls.return_value.query_by_milestone.return_value = prior_evidences or []
+        orch._run_test_phase(wf, 1, orch._gh)
+    return patches, orch
+
+
+def _comment_text(orch) -> str:
+    for call in orch._post_github_comment.call_args_list:
+        body = call.args[2] if len(call.args) > 2 else call.kwargs.get("body", "")
+        if "Test Results" in str(body):
+            return str(body)
+    return ""
+
+
+# --- Carry-forward: prior FAILED keeps the run failing, not inconclusive ----
+
+
+def test_prior_failed_is_carried_forward_not_inconclusive():
+    """A retry whose current milestone has NO evidence but whose prior milestone
+    structurally FAILED must carry FAILED forward — not fall to the heuristic
+    and report inconclusive on stale session text."""
+    wf = _workflow(test_retries=1)
+    orch, _ = _orchestrator(wf)
+
+    # Prior milestone ms-prev was FAILED. The agent's stale session text has
+    # "N passed" from the prior round (which the heuristic would read), but
+    # the prior structured verdict is the source of truth.
+    prior_ev = TestExecutionEvidence(
+        command_id="c-prev",
+        verdict=ExecutionVerdict.FAILED.value,
+        framework="python",
+        parser_confidence="high",
+        passed=1,
+        failed=1,
+    )
+    prior_ms = [
+        {
+            "milestone_id": "ms-prev",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 1,
+            "id": 10,
+        },
+        {
+            "milestone_id": "ms-cur",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 1,
+            "id": 20,
+        },
+    ]
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.NOT_RUN,
+        text="=== 243 passed in 30.12s ===",
+        tool_pass=False,
+        prior_evidences=[prior_ev],
+        prior_milestones=prior_ms,
+    )
+    # FAILED carry-forward takes the inconclusive/test_retries route (stays
+    # failing), NOT pr_review.
+    assert any(
+        "test_retries" in p for p in patches
+    ), f"prior FAILED must carry forward (retry), got {patches}"
+    assert not any(p.get("current_phase") == "pr_review" for p in patches), patches
+    # The status line must report the failed verdict, not "no output captured".
+    comment = _comment_text(orch)
+    assert "structured evidence reports a failing test command" in comment, comment
+
+
+def test_prior_passed_is_carried_forward_proceeds():
+    """A retry whose current milestone has NO evidence but whose prior milestone
+    structurally PASSED must carry PASSED forward — proceed to pr_review."""
+    wf = _workflow(test_retries=1)
+    orch, _ = _orchestrator(wf)
+
+    prior_ev = TestExecutionEvidence(
+        command_id="c-prev",
+        verdict=ExecutionVerdict.PASSED.value,
+        framework="python",
+        parser_confidence="high",
+        passed=243,
+        failed=0,
+    )
+    prior_ms = [
+        {
+            "milestone_id": "ms-prev",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 1,
+            "id": 10,
+        },
+        {
+            "milestone_id": "ms-cur",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 1,
+            "id": 20,
+        },
+    ]
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.NOT_RUN,
+        text="=== 243 passed in 30.12s ===",
+        tool_pass=False,
+        prior_evidences=[prior_ev],
+        prior_milestones=prior_ms,
+    )
+    assert any(
+        p.get("current_phase") == "pr_review" for p in patches
+    ), f"prior PASSED must proceed to pr_review, got {patches}"
+
+
+def test_no_prior_milestone_keeps_existing_behavior():
+    """First attempt (test_retries=0) with NOT_RUN: no carry-forward, the gate
+    behaves as before (heuristic / inconclusive). No regression."""
+    wf = _workflow(test_retries=0)
+    orch, _ = _orchestrator(wf)
+
+    # No prior milestones at all. Text has a pytest marker ("AssertionError")
+    # but NOT the "N passed" pattern, so the heuristic cannot confirm it
+    # passed → inconclusive. The point is this is the UNCHANGED existing path.
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.NOT_RUN,
+        text="=== AssertionError ===",
+        tool_pass=False,
+        prior_evidences=[],
+        prior_milestones=[],
+    )
+    # Must NOT proceed to pr_review (no evidence + no "N passed" text → the
+    # heuristic cannot confirm). The exact route is whatever the existing logic
+    # decides — the assertion is "no carry-forward changed it".
+    assert not any(p.get("current_phase") == "pr_review" for p in patches), patches
+
+
+def test_carry_forward_only_on_retry():
+    """test_retries=0 must never carry forward — a first attempt has no prior
+    milestone to read, even if stale milestones exist in the DB."""
+    wf = _workflow(test_retries=0)
+    orch, _ = _orchestrator(wf)
+
+    prior_ev = TestExecutionEvidence(
+        command_id="c-prev",
+        verdict=ExecutionVerdict.FAILED.value,
+        framework="python",
+        parser_confidence="high",
+        passed=1,
+        failed=1,
+    )
+    prior_ms = [
+        {
+            "milestone_id": "ms-prev",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 0,
+            "id": 5,
+        },
+        {
+            "milestone_id": "ms-cur",
+            "workflow_id": "wf-2590",
+            "phase": "development",
+            "milestone_type": "tests_run",
+            "dev_round": 1,
+            "id": 6,
+        },
+    ]
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.NOT_RUN,
+        text="=== 1 failed ===",
+        tool_pass=False,
+        prior_evidences=[prior_ev],
+        prior_milestones=prior_ms,
+    )
+    # test_retries=0 → no carry-forward → must NOT report the prior FAILED
+    # verdict in the comment (the existing heuristic path applies instead).
+    comment = _comment_text(orch)
+    assert (
+        "structured evidence reports a failing test command" not in comment
+    ), "carry-forward must not fire on test_retries=0"


### PR DESCRIPTION
## Summary

**Issue #2590 / workflow 9f2ac698**: On a test-phase retry the agent session is reused (#2390), so the current milestone has no stamped evidence and `_compute_structured_test_verdict` correctly yields NOT_RUN — the agent saw the full prior context and summarized the old results instead of re-running. But the heuristic fallback then reads the entire session text (including the prior round's stale output) and misclassifies the run, promoting a real FAILED to inconclusive or even pr_review.

## Root cause (confirmed with primary evidence)

Structured verdict NOT_RUN is correct (the #2390 milestone filter prevents cross-round contamination). The defect is the **fallback to reading stale session text** — the heuristic has no notion of milestone scope, so prior-round "N passed" text from the reused session flips `has_test_result=True` → misclassification.

## Fix (Option A, lowest risk — gate logic only)

When the current milestone's structured verdict is NOT_RUN and `test_retries > 0`, re-read the prior test milestone's persisted `test_execution_evidence` rows and carry its decisive verdict forward:
- prior FAILED → stays FAILED (keeps retrying, never pr_review)
- prior PASSED → proceeds to pr_review
- no prior milestone / prior NOT_RUN / not a retry → falls through to the unchanged heuristic

**Only gate logic changes.** The #2390 milestone filter, the prompt, and the session-reuse semantics are untouched.

### Files changed

- `app/modules/workspace/autonomous/orchestrator.py`
  - New `_carry_forward_prior_test_verdict` helper (after `_compute_structured_test_verdict`): queries the prior `tests_run` milestone's test evidence and recomputes `compute_run_verdict` on it.
  - Gate integration in `_run_test_phase` (after the structured verdict call): on NOT_RUN + retry, carries forward a decisive prior verdict.

### RED → GREEN evidence

4 tests in `tests/unit/test_prior_milestone_verdict_carryforward.py` (marked `regression` + `issue(2590)`):

1. **`test_prior_failed_is_carried_forward_not_inconclusive`** — RED on main (proceeds to pr_review on stale "243 passed" text), GREEN after fix (carries FAILED, takes the retry path).
2. **`test_prior_passed_is_carried_forward_proceeds`** — prior PASSED proceeds to pr_review.
3. **`test_no_prior_milestone_keeps_existing_behavior`** — first attempt (test_retries=0) with NOT_RUN: no carry-forward, heuristic path unchanged.
4. **`test_carry_forward_only_on_retry`** — test_retries=0 must never carry forward even if prior milestones exist.

#2189 scanner: 0 findings on the new test file.

### Constraints honored

- Isolated worktree off origin/main (no overlap with Fix B which touches L6460).
- Commit/PR text has no `closes|fixes|resolves` near issue numbers.
- No merge / deploy / workflow reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)