### PR TITLE
agent_runner: recover response text from result event and transcript

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -247,6 +247,13 @@ class _LocalSession:
     # Distinct assistant message_ids counted toward request_count (dedup, since
     # claude emits multiple assistant events per message: thinking then text).
     _counted_message_ids: set = field(default_factory=set)
+    # #2640: final-answer text from the terminal stream-json ``result`` event.
+    # The CLI puts the turn's answer here; assistant stream events can be
+    # dropped near the context limit, so this is kept as a fallback response
+    # source (see _recover_final_response_text). Empty string = not captured.
+    result_text: str = ""
+    # #2640 diagnostics: count of stdout lines that failed JSON parsing.
+    _unparseable_stdout_lines: int = 0
     _paused: threading.Event = field(default_factory=threading.Event)  # set when SIGSTOPed
     # Serializes remote session-id publication/message dispatch with shutdown.
     # Local subprocess sessions do not use it, but keeping it on the tracker
@@ -1771,6 +1778,146 @@ class AutonomousAgentRunner:
                 cli_session_id[:8],
             )
 
+    def _recover_response_text_from_jsonl(self, session: _LocalSession, cli_session_id: str) -> str:
+        """Return the last visible assistant text from the session JSONL (#2640).
+
+        Uses the same transcript-reading machinery as
+        ``_replay_usage_from_jsonl`` (projects root + owning-user read) but
+        extracts assistant text instead of usage, keeping only records with
+        timestamp >= this run's ``started_at_epoch``. Fail-soft: any error
+        logs a warning and returns "" so a broken fallback can never fail
+        the run itself.
+        """
+        if not cli_session_id or not session.encoded_project_path:
+            return ""
+        try:
+            jsonl_path = (
+                self._claude_projects_root(session.system_account, session.task_id)
+                / session.encoded_project_path
+                / f"{cli_session_id}.jsonl"
+            )
+            content = self._read_text_as_user(jsonl_path, session.system_account)
+        except OSError as exc:
+            logger.warning(
+                "Transcript text fallback could not read JSONL (session=%s): %s",
+                cli_session_id[:8],
+                exc,
+            )
+            return ""
+        last_text = ""
+        try:
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(rec, dict) or rec.get("type") != "assistant":
+                    continue
+                ts_epoch = _iso_to_epoch(rec.get("timestamp", ""))
+                if ts_epoch is not None and ts_epoch < session.started_at_epoch:
+                    continue
+                msg = rec.get("message")
+                if not isinstance(msg, dict):
+                    continue
+                text = _extract_visible_text(msg.get("content", ""))
+                if text.strip():
+                    last_text = text
+        except Exception as exc:  # fail-soft by contract (#2640)
+            logger.warning(
+                "Transcript text fallback failed (session=%s): %s",
+                cli_session_id[:8],
+                exc,
+            )
+            return ""
+        return last_text.strip()
+
+    def _recover_final_response_text(self, session: _LocalSession, cli_session_id: str) -> None:
+        """Recover response text when assistant stream events were dropped (#2640).
+
+        Large-context (--resume) turns can complete with a terminal ``result``
+        event — usage accounted, exit 0 — while the final assistant stream
+        event never arrives, leaving ``event_log`` without any assistant text.
+        The orchestrator then terminal-fails the phase with "<agent> returned
+        no result" even though the deliverable exists.
+
+        Layered fallback, only when event_log has NO assistant text:
+        1. the ``result`` event's ``result`` text (captured in _read_stdout);
+        2. the last visible assistant message in the transcript JSONL written
+           at/after this run's start.
+
+        On recovery the text is written back into ``session.event_log`` (a
+        synthetic assistant entry) and ``session.assistant_text`` so both
+        ``_build_agent_task_result`` and ``_persist_local_session_messages``
+        see the turn — the DB timeline recovers it too.
+        """
+        if any(
+            event.get("type") == "assistant" and str(event.get("text") or "").strip()
+            for event in session.event_log
+        ):
+            return  # normal path: assistant stream events were captured
+
+        recovered = (session.result_text or "").strip()
+        source = "result_event"
+        if not recovered and cli_session_id:
+            recovered = self._recover_response_text_from_jsonl(session, cli_session_id)
+            source = "transcript_jsonl"
+
+        if not recovered:
+            return
+
+        session.event_log.append(
+            {
+                "type": "assistant",
+                "text": recovered,
+                "message_id": None,
+                "model": None,
+            }
+        )
+        session.assistant_text += recovered
+        logger.info(
+            "Recovered final response text from %s for session %s (%d chars)",
+            source,
+            session.session_id[:8],
+            len(recovered),
+        )
+
+    def _finalize_local_completed_result(
+        self,
+        session: _LocalSession,
+        session_id: str,
+        resolved_session_id: str,
+    ) -> AgentTaskResult:
+        """Build the AgentTaskResult for a completed local run (#2640).
+
+        Runs the response-text recovery first so the returned result AND the
+        session persistence (which consumes result.event_log) both see the
+        recovered turn.
+        """
+        self._recover_final_response_text(session, resolved_session_id or session.cli_session_id)
+        result = _build_agent_task_result(
+            session_id=session_id,
+            tracking_session_id=session_id,
+            source_session_id=resolved_session_id,
+            event_log=session.event_log,
+            fallback_text=session.assistant_text,
+            total_tokens=session.total_tokens,
+            total_input_tokens=session.total_input_tokens,
+            total_output_tokens=session.total_output_tokens,
+            request_count=session.request_count,
+            tool_calls=session.tool_calls,
+            success=session.error is None,
+            error=session.error,
+            error_code=session.error_code,
+        )
+        # #2022 P5: attribute the result (provider/id/generation/state) so the
+        # orchestrator can persist sandbox identity + every evidence path carries it.
+        return self._stamp_sandbox_attribution(
+            result, session.sandbox_handle, session.sandbox_provider
+        )
+
     def _ensure_sidebar_session(self, session: _LocalSession) -> str:
         """Resolve the real sidebar Claude session id for a workflow-owned line."""
         if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
@@ -2607,24 +2754,10 @@ class AutonomousAgentRunner:
                 self._sandbox_provider,
             )
 
-        result = _build_agent_task_result(
-            session_id=session_id,
-            tracking_session_id=session_id,
-            source_session_id=resolved_session_id,
-            event_log=session.event_log,
-            fallback_text=session.assistant_text,
-            total_tokens=session.total_tokens,
-            total_input_tokens=session.total_input_tokens,
-            total_output_tokens=session.total_output_tokens,
-            request_count=session.request_count,
-            tool_calls=session.tool_calls,
-            success=session.error is None,
-            error=session.error,
-            error_code=session.error_code,
-        )
-        # #2022 P5: attribute the result (provider/id/generation/state) so the
-        # orchestrator can persist sandbox identity + every evidence path carries it.
-        return self._stamp_sandbox_attribution(result, sandbox_handle, self._sandbox_provider)
+        # #2640: route through the recovery-aware finalizer so a run whose
+        # assistant stream events were dropped (large-context --resume) still
+        # yields its deliverable as response_text and session persistence.
+        return self._finalize_local_completed_result(session, session_id, resolved_session_id)
 
     def _create_workflow_session(
         self,
@@ -4039,6 +4172,15 @@ class AutonomousAgentRunner:
                         # bump (it summarizes the whole --print run).
                         if not session._counted_message_ids and session.request_count == 0:
                             session.request_count += 1
+                        # #2640: the terminal ``result`` event carries the
+                        # CLI's final answer in its ``result`` text field.
+                        # Assistant stream events can be dropped near the
+                        # context limit (large-context --resume turns), so
+                        # capture it as a fallback response source instead of
+                        # discarding it (see _recover_final_response_text).
+                        result_value = parsed.get("result")
+                        if isinstance(result_value, str) and result_value.strip():
+                            session.result_text = result_value
                         error_code, error_message = _extract_cli_result_error(
                             parsed, session.last_stderr
                         )
@@ -4194,7 +4336,22 @@ class AutonomousAgentRunner:
                         self._resolve_sidebar_session(session)
 
                 except (json.JSONDecodeError, ValueError):
-                    pass  # Non-JSON output, skip
+                    # Non-JSON output line. #2640: these were silently
+                    # swallowed, hiding CLI stream-json protocol drift (e.g.
+                    # dropped assistant events near the context limit) from
+                    # diagnosis. Emit a truncated-prefix warning with a
+                    # per-run counter — never the full line.
+                    session._unparseable_stdout_lines += 1
+                    if (
+                        session._unparseable_stdout_lines <= 5
+                        or session._unparseable_stdout_lines % 100 == 0
+                    ):
+                        logger.warning(
+                            "Agent CLI emitted non-JSON stdout line #%d " "(session=%s): %.200s",
+                            session._unparseable_stdout_lines,
+                            session.session_id[:8],
+                            line,
+                        )
 
         except (OSError, ValueError):
             pass

--- a/tests/unit/test_agent_result_text_fallback.py
+++ b/tests/unit/test_agent_result_text_fallback.py
@@ -1,0 +1,260 @@
+"""Regression: recover response text when assistant stream events are dropped.
+
+Large-context (--resume) CLI turns can complete with a terminal ``result``
+event — usage accounted, exit 0 — while the final ``assistant`` stream event
+never arrives. ``_read_stdout`` only built response_text from assistant
+events, so the orchestrator terminal-failed the phase with
+"<agent> returned no result" even though the deliverable existed (#2640).
+
+This suite pins the two-layer fallback in agent_runner:
+A.1 the ``result`` event's ``result`` text field, and
+A.2 the session transcript JSONL's last visible assistant message
+    (same reading machinery as ``_replay_usage_from_jsonl``).
+Refs #2640, #2570.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.modules.workspace.autonomous.agent_runner import (
+    AutonomousAgentRunner,
+    _ensure_usage_parser,
+    _LocalSession,
+)
+
+RESULT_TEXT = 'REVIEW_RESULT: {"verdict":"APPROVE","summary":"clean"}'
+API_ERROR_ENVELOPE = (
+    "API Error: 400 InvalidParameter: Range of input length is [1, 260000], "
+    "but current is 300000"
+)
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self.lines = [ln.encode() if isinstance(ln, str) else ln for ln in lines]
+
+    def readline(self):
+        return self.lines.pop(0) if self.lines else b""
+
+
+def _make_runner():
+    """Runner skeleton matching the harness in test_agent_runner_session_id_capture."""
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = None
+    runner.session_manager = None
+    runner._resolve_sidebar_session = lambda *_args, **_kwargs: ""
+    return runner
+
+
+def _make_session(lines):
+    session = _LocalSession(
+        session_id="tracking-2640",
+        process=SimpleNamespace(
+            stdout=_FakeStdout(lines), stdin=None, returncode=None, poll=lambda: None
+        ),
+    )
+    session.workflow_id = "wf-2640"
+    session.started_at_epoch = datetime.now(timezone.utc).timestamp()
+    return session
+
+
+def _run_messages(messages):
+    _ensure_usage_parser()
+    runner = _make_runner()
+    session = _make_session([json.dumps(m) for m in messages])
+    runner._read_stdout(session)
+    return runner, session
+
+
+def _result_event(result_text=RESULT_TEXT, input_tokens=170000, output_tokens=92):
+    return {
+        "type": "result",
+        "subtype": "success",
+        "session_id": "cli-sid-2640",
+        "result": result_text,
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+    }
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_result_event_text_recovered_when_no_assistant_events():
+    """A.1: result event with text+usage but no assistant events must not
+    produce an empty response_text."""
+    runner, session = _run_messages([_result_event()])
+
+    assert session.result_text == RESULT_TEXT
+
+    result = runner._finalize_local_completed_result(session, session.session_id, "")
+    assert result.success is True
+    assert result.response_text == RESULT_TEXT
+    assert result.total_tokens == 170000 + 92
+    # The recovered turn must also be visible to session persistence.
+    assert any(
+        e.get("type") == "assistant" and e.get("text") == RESULT_TEXT for e in result.event_log
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_transcript_jsonl_fallback_when_result_text_empty(tmp_path, monkeypatch):
+    """A.2: empty result text + transcript JSONL with a final assistant
+    message -> fall back to the transcript's last assistant text."""
+    monkeypatch.setattr(
+        AutonomousAgentRunner,
+        "_claude_projects_root",
+        classmethod(lambda cls, system_account, task_id=None: tmp_path / "projects"),
+    )
+
+    runner, session = _run_messages([_result_event(result_text="")])
+    session.encoded_project_path = "encoded-proj"
+
+    # Write the transcript AFTER the session started so records fall inside
+    # the run's [started_at_epoch, now] window (mirrors the real CLI).
+    projects_root = tmp_path / "projects" / "encoded-proj"
+    projects_root.mkdir(parents=True)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    old_iso = "2020-01-01T00:00:00.000Z"
+    transcript = "\n".join(
+        json.dumps(rec)
+        for rec in [
+            # A stale pre-run assistant message — must be filtered by timestamp.
+            {
+                "type": "assistant",
+                "timestamp": old_iso,
+                "sessionId": "cli-sid-2640",
+                "message": {
+                    "id": "msg_old",
+                    "content": [{"type": "text", "text": "stale previous turn"}],
+                },
+            },
+            # The deliverable written during this run.
+            {
+                "type": "assistant",
+                "timestamp": now_iso,
+                "sessionId": "cli-sid-2640",
+                "message": {
+                    "id": "msg_new",
+                    "content": [{"type": "text", "text": RESULT_TEXT}],
+                },
+            },
+            # A later thinking-only record — no visible text, must not win.
+            {
+                "type": "assistant",
+                "timestamp": now_iso,
+                "sessionId": "cli-sid-2640",
+                "message": {
+                    "id": "msg_think",
+                    "content": [{"type": "thinking", "text": "hidden"}],
+                },
+            },
+        ]
+    )
+    (projects_root / "cli-sid-2640.jsonl").write_text(transcript, encoding="utf-8")
+
+    assert session.result_text == ""
+    result = runner._finalize_local_completed_result(session, session.session_id, "cli-sid-2640")
+    assert result.success is True
+    assert result.response_text == RESULT_TEXT
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_normal_assistant_path_unchanged():
+    """Assistant events present -> response_text from event_log; the result
+    text fallback never fires."""
+    assistant_event = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "model": "test-model",
+            "content": [{"type": "text", "text": "final answer from stream"}],
+        },
+    }
+    runner, session = _run_messages([assistant_event, _result_event()])
+
+    result = runner._finalize_local_completed_result(session, session.session_id, "")
+    assert result.response_text == "final answer from stream"
+    # No synthetic assistant entry appended on top of the real turn.
+    assistant_entries = [
+        e for e in result.event_log if e.get("type") == "assistant" and e.get("text")
+    ]
+    assert len(assistant_entries) == 1
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_recovered_text_reaches_session_persistence():
+    """The recovered text must land in session state BEFORE
+    _persist_local_session_messages consumes the result, so the DB timeline
+    does not lose the turn."""
+
+    class _RecordingManager:
+        def __init__(self):
+            self.calls = []
+
+        def append_transcript_message(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(_was_inserted=True)
+
+    runner, session = _run_messages([_result_event()])
+    session_manager = _RecordingManager()
+    runner.session_manager = session_manager
+
+    result = runner._finalize_local_completed_result(session, session.session_id, "")
+    # Session state carries the synthetic assistant entry for persistence.
+    assert any(
+        e.get("type") == "assistant" and e.get("text") == RESULT_TEXT for e in session.event_log
+    )
+    assert session.assistant_text.strip() == RESULT_TEXT
+
+    persisted = runner._persist_local_session_messages("sess-2640", result, "m1")
+    assert persisted >= 1
+    assistant_messages = [c for c in session_manager.calls if c.get("role") == "assistant"]
+    assert assistant_messages, "no assistant message persisted for recovered turn"
+    assert RESULT_TEXT in assistant_messages[0].get("content", "")
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_unparseable_stdout_line_logs_truncated_warning(caplog):
+    """Non-JSON stdout lines must produce a warning with a truncated prefix
+    instead of being silently swallowed, and must not fail the run."""
+    long_garbage = "X" * 500
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = None
+    runner.session_manager = None
+    runner._resolve_sidebar_session = lambda *_a, **_k: ""
+    _ensure_usage_parser()
+
+    session = _make_session(["{" + long_garbage, json.dumps(_result_event())])
+    with caplog.at_level(logging.WARNING, logger="app.modules.workspace.autonomous.agent_runner"):
+        runner._read_stdout(session)
+
+    warnings = [r for r in caplog.records if "non-JSON" in r.getMessage()]
+    assert warnings, "no warning emitted for unparseable stdout line"
+    message = warnings[0].getMessage()
+    assert "X" * 200 in message or ("X" * 100 in message and "X" * 300 not in message)
+    assert "X" * 400 not in message  # not the full line
+    # The run still completes via the result event.
+    assert session.completed.is_set()
+    assert session.result_text == RESULT_TEXT
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2640)
+def test_api_error_400_envelope_reaches_context_overflow_detection():
+    """A result-text-carried ``API Error: 400 ... Range of input length``
+    envelope must surface in response_text so the orchestrator's
+    _is_context_overflow can route the phase to context recovery."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    runner, session = _run_messages([_result_event(result_text=API_ERROR_ENVELOPE)])
+    result = runner._finalize_local_completed_result(session, session.session_id, "")
+
+    assert result.response_text.strip()
+    assert AutonomousOrchestrator._is_context_overflow(result) is True


### PR DESCRIPTION
## Root cause (#2640, verified against prod primary evidence — adb351ec/#2565)

A review agent (`session_line="review"`, `--resume`, 255k input tokens) completed its turn: the transcript JSONL's last assistant message WAS the deliverable (`REVIEW_RESULT: {...}`, 92 output tokens, stop_reason=end_turn) and `phase_total_tokens` was accounted correctly — but the workflow still terminal-failed with "PR review agent returned no result".

`_read_stdout` builds response_text ONLY from stdout **assistant stream events** (event_log → `_extract_final_response_text`). The **`result` event's `result` text field** — where the CLI puts the final answer — was read for classification but never captured as response text and simply discarded. Tokens were recorded (the result handler accumulates usage), proving the result event arrived; what was lost was the final assistant stream event (large-context stream-json fragility, same family as the documented 2.1.x near-context-limit quirks). Unparseable stdout lines were silently swallowed (`except: pass`), making the drift undiagnosable.

`success=True` (exit 0, result event not error-bearing) and Fix B (`_is_resume_noop_result`, 0-token gate) correctly did not fire — this variant has tokens. Affected paths: pr_review review (no retry, the prod case), summary (#2570 retry path), fix agent (#2611), planning review, dev/test agents, acceptance verifier, ci_repair. `_persist_local_session_messages` also fed from the empty event_log, so the DB timeline lost the turn.

## Fix (Option A, agent_runner layer — below Fix B/#2570/#2611, no agent rerun)

Two-layer fallback, only when `event_log` has NO assistant text (normal path untouched):

1. **A.1 result-event text**: the `_read_stdout` result handler stores `parsed["result"]` (non-empty str) into `session.result_text`.
2. **A.2 transcript JSONL backstop**: when the run completed, `result_text` is empty and the CLI session id is known, `_recover_response_text_from_jsonl` reads the session transcript via the same machinery as `_replay_usage_from_jsonl` (`_claude_projects_root` + owning-user read) and takes the last visible assistant message with `timestamp >= started_at_epoch`. Fail-soft: any exception → warning log + empty.

**Write-back for persistence**: the recovered text is appended to `session.event_log` as a synthetic assistant entry (existing entry shape) and `session.assistant_text`, BEFORE the result is built — so `_build_agent_task_result` and `_persist_local_session_messages`/timeline UI recover the turn too. Wired via a new `_finalize_local_completed_result` seam that `_run_local`'s completed branch now routes through.

**Diagnostics**: stdout lines failing JSON parse now emit a warning with a ~200-char truncated prefix and a per-run counter (throttled: first 5, then every 100th) — no full lines.

Bonus routing fix: an `API Error: 400 InvalidParameter: Range of input length ...` envelope arriving via result text now surfaces in `response_text`, so the orchestrator's `_is_context_overflow` can route the phase to context recovery (pinned by test).

Not touched: `_is_resume_noop_result` / Fix B semantics, the #2570/#2611 fresh-retry backstops, orchestrator.py.

## Test evidence (TDD red → green)

New `tests/unit/test_agent_result_text_fallback.py` (6 tests, all `@pytest.mark.regression` + `@pytest.mark.issue(2640)`, real assertions):

1. result event with text+usage, NO assistant events → `response_text == result text`, success True, `total_tokens` from usage — RED (`AttributeError: result_text`) → GREEN
2. empty result text + transcript JSONL (temp file, monkeypatched `_claude_projects_root`) → falls back to the last in-window visible assistant text (stale pre-run record and thinking-only record correctly ignored) — RED → GREEN
3. assistant events present → response_text from event_log; result_text ignored; no synthetic entry appended
4. recovered text reaches persistence: synthetic event_log entry + `assistant_text` before `_persist_local_session_messages`, verified with a recording session manager (assistant-role message persisted with the recovered text) — RED → GREEN
5. unparseable stdout line → warning logged (caplog) with truncated prefix, full line absent; run still completes via result event — RED → GREEN
6. `API Error: 400 ... Range of input length` envelope via result text → non-empty `response_text` and `AutonomousOrchestrator._is_context_overflow(result) is True`

Neighboring suites (all agent_runner-touching unit files): `test_agent_runner_session_id_capture.py`, `test_zcode_adapter.py`, `test_agent_context_recovery_resume_noop.py`, `test_autonomous_ci_guardrails.py`, `test_remote_sync_message_count.py`, `test_zcode_workflow_session_persistence.py`, `test_llm_proxy_autonomous_exempt.py` — 138 passed. `pre-commit run --files` clean (black/isort/ruff/mypy/bandit/pydocstyle).

Refs #2640
Refs #2570 (context: same "returned no result" family, different variant — tokens present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)