### PR TITLE
fix: preserve encrypted secrets during package upgrades

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -4003,12 +4003,13 @@ install_local() {
         # -- Phase 1: Fix missing config in service file (runs always) --
         if [ -n "$service_file" ] && [ -f "$service_file" ]; then
             # Check if systemd service is missing SECRET_KEY (upgrade from older version)
-            local current_secret=$(grep "^Environment=SECRET_KEY=" "$service_file" 2>/dev/null | cut -d'=' -f3)
+            local current_secret=$(sed -n 's/^Environment=SECRET_KEY=//p' "$service_file" 2>/dev/null | tail -1)
             if [ -z "$current_secret" ]; then
                 print_warning "Adding missing SECRET_KEY to systemd service..."
                 local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
                 sed -i "/^Environment=HOME=/a Environment=SECRET_KEY=$secret_key" "$service_file"
                 print_info "Generated SECRET_KEY for Flask encryption"
+                current_secret="$secret_key"
             fi
 
             # Check and fix WORKSPACE_BASE_DIR (Issue #1217, #1308, #2290)
@@ -4039,9 +4040,13 @@ install_local() {
 
             if [ "$has_enc_key_in_service" = "no" ] && [ "$has_secrets_env" != "yes" ]; then
                 print_warning "Adding missing OPENACE_ENCRYPTION_KEY to systemd service..."
-                local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
+                # Before OPENACE_ENCRYPTION_KEY was introduced, persisted API keys,
+                # SMTP passwords, and SSO secrets were encrypted with SECRET_KEY.
+                # Reusing it here is required for upgrade compatibility. Generating
+                # a new random key would leave every existing ciphertext unreadable.
+                local enc_key="${OPENACE_ENCRYPTION_KEY:-$current_secret}"
                 sed -i "/^Environment=SECRET_KEY=/a Environment=OPENACE_ENCRYPTION_KEY=$enc_key" "$service_file"
-                print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption (Issue #2359)"
+                print_info "Initialized OPENACE_ENCRYPTION_KEY from the existing encryption secret (Issue #2626)"
             fi
         fi
 

--- a/tests/unit/test_issue_2626_upgrade_encryption_key.py
+++ b/tests/unit/test_issue_2626_upgrade_encryption_key.py
@@ -1,0 +1,41 @@
+"""Regression coverage for encryption-key compatibility during package upgrades."""
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = PROJECT_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
+
+pytestmark = [pytest.mark.issue(2626), pytest.mark.regression]
+
+
+def _upgrade_key_migration_block() -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    start = text.index("# Check if systemd service is missing SECRET_KEY")
+    end = text.index("# -- Phase 2: Update service config", start)
+    return text[start:end]
+
+
+def test_upgrade_reuses_legacy_secret_for_missing_encryption_key() -> None:
+    block = _upgrade_key_migration_block()
+
+    assert 'local enc_key="${OPENACE_ENCRYPTION_KEY:-$current_secret}"' in block
+    assert 'current_secret="$secret_key"' in block
+
+
+def test_upgrade_does_not_generate_an_unrelated_encryption_key() -> None:
+    block = _upgrade_key_migration_block()
+    encryption_key_section = block[block.index("# Check if OPENACE_ENCRYPTION_KEY is missing") :]
+
+    assert "openssl rand" not in encryption_key_section
+
+
+def test_upgrade_reads_the_complete_secret_value() -> None:
+    block = _upgrade_key_migration_block()
+    secret_assignment = next(
+        line for line in block.splitlines() if "local current_secret=" in line
+    )
+
+    assert "sed -n 's/^Environment=SECRET_KEY=//p'" in secret_assignment
+    assert "cut -d'=' -f3" not in secret_assignment

--- a/tests/unit/test_issue_2626_upgrade_encryption_key.py
+++ b/tests/unit/test_issue_2626_upgrade_encryption_key.py
@@ -33,9 +33,7 @@ def test_upgrade_does_not_generate_an_unrelated_encryption_key() -> None:
 
 def test_upgrade_reads_the_complete_secret_value() -> None:
     block = _upgrade_key_migration_block()
-    secret_assignment = next(
-        line for line in block.splitlines() if "local current_secret=" in line
-    )
+    secret_assignment = next(line for line in block.splitlines() if "local current_secret=" in line)
 
     assert "sed -n 's/^Environment=SECRET_KEY=//p'" in secret_assignment
     assert "cut -d'=' -f3" not in secret_assignment


### PR DESCRIPTION
## Summary

- preserve access to secrets encrypted by legacy package installations when upgrading
- initialize a missing `OPENACE_ENCRYPTION_KEY` from the existing `SECRET_KEY` instead of generating an unrelated random value
- keep explicit `OPENACE_ENCRYPTION_KEY` values unchanged
- add regression coverage for the package upgrade migration path

Fixes #2626.

## Root cause

Before `OPENACE_ENCRYPTION_KEY` was introduced, stored API keys, SMTP passwords, and SSO secrets were encrypted using key material derived from `SECRET_KEY`.

The package upgrade path added a missing `OPENACE_ENCRYPTION_KEY` by generating a fresh random value. Existing ciphertext therefore became unreadable after restart. API-key metadata remained visible because the listing path does not decrypt it, while runtime resolution skipped every key that failed decryption and eventually reported that no API key was configured.

## Changes

The package upgrade migration now:

1. reads the complete existing `SECRET_KEY` value from the systemd unit;
2. retains a newly generated `SECRET_KEY` in the local migration state when the legacy unit lacks one;
3. uses an explicitly supplied `OPENACE_ENCRYPTION_KEY` when present, otherwise initializes it from the current `SECRET_KEY`;
4. never generates an unrelated encryption key in the upgrade compatibility block.

Fresh-install behavior is unchanged and continues to generate a dedicated random encryption key.

## Validation

- `python -m pytest tests/unit/test_issue_2626_upgrade_encryption_key.py tests/unit/test_issue_2624_legacy_server_reconciliation.py tests/unit/test_issue_2583_package_autostart_pid_path.py -q` — 10 passed
- `python -m ruff check tests/unit/test_issue_2626_upgrade_encryption_key.py`
- `python -m compileall -q tests/unit/test_issue_2626_upgrade_encryption_key.py`
- `git diff --check`

A local Bash interpreter was unavailable on the Windows host, so `bash -n` could not be run locally; the changed shell syntax is covered by focused source regression assertions and CI.