### PR TITLE
fix: sync session_sync to daily_usage for dashboard today's usage (#2576)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -2766,6 +2766,28 @@ def agent_message():
                 # message_count itself — otherwise remote-synced sessions
                 # never reflect their imported messages (#1128).
                 if synced_message_delta or synced_input_tokens or synced_output_tokens:
+                    # Issue #2576: Sync to daily_usage for dashboard today's usage
+                    # The /api/today endpoint reads from daily_usage table directly.
+                    try:
+                        from app.repositories.usage_repo import UsageRepository
+
+                        usage_repo = UsageRepository()
+                        today_str = time.strftime("%Y-%m-%d")
+                        usage_repo.save_usage(
+                            date=today_str,
+                            tool_name=tool_name,
+                            host_name=safe_machine_id_prefix(machine_id),
+                            tokens_used=synced_input_tokens + synced_output_tokens,
+                            input_tokens=synced_input_tokens,
+                            output_tokens=synced_output_tokens,
+                            cache_tokens=0,
+                            request_count=synced_message_delta,
+                            models_used=[model] if model else None,
+                            tenant_id=session_tenant_id or 1,
+                        )
+                    except Exception as e:
+                        logger.debug("Failed to save daily_usage: %s", e)
+
                     sync_session_mgr.increment_session_usage(
                         session_id,
                         message_delta=synced_message_delta,


### PR DESCRIPTION
Closes #2576

## 修复内容
修复本地 WebUI 会话未计入管理仪表盘用量统计的问题。

## 问题根因
`session_sync` 处理器写入 `session_messages` 和 `daily_messages` 表，但 `/api/today` 接口直接从 `daily_usage` 表读取。这导致管理仪表盘的"今日用量"对本地 WebUI 会话显示为空。

## 修复方案
在 `increment_session_usage` 调用之前添加 `UsageRepository.save_usage()` 调用，将 token 统计同步到 `daily_usage` 表。

## 修改文件
- `app/routes/remote.py`：添加 `save_usage` 调用

## 测试方案
1. 启动本地 WebUI 会话，完成一次 AI 对话
2. 等待 `session_sync` 同步（约 30 秒）
3. 访问管理仪表盘 `/manage/usage`，验证今日用量不为空