### PR TITLE
orchestrator: retry resumed agent sessions once on empty result

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6759,6 +6759,22 @@ class AutonomousOrchestrator:
         visible = (result.response_text or "").strip()
         return bool(re.match(r"^API Error:\s*400\b", visible, re.IGNORECASE))
 
+    @classmethod
+    def _is_resume_noop_result(cls, result: AgentTaskResult | None) -> bool:
+        """Detect the structural resume-no-op signature (Refs #2570).
+
+        A ``--resume``'d session line whose last turn already ended can
+        synthesize a result-without-turn: the run reports success but
+        produced no measurable output — zero tokens AND empty artifact
+        text. Genuine work always moves at least one of those, so requiring
+        both keeps the retry backstop narrowly scoped.
+        """
+        if not result or not getattr(result, "success", False):
+            return False
+        if int(getattr(result, "total_tokens", 0) or 0) > 0:
+            return False
+        return not cls._artifact_text(result).strip()
+
     def _run_agent_with_context_recovery(
         self,
         wf: dict,
@@ -6775,14 +6791,58 @@ class AutonomousOrchestrator:
         The runner then rebinds the new provider transcript to the SAME tracking
         row. Usage from the rejected attempt is carried into the retry's final
         milestone write; the caller accounts the returned result as usual.
+
+        Resume no-op backstop (Refs #2570): when a NAMED line that actually
+        resumed an existing session returns success-but-empty (see
+        ``_is_resume_noop_result``), retry once with ``force_fresh=True`` on
+        the same tracking line. A fresh run cannot no-op this way and is
+        never retried; genuine failures and overflow/integrity results keep
+        their existing paths. If the retry is also empty, its result is
+        returned as-is so callers still see emptiness and fail closed.
         """
+        # Only a run that actually resumed an established session line can
+        # hit the resume no-op. Resolve that BEFORE the run: afterwards the
+        # line's mapping may have been (re)written by the run itself. Pop the
+        # (rarely passed) force_fresh kwarg so the retry calls below can pass
+        # their own without a duplicate-keyword collision.
+        force_fresh = bool(kwargs.pop("force_fresh", False))
+        resumed = False
+        if not force_fresh and SESSION_LINE_FIELDS.get(session_line):
+            try:
+                _, _, resumed = self._resolve_session_line(wf or self.workflow, session_line)
+            except Exception:
+                # Resolution is read-only; an outage must not block the run.
+                logger.warning(
+                    "Failed to pre-check resume state for session line %s",
+                    session_line,
+                    exc_info=True,
+                )
+                resumed = False
+
         result = self._run_agent(
             wf=wf,
             session_line=session_line,
             milestone_id=milestone_id,
+            force_fresh=force_fresh,
             **kwargs,
         )
         if not self._is_context_overflow(result):
+            if resumed and self._is_resume_noop_result(result):
+                logger.warning(
+                    "Workflow %s: session line %s resumed but returned an empty "
+                    "successful result (resume no-op); retrying once with a "
+                    "fresh provider transcript",
+                    self._workflow_id[:8],
+                    session_line,
+                )
+                self._accumulate_tokens(result)
+                return self._run_agent(
+                    wf=wf,
+                    session_line=session_line,
+                    milestone_id=milestone_id,
+                    force_fresh=True,
+                    **kwargs,
+                )
             return result
 
         field = SESSION_LINE_FIELDS.get(session_line)

--- a/tests/unit/test_agent_context_recovery_resume_noop.py
+++ b/tests/unit/test_agent_context_recovery_resume_noop.py
@@ -1,0 +1,169 @@
+"""Systematic resume no-op backstop in _run_agent_with_context_recovery.
+
+A --resume'd session line whose last turn already ended can return
+success=True with ~0 tokens and empty artifact text when a stale
+background-shell notification makes the model emit a result-without-turn.
+Callers then terminal-fail the workflow with "<agent> returned no result".
+This suite pins the Fix B backstop: when a RESUMED named line returns
+success-but-empty, the method retries once with force_fresh=True on the
+same session line. Fresh runs, genuine failures, and overflow/integrity
+paths are never retried. Refs #2570.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+WF = {
+    "workflow_id": "wf-resume-noop",
+    "cli_tool": "claude-code",
+    "worktree_path": "/tmp/repo",
+    "project_path": "/tmp/repo",
+}
+
+
+def _make_orchestrator(*, resume: bool = True):
+    """Bare orchestrator with the agent-run internals mocked.
+
+    _resolve_session_line reports whether the upcoming run would resume an
+    established session line (the precondition for the no-op retry).
+    """
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-resume-noop"
+    orch._is_context_overflow = MagicMock(return_value=False)
+    orch._accumulate_tokens = MagicMock()
+    orch._resolve_session_line = MagicMock(return_value=("tracking-main", "cli-main", resume))
+    return orch
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_resumed_empty_success_retries_once_fresh_and_returns_second_result():
+    """Resumed 'main' line + success + 0 tokens + empty text -> retried once
+    with force_fresh=True (same session_line/prompt); the second result is
+    returned to the caller."""
+    orch = _make_orchestrator(resume=True)
+    empty_noop = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    recovered = AgentTaskResult(
+        success=True, response_text="Completed the requested work.", total_tokens=120
+    )
+    orch._run_agent = MagicMock(side_effect=[empty_noop, recovered])
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="main", milestone_id="ms-1", prompt="do the work"
+    )
+
+    # The recovered (non-empty) result is what the caller receives.
+    assert result is recovered
+    assert result.response_text == "Completed the requested work."
+    # Exactly one retry — no loop.
+    assert orch._run_agent.call_count == 2
+    first_kwargs = orch._run_agent.call_args_list[0].kwargs
+    second_kwargs = orch._run_agent.call_args_list[1].kwargs
+    # The retry forces a fresh provider transcript on the SAME session line.
+    assert second_kwargs.get("force_fresh") is True
+    assert second_kwargs.get("session_line") == "main"
+    # Same prompt (same kwargs contract) is replayed.
+    assert second_kwargs.get("prompt") == "do the work"
+    assert second_kwargs.get("milestone_id") == "ms-1"
+    # The first attempt was the plain (resumed) run.
+    assert first_kwargs.get("force_fresh") is not True
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_fresh_session_line_empty_success_is_not_retried():
+    """session_line='fresh' + success-but-empty -> NOT retried; the first
+    (empty) result is returned so the caller's fail-closed path still sees
+    the emptiness."""
+    orch = _make_orchestrator()
+    empty_noop = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    orch._run_agent = MagicMock(return_value=empty_noop)
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="fresh", prompt="do the work"
+    )
+
+    assert result is empty_noop
+    assert orch._run_agent.call_count == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_force_fresh_run_empty_success_is_not_retried():
+    """An explicit force_fresh=True run cannot be a resume no-op and must not
+    be retried even when the named line would otherwise resolve to resume."""
+    orch = _make_orchestrator(resume=True)
+    empty_noop = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    orch._run_agent = MagicMock(return_value=empty_noop)
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="main", prompt="do the work", force_fresh=True
+    )
+
+    assert result is empty_noop
+    assert orch._run_agent.call_count == 1
+    # The single call forwarded the caller's force_fresh=True.
+    assert orch._run_agent.call_args.kwargs.get("force_fresh") is True
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_named_line_without_resume_target_empty_success_is_not_retried():
+    """A named line whose mapping is lost (resume=False) starts fresh on the
+    same line — that run cannot resume-no-op and must not be retried."""
+    orch = _make_orchestrator(resume=False)
+    empty_noop = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    orch._run_agent = MagicMock(return_value=empty_noop)
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="review", prompt="review the PR"
+    )
+
+    assert result is empty_noop
+    assert orch._run_agent.call_count == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_genuine_failure_is_not_retried():
+    """success=False (agent process failure / integrity path) takes the
+    existing failure path — the agent runs exactly ONCE."""
+    orch = _make_orchestrator(resume=True)
+    failed = AgentTaskResult(success=False, error="agent process exited 1")
+    orch._run_agent = MagicMock(return_value=failed)
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="main", prompt="do the work"
+    )
+
+    assert result is failed
+    assert result.success is False
+    assert orch._run_agent.call_count == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2570)
+def test_fresh_retry_also_empty_surfaces_empty_result_without_second_retry():
+    """Fail-closed preserved: if the force_fresh retry is ALSO empty, the
+    method returns that empty-but-successful result (the caller's existing
+    'returned no result' path still sees emptiness) and does not retry again."""
+    orch = _make_orchestrator(resume=True)
+    empty_noop = AgentTaskResult(success=True, response_text="", total_tokens=0)
+    empty_retry = AgentTaskResult(success=True, response_text="   ", total_tokens=0)
+    orch._run_agent = MagicMock(side_effect=[empty_noop, empty_retry])
+
+    result = orch._run_agent_with_context_recovery(
+        wf=dict(WF), session_line="main", prompt="do the work"
+    )
+
+    # The empty retry result is surfaced — not a fabricated success.
+    assert result is empty_retry
+    assert result.success is True
+    assert not (result.response_text or "").strip()
+    # Exactly one retry — no second retry loop.
+    assert orch._run_agent.call_count == 2


### PR DESCRIPTION
## Root cause

Autonomous workflow agents run via `--print --input-format stream-json` + `--resume <session_id>` for long-lived session lines (main/review/test) to preserve context. When a resumed session's last turn already ended and a stale background-shell notification (e.g. `<status>stopped</status>`) is injected, the model can emit a result-without-turn: the agent controller closes stdin, the real prompt is never processed, and the run returns `success=True` with `total_tokens≈0` and empty response text. Callers then terminally fail the workflow with `<agent> returned no result`. This is a structural resume no-op, not a model glitch (verified root cause, Refs #2570).

## Change (systematic Fix B backstop)

In `AutonomousOrchestrator._run_agent_with_context_recovery` (`app/modules/workspace/autonomous/orchestrator.py`):

- New classmethod `_is_resume_noop_result`: detects the no-op signature narrowly — `success=True` AND zero `total_tokens` AND empty `_artifact_text(...)` (mirrors the emptiness notion callers like `_apply_pr_review_fix` use). Genuine work always moves at least one of those, so requiring both keeps the retry narrowly scoped.
- Before the agent run, pre-resolve whether this call actually resumes an established session line (`_resolve_session_line`, read-only; must be done before the run because the run itself rewrites the line mapping). Fail-safe: any resolution outage logs a warning and treats the run as non-resumed (no retry).
- After a non-overflow run: if the run resumed AND the result is success-but-empty, log a warning naming the session line and retry **once** with `force_fresh=True` on the SAME tracking line (new provider transcript, stable session identity — same pattern as the existing context-overflow recovery path).

## Guards

- Retry at most once (no loop); an also-empty retry result is returned as-is so existing caller fail-closed paths still see emptiness (no fabricated success).
- Never retried: genuine failures (`success=False`, incl. repo_integrity/integrity paths), context overflow (keeps the existing recovery path), already-fresh runs (`session_line == "fresh"` or `force_fresh=True`), and named lines whose mapping is lost (`resume=False`).
- The two existing local backstops (pr_review summary agent, `_apply_pr_review_fix` fix agent) are left untouched and remain as redundant defense — this change makes them redundant, not conflicting.

## Test evidence (TDD red → green)

New suite `tests/unit/test_agent_context_recovery_resume_noop.py` (all `@pytest.mark.regression` + `@pytest.mark.issue(2570)`), written first and RED before the implementation:

- `test_resumed_empty_success_retries_once_fresh_and_returns_second_result` — RED → GREEN
- `test_fresh_retry_also_empty_surfaces_empty_result_without_second_retry` — RED → GREEN
- `test_fresh_session_line_empty_success_is_not_retried` — guard, green both sides
- `test_force_fresh_run_empty_success_is_not_retried` — guard, green both sides
- `test_named_line_without_resume_target_empty_success_is_not_retried` — guard, green both sides
- `test_genuine_failure_is_not_retried` — guard, green both sides

Neighboring suites: `tests/unit/test_autonomous_ci_guardrails.py` 87 passed; `tests/unit/test_pr_review_diff_merge_base.py` + `tests/unit/test_prior_milestone_verdict_carryforward.py` 8 passed. Quarantined `tests/issues/` suites referencing the changed symbol (1897/1813/1816) show the identical 5 failures with and without this change (pre-existing on the branch base, not a regression). Pre-commit passes on both touched files.

Refs #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)