### PR TITLE
fix(installer): reconcile legacy server before systemd restart

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3827,6 +3827,89 @@ configure_deploy_remaining() {
     INSTALL_SERVICE="$install_service"
 }
 
+# Stop only the package installer's own non-systemd fallback process.  The PID
+# file is untrusted/stale input: validate the PID, owner, cwd, and command before
+# sending a signal so PID reuse can never terminate an unrelated process.
+stop_legacy_package_server() {
+    local target_path="$1"
+    local deploy_user="$2"
+    local pid_file="$target_path/logs/server.pid"
+
+    [ -f "$pid_file" ] || return 0
+
+    local legacy_pid
+    legacy_pid=$(tr -d '[:space:]' < "$pid_file" 2>/dev/null || true)
+    if ! [[ "$legacy_pid" =~ ^[1-9][0-9]*$ ]]; then
+        print_warning "Removing malformed legacy server PID file"
+        rm -f -- "$pid_file"
+        return 0
+    fi
+
+    if ! kill -0 "$legacy_pid" 2>/dev/null; then
+        print_info "Removing stale legacy server PID file"
+        rm -f -- "$pid_file"
+        return 0
+    fi
+
+    # A stale PID file can occasionally point at the current systemd process.
+    # Let systemd stop its own MainPID instead of signaling it here.
+    local service_pid
+    service_pid=$(systemctl show open-ace.service -p MainPID --value 2>/dev/null || true)
+    if [ "$legacy_pid" = "$service_pid" ] && [ "$service_pid" != "0" ]; then
+        rm -f -- "$pid_file"
+        return 0
+    fi
+
+    local process_user process_cwd process_cmd
+    process_user=$(ps -o user= -p "$legacy_pid" 2>/dev/null | xargs || true)
+    process_cwd=$(readlink -f "/proc/$legacy_pid/cwd" 2>/dev/null || true)
+    process_cmd=$(tr '\0' ' ' < "/proc/$legacy_pid/cmdline" 2>/dev/null || true)
+
+    if [ "$process_user" != "$deploy_user" ] || \
+       [ "$process_cwd" != "$target_path" ] || \
+       ! printf '%s\n' "$process_cmd" | grep -Eq '(^|[[:space:]])server\.py([[:space:]]|$)'; then
+        print_warning "Legacy server PID file does not match the expected Open ACE process; removing it without signaling PID $legacy_pid"
+        rm -f -- "$pid_file"
+        return 0
+    fi
+
+    print_info "Stopping legacy non-systemd Open ACE server (PID: $legacy_pid)..."
+    kill "$legacy_pid" 2>/dev/null || true
+    local waited=0
+    while kill -0 "$legacy_pid" 2>/dev/null && [ "$waited" -lt 10 ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$legacy_pid" 2>/dev/null; then
+        print_error "Legacy Open ACE server did not stop after ${waited}s"
+        return 1
+    fi
+
+    rm -f -- "$pid_file"
+    print_success "Legacy non-systemd Open ACE server stopped"
+}
+
+# Confirm both that systemd considers the unit active and that its MainPID owns
+# the configured web port.  This avoids treating a short-lived process in an
+# auto-restart loop as a successful upgrade.
+wait_for_openace_service() {
+    local port="${1:-19888}"
+    local timeout="${2:-15}"
+    local waited=0 main_pid
+
+    while [ "$waited" -lt "$timeout" ]; do
+        main_pid=$(systemctl show open-ace.service -p MainPID --value 2>/dev/null || true)
+        if systemctl is-active --quiet open-ace.service 2>/dev/null && \
+           [[ "$main_pid" =~ ^[1-9][0-9]*$ ]] && \
+           ss -ltnp 2>/dev/null | grep -E ":${port}[[:space:]]" | grep -q "pid=${main_pid},"; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
 # ============================================================================
 # Local Installation
 # ============================================================================
@@ -4011,14 +4094,27 @@ install_local() {
                 print_success "Service configuration updated (SECRET_KEY preserved)"
             fi
 
+            # A previous package install may have used the non-systemd fallback
+            # and left a server.py process outside this unit's cgroup.  A plain
+            # systemctl restart cannot stop that process, so it would retain the
+            # web port and make the upgraded unit restart forever (#2624).
+            if ! stop_legacy_package_server "$target_path" "$DEPLOY_USER"; then
+                print_error "Unable to stop the legacy Open ACE server safely"
+                return 1
+            fi
+
             print_info "Restarting open-ace service..."
             systemctl daemon-reload
-            systemctl restart open-ace.service
-            sleep 3
-            if systemctl is-active --quiet open-ace.service; then
+            if ! systemctl restart open-ace.service; then
+                print_error "Failed to restart open-ace.service"
+                return 1
+            fi
+            if wait_for_openace_service "$SERVICE_PORT" 15; then
                 print_success "Service restarted successfully"
             else
-                print_warning "Service not yet active, check with: systemctl status open-ace"
+                print_error "open-ace.service did not become ready on port ${SERVICE_PORT:-19888}"
+                print_info "Check: systemctl status open-ace && journalctl -u open-ace -n 100"
+                return 1
             fi
             INSTALL_SERVICE="yes"
         fi

--- a/tests/unit/test_issue_2624_legacy_server_reconciliation.py
+++ b/tests/unit/test_issue_2624_legacy_server_reconciliation.py
@@ -26,19 +26,23 @@ def test_upgrade_reconciles_legacy_server_before_systemd_restart() -> None:
 
 def test_legacy_pid_is_validated_before_signal() -> None:
     text = _installer_text()
-    function = text[text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")]
+    function = text[
+        text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")
+    ]
 
     assert '[[ "$legacy_pid" =~ ^[1-9][0-9]*$ ]]' in function
     assert 'process_user=$(ps -o user= -p "$legacy_pid"' in function
     assert 'process_cwd=$(readlink -f "/proc/$legacy_pid/cwd"' in function
     assert "server\\.py" in function
-    assert function.index('process_user=$(ps') < function.index('kill "$legacy_pid"')
+    assert function.index("process_user=$(ps") < function.index('kill "$legacy_pid"')
     assert "pkill" not in function
 
 
 def test_systemd_main_pid_is_never_signaled_as_legacy() -> None:
     text = _installer_text()
-    function = text[text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")]
+    function = text[
+        text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")
+    ]
 
     assert "systemctl show open-ace.service -p MainPID --value" in function
     assert '[ "$legacy_pid" = "$service_pid" ]' in function

--- a/tests/unit/test_issue_2624_legacy_server_reconciliation.py
+++ b/tests/unit/test_issue_2624_legacy_server_reconciliation.py
@@ -1,0 +1,54 @@
+"""Regression coverage for package upgrade legacy-server reconciliation."""
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = PROJECT_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
+
+pytestmark = [pytest.mark.issue(2624), pytest.mark.regression]
+
+
+def _installer_text() -> str:
+    return INSTALL_SH.read_text(encoding="utf-8")
+
+
+def test_upgrade_reconciles_legacy_server_before_systemd_restart() -> None:
+    text = _installer_text()
+
+    cleanup = text.index('stop_legacy_package_server "$target_path" "$DEPLOY_USER"')
+    restart = text.index("systemctl restart open-ace.service", cleanup)
+
+    assert cleanup < restart
+    assert 'print_error "Unable to stop the legacy Open ACE server safely"' in text
+
+
+def test_legacy_pid_is_validated_before_signal() -> None:
+    text = _installer_text()
+    function = text[text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")]
+
+    assert '[[ "$legacy_pid" =~ ^[1-9][0-9]*$ ]]' in function
+    assert 'process_user=$(ps -o user= -p "$legacy_pid"' in function
+    assert 'process_cwd=$(readlink -f "/proc/$legacy_pid/cwd"' in function
+    assert "server\\.py" in function
+    assert function.index('process_user=$(ps') < function.index('kill "$legacy_pid"')
+    assert "pkill" not in function
+
+
+def test_systemd_main_pid_is_never_signaled_as_legacy() -> None:
+    text = _installer_text()
+    function = text[text.index("stop_legacy_package_server() {") : text.index("wait_for_openace_service() {")]
+
+    assert "systemctl show open-ace.service -p MainPID --value" in function
+    assert '[ "$legacy_pid" = "$service_pid" ]' in function
+
+
+def test_upgrade_requires_systemd_main_pid_to_own_web_port() -> None:
+    text = _installer_text()
+    function = text[text.index("wait_for_openace_service() {") : text.index("# Local Installation")]
+
+    assert "systemctl is-active --quiet open-ace.service" in function
+    assert "systemctl show open-ace.service -p MainPID --value" in function
+    assert 'grep -q "pid=${main_pid},"' in function
+    assert 'print_error "open-ace.service did not become ready' in text


### PR DESCRIPTION
## What changed

- reconcile package-managed legacy `server.pid` processes before restarting an existing systemd unit
- validate PID format, process owner, working directory, command line, and systemd `MainPID` before signaling anything
- remove malformed and stale PID files without signaling unrelated processes
- require the systemd `MainPID` to own the configured web port before reporting upgrade success
- fail the installer with actionable diagnostics when cleanup or service readiness verification fails
- add regression coverage for cleanup ordering, validation safeguards, systemd PID protection, and port ownership verification

## Why

A server started by the package installer's non-systemd fallback can survive outside the systemd unit cgroup. During a later upgrade, `systemctl restart` cannot stop that process, so the upgraded service fails with an address-in-use error while the installer previously continued to report completion.

## Validation

- `bash -n scripts/install-central/package-method/install.sh`
- `python -m pytest tests/unit/test_issue_2583_package_autostart_pid_path.py tests/unit/test_issue_2624_legacy_server_reconciliation.py -q` (7 passed)
- `git diff --check`

Fixes #2624