### PR TITLE
[Bug][Migration] Fix initial platform admin downgrade when tenant_id exists (#2633)

### DIFF
--- a/migrations/versions/20260810_001_enforce_admin_role_migration.py
+++ b/migrations/versions/20260810_001_enforce_admin_role_migration.py
@@ -407,10 +407,32 @@ def _classify_admin_accounts(
 
     Returns:
         Dict with classification results.
+
+    Issue #2633: Added Step 0 to protect initial platform admins BEFORE Step 1,
+    ensuring that admins with id=1 or in whitelist are protected regardless of tenant_id.
     """
     results = {"tenant_admin_count": 0, "platform_admin_count": 0, "remaining_admin_count": 0}
 
-    # Step 1: Classify admin + tenant_id NOT NULL → tenant_admin
+    # Step 0 (Issue #2633): Protect initial platform admins FIRST
+    # This must execute BEFORE Step 1 to prevent misclassification when admin has tenant_id.
+    # The protection is based on id=1 or whitelist, NOT on tenant_id.
+    whitelist_condition, whitelist_params = _build_whitelist_condition(whitelist)
+    proven_condition = f"({whitelist_condition} OR id = 1)"
+
+    result = conn.execute(
+        sa.text(f"""
+            UPDATE users
+            SET role = 'platform_admin'
+            WHERE role = 'admin'
+              AND {proven_condition}
+        """),
+        whitelist_params,
+    )
+    results["platform_admin_count"] = result.rowcount
+    log.info(f"Protected {results['platform_admin_count']} initial platform admins")
+
+    # Step 1: Classify remaining admin + tenant_id NOT NULL → tenant_admin
+    # Note: Accounts with id=1 or in whitelist are already classified, so excluded.
     result = conn.execute(sa.text("""
             UPDATE users
             SET role = 'tenant_admin'
@@ -420,15 +442,11 @@ def _classify_admin_accounts(
     results["tenant_admin_count"] = result.rowcount
     log.info(f"Classified {results['tenant_admin_count']} accounts as tenant_admin")
 
-    # Step 2: Classify admin + tenant_id NULL + proven → platform_admin
-    # Build whitelist condition with parameterized query
+    # Step 2: Classify remaining admin + tenant_id NULL + proven → platform_admin (fallback)
+    # This handles edge cases where initial admin has no tenant_id but wasn't in whitelist.
+    # Accounts with id=1 are already handled by Step 0, so this is a no-op in most cases.
     whitelist_condition, whitelist_params = _build_whitelist_condition(whitelist)
-
-    # Heuristic: user.id = 1
-    heuristic_condition = "id = 1"
-
-    # Combine conditions
-    proven_condition = f"({whitelist_condition} OR {heuristic_condition})"
+    proven_condition = f"({whitelist_condition} OR id = 1)"
 
     result = conn.execute(
         sa.text(f"""
@@ -440,8 +458,9 @@ def _classify_admin_accounts(
         """),
         whitelist_params,
     )
-    results["platform_admin_count"] = result.rowcount
-    log.info(f"Classified {results['platform_admin_count']} accounts as platform_admin")
+    # Add to platform_admin_count (these are additional platform admins)
+    results["platform_admin_count"] += result.rowcount
+    log.info(f"Classified {result.rowcount} additional accounts as platform_admin")
 
     # Step 3: Check for remaining admin accounts (should be 0)
     result = conn.execute(sa.text("SELECT COUNT(*) FROM users WHERE role = 'admin'"))

--- a/tests/integration/test_admin_role_migration_2332.py
+++ b/tests/integration/test_admin_role_migration_2332.py
@@ -195,7 +195,12 @@ class TestMigrationClassification:
         return engine
 
     def test_classifies_tenant_admin(self, db_connection):
-        """Test classification of admin with tenant_id."""
+        """Test classification of admin with tenant_id.
+
+        Note: This test has a user with id=1 and tenant_id=1.
+        Due to Issue #2633 fix, id=1 is protected as platform_admin.
+        The test now verifies that a tenant admin (not id=1) is correctly classified.
+        """
         import importlib
 
         migration_module = importlib.import_module(
@@ -203,11 +208,11 @@ class TestMigrationClassification:
         )
 
         with db_connection.connect() as conn:
-            # Create tenant and admin
+            # Create tenant and admin (using id != 1 to test tenant_admin classification)
             conn.execute(sa.text("INSERT INTO tenants (id, name) VALUES (1, 'tenant1')"))
             conn.execute(
                 sa.text(
-                    "INSERT INTO users (id, username, role, tenant_id) VALUES (1, 'user1', 'admin', 1)"
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (2, 'user1', 'admin', 1)"
                 )
             )
             conn.commit()
@@ -220,7 +225,7 @@ class TestMigrationClassification:
             assert results["remaining_admin_count"] == 0
 
             # Verify role updated
-            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 1"))
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 2"))
             assert result.scalar() == "tenant_admin"
 
     def test_classifies_platform_admin_with_whitelist(self, db_connection):
@@ -295,6 +300,124 @@ class TestMigrationClassification:
             # Should raise RuntimeError
             with pytest.raises(RuntimeError, match="could not be classified"):
                 migration_module._classify_admin_accounts(conn, [])
+
+    def test_initial_admin_with_tenant_id_becomes_platform_admin(self, db_connection):
+        """Issue #2633: Initial admin (id=1) with tenant_id should become platform_admin.
+
+        This tests the fix for the bug where initial admin with tenant_id
+        was incorrectly classified as tenant_admin.
+        """
+        import importlib
+
+        migration_module = importlib.import_module(
+            "migrations.versions.20260810_001_enforce_admin_role_migration"
+        )
+
+        with db_connection.connect() as conn:
+            # Create tenant
+            conn.execute(sa.text("INSERT INTO tenants (id, name) VALUES (1, 'default')"))
+
+            # Create initial admin with tenant_id (the bug scenario)
+            conn.execute(
+                sa.text(
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (1, 'initial_admin', 'admin', 1)"
+                )
+            )
+            conn.commit()
+
+            # Classify without whitelist (using heuristic id=1)
+            results = migration_module._classify_admin_accounts(conn, [])
+
+            # Should be classified as platform_admin, NOT tenant_admin
+            assert results["platform_admin_count"] == 1
+            assert results["tenant_admin_count"] == 0
+            assert results["remaining_admin_count"] == 0
+
+            # Verify role is platform_admin
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 1"))
+            assert result.scalar() == "platform_admin"
+
+    def test_initial_admin_with_tenant_id_and_whitelist(self, db_connection):
+        """Issue #2633: Whitelisted admin with tenant_id should become platform_admin."""
+        import importlib
+
+        migration_module = importlib.import_module(
+            "migrations.versions.20260810_001_enforce_admin_role_migration"
+        )
+
+        with db_connection.connect() as conn:
+            # Create tenant
+            conn.execute(sa.text("INSERT INTO tenants (id, name) VALUES (1, 'default')"))
+
+            # Create whitelisted admin with tenant_id
+            conn.execute(
+                sa.text(
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (2, 'whitelisted', 'admin', 1)"
+                )
+            )
+            conn.commit()
+
+            # Classify with whitelist
+            results = migration_module._classify_admin_accounts(conn, ["whitelisted"])
+
+            # Should be classified as platform_admin
+            assert results["platform_admin_count"] == 1
+            assert results["tenant_admin_count"] == 0
+
+            # Verify role
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 2"))
+            assert result.scalar() == "platform_admin"
+
+    def test_multiple_admins_with_mixed_tenant_ids(self, db_connection):
+        """Issue #2633: Test multiple admins with mixed tenant_id scenarios."""
+        import importlib
+
+        migration_module = importlib.import_module(
+            "migrations.versions.20260810_001_enforce_admin_role_migration"
+        )
+
+        with db_connection.connect() as conn:
+            # Create tenant
+            conn.execute(sa.text("INSERT INTO tenants (id, name) VALUES (1, 'default')"))
+
+            # Initial admin with tenant_id (should be platform_admin via id=1 heuristic)
+            conn.execute(
+                sa.text(
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (1, 'initial', 'admin', 1)"
+                )
+            )
+            # Regular tenant admin with tenant_id
+            conn.execute(
+                sa.text(
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (2, 'tenant_admin', 'admin', 1)"
+                )
+            )
+            # Platform admin without tenant_id (needs whitelist)
+            conn.execute(
+                sa.text(
+                    "INSERT INTO users (id, username, role, tenant_id) VALUES (3, 'platform_only', 'admin', NULL)"
+                )
+            )
+            conn.commit()
+
+            # Classify with whitelist for platform_only
+            results = migration_module._classify_admin_accounts(conn, ["platform_only"])
+
+            # Initial admin (id=1) and platform_only (id=3) should be platform_admin
+            # tenant_admin (id=2) should be tenant_admin
+            assert results["platform_admin_count"] == 2
+            assert results["tenant_admin_count"] == 1
+            assert results["remaining_admin_count"] == 0
+
+            # Verify roles
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 1"))
+            assert result.scalar() == "platform_admin"
+
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 2"))
+            assert result.scalar() == "tenant_admin"
+
+            result = conn.execute(sa.text("SELECT role FROM users WHERE id = 3"))
+            assert result.scalar() == "platform_admin"
 
 
 class TestMigrationIdempotency:


### PR DESCRIPTION
## 修复说明

关联 Issue：#2633

## 根因

迁移脚本 `20260810_001_enforce_admin_role_migration.py` 的 `_classify_admin_accounts()` 函数存在执行顺序问题：

1. **Step 1** 先执行 `admin + tenant_id NOT NULL → tenant_admin`
2. **Step 2** 的初始管理员保护（id=1 或 whitelist）只对 `tenant_id IS NULL` 的账号生效

当初始平台管理员绑定默认租户（id=1, tenant_id=1）时：
- Step 1 先将其降级为 `tenant_admin`
- Step 2 无法保护（因为 role 已是 `tenant_admin`，且 tenant_id 非空）

## 修复方案

新增 **Step 0**：在 Step 1 之前执行"初始平台管理员保护"，保护条件为 `id=1 或 whitelist`，**不依赖 tenant_id**。

### 修改内容

1. **迁移脚本修改**：
   - 新增 Step 0：先执行 `UPDATE users SET role = 'platform_admin' WHERE role = 'admin' AND (id = 1 OR username IN whitelist)`
   - Step 1 和 Step 2 逻辑保持不变，处理剩余账号

2. **测试补充**：
   - `test_initial_admin_with_tenant_id_becomes_platform_admin`：验证 id=1 带 tenant_id 场景
   - `test_initial_admin_with_tenant_id_and_whitelist`：验证 whitelist 带 tenant_id 场景
   - `test_multiple_admins_with_mixed_tenant_ids`：验证混合场景

## 主要变更

- `migrations/versions/20260810_001_enforce_admin_role_migration.py`：新增 Step 0 保护逻辑
- `tests/integration/test_admin_role_migration_2332.py`：新增测试用例

## 测试

- 测试环境：本地开发环境
- 已运行测试：`pytest tests/integration/test_admin_role_migration_2332.py`
- 测试结果：17 passed, 2 skipped
- 新增测试：
  - `test_initial_admin_with_tenant_id_becomes_platform_admin`
  - `test_initial_admin_with_tenant_id_and_whitelist`
  - `test_multiple_admins_with_mixed_tenant_ids`

## 风险

- 兼容性风险：无。已迁移环境通过幂等性检查跳过原迁移
- 性能风险：无。新增一次 UPDATE 操作，影响可忽略
- 安全风险：无。只提升初始管理员权限，不降低权限
- 回归风险：无。已正确迁移的环境不受影响