### PR TITLE
fix(security): close cross-tenant account takeover, wire platform-admin strict mode, restore renamed migration id

### DIFF
--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -106,10 +106,15 @@ jobs:
       # surface when migrations load from a synthetic tree without the app/
       # package, and because MIG003's post-merge id set is only knowable here.
       #
-      # MIG003's baseline is the PR's own base branch, so the comparison is
-      # exactly "what does main have today vs what will exist after this
-      # merges". The git commands run against $GITHUB_WORKSPACE (the script
-      # resolves the repo from its own location), not $MERGED_DIR.
+      # MIG003 compares against the merge bases of the base branch and HEAD,
+      # not the base branch's tip. On `pull_request`, actions/checkout checks
+      # out the MERGE ref, so the base tip IS a merge base and the comparison
+      # is effectively "what does main have today vs what exists after this
+      # merges" -- the strongest form. That equivalence depends on checking out
+      # the merge ref: adding `ref: github.event.pull_request.head.sha` here
+      # would silently downgrade this gate to fork-point semantics with no
+      # visible change. The git commands run against $GITHUB_WORKSPACE (the
+      # script resolves the repo from its own location), not $MERGED_DIR.
       - name: Enforce migration authoring rules (MIG001/MIG002/MIG003)
         working-directory: ${{ env.MERGED_DIR }}
         env:

--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -12,9 +12,12 @@ name: Migration Graph
 # Authoring rules (Issue #1704) are enforced on the same pre-merged tree:
 #   - MIG001: no runtime app.* imports (migrations load from a tree without app/)
 #   - MIG002: CONCURRENTLY ops use the approved autocommit_block() pattern
-# These surface only when migrations load from a synthetic tree without the
-# app/ package, which the pre-merged tree reproduces — so they are checked here
-# in addition to pre-commit.
+#   - MIG003: a revision id that shipped on the base branch must still exist
+# MIG001/MIG002 surface only when migrations load from a synthetic tree without
+# the app/ package, which the pre-merged tree reproduces. MIG003 needs the same
+# tree for a different reason: it compares post-merge ids against the base
+# branch, which is precisely what a deployed database will experience.
+# All three are checked here in addition to pre-commit.
 
 on:
   pull_request:
@@ -97,12 +100,20 @@ jobs:
         run: python "$GITHUB_WORKSPACE/scripts/check_migration_heads.py"
 
       # Enforce repository migration authoring rules (Issue #1704) against the
-      # same pre-merged tree: no runtime app.* imports (MIG001) and the approved
-      # CONCURRENTLY pattern (MIG002). Run here — not just in pre-commit —
-      # because these failures surface when migrations load from a synthetic tree
-      # without the app/ package, which the pre-merged tree reproduces.
-      - name: Enforce migration authoring rules (MIG001/MIG002)
+      # same pre-merged tree: no runtime app.* imports (MIG001), the approved
+      # CONCURRENTLY pattern (MIG002), and no vanishing released revision ids
+      # (MIG003). Run here — not just in pre-commit — because MIG001/MIG002
+      # surface when migrations load from a synthetic tree without the app/
+      # package, and because MIG003's post-merge id set is only knowable here.
+      #
+      # MIG003's baseline is the PR's own base branch, so the comparison is
+      # exactly "what does main have today vs what will exist after this
+      # merges". The git commands run against $GITHUB_WORKSPACE (the script
+      # resolves the repo from its own location), not $MERGED_DIR.
+      - name: Enforce migration authoring rules (MIG001/MIG002/MIG003)
         working-directory: ${{ env.MERGED_DIR }}
+        env:
+          MIG003_BASELINE_REF: origin/${{ github.base_ref }}
         run: python "$GITHUB_WORKSPACE/scripts/lint/check_migration_rules.py" migrations/versions
 
       - name: Cleanup merged tree

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,14 @@ repos:
       #            migration-graph load with an opaque ImportError)
       #   MIG002 — CONCURRENTLY index ops must use the approved
       #            autocommit_block() + postgresql_concurrently=True pattern
+      #   MIG003 — a revision id present on origin/main must still exist here;
+      #            deleting or rewriting one wedges every database stamped with
+      #            it (skipped automatically if origin/main is unreadable, so a
+      #            stale local remote can miss a violation but never invent one)
       # This sees only the current working tree; the migration-graph CI job runs
       # the authoritative check against the pre-merged tree (see that workflow).
       - id: check-migration-rules
-        name: Check migration authoring rules (MIG001/MIG002)
+        name: Check migration authoring rules (MIG001/MIG002/MIG003)
         entry: python3 scripts/lint/check_migration_rules.py
         language: system
         files: ^migrations/versions/.*\.py$

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -325,6 +325,15 @@ def create_app(config=None):
     # Register error handlers
     register_error_handlers(app)
 
+    # Freeze the platform-admin strict mode flag before serving any request, so
+    # every request in this process agrees on who counts as a platform admin
+    # (Issue #2332). Resolving it lazily on the first role check would work too,
+    # but doing it here is what makes the documented "cached at application
+    # startup" contract true and puts the ENABLED/DISABLED line in the boot log.
+    from app.auth.permissions import init_platform_admin_strict_mode
+
+    init_platform_admin_strict_mode()
+
     # Initialize Prometheus metrics (Issue #2186)
     # Only for web workers - scheduler has its own metrics server
     scheduler_mode = os.environ.get("SCHEDULER_MODE", "web")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -330,9 +330,16 @@ def create_app(config=None):
     # (Issue #2332). Resolving it lazily on the first role check would work too,
     # but doing it here is what makes the documented "cached at application
     # startup" contract true and puts the ENABLED/DISABLED line in the boot log.
-    from app.auth.permissions import init_platform_admin_strict_mode
+    from app.auth.permissions import (
+        init_platform_admin_strict_mode,
+        warn_if_strict_mode_locks_out_legacy_admins,
+    )
 
     init_platform_admin_strict_mode()
+    # The flag used to be inert, so operators may have set it long ago and seen
+    # nothing happen. Now that it works, say so loudly if turning it on is about
+    # to strip platform access from accounts that still use the legacy role.
+    warn_if_strict_mode_locks_out_legacy_admins()
 
     # Initialize Prometheus metrics (Issue #2186)
     # Only for web workers - scheduler has its own metrics server

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -330,16 +330,9 @@ def create_app(config=None):
     # (Issue #2332). Resolving it lazily on the first role check would work too,
     # but doing it here is what makes the documented "cached at application
     # startup" contract true and puts the ENABLED/DISABLED line in the boot log.
-    from app.auth.permissions import (
-        init_platform_admin_strict_mode,
-        warn_if_strict_mode_locks_out_legacy_admins,
-    )
+    from app.auth.permissions import init_platform_admin_strict_mode
 
     init_platform_admin_strict_mode()
-    # The flag used to be inert, so operators may have set it long ago and seen
-    # nothing happen. Now that it works, say so loudly if turning it on is about
-    # to strip platform access from accounts that still use the legacy role.
-    warn_if_strict_mode_locks_out_legacy_admins()
 
     # Initialize Prometheus metrics (Issue #2186)
     # Only for web workers - scheduler has its own metrics server
@@ -451,6 +444,19 @@ def create_app(config=None):
 
         ensure_all_tables()
         logger.info(f"Development schema bootstrap completed (mode={env_mode})")
+
+    # Deliberately AFTER the schema check above, which is the first thing that
+    # talks to the database. This query is only a diagnostic, and placing it
+    # earlier would make a startup diagnostic the first blocking call -- on an
+    # unreachable host (firewall DROP, no connect_timeout configured) it would
+    # hang before the check whose job is to report exactly that.
+    #
+    # The flag used to be inert, so operators may have set it long ago and seen
+    # nothing happen. Now that it works, say so loudly if turning it on is about
+    # to strip platform access from accounts that still use the legacy role.
+    from app.auth.permissions import warn_if_strict_mode_locks_out_legacy_admins
+
+    warn_if_strict_mode_locks_out_legacy_admins()
 
     # Pre-check encryption key registry (Issue #1820, #2186)
     try:

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1396,12 +1396,22 @@ def enforce_target_user_tenant(target_user: dict | None) -> tuple[Response, int]
 
     * Platform admin: always allowed; a cross-tenant target is audit-logged.
     * Tenant-scoped admin: allowed only when the target user carries the same
-      ``tenant_id``. A target with no tenant (platform-level accounts) is
-      denied -- fail closed rather than treating NULL as a wildcard.
+      ``tenant_id`` AND is not itself a platform-level account.
+
+      A target with ``tenant_id IS NULL`` is denied. NULL here does not mean
+      "platform-level" -- ``users.tenant_id`` is simply nullable and rows
+      predating the tenant model still have it unset (``api_update_user``
+      expects such rows to exist). Denying is a deliberate behavior change:
+      those users become unmanageable by tenant admins until someone assigns
+      them a tenant. The alternative -- treating NULL as "matches anything" --
+      is the wildcard bug this whole guard exists to prevent.
     * ``target_user is None``: allowed through, so the endpoint keeps emitting
-      its own 404/500 for a missing user. A tenant admin cannot learn anything
-      from this that a plain 404 would not already tell them.
+      its own 404/500 for a missing user. Callers that act on the raw id
+      without a not-found branch must deny instead -- see
+      :func:`same_tenant_user_required`, which does.
     """
+    from app.auth.permissions import is_platform_level_role
+
     actor_tenant_id, denial = resolve_admin_tenant_scope()
     if denial is not None:
         return denial
@@ -1415,6 +1425,28 @@ def enforce_target_user_tenant(target_user: dict | None) -> tuple[Response, int]
         # Platform admin: permitted, but record the boundary crossing.
         _audit_cross_tenant_user_access(target_user)
         return None
+
+    # Vertical check, not just horizontal. Sharing a tenant does NOT make a
+    # platform admin a legitimate target for a tenant admin: platform accounts
+    # reach every tenant, so taking one over escapes the boundary entirely.
+    #
+    # This is reachable by design rather than by accident -- api_create_user
+    # rejects a missing tenant_id (400), so every platform admin minted through
+    # the admin API necessarily carries some tenant, and the schema only
+    # constrains tenant_admin to have one (chk_2332_tenant_admin_requires_tenant).
+    # Without this branch a tenant admin could reset the password of a
+    # platform_admin filed under its own tenant and read it from the response.
+    if is_platform_level_role(target_user.get("role")):
+        logger.warning(
+            "Tenant admin denied operation on platform-level account: "
+            "actor=%s actor_tenant=%s target=%s target_role=%s path=%s",
+            getattr(g, "user_id", None),
+            actor_tenant_id,
+            target_user.get("id"),
+            target_user.get("role"),
+            request.path,
+        )
+        return jsonify({"error": "Cross-tenant access denied"}), 403
 
     if target_tenant_id is None or target_tenant_id != actor_tenant_id:
         logger.warning(
@@ -1542,12 +1574,27 @@ def enforce_requested_tenant_scope(
     * Tenant-scoped admin -> their own tenant. Asking for a different tenant
       is denied instead of silently rewritten, so a caller never believes it
       read another tenant's data.
+
+    A value that was supplied but cannot be read as a tenant id (``0``, ``-1``,
+    ``""``, ``"abc"``) is rejected with 400 rather than normalized to ``None``.
+    Collapsing it to ``None`` would make it indistinguishable from "no tenant
+    requested", which for a tenant-scoped admin silently rewrites the request
+    to their own tenant and for a platform admin silently widens it to all
+    tenants -- in both cases acting on something the caller did not ask for.
     """
     actor_tenant_id, denial = resolve_admin_tenant_scope()
     if denial is not None:
         return None, denial
 
     requested = _normalize_user_tenant_id(requested_tenant_id)
+    if requested_tenant_id is not None and requested is None:
+        logger.warning(
+            "Unusable tenant_id %r from actor=%s at %s",
+            requested_tenant_id,
+            getattr(g, "user_id", None),
+            request.path,
+        )
+        return None, (jsonify({"error": "Invalid tenant_id"}), 400)
 
     if actor_tenant_id is None:
         return requested, None

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1347,6 +1347,47 @@ def resolve_admin_tenant_scope() -> tuple[int | None, tuple[Response, int] | Non
     return tenant_id, None
 
 
+def _load_target_user(user_id: int) -> dict | None:
+    """Fetch the user an admin endpoint is about to act on.
+
+    Single choke point so the boundary check and any future caller agree on
+    where target-user data comes from. Raises whatever the repository raises;
+    callers decide whether that is fatal (see ``same_tenant_user_required``).
+    """
+    from app.repositories.user_repo import UserRepository
+
+    return UserRepository().get_user_by_id(user_id)
+
+
+def _audit_cross_tenant_user_access(target_user: dict | None) -> None:
+    """Record a platform admin reaching into another tenant's user.
+
+    No-op when the target is in the actor's own tenant, has no tenant, or
+    could not be resolved.
+    """
+    if not target_user:
+        return
+
+    target_tenant_id = _normalize_user_tenant_id(target_user.get("tenant_id"))
+    if target_tenant_id is None:
+        return
+
+    actor_id = getattr(g, "user_id", None)
+    if not isinstance(actor_id, int):
+        return
+
+    own_tenant_id = _normalize_user_tenant_id((getattr(g, "user", None) or {}).get("tenant_id"))
+    if target_tenant_id == own_tenant_id:
+        return
+
+    _log_cross_tenant_operation(
+        actor_user_id=actor_id,
+        actor_tenant_id=own_tenant_id,
+        target_tenant_id=target_tenant_id,
+        action=f"{request.method} {request.path}",
+    )
+
+
 def enforce_target_user_tenant(target_user: dict | None) -> tuple[Response, int] | None:
     """Deny when the current admin may not operate on ``target_user``.
 
@@ -1372,19 +1413,7 @@ def enforce_target_user_tenant(target_user: dict | None) -> tuple[Response, int]
 
     if actor_tenant_id is None:
         # Platform admin: permitted, but record the boundary crossing.
-        actor_id = getattr(g, "user_id", None)
-        own_tenant_id = _normalize_user_tenant_id((getattr(g, "user", None) or {}).get("tenant_id"))
-        if (
-            isinstance(actor_id, int)
-            and target_tenant_id is not None
-            and target_tenant_id != own_tenant_id
-        ):
-            _log_cross_tenant_operation(
-                actor_user_id=actor_id,
-                actor_tenant_id=own_tenant_id,
-                target_tenant_id=target_tenant_id,
-                action=f"{request.method} {request.path}",
-            )
+        _audit_cross_tenant_user_access(target_user)
         return None
 
     if target_tenant_id is None or target_tenant_id != actor_tenant_id:
@@ -1411,8 +1440,10 @@ def same_tenant_user_required(f=None, *, arg: str = "user_id"):
         @same_tenant_user_required
         def api_reset_user_password(user_id): ...
 
-    The looked-up target user is cached on ``g.target_user`` so the view can
-    reuse it instead of issuing a second query.
+    A platform admin costs no extra query: there is no boundary to check, so
+    the target is only fetched to name the tenant in the audit entry, and that
+    fetch is best-effort. A tenant-scoped admin does pay one lookup, and there
+    the lookup is load-bearing -- if it fails, the request is denied.
 
     Args:
         f: the view function, when applied bare as ``@same_tenant_user_required``.
@@ -1422,18 +1453,74 @@ def same_tenant_user_required(f=None, *, arg: str = "user_id"):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            target_user_id = kwargs.get(arg)
-            target_user = None
-            if target_user_id is not None:
-                from app.repositories.user_repo import UserRepository
+            actor_tenant_id, denial = resolve_admin_tenant_scope()
+            if denial is not None:
+                return denial
 
-                target_user = UserRepository().get_user_by_id(target_user_id)
+            raw_target_id = kwargs.get(arg)
+            try:
+                target_user_id: int | None = int(raw_target_id)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                target_user_id = None
+
+            if actor_tenant_id is None:
+                # Platform admin. There is no boundary to enforce, so the
+                # lookup here exists only to name the target tenant in the
+                # cross-tenant audit entry. Keep it strictly best-effort: a
+                # repository failure must not turn a permitted request into a
+                # 500, and the endpoint writes its own audit record either way.
+                if target_user_id is not None:
+                    try:
+                        target_user = _load_target_user(target_user_id)
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.warning(
+                            "Cross-tenant audit lookup failed for user %s at %s: %s",
+                            target_user_id,
+                            request.path,
+                            exc,
+                        )
+                    else:
+                        _audit_cross_tenant_user_access(target_user)
+                return func(*args, **kwargs)
+
+            # Tenant-scoped admin. Here the lookup gates access, so it is not
+            # optional: if the target's tenant cannot be established the
+            # request is denied rather than allowed or 500'd.
+            if target_user_id is None:
+                logger.warning(
+                    "Tenant boundary check has no usable %s view arg at %s (got %r)",
+                    arg,
+                    request.path,
+                    raw_target_id,
+                )
+                return jsonify({"error": "Cross-tenant access denied"}), 403
+
+            try:
+                target_user = _load_target_user(target_user_id)
+            except Exception as exc:
+                logger.warning(
+                    "Tenant boundary check could not resolve user %s at %s: %s",
+                    target_user_id,
+                    request.path,
+                    exc,
+                )
+                return jsonify({"error": "Cross-tenant access denied"}), 403
+
+            if target_user is None:
+                # Deny rather than fall through to the view's own 404. Two
+                # reasons: api_update_user / api_delete_user act on the raw
+                # user_id without a not-found branch, so any divergence between
+                # this lookup and theirs would be a fail-open; and a 403 gives
+                # a tenant admin no oracle for whether an id exists elsewhere.
+                logger.warning(
+                    "Tenant boundary check found no user %s at %s", target_user_id, request.path
+                )
+                return jsonify({"error": "Cross-tenant access denied"}), 403
 
             denial = enforce_target_user_tenant(target_user)
             if denial is not None:
                 return denial
 
-            g.target_user = target_user
             return func(*args, **kwargs)
 
         return wrapper

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -838,8 +838,23 @@ def security_annotated(reason: str = ""):
 
 
 def _normalize_user_tenant_id(value: object) -> int | None:
-    """Coerce a raw ``tenant_id`` value into a positive int or None."""
-    if value in (None, ""):
+    """Coerce a raw ``tenant_id`` value into a positive int, or None.
+
+    Rejects two shapes that ``int()`` would otherwise accept silently, because
+    both let a caller act on a tenant it never named:
+
+    * ``bool`` -- ``int(True) == 1``, so a JSON body of ``{"tenant_id": true}``
+      would resolve to tenant 1.
+    * a non-integral ``float`` -- ``int(1.9) == 1``, so ``{"tenant_id": 1.9}``
+      would silently truncate onto tenant 1.
+
+    Neither can cross a tenant boundary (the result is still compared like any
+    other value), but "acts on a tenant the request did not ask for" is the
+    same failure mode that makes an unusable id a 400 rather than a None.
+    """
+    if value in (None, "") or isinstance(value, bool):
+        return None
+    if isinstance(value, float) and not value.is_integer():
         return None
     try:
         tenant_id = int(value)  # type: ignore[call-overload]

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1307,6 +1307,177 @@ def _log_cross_tenant_operation(
         logger.warning(f"Failed to log cross-tenant operation: {e}")
 
 
+# ── Tenant boundary for admin endpoints that target a specific user ───────
+#
+# admin_required authenticates admin/platform_admin/tenant_admin and sets
+# g.tenant_id, but it does NOT compare that tenant against the tenant of the
+# resource being operated on. On endpoints keyed by a user id that gap is a
+# cross-tenant account takeover: any tenant admin could reset any user's
+# password -- including a platform admin's -- and read the new password out of
+# the response. The helpers below close that gap without requiring all 90+
+# admin_required call sites to migrate to the tenant-aware decorators at once.
+
+
+def resolve_admin_tenant_scope() -> tuple[int | None, tuple[Response, int] | None]:
+    """Return the tenant an already-authenticated admin may act within.
+
+    Must run behind an admin decorator (``g.user`` populated).
+
+    Returns:
+        ``(None, None)``  -- platform admin; global scope, no confinement.
+        ``(tid, None)``   -- tenant-scoped admin, confined to ``tid``.
+        ``(None, resp)``  -- deny; caller must return ``resp``.
+
+    Unlike :func:`resolve_tenant_scope`, a tenant-scoped admin with no usable
+    ``tenant_id`` is denied rather than silently handed global scope.
+    """
+    from app.auth.permissions import is_platform_admin_role
+
+    user = getattr(g, "user", None) or {}
+    role = user.get("role")
+
+    if is_platform_admin_role(role):
+        return None, None
+
+    tenant_id = _normalize_user_tenant_id(user.get("tenant_id"))
+    if tenant_id is None:
+        # tenant_admin without a tenant, or a non-admin role that reached here.
+        # Either way there is no scope to confine to, so fail closed.
+        return None, (jsonify({"error": "Tenant scope required"}), 403)
+    return tenant_id, None
+
+
+def enforce_target_user_tenant(target_user: dict | None) -> tuple[Response, int] | None:
+    """Deny when the current admin may not operate on ``target_user``.
+
+    Returns ``None`` when the request may proceed, otherwise the error
+    response the caller must return.
+
+    * Platform admin: always allowed; a cross-tenant target is audit-logged.
+    * Tenant-scoped admin: allowed only when the target user carries the same
+      ``tenant_id``. A target with no tenant (platform-level accounts) is
+      denied -- fail closed rather than treating NULL as a wildcard.
+    * ``target_user is None``: allowed through, so the endpoint keeps emitting
+      its own 404/500 for a missing user. A tenant admin cannot learn anything
+      from this that a plain 404 would not already tell them.
+    """
+    actor_tenant_id, denial = resolve_admin_tenant_scope()
+    if denial is not None:
+        return denial
+
+    if target_user is None:
+        return None
+
+    target_tenant_id = _normalize_user_tenant_id(target_user.get("tenant_id"))
+
+    if actor_tenant_id is None:
+        # Platform admin: permitted, but record the boundary crossing.
+        actor_id = getattr(g, "user_id", None)
+        own_tenant_id = _normalize_user_tenant_id((getattr(g, "user", None) or {}).get("tenant_id"))
+        if (
+            isinstance(actor_id, int)
+            and target_tenant_id is not None
+            and target_tenant_id != own_tenant_id
+        ):
+            _log_cross_tenant_operation(
+                actor_user_id=actor_id,
+                actor_tenant_id=own_tenant_id,
+                target_tenant_id=target_tenant_id,
+                action=f"{request.method} {request.path}",
+            )
+        return None
+
+    if target_tenant_id is None or target_tenant_id != actor_tenant_id:
+        logger.warning(
+            "Cross-tenant user operation denied: actor=%s actor_tenant=%s "
+            "target_tenant=%s path=%s",
+            getattr(g, "user_id", None),
+            actor_tenant_id,
+            target_tenant_id,
+            request.path,
+        )
+        return jsonify({"error": "Cross-tenant access denied"}), 403
+
+    return None
+
+
+def same_tenant_user_required(f=None, *, arg: str = "user_id"):
+    """Confine a user-targeted admin endpoint to the caller's tenant.
+
+    Stack this *below* the authenticating decorator so ``g.user`` is set::
+
+        @admin_bp.route("/admin/users/<int:user_id>/reset-password", ...)
+        @admin_required
+        @same_tenant_user_required
+        def api_reset_user_password(user_id): ...
+
+    The looked-up target user is cached on ``g.target_user`` so the view can
+    reuse it instead of issuing a second query.
+
+    Args:
+        f: the view function, when applied bare as ``@same_tenant_user_required``.
+        arg: name of the view argument holding the target user id.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            target_user_id = kwargs.get(arg)
+            target_user = None
+            if target_user_id is not None:
+                from app.repositories.user_repo import UserRepository
+
+                target_user = UserRepository().get_user_by_id(target_user_id)
+
+            denial = enforce_target_user_tenant(target_user)
+            if denial is not None:
+                return denial
+
+            g.target_user = target_user
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if f is not None:
+        return decorator(f)
+    return decorator
+
+
+def enforce_requested_tenant_scope(
+    requested_tenant_id: object,
+) -> tuple[int | None, tuple[Response, int] | None]:
+    """Resolve the tenant filter an admin endpoint should actually apply.
+
+    For list/create endpoints that take ``tenant_id`` from the request rather
+    than from a resource. Returns ``(effective_tenant_id, None)`` on success:
+
+    * Platform admin -> whatever was requested (``None`` means all tenants).
+    * Tenant-scoped admin -> their own tenant. Asking for a different tenant
+      is denied instead of silently rewritten, so a caller never believes it
+      read another tenant's data.
+    """
+    actor_tenant_id, denial = resolve_admin_tenant_scope()
+    if denial is not None:
+        return None, denial
+
+    requested = _normalize_user_tenant_id(requested_tenant_id)
+
+    if actor_tenant_id is None:
+        return requested, None
+
+    if requested is not None and requested != actor_tenant_id:
+        logger.warning(
+            "Cross-tenant scope denied: actor=%s actor_tenant=%s requested_tenant=%s path=%s",
+            getattr(g, "user_id", None),
+            actor_tenant_id,
+            requested,
+            request.path,
+        )
+        return None, (jsonify({"error": "Cross-tenant access denied"}), 403)
+
+    return actor_tenant_id, None
+
+
 # ── ActorScope and Tenant Authorization (Issue #2327) ─────────────────────
 
 

--- a/app/auth/permissions.py
+++ b/app/auth/permissions.py
@@ -96,6 +96,49 @@ def init_platform_admin_strict_mode() -> bool:
     return is_platform_admin_strict_mode()
 
 
+def warn_if_strict_mode_locks_out_legacy_admins() -> int | None:
+    """Shout at startup if enabling strict mode is about to lock people out.
+
+    This flag spent its whole life as dead code: nothing populated the cache,
+    so ``OPENACE_PLATFORM_ADMIN_STRICT_MODE=true`` did nothing. Meanwhile
+    ``docs/admin_role_migration_runbook_2332.md`` step 5 told operators to set
+    exactly that variable. Anyone who followed the runbook has it exported and
+    has seen no effect -- so the deploy that finally wires the flag up is the
+    deploy where every remaining ``role='admin'`` account silently stops being
+    a platform admin.
+
+    Best-effort and never fatal: a missing table or unreachable database just
+    skips the check.
+
+    Returns:
+        int | None: number of legacy admin rows found, or None if not checked.
+    """
+    if not get_cached_strict_mode():
+        return None
+
+    try:
+        from app.repositories.database import Database
+
+        rows = Database().fetch_one(
+            "SELECT COUNT(*) AS n FROM users WHERE role = 'admin' AND deleted_at IS NULL"
+        )
+        count = int(rows["n"]) if rows else 0
+    except Exception as exc:  # pragma: no cover - startup diagnostics only
+        logger.debug("Could not count legacy admin accounts: %s", exc)
+        return None
+
+    if count:
+        logger.error(
+            "Platform admin strict mode is ENABLED but %d account(s) still have "
+            "role='admin'. Those accounts are NO LONGER platform admins and will "
+            "get 403 on platform-admin endpoints. Migrate them to "
+            "role='platform_admin' or unset OPENACE_PLATFORM_ADMIN_STRICT_MODE. "
+            "See docs/admin_role_migration_runbook_2332.md.",
+            count,
+        )
+    return count
+
+
 def reset_strict_mode_cache() -> None:
     """Clear the cached strict mode flag. Test-only.
 
@@ -105,6 +148,27 @@ def reset_strict_mode_cache() -> None:
     """
     global _PLATFORM_ADMIN_STRICT_MODE
     _PLATFORM_ADMIN_STRICT_MODE = None
+
+
+# Roles that carry reach across every tenant. Unlike is_platform_admin_role
+# this is NOT affected by strict mode: it answers "would this account be
+# platform-level under any configuration", which is the right question when
+# deciding whether a tenant admin may manage or hand out the role. Using the
+# flag-sensitive check there would silently narrow protection the moment strict
+# mode is enabled.
+PLATFORM_LEVEL_ROLES: tuple[str, ...] = ("platform_admin", "admin")
+
+
+def is_platform_level_role(role: str | None) -> bool:
+    """Check if a role is platform-level regardless of strict mode.
+
+    Args:
+        role: User role string to check
+
+    Returns:
+        bool: True for 'platform_admin' or the legacy 'admin'.
+    """
+    return role in PLATFORM_LEVEL_ROLES
 
 
 def is_platform_admin_role(role: str | None) -> bool:

--- a/app/auth/permissions.py
+++ b/app/auth/permissions.py
@@ -33,6 +33,15 @@ def is_platform_admin_strict_mode() -> bool:
         bool: True if strict mode is enabled (only accept explicit platform_admin).
               False if legacy admin is accepted for backward compatibility.
 
+    Scope, so nobody over-trusts this flag: it governs the checks that route
+    through is_platform_admin_role / User.is_platform_admin -- notably
+    platform_admin_required, same_tenant_or_platform_admin and
+    resolve_admin_tenant_scope. It does NOT reach code that compares role
+    strings directly, e.g. admin_required's own allow-list or
+    app/routes/mapping_rules.py, which gates on `user_role == "tenant_admin"`
+    and so leaves a legacy admin with unrestricted reach there. Enabling the
+    flag narrows authorization; it does not make the legacy role disappear.
+
     Deployment Notes:
         1. Migrate every remaining ``role='admin'`` account to
            ``role='platform_admin'`` FIRST -- in strict mode a legacy admin

--- a/app/auth/permissions.py
+++ b/app/auth/permissions.py
@@ -34,10 +34,13 @@ def is_platform_admin_strict_mode() -> bool:
               False if legacy admin is accepted for backward compatibility.
 
     Deployment Notes:
-        1. Set OPENACE_PLATFORM_ADMIN_STRICT_MODE=true before deployment
-        2. Deploy new code with strict mode enabled
-        3. Restart all application processes to pick up new value
-        4. Verify strict mode is active via /api/system/config endpoint
+        1. Migrate every remaining ``role='admin'`` account to
+           ``role='platform_admin'`` FIRST -- in strict mode a legacy admin
+           stops being a platform admin and loses access.
+        2. Set OPENACE_PLATFORM_ADMIN_STRICT_MODE=true
+        3. Restart all application processes to pick up the new value
+        4. Verify: each process logs "Platform admin strict mode: ENABLED"
+           once at startup (see init_platform_admin_strict_mode).
 
     Issue #2332: Feature flag for phased rollout.
     """
@@ -59,12 +62,49 @@ def is_platform_admin_strict_mode() -> bool:
 
 
 def get_cached_strict_mode() -> bool:
-    """Get the cached strict mode value without re-reading env var.
+    """Get the strict mode value, resolving the cache on first access.
 
     Used by decorators and utility functions to ensure consistent behavior
     across all checks within a single process.
+
+    This delegates to :func:`is_platform_admin_strict_mode` so the flag is
+    populated on first use. Before this delegation existed the function read
+    the module global directly and returned ``_PLATFORM_ADMIN_STRICT_MODE or
+    False``; because nothing in production ever called
+    ``is_platform_admin_strict_mode``, the global stayed ``None`` forever and
+    every consumer saw ``False``. ``OPENACE_PLATFORM_ADMIN_STRICT_MODE=true``
+    had no effect at all -- the flag was dead code while reading as wired up.
+
+    Call :func:`init_platform_admin_strict_mode` at application startup so the
+    value is frozen (and logged) before the first request rather than on
+    whichever request happens to check a role first.
     """
-    return _PLATFORM_ADMIN_STRICT_MODE or False
+    return is_platform_admin_strict_mode()
+
+
+def init_platform_admin_strict_mode() -> bool:
+    """Resolve and freeze the strict mode flag at application startup.
+
+    Idempotent: the first call reads the environment variable and caches it;
+    later calls return the cached value. Called from ``create_app`` so the
+    documented "cached at application startup" contract is actually true and
+    the mode is logged once at boot.
+
+    Returns:
+        bool: the resolved strict mode value.
+    """
+    return is_platform_admin_strict_mode()
+
+
+def reset_strict_mode_cache() -> None:
+    """Clear the cached strict mode flag. Test-only.
+
+    Production code must not call this: the cache exists precisely so that a
+    mid-flight environment change cannot make two requests in the same process
+    disagree about who counts as a platform admin.
+    """
+    global _PLATFORM_ADMIN_STRICT_MODE
+    _PLATFORM_ADMIN_STRICT_MODE = None
 
 
 def is_platform_admin_role(role: str | None) -> bool:

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -945,8 +945,15 @@ def api_quota_health_check():
 
     data = request.get_json(silent=True) or {}
 
-    # Get tenant_id from request or current user
-    tenant_id = data.get("tenant_id") or g.user.get("tenant_id")
+    # Get tenant_id from request, confined to what the caller may look at. The
+    # body value used to be taken on trust, so a tenant admin could read any
+    # other tenant's quota allocation and headroom by naming it here.
+    tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    if denial is not None:
+        return denial
+    if tenant_id is None:
+        # Platform admin with no tenant named, or a caller with no tenant.
+        tenant_id = g.user.get("tenant_id")
     if not tenant_id:
         return jsonify({"error": "Tenant ID is required"}), 400
 
@@ -1045,15 +1052,18 @@ def api_quota_health_check():
 @admin_bp.route("/admin/feishu/sync", methods=["POST"])
 @admin_required
 def api_sync_feishu_org():
-    """Manually trigger a Feishu organization sync."""
-    data = request.get_json(silent=True) or {}
-    tenant_id = data.get("tenant_id")
+    """Manually trigger a Feishu organization sync.
 
-    if tenant_id is not None:
-        try:
-            tenant_id = int(tenant_id)
-        except (TypeError, ValueError):
-            return jsonify({"error": "tenant_id must be an integer"}), 400
+    The body's ``tenant_id`` used to be taken on trust. Because a sync creates
+    and updates users and teams in the target tenant, that was a cross-tenant
+    *write*: a tenant admin could name somebody else's tenant and reshape its
+    org tree. enforce_requested_tenant_scope also handles the int coercion and
+    the 400 that used to be done by hand here.
+    """
+    data = request.get_json(silent=True) or {}
+    tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    if denial is not None:
+        return denial
 
     try:
         from app.services.feishu_org_sync import FeishuOrgSyncService
@@ -1070,15 +1080,14 @@ def api_sync_feishu_org():
 @admin_bp.route("/admin/dingtalk/sync", methods=["POST"])
 @admin_required
 def api_sync_dingtalk_org():
-    """Manually trigger a DingTalk organization sync."""
-    data = request.get_json(silent=True) or {}
-    tenant_id = data.get("tenant_id")
+    """Manually trigger a DingTalk organization sync.
 
-    if tenant_id is not None:
-        try:
-            tenant_id = int(tenant_id)
-        except (TypeError, ValueError):
-            return jsonify({"error": "tenant_id must be an integer"}), 400
+    Same cross-tenant write as the Feishu sibling above -- see that docstring.
+    """
+    data = request.get_json(silent=True) or {}
+    tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    if denial is not None:
+        return denial
 
     try:
         from app.services.dingtalk_org_sync import DingTalkOrgSyncService

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -88,7 +88,7 @@ def api_get_users():
     ``tenant_id`` is narrowed to theirs rather than left as "all tenants",
     and naming somebody else's tenant is rejected.
     """
-    tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id", type=int))
+    tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id"))
     if denial is not None:
         return denial
 
@@ -692,10 +692,22 @@ def api_update_user_quota(user_id):
 @admin_bp.route("/admin/quota/usage", methods=["GET"])
 @admin_required
 def api_quota_usage():
-    """Get quota usage for all users."""
+    """Get quota usage for all users the caller may see.
+
+    Same tenant confinement as ``GET /admin/users`` -- this endpoint returns
+    the user list too (``SELECT *`` minus the password hash, plus usage), so
+    leaving it unscoped would reopen cross-tenant user enumeration at a
+    sibling URL. It actually exposes more than /admin/users does, including
+    each account's role, which is precisely the targeting data an attacker
+    needs.
+    """
     from datetime import datetime
 
-    users = user_repo.get_all_users()
+    scope_tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id"))
+    if denial is not None:
+        return denial
+
+    users = user_repo.get_all_users(tenant_id=scope_tenant_id)
     today = datetime.now().strftime("%Y-%m-%d")
     month_start = datetime.now().replace(day=1).strftime("%Y-%m-%d")
 
@@ -737,17 +749,23 @@ def api_quota_stats():
     """Get quota allocation statistics for reference."""
     from app.services.tenant_service import TenantService
 
+    scope_tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id"))
+    if denial is not None:
+        return denial
+
     tenant_service = TenantService()
 
     # Get tenant info (default tenant_id=1 for single-tenant mode)
-    tenant = tenant_service.get_tenant(1)
+    tenant = tenant_service.get_tenant(scope_tenant_id or 1)
     if not tenant:
         return jsonify({"error": "Tenant not found"}), 404
 
     tenant_quota = tenant.quota
 
-    # Calculate allocated quotas from all users
-    users = user_repo.get_all_users()
+    # Calculate allocated quotas from users in scope. Summing every tenant's
+    # users against one tenant's limit was both a cross-tenant read and an
+    # arithmetically wrong answer.
+    users = user_repo.get_all_users(tenant_id=scope_tenant_id)
 
     allocated = {
         "daily_token": 0,

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -12,7 +12,12 @@ from typing import Any, cast
 import bcrypt
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import admin_required
+from app.auth.decorators import (
+    admin_required,
+    enforce_requested_tenant_scope,
+    resolve_admin_tenant_scope,
+    same_tenant_user_required,
+)
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
@@ -42,11 +47,51 @@ def get_client_info():
     }
 
 
+# Roles a tenant-scoped admin must not be able to hand out. Granting these is
+# equivalent to escaping the tenant: the grantee (possibly the grantor's own
+# account) becomes a platform admin and can then reach every other tenant.
+PLATFORM_LEVEL_ROLES = ("platform_admin", "admin")
+
+
+def reject_privilege_escalation(role: object) -> tuple[Any, int] | None:
+    """Deny a tenant-scoped admin assigning a platform-level role.
+
+    Returns ``None`` when the assignment is allowed (no role given, an
+    ordinary role, or the actor is a platform admin), otherwise the 403 the
+    caller must return.
+    """
+    if role is None or role not in PLATFORM_LEVEL_ROLES:
+        return None
+
+    actor_tenant_id, denial = resolve_admin_tenant_scope()
+    if denial is not None:
+        return denial
+    if actor_tenant_id is None:
+        # Platform admin: allowed to create peers.
+        return None
+
+    logger.warning(
+        "Privilege escalation denied: actor=%s actor_tenant=%s requested_role=%s path=%s",
+        g.user_id,
+        actor_tenant_id,
+        role,
+        request.path,
+    )
+    return jsonify({"error": "Cannot assign platform-level role"}), 403
+
+
 @admin_bp.route("/admin/users", methods=["GET"])
 @admin_required
 def api_get_users():
-    """Get all users, optionally filtered by tenant."""
-    tenant_id = request.args.get("tenant_id", type=int)
+    """Get all users, optionally filtered by tenant.
+
+    A tenant-scoped admin only ever sees their own tenant: an omitted
+    ``tenant_id`` is narrowed to theirs rather than left as "all tenants",
+    and naming somebody else's tenant is rejected.
+    """
+    tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id", type=int))
+    if denial is not None:
+        return denial
 
     users = user_repo.get_all_users(tenant_id=tenant_id)
 
@@ -81,6 +126,20 @@ def api_create_user():
     tenant_id = data.get("tenant_id")
     if tenant_id is None:
         return jsonify({"error": "tenant_id is required"}), 400
+
+    # A tenant-scoped admin may only populate their own tenant, and may not
+    # mint a platform-level account there.
+    tenant_id, denial = enforce_requested_tenant_scope(tenant_id)
+    if denial is not None:
+        return denial
+    if tenant_id is None:
+        # The raw value was present but not a usable tenant id (non-numeric,
+        # zero, negative). Reject rather than fall through to an unscoped
+        # create.
+        return jsonify({"error": "Invalid tenant_id"}), 400
+    escalation = reject_privilege_escalation(role)
+    if escalation is not None:
+        return escalation
 
     # Validate inputs
     if not validate_username(username):
@@ -160,12 +219,24 @@ def api_create_user():
 
 @admin_bp.route("/admin/users/<int:user_id>", methods=["PUT"])
 @admin_required
+@same_tenant_user_required
 def api_update_user(user_id):
     """Update a user."""
     data = request.get_json() or {}
 
     # Get current user state for audit diff (before update)
     current_user = user_repo.get_user_by_id(user_id)
+
+    # A tenant-scoped admin must not grant a platform-level role, and must not
+    # move a user across the tenant boundary in either direction: pulling a
+    # foreign user in is takeover, pushing one out is exfiltration.
+    escalation = reject_privilege_escalation(data.get("role"))
+    if escalation is not None:
+        return escalation
+    if data.get("tenant_id") is not None:
+        _, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+        if denial is not None:
+            return denial
 
     # Auto-create system user if system_account is being set
     system_account = data.get("system_account")
@@ -244,6 +315,7 @@ def api_update_user(user_id):
 
 @admin_bp.route("/admin/users/<int:user_id>", methods=["DELETE"])
 @admin_required
+@same_tenant_user_required
 def api_delete_user(user_id):
     """Delete a user."""
     # Prevent deleting yourself
@@ -276,6 +348,7 @@ def api_delete_user(user_id):
 
 @admin_bp.route("/admin/users/<int:user_id>/password", methods=["PUT"])
 @admin_required
+@same_tenant_user_required
 def api_update_user_password(user_id):
     """Update a user's password."""
     data = request.get_json() or {}
@@ -313,6 +386,7 @@ def api_update_user_password(user_id):
 
 @admin_bp.route("/admin/users/<int:user_id>/reset-password", methods=["POST"])
 @admin_required
+@same_tenant_user_required
 def api_reset_user_password(user_id):
     """Reset user password and generate a temporary password.
 
@@ -400,6 +474,7 @@ def api_reset_user_password(user_id):
 
 @admin_bp.route("/admin/users/<int:user_id>/quota", methods=["PUT"])
 @admin_required
+@same_tenant_user_required
 def api_update_user_quota(user_id):
     """Update a user's quota.
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -18,6 +18,7 @@ from app.auth.decorators import (
     resolve_admin_tenant_scope,
     same_tenant_user_required,
 )
+from app.auth.permissions import is_platform_level_role
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
@@ -47,20 +48,18 @@ def get_client_info():
     }
 
 
-# Roles a tenant-scoped admin must not be able to hand out. Granting these is
-# equivalent to escaping the tenant: the grantee (possibly the grantor's own
-# account) becomes a platform admin and can then reach every other tenant.
-PLATFORM_LEVEL_ROLES = ("platform_admin", "admin")
-
-
 def reject_privilege_escalation(role: object) -> tuple[Any, int] | None:
     """Deny a tenant-scoped admin assigning a platform-level role.
+
+    Granting one is equivalent to escaping the tenant: the grantee (possibly
+    the grantor's own account) becomes a platform admin and can then reach
+    every other tenant.
 
     Returns ``None`` when the assignment is allowed (no role given, an
     ordinary role, or the actor is a platform admin), otherwise the 403 the
     caller must return.
     """
-    if role is None or role not in PLATFORM_LEVEL_ROLES:
+    if role is None or not is_platform_level_role(cast("str | None", role)):
         return None
 
     actor_tenant_id, denial = resolve_admin_tenant_scope()
@@ -129,14 +128,11 @@ def api_create_user():
 
     # A tenant-scoped admin may only populate their own tenant, and may not
     # mint a platform-level account there.
+    # Also 400s an unusable tenant_id, so nothing unvalidated reaches the
+    # quota check or the INSERT.
     tenant_id, denial = enforce_requested_tenant_scope(tenant_id)
     if denial is not None:
         return denial
-    if tenant_id is None:
-        # The raw value was present but not a usable tenant id (non-numeric,
-        # zero, negative). Reject rather than fall through to an unscoped
-        # create.
-        return jsonify({"error": "Invalid tenant_id"}), 400
     escalation = reject_privilege_escalation(role)
     if escalation is not None:
         return escalation
@@ -233,8 +229,15 @@ def api_update_user(user_id):
     escalation = reject_privilege_escalation(data.get("role"))
     if escalation is not None:
         return escalation
+
+    # Use the value the scope guard returns, never the raw body value. A value
+    # the guard cannot normalize (0, -1, "", "abc") comes back as None, which
+    # enforce_requested_tenant_scope treats as "no tenant requested" and lets
+    # through -- so re-reading data["tenant_id"] afterwards would hand that
+    # unvalidated value to the quota check and the UPDATE.
+    new_tenant_id = None
     if data.get("tenant_id") is not None:
-        _, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+        new_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
         if denial is not None:
             return denial
 
@@ -247,7 +250,6 @@ def api_update_user(user_id):
         ensure_system_user(system_account, uid=uid)
 
     # Handle tenant_id change
-    new_tenant_id = data.get("tenant_id")
     if new_tenant_id is not None:
         from app.services.tenant_service import TenantService
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -755,17 +755,24 @@ def api_quota_stats():
 
     tenant_service = TenantService()
 
-    # Get tenant info (default tenant_id=1 for single-tenant mode)
-    tenant = tenant_service.get_tenant(scope_tenant_id or 1)
+    # This endpoint compares allocation against ONE tenant's limits, so the
+    # limits and the users summed against them must come from the SAME tenant.
+    # Resolve a single concrete id and use it for both.
+    #
+    # Getting this wrong is not hypothetical: scoping only the user query left
+    # a platform admin (scope_tenant_id None, which is how the dashboard calls
+    # it -- getQuotaStats() sends no tenant_id) reading tenant 1's limits while
+    # summing EVERY tenant's users, which reports percentages like 500%.
+    effective_tenant_id = scope_tenant_id or g.user.get("tenant_id") or 1
+
+    # Default tenant_id=1 for single-tenant mode.
+    tenant = tenant_service.get_tenant(effective_tenant_id)
     if not tenant:
         return jsonify({"error": "Tenant not found"}), 404
 
     tenant_quota = tenant.quota
 
-    # Calculate allocated quotas from users in scope. Summing every tenant's
-    # users against one tenant's limit was both a cross-tenant read and an
-    # arithmetically wrong answer.
-    users = user_repo.get_all_users(tenant_id=scope_tenant_id)
+    users = user_repo.get_all_users(tenant_id=effective_tenant_id)
 
     allocated = {
         "daily_token": 0,

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -11,7 +11,12 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, g, jsonify, request
 
-from app.auth.decorators import admin_required, resolve_tenant_scope, same_tenant_user_required
+from app.auth.decorators import (
+    admin_required,
+    enforce_requested_tenant_scope,
+    resolve_tenant_scope,
+    same_tenant_user_required,
+)
 from app.models.user import User
 from app.modules.compliance.audit import AuditAnalyzer
 from app.modules.compliance.report import ReportGenerator, ReportType
@@ -320,10 +325,19 @@ def generate_report():
 @compliance_bp.route("/reports/saved", methods=["GET"])
 @admin_required
 def list_saved_reports():
-    """List saved reports (admin only)."""
+    """List saved reports the caller may see.
+
+    The query's ``tenant_id`` went straight to the repository, so a tenant
+    admin could name another tenant -- or omit it entirely and get every
+    tenant's reports. Reading a single report by id
+    (``GET /reports/<report_id>``) still needs a per-resource owner lookup and
+    is tracked in docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md.
+    """
 
     report_type = request.args.get("report_type")
-    tenant_id = request.args.get("tenant_id", type=int)
+    tenant_id, denial = enforce_requested_tenant_scope(request.args.get("tenant_id"))
+    if denial is not None:
+        return denial
     limit = request.args.get("limit", 50, type=int)
 
     try:

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, g, jsonify, request
 
-from app.auth.decorators import admin_required, resolve_tenant_scope
+from app.auth.decorators import admin_required, resolve_tenant_scope, same_tenant_user_required
 from app.models.user import User
 from app.modules.compliance.audit import AuditAnalyzer
 from app.modules.compliance.report import ReportGenerator, ReportType
@@ -451,8 +451,13 @@ def detect_anomalies():
 
 @compliance_bp.route("/audit/user/<int:user_id>/profile", methods=["GET"])
 @admin_required
+@same_tenant_user_required
 def get_user_profile(user_id: int):
-    """Get user behavior profile (admin only)."""
+    """Get user behavior profile (admin only).
+
+    get_user_behavior_profile applies no tenant filter of its own, so the
+    boundary has to be enforced here.
+    """
 
     days = request.args.get("days", 30, type=int)
 

--- a/app/routes/governance.py
+++ b/app/routes/governance.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import admin_required, auth_required
+from app.auth.decorators import admin_required, auth_required, same_tenant_user_required
 from app.modules.governance.audit_logger import AuditAction, AuditLogger, get_action_categories
 from app.modules.governance.content_filter import ContentFilter
 from app.modules.governance.quota_manager import QuotaManager
@@ -239,8 +239,13 @@ def api_export_audit_logs():
 
 @governance_bp.route("/audit/user/<int:user_id>/activity", methods=["GET"])
 @admin_required
+@same_tenant_user_required
 def api_user_activity(user_id):
-    """Get activity summary for a user."""
+    """Get activity summary for a user.
+
+    The tenant_id passed below already narrows the query, but that only makes
+    a foreign user look inactive. Deny the request outright instead.
+    """
 
     days = request.args.get("days", default=30, type=int)
 

--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -13,6 +13,7 @@ import logging
 from flask import Blueprint, g, jsonify, request
 
 from app.auth.decorators import admin_required
+from app.auth.permissions import is_platform_level_role
 from app.models.user import User
 from app.repositories.tool_account_mapping_rule_repo import ToolAccountMappingRuleRepository
 from app.repositories.user_repo import UserRepository
@@ -27,12 +28,21 @@ user_repo = UserRepository()
 
 def _validate_user_in_tenant(user_id: int, tenant_id: int) -> bool:
     """
-    Validate that a user belongs to the specified tenant.
+    Validate that a tenant admin may operate on ``user_id``.
 
     Issue #2180: Ensures tenant admin can only operate on users in their tenant.
+
+    The role check is not redundant with the tenant check. Comparing tenants
+    alone is horizontal-only, and a platform-level account can perfectly well
+    carry a tenant id -- ``api_create_user`` requires one, and the schema only
+    forces ``tenant_admin`` to have it. Without this, a tenant admin can act on
+    a ``platform_admin`` filed under its own tenant. Mirrors
+    ``app.auth.decorators.enforce_target_user_tenant``.
     """
     user = user_repo.get_user_by_id(user_id)
     if not user:
+        return False
+    if is_platform_level_role(user.get("role")):
         return False
     user_tenant_id = user.get("tenant_id")
     return user_tenant_id == tenant_id

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -1,0 +1,95 @@
+# `@admin_required` 租户边界审计（2026-08-14）
+
+配套 PR 修的是**跨租户账号接管**。这份笔记记录顺带做完的全量审计，给后续 PR 留工作清单。
+
+## 洞是什么
+
+`admin_required` 认证 `admin` / `platform_admin` / `tenant_admin` 三种角色并写入
+`g.tenant_id`，但**从不把这个租户和被操作资源的租户做比对**。在按 user_id 索引的端点上，
+这等于任意租户管理员可以：
+
+- 重置任意租户任意用户（含平台管理员）的密码，并从响应体里直接读到新密码
+  （`app/routes/admin.py` 的 `/admin/users/<id>/reset-password`）
+- 改密码 / 删用户 / 改配额 / 改用户资料
+- `GET /admin/users` 不带 `tenant_id` 时返回**全部租户**的用户表（接管前的侦察步骤）
+- 把自己租户内的用户提权成 `platform_admin`，或把用户搬进/搬出租户
+
+`admin_required` 自身零租户校验这一点，在 #2179 把 `tenant_admin` 加进放行名单之后
+才变成 P0：在那之前只有平台级角色能进这些端点。
+
+## 本次修法
+
+新增三个复用件（`app/auth/decorators.py`）：
+
+| 名字 | 用途 |
+|---|---|
+| `resolve_admin_tenant_scope()` | 已认证 admin 的可操作租户；平台管理员 = 全局，租户管理员 = 自己那个，无租户的一律拒 |
+| `same_tenant_user_required` | 装饰器，叠在 `admin_required` 下面，按路径里的 user_id 查目标用户并比对 |
+| `enforce_requested_tenant_scope()` | list/create 类端点：平台管理员按请求走，租户管理员被收敛到自己租户，点名别人的租户直接 403 |
+
+外加 `app/routes/admin.py` 里的 `reject_privilege_escalation()`，挡住租户管理员发放
+`platform_admin` / `admin` 角色。
+
+选装饰器叠加而不是逐个端点手写 if，是因为后者「忘记调用」就是静默失效——
+`mapping_rules.py` 那两个端点手写了同样的逻辑（#2180），能用但没有复用。
+
+**行为不变的部分**：平台管理员（含 strict mode 关闭时的 legacy `admin`）跨租户能力
+完全保留，只是会写一条 `ADMIN_CROSS_TENANT_ACCESS` 审计日志。
+
+## 全量审计结果
+
+`app/routes/` 下共 **92** 个 `@admin_required` 端点：
+
+| 文件 | 端点数 |
+|---|---|
+| governance.py | 18 |
+| admin.py | 17 |
+| compliance.py | 17 |
+| mapping_rules.py | 12 |
+| sso.py | 9 |
+| policy.py | 5 |
+| remote.py | 5 |
+| analytics.py | 4 |
+| ai_agent_settings.py | 3 |
+| fetch.py | 2 |
+
+路径里带资源 id 的共 24 个，其中 19 个现在是租户感知的：
+
+- **本次修掉的 9 个用户端点**：admin.py 的 5 个（改/删/改密/重置密码/改配额）、
+  compliance.py:452 用户行为画像、governance.py:240 用户活动
+- 已有自建校验的：mapping_rules.py 的 2 个（#2180 手写）、remote.py 的 3 个
+  （`_check_machine_tenant_access`）、sso.py 的 7 个（provider 按租户取）
+
+### 剩余 5 个：有资源 id 且完全没有租户处理
+
+这些**不是**账号接管，所以没有塞进本次 PR，但都是真实的跨租户读写面：
+
+| 位置 | 端点 | 风险 |
+|---|---|---|
+| `app/routes/compliance.py:347` | `GET /reports/<report_id>` | 读到别的租户的合规报告 |
+| `app/routes/governance.py:303` | `POST /quota/alerts/<alert_id>/acknowledge` | 消掉别的租户的配额告警 |
+| `app/routes/governance.py:513` | `PUT /filter-rules/<rule_id>` | 改别的租户的内容过滤规则 |
+| `app/routes/governance.py:552` | `DELETE /filter-rules/<rule_id>` | 删别的租户的内容过滤规则 |
+| `app/routes/policy.py:169` | `PUT /policy/rules/<rule_id>/enabled` | 开关别的租户的策略规则 |
+
+后两类（filter-rules / policy rules）值得优先，因为它们是**关掉别人的管控**，
+不是读数据。修法和本次一样：加一个按资源 id 查出 owner tenant 再比对的守卫；
+这几个资源不是 user，所以需要各自的 repo 查询，不能直接复用
+`same_tenant_user_required`。
+
+### 剩余 68 个不带资源 id 的端点
+
+多数是 list / 统计 / 配置类。它们的租户边界取决于底层 repo 有没有按 `g.tenant_id`
+过滤，这份审计没有逐个核实 repo——那是 #2429 数据层收敛的范围，而且报告已经点明
+根因：**26 个 repository 里 11 个完全没有 tenant_id 概念，隔离靠「记得调对装饰器」，
+不是靠架构**。逐端点补装饰器只能压住症状。
+
+## 该往哪走
+
+`platform_admin_required` / `same_tenant_or_platform_admin` 这两个装饰器早就存在
+（#2179/#2332），迁移完成度约 15%。`admin_required` 自己的 docstring 已经标了
+DEPRECATED，每次调用还打一条 deprecation 日志。真正的收口是把 92 个使用点迁走，
+但 `same_tenant_or_platform_admin` 依赖 `_extract_target_tenant_id()` 从请求里取
+`tenant_id`——按 user_id 索引的端点请求里根本没有 tenant_id，直接换会全部 400
+（fail-closed，安全但功能坏）。所以本次走的是「查资源再比对」的路子，
+迁移那条路要先给 `same_tenant_or_platform_admin` 加一个从资源反查租户的钩子。

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -122,6 +122,25 @@ owner tenant。分两类：
 
 全部无需迁移。
 
+### 不带资源 id 但同样泄露：`/admin/quota/usage`
+
+第一版只收紧了 `GET /admin/users`，漏了 `GET /admin/quota/usage`——它同样
+`user_repo.get_all_users()` 无过滤，返回的还**更多**（`SELECT *` 去掉密码哈希，
+再加用量），其中包含 `role`，正好是「先找出哪个账号是平台管理员」这一步需要的数据。
+本次一并收紧了它和 `/admin/quota/stats`（后者原本还把所有租户的用户配额加总去和
+单个租户的上限比，数字本身就是错的）。
+
+**教训**：按「路径里有没有资源 id」来枚举审计面是不够的，list 类端点从 query 或
+body 取租户，同样是跨租户面。
+
+### 已知但本次未动：非角色的跨租户路径
+
+`app/routes/remote.py:1043` 的 `assign_user` 不校验被指派的 `user_id` 是否属于该机器
+的租户。平台管理员可以把租户 A 的普通用户设为租户 B 机器的管理员；那个账号
+`role='user'`，所以 `is_platform_level_role` 保护不到它，租户 A 的管理员接管它之后就
+继承了伸进租户 B 的机器管理权。先于本 PR 存在，范围外，但它是「除了角色以外还有没有
+别的跨租户途径」这个问题的真实答案，记在这里。
+
 ### 潜伏陷阱：`require_tenant_scope()` 把 tenant_admin 当全局管理员
 
 `app/models/user.py:24` 的 `ADMIN_ROLES` 里**包含 `tenant_admin`**，所以
@@ -137,6 +156,17 @@ owner tenant。分两类：
 平台管理员，而 `is_admin_role` 把租户管理员也算了进去。**下一个照着签名用返回值的调用者
 就会给租户管理员全局作用域。** 要么收窄 `resolve_tenant_scope` 的 admin 判断，要么把
 返回值改成不可忽略的形状。
+
+`app/routes/analysis.py:36` 另有一份同模式的复制品，那一份**确实**把返回值当作用域用，
+所以租户管理员在那里拿到的是全局作用域。先于本 PR 存在，未在本次改动范围内，一并记下。
+
+### 副作用：跨租户读也会写审计
+
+平台管理员的 `tenant_id` 是 NULL，所以任何带租户的目标都算跨租户，
+`same_tenant_user_required` 会为它写一条 `ADMIN_CROSS_TENANT_ACCESS`。
+`GET /audit/user/<id>/profile` 与 `GET /audit/user/<id>/activity` 是仪表盘轮询的
+GET，于是每刷一次就多一行审计。这是刻意保留的——「谁看了别的租户的审计画像」正是
+合规产品该留痕的事——但如果前端轮询频率高，值得改成按会话去重，而不是删掉。
 
 ### 剩余 68 个不带资源 id 的端点
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -77,34 +77,50 @@ legacy `admin` 行就会突然失去保护，等于「开了更严的开关反�
 | model_gateway.py | 1（before_request） |
 | smtp_config.py | 1（before_request） |
 
-路径里带资源 id 的共 24 个，其中 19 个现在是租户感知的：
+路径里带资源 id 的共 **29** 个，其中 23 个现在是租户感知的：
 
 - **本次加装饰器的 7 个**：admin.py 的 5 个（改/删/改密/重置密码/改配额）、
   compliance.py:452 用户行为画像、governance.py:240 用户活动
 - **本次没动、原本就有自建校验的 2 个用户端点**：mapping_rules.py:84 与 :237
   （#2180 手写的 `_validate_user_in_tenant`，读过，是有效的）
 - 其余非用户资源已有校验的：remote.py 的 3 个（`_check_machine_tenant_access`）、
-  sso.py 的 7 个（provider 按租户取）
+  sso.py 的 7 个（provider 按租户取）、mapping_rules.py 另外 4 个
+  （`update_rule` / `delete_rule` / `suggest_mapping` / `manual_map_account`，
+  同样是 #2180 手写的）
 
 也就是说「9 个用户端点现在都受控」是对的，但其中只有 **7 个**是本次加的装饰器，
 另外 2 个是沿用既有的手写校验（重复实现，将来值得合并到同一个装饰器）。
 
-### 剩余 5 个：有资源 id 且完全没有租户处理
+### 剩余 6 个：有资源 id 且完全没有租户处理
 
-这些**不是**账号接管，所以没有塞进本次 PR，但都是真实的跨租户读写面：
+带路径参数的 `@admin_required` 路由共 **29** 个（第一版这里写 24 是错的：用正则枚举
+时只匹配了固定的几个 id 名，漏掉了 `<int:id>` / `<sender_name>` / `<rule_key>` 这些
+写法。AST 枚举才是准的）。29 个里 23 个已有校验，剩下这 6 个完全没有：
 
 | 位置 | 端点 | 风险 |
 |---|---|---|
-| `app/routes/compliance.py:347` | `GET /reports/<report_id>` | 读到别的租户的合规报告 |
-| `app/routes/governance.py:303` | `POST /quota/alerts/<alert_id>/acknowledge` | 消掉别的租户的配额告警 |
-| `app/routes/governance.py:513` | `PUT /filter-rules/<rule_id>` | 改别的租户的内容过滤规则 |
-| `app/routes/governance.py:552` | `DELETE /filter-rules/<rule_id>` | 删别的租户的内容过滤规则 |
-| `app/routes/policy.py:169` | `PUT /policy/rules/<rule_id>/enabled` | 开关别的租户的策略规则 |
+| `app/routes/policy.py:149` | `PUT /policy/rules/<rule_key>` | **改掉别的租户的策略规则**（整版本 supersede） |
+| `app/routes/policy.py:171` | `PATCH /policy/rules/<rule_id>/enabled` | 开关别的租户的策略规则 |
+| `app/routes/governance.py:515` | `PUT /filter-rules/<rule_id>` | 改别的租户的内容过滤规则 |
+| `app/routes/governance.py:554` | `DELETE /filter-rules/<rule_id>` | 删别的租户的内容过滤规则 |
+| `app/routes/governance.py:305` | `POST /quota/alerts/<alert_id>/acknowledge` | 消掉别的租户的配额告警 |
+| `app/routes/compliance.py:349` | `GET /reports/<report_id>` | 读到别的租户的合规报告 |
 
-后两类（filter-rules / policy rules）值得优先，因为它们是**关掉别人的管控**，
-不是读数据。修法和本次一样：加一个按资源 id 查出 owner tenant 再比对的守卫；
-这几个资源不是 user，所以需要各自的 repo 查询，不能直接复用
-`same_tenant_user_required`。
+**`policy.py:149` 是这批里最严重的**，也是第一版漏掉的：它不是开关，而是
+`PolicyRepository().create_rule(**fields)` 整条规则版本替换——外人可以把别的租户
+当前生效的策略直接顶掉。它比同文件里那个已经列出的 toggle 危险得多。
+
+修法不能直接复用 `same_tenant_user_required`（资源不是 user），要各自按 repo 反查
+owner tenant。分两类：
+
+- **`policy_rules` 与 `compliance_reports` 有 `tenant_id` 列** → 直接比对
+- **`quota_alerts` 没有 tenant 列，但有 `user_id NOT NULL`** → 经 user 反查租户
+- **`content_filter_rules` 一列 tenant 都没有**，repo 层 `get_filter_rule(rule_id)`
+  也不收租户参数——这张表在设计上就是全局的。所以那两个端点不该「补租户比对」，
+  应当收成 `platform_admin_required`：租户管理员改一条全局过滤规则，影响的是所有
+  租户，本来就不该是租户级权限。
+
+全部无需迁移。
 
 ### 潜伏陷阱：`require_tenant_scope()` 把 tenant_admin 当全局管理员
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -30,6 +30,23 @@
 外加 `app/routes/admin.py` 里的 `reject_privilege_escalation()`，挡住租户管理员发放
 `platform_admin` / `admin` 角色。
 
+### 只查租户是不够的：还要查角色
+
+第一版只做了**横向**比对（租户 == 租户），独立评审把它打穿了：
+
+1. `api_create_user` 强制要求 `tenant_id`（缺了直接 400），所以**凡是从 admin API
+   建出来的 platform_admin 都必然挂在某个租户下**；
+2. schema 只约束 `tenant_admin` 必须有租户
+   （`chk_2332_tenant_admin_requires_tenant`），没有任何约束禁止 platform_admin
+   带租户；
+3. 于是把一个 platform_admin 归到租户 A，租户 A 的管理员就能重置它的密码并从响应里
+   读出来——**没有发放任何角色，所以 `reject_privilege_escalation` 完全不触发**。
+
+修法是补一条**纵向**判断：租户级管理员不得操作平台级账号，无论租户是否相同。
+判断走 `app/auth/permissions.py::is_platform_level_role`，它**刻意不受 strict mode
+影响**——如果用受 flag 影响的 `is_platform_admin_role`，一旦打开 strict mode，
+legacy `admin` 行就会突然失去保护，等于「开了更严的开关反而更不安全」。
+
 选装饰器叠加而不是逐个端点手写 if，是因为后者「忘记调用」就是静默失效——
 `mapping_rules.py` 那两个端点手写了同样的逻辑（#2180），能用但没有复用。
 
@@ -38,9 +55,13 @@
 
 ## 全量审计结果
 
-`app/routes/` 下共 **92** 个 `@admin_required` 端点：
+用 AST 枚举（不是正则，正则会漏），`app/routes/` 下共 **95** 个函数挂了
+`@admin_required`：其中 **92** 个是路由处理函数，另外 **3** 个是蓝图级
+`before_request` 守卫（`feishu_config.py:27`、`model_gateway.py:27`、
+`smtp_config.py:29` 的 `check_admin`）——对这三个，「按函数数」低估了覆盖面，
+一个钩子守的是整个蓝图的所有路由。
 
-| 文件 | 端点数 |
+| 文件 | 挂 `@admin_required` 的函数 |
 |---|---|
 | governance.py | 18 |
 | admin.py | 17 |
@@ -52,13 +73,21 @@
 | analytics.py | 4 |
 | ai_agent_settings.py | 3 |
 | fetch.py | 2 |
+| feishu_config.py | 1（before_request） |
+| model_gateway.py | 1（before_request） |
+| smtp_config.py | 1（before_request） |
 
 路径里带资源 id 的共 24 个，其中 19 个现在是租户感知的：
 
-- **本次修掉的 9 个用户端点**：admin.py 的 5 个（改/删/改密/重置密码/改配额）、
+- **本次加装饰器的 7 个**：admin.py 的 5 个（改/删/改密/重置密码/改配额）、
   compliance.py:452 用户行为画像、governance.py:240 用户活动
-- 已有自建校验的：mapping_rules.py 的 2 个（#2180 手写）、remote.py 的 3 个
-  （`_check_machine_tenant_access`）、sso.py 的 7 个（provider 按租户取）
+- **本次没动、原本就有自建校验的 2 个用户端点**：mapping_rules.py:84 与 :237
+  （#2180 手写的 `_validate_user_in_tenant`，读过，是有效的）
+- 其余非用户资源已有校验的：remote.py 的 3 个（`_check_machine_tenant_access`）、
+  sso.py 的 7 个（provider 按租户取）
+
+也就是说「9 个用户端点现在都受控」是对的，但其中只有 **7 个**是本次加的装饰器，
+另外 2 个是沿用既有的手写校验（重复实现，将来值得合并到同一个装饰器）。
 
 ### 剩余 5 个：有资源 id 且完全没有租户处理
 
@@ -76,6 +105,22 @@
 不是读数据。修法和本次一样：加一个按资源 id 查出 owner tenant 再比对的守卫；
 这几个资源不是 user，所以需要各自的 repo 查询，不能直接复用
 `same_tenant_user_required`。
+
+### 潜伏陷阱：`require_tenant_scope()` 把 tenant_admin 当全局管理员
+
+`app/models/user.py:24` 的 `ADMIN_ROLES` 里**包含 `tenant_admin`**，所以
+`resolve_tenant_scope()`（decorators.py:851）对租户管理员返回 `is_admin=True`，
+`require_tenant_scope()` 随之返回 `tenant_id=None`（全局作用域）。
+
+**目前不构成泄露**：三个调用点（`roi.py:129`、`usage.py:35`、`projects.py:98`）
+全都写成 `_, error = require_tenant_scope()`，**丢掉了返回的 tenant_id**，只把它当
+「无租户的普通用户一律拒」的闸门用；真正的查询作用域另外从 `g.user.tenant_id` /
+`get_current_tenant_id()` 取，那里租户管理员拿到的是自己的租户。
+
+但这是个上了膛的枪：三处的 docstring 都写着「Admins keep global scope」，作者指的是
+平台管理员，而 `is_admin_role` 把租户管理员也算了进去。**下一个照着签名用返回值的调用者
+就会给租户管理员全局作用域。** 要么收窄 `resolve_tenant_scope` 的 admin 判断，要么把
+返回值改成不可忽略的形状。
 
 ### 剩余 68 个不带资源 id 的端点
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -104,7 +104,7 @@ legacy `admin` 行就会突然失去保护，等于「开了更严的开关反�
 | `app/routes/governance.py:515` | `PUT /filter-rules/<rule_id>` | 改别的租户的内容过滤规则 |
 | `app/routes/governance.py:554` | `DELETE /filter-rules/<rule_id>` | 删别的租户的内容过滤规则 |
 | `app/routes/governance.py:305` | `POST /quota/alerts/<alert_id>/acknowledge` | 消掉别的租户的配额告警 |
-| `app/routes/compliance.py:349` | `GET /reports/<report_id>` | 读到别的租户的合规报告 |
+| `app/routes/compliance.py:349` | `GET /reports/<report_id>` | 读到别的租户的合规报告（列表侧 `GET /reports/saved` 本次已收紧，单条读还要按 id 反查 owner，留给 follow-up） |
 
 **`policy.py:149` 是这批里最严重的**，也是第一版漏掉的：它不是开关，而是
 `PolicyRepository().create_rule(**fields)` 整条规则版本替换——外人可以把别的租户
@@ -122,16 +122,28 @@ owner tenant。分两类：
 
 全部无需迁移。
 
-### 不带资源 id 但同样泄露：`/admin/quota/usage`
+### 不带资源 id 但同样泄露：从请求里取租户的端点
 
-第一版只收紧了 `GET /admin/users`，漏了 `GET /admin/quota/usage`——它同样
-`user_repo.get_all_users()` 无过滤，返回的还**更多**（`SELECT *` 去掉密码哈希，
-再加用量），其中包含 `role`，正好是「先找出哪个账号是平台管理员」这一步需要的数据。
-本次一并收紧了它和 `/admin/quota/stats`（后者原本还把所有租户的用户配额加总去和
-单个租户的上限比，数字本身就是错的）。
+第一版只收紧了 `GET /admin/users`，漏了同类的一批。**教训**：按「路径里有没有资源
+id」来枚举审计面是错的方法——list / 聚合 / 触发类端点从 query 或 body 取租户，
+同样是跨租户面，而且往往泄露得更多。
 
-**教训**：按「路径里有没有资源 id」来枚举审计面是不够的，list 类端点从 query 或
-body 取租户，同样是跨租户面。
+改用「**谁从请求里读 tenant_id 却没过 `enforce_requested_tenant_scope`**」重新扫
+（AST 枚举全部 route handler + 正则匹配 `data.get("tenant_id")` /
+`request.args.get("tenant_id")`），本次一并收紧的：
+
+| 端点 | 原问题 |
+|---|---|
+| `GET /admin/quota/usage` | `get_all_users()` 无过滤；返回的比 `/admin/users` **还多**（`SELECT *` 去密码哈希 + 用量），含 `role`——正好是「先找出谁是平台管理员」这一步要的数据 |
+| `GET /admin/quota/stats` | 同上；且把所有租户的配额加总去和单租户上限比，数字本身就是错的 |
+| `POST /admin/quota/health-check` | body 的 `tenant_id` 直接采信，可读任意租户的配额余量 |
+| `POST /admin/feishu/sync`、`POST /admin/dingtalk/sync` | body 的 `tenant_id` 直接采信——**这是跨租户写**：同步会在目标租户里建/改用户和团队 |
+| `GET /reports/saved` | query 的 `tenant_id` 直接透传给仓储；不传则返回所有租户的合规报告 |
+
+扫描命中但**核实后是安全的**（各自有自建校验，未改动）：
+`compliance.py:138 generate_report`（`resolve_tenant_scope` + 平台管理员显式门）、
+`sso.py:511/1205`（`validate_tenant_access`）、
+`remote.py:867/956`（#2180 的 fail-closed 处理）。
 
 ### 已知但本次未动：非角色的跨租户路径
 

--- a/migrations/versions/20260731_003_add_teams_sync_source_indexes.py
+++ b/migrations/versions/20260731_003_add_teams_sync_source_indexes.py
@@ -3,9 +3,15 @@
 Issue #2174 F1/F5: Optimize organization sync full table scan.
 
 Revision ID: 20260731_003_add_teams_sync_source_indexes
-Revises: 20260731_002_add_ci_repair_transient_retries
+Revises: 20260731_003_add_proxy_token_terminated_fields
 Create Date: 2026-07-31
 
+Re-parented 2026-08-14: this migration originally followed
+20260731_002_add_ci_repair_transient_retries directly. The no-op bridge
+20260731_003_add_proxy_token_terminated_fields was inserted ahead of it to
+restore a revision id that was renamed after release -- see that file for the
+full explanation. Only the path *into* this revision changed; databases already
+stamped here are unaffected.
 """
 
 from __future__ import annotations
@@ -20,7 +26,7 @@ if TYPE_CHECKING:
 
 # revision identifiers, used by Alembic.
 revision: str = "20260731_003_add_teams_sync_source_indexes"
-down_revision: str | None = "20260731_002_add_ci_repair_transient_retries"
+down_revision: str | None = "20260731_003_add_proxy_token_terminated_fields"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/20260731_003_bridge_renamed_proxy_token_revision.py
+++ b/migrations/versions/20260731_003_bridge_renamed_proxy_token_revision.py
@@ -1,0 +1,62 @@
+"""Re-home the orphaned revision id 20260731_003_add_proxy_token_terminated_fields.
+
+Revision ID: 20260731_003_add_proxy_token_terminated_fields
+Revises: 20260731_002_add_ci_repair_transient_retries
+Create Date: 2026-08-14
+
+This migration applies no DDL. It exists so that an already-released revision
+id keeps resolving.
+
+What happened
+-------------
+``20260731_003_add_proxy_token_terminated_fields.py`` shipped on main (commit
+05bcca72) declaring ``revision = "20260731_003_add_proxy_token_terminated_fields"``
+with ``down_revision = "20260731_002_add_ci_repair_transient_retries"``. It was
+later renumbered to ``20260731_004_add_proxy_token_terminated_fields`` so that
+``20260731_003_add_teams_sync_source_indexes`` could take the 003 slot.
+
+Alembic keys history off the revision **id**, not the filename, so the rename
+deleted a node that databases were already stamped with. Every deployment that
+ran ``upgrade head`` inside that window now has
+``alembic_version.version_num = '20260731_003_add_proxy_token_terminated_fields'``
+and fails with ``Can't locate revision identified by
+'20260731_003_add_proxy_token_terminated_fields'`` -- not just for this
+migration, but for every migration after it. The database is wedged.
+
+Why this shape
+--------------
+Restoring the id as an empty node parented to 002 puts those databases back on
+the graph without re-running the DDL they already applied::
+
+    002 -> 003(this, no-op) -> 003_teams_sync_source_indexes -> 004_proxy_token...
+
+* A stuck database resolves its stamp here, then applies the teams index
+  migration (which it never saw) and finally 004. 004 already guards every
+  ``add_column`` with an inspector check, so the proxy-token columns it applied
+  under the old id are not added twice.
+* A fresh database passes through this no-op and reaches exactly the same
+  schema.
+
+Renaming ``20260731_004_...`` back is NOT an option: that id has shipped too,
+and renaming it would strand a second set of databases the same way.
+
+The lint added alongside this file (``scripts/lint/check_migration_rules.py``,
+rule MIG003) rejects any future edit that removes or rewrites a revision id
+that is already reachable from origin/main.
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision: str = "20260731_003_add_proxy_token_terminated_fields"
+down_revision: str | None = "20260731_002_add_ci_repair_transient_retries"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """No-op: the DDL for this id lives in 20260731_004_add_proxy_token_terminated_fields."""
+
+
+def downgrade() -> None:
+    """No-op: nothing was applied here."""

--- a/scripts/lint/check_migration_rules.py
+++ b/scripts/lint/check_migration_rules.py
@@ -375,6 +375,30 @@ def _git(args: list[str]) -> str | None:
     return result.stdout
 
 
+def _baseline_commit(ref: str) -> str | None:
+    """Resolve the commit whose revision ids this tree must still contain.
+
+    That is ``merge-base(ref, HEAD)`` -- the point this branch forked from --
+    NOT the tip of ``ref``. Using the tip makes every branch that simply lags
+    behind main fail: a migration merged to main after the fork is "missing"
+    from the branch, and the obvious way to silence that is to add its id to
+    RETIRED_REVISION_IDS, which is precisely the mistake this rule exists to
+    prevent.
+
+    The merge-base is still complete, not a weakening. A branch's diff is
+    computed from its fork point, so it cannot express the deletion of a file
+    that did not exist there; every id a branch is capable of removing is an
+    id present at the merge-base.
+
+    Falls back to ``ref`` when there is no common ancestor (unrelated
+    histories, or a synthetic tree with no HEAD).
+    """
+    merge_base = _git(["merge-base", ref, "HEAD"])
+    if merge_base and merge_base.strip():
+        return merge_base.strip()
+    return ref if _git(["rev-parse", "--verify", f"{ref}^{{commit}}"]) else None
+
+
 def _revision_ids_at_ref(ref: str) -> dict[str, str] | None:
     """Map revision id -> path for every migration on ``ref``.
 
@@ -401,8 +425,21 @@ def _revision_ids_at_ref(ref: str) -> dict[str, str] | None:
 def check_released_revision_ids(
     versions_dir: Path, baseline_ref: str = DEFAULT_BASELINE_REF
 ) -> list[Violation]:
-    """MIG003: every revision id on ``baseline_ref`` must still exist locally."""
-    baseline = _revision_ids_at_ref(baseline_ref)
+    """MIG003: every revision id this branch forked from must still exist.
+
+    The comparison point is ``merge-base(baseline_ref, HEAD)`` rather than the
+    tip of ``baseline_ref`` -- see :func:`_baseline_commit` for why the tip
+    produces false positives on any branch that lags behind.
+    """
+    commit = _baseline_commit(baseline_ref)
+    if commit is None:
+        print(
+            f"MIG003: skipped (cannot resolve a baseline commit for '{baseline_ref}').",
+            file=sys.stderr,
+        )
+        return []
+
+    baseline = _revision_ids_at_ref(commit)
     if baseline is None:
         print(
             f"MIG003: skipped (cannot read migrations from '{baseline_ref}').",

--- a/scripts/lint/check_migration_rules.py
+++ b/scripts/lint/check_migration_rules.py
@@ -334,6 +334,12 @@ DEFAULT_BASELINE_REF = os.environ.get("MIG003_BASELINE_REF", "origin/main")
 # ``upgrade()`` — that costs nothing and cannot be wrong.
 RETIRED_REVISION_IDS: frozenset[str] = frozenset()
 
+# Whether the last check_released_revision_ids() call actually compared
+# anything. "No violations" and "did not look" are very different outcomes, and
+# the required `lint` lane checks out shallow with no origin/main -- so without
+# this the summary line would report a skip as a clean pass.
+_released_check_ran = False
+
 
 def _revision_id_from_source(source: str, filename: str = "<baseline>") -> str | None:
     """Extract the module-level ``revision`` id, or None if absent/dynamic.
@@ -362,41 +368,63 @@ def _revision_id_from_source(source: str, filename: str = "<baseline>") -> str |
 
 
 def _git(args: list[str]) -> str | None:
-    """Run a git command from the project root; None if git/ref is unavailable."""
+    """Run a git command from the project root; None if git/ref is unavailable.
+
+    Every failure mode collapses to None so MIG003 degrades to "skip" rather
+    than crashing a commit. That includes decode errors -- migration files
+    contain non-ASCII, and ``text=True`` decodes with the locale encoding, so a
+    C-locale environment could otherwise raise UnicodeDecodeError out of a lint
+    hook -- and a hung git, which without a timeout would block pre-commit
+    indefinitely.
+    """
     try:
         result = subprocess.run(  # nosec: B603 - fixed argv, no shell
             ["git", "-C", str(PROJECT_ROOT), *args],
             capture_output=True,
             text=True,
+            errors="replace",
             check=True,
+            timeout=30,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        UnicodeDecodeError,
+        FileNotFoundError,
+        OSError,
+    ):
         return None
     return result.stdout
 
 
-def _baseline_commit(ref: str) -> str | None:
-    """Resolve the commit whose revision ids this tree must still contain.
+def _baseline_commits(ref: str) -> list[str]:
+    """Resolve the commits whose revision ids this tree must still contain.
 
-    That is ``merge-base(ref, HEAD)`` -- the point this branch forked from --
-    NOT the tip of ``ref``. Using the tip makes every branch that simply lags
-    behind main fail: a migration merged to main after the fork is "missing"
-    from the branch, and the obvious way to silence that is to add its id to
-    RETIRED_REVISION_IDS, which is precisely the mistake this rule exists to
-    prevent.
+    Those are the merge bases of ``ref`` and ``HEAD`` -- the points this branch
+    forked from -- NOT the tip of ``ref``. Using the tip makes every branch
+    that simply lags behind main fail: a migration merged to main after the
+    fork is "missing" from the branch, and the obvious way to silence that is
+    to add its id to RETIRED_REVISION_IDS, which is precisely the mistake this
+    rule exists to prevent.
 
-    The merge-base is still complete, not a weakening. A branch's diff is
-    computed from its fork point, so it cannot express the deletion of a file
-    that did not exist there; every id a branch is capable of removing is an
-    id present at the merge-base.
+    ALL merge bases, via ``--all``. A criss-cross history has more than one,
+    and plain ``git merge-base`` picks an arbitrary single base: if the id was
+    added on the branch that the chosen base does not descend from, deleting it
+    goes unnoticed. Concretely -- main gains X at B, a side branch forks at C,
+    main merges the side branch, then a feature branch forks from C, merges B
+    (so it has X), and deletes X. The bases are {B, C}; plain merge-base
+    returns C, which never had X, so the deletion passes. Unioning the ids
+    across every base closes that.
 
-    Falls back to ``ref`` when there is no common ancestor (unrelated
-    histories, or a synthetic tree with no HEAD).
+    Falls back to ``ref`` itself when there is no common ancestor (unrelated
+    histories, or a synthetic tree with no HEAD) -- the conservative direction.
+
+    Returns an empty list when nothing can be resolved.
     """
-    merge_base = _git(["merge-base", ref, "HEAD"])
-    if merge_base and merge_base.strip():
-        return merge_base.strip()
-    return ref if _git(["rev-parse", "--verify", f"{ref}^{{commit}}"]) else None
+    all_bases = _git(["merge-base", "--all", ref, "HEAD"])
+    if all_bases and all_bases.strip():
+        return [line.strip() for line in all_bases.splitlines() if line.strip()]
+    return [ref] if _git(["rev-parse", "--verify", f"{ref}^{{commit}}"]) else []
 
 
 def _revision_ids_at_ref(ref: str) -> dict[str, str] | None:
@@ -427,31 +455,48 @@ def check_released_revision_ids(
 ) -> list[Violation]:
     """MIG003: every revision id this branch forked from must still exist.
 
-    The comparison point is ``merge-base(baseline_ref, HEAD)`` rather than the
-    tip of ``baseline_ref`` -- see :func:`_baseline_commit` for why the tip
-    produces false positives on any branch that lags behind.
+    The comparison points are the merge bases of ``baseline_ref`` and ``HEAD``
+    rather than the tip of ``baseline_ref`` -- see :func:`_baseline_commits`
+    for why the tip produces false positives on any branch that lags behind,
+    and why all bases are unioned rather than just one.
     """
-    commit = _baseline_commit(baseline_ref)
-    if commit is None:
+    global _released_check_ran
+    _released_check_ran = False
+
+    commits = _baseline_commits(baseline_ref)
+    if not commits:
         print(
-            f"MIG003: skipped (cannot resolve a baseline commit for '{baseline_ref}').",
+            f"MIG003: SKIPPED (cannot resolve a baseline commit for '{baseline_ref}') "
+            "-- released revision ids were NOT checked.",
             file=sys.stderr,
         )
         return []
 
-    baseline = _revision_ids_at_ref(commit)
-    if baseline is None:
+    baseline: dict[str, str] = {}
+    unreadable = 0
+    for commit in commits:
+        ids = _revision_ids_at_ref(commit)
+        if ids is None:
+            unreadable += 1
+            continue
+        baseline.update(ids)
+
+    if unreadable == len(commits):
         print(
-            f"MIG003: skipped (cannot read migrations from '{baseline_ref}').",
+            f"MIG003: SKIPPED (cannot read migrations from '{baseline_ref}') "
+            "-- released revision ids were NOT checked.",
             file=sys.stderr,
         )
         return []
     if not baseline:
         print(
-            f"MIG003: skipped ('{baseline_ref}' has no migrations to compare).",
+            f"MIG003: SKIPPED ('{baseline_ref}' has no migrations to compare) "
+            "-- released revision ids were NOT checked.",
             file=sys.stderr,
         )
         return []
+
+    _released_check_ran = True
 
     current: set[str] = set()
     for f in sorted(versions_dir.glob("*.py")):
@@ -564,8 +609,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    rules = "MIG001/MIG002" if skip_released else "MIG001/MIG002/MIG003"
-    print(f"OK: {len(migration_files)} migration file(s) pass {rules}.", file=sys.stderr)
+    # Say plainly which rules actually ran. MIG003 skips itself when the git
+    # baseline is unreadable, and claiming it "passed" there is how a check
+    # quietly stops being a check.
+    if skip_released:
+        checked = "MIG001/MIG002 (MIG003 skipped by request)"
+    elif _released_check_ran:
+        checked = "MIG001/MIG002/MIG003"
+    else:
+        checked = "MIG001/MIG002 (MIG003 NOT checked -- no usable git baseline)"
+    print(f"OK: {len(migration_files)} migration file(s) pass {checked}.", file=sys.stderr)
     return 0
 
 

--- a/scripts/lint/check_migration_rules.py
+++ b/scripts/lint/check_migration_rules.py
@@ -42,7 +42,27 @@ The correct template (see docs/en/DATABASE-CONVENTIONS.md) is::
     else:
         op.create_index(NAME, TABLE, COLS)
 
+  MIG003 — A revision id that has shipped must never disappear. Alembic keys
+    history off the ``revision`` string, not the filename: every deployed
+    database stores it verbatim in ``alembic_version.version_num``. Delete or
+    rewrite an id that is already reachable from the base branch and every
+    database stamped with it dies on the next ``upgrade head`` with
+    ``Can't locate revision identified by '<id>'`` — and stays stuck for every
+    later migration too.
+
+    This is not hypothetical: ``20260731_003_add_proxy_token_terminated_fields``
+    was renumbered to ``20260731_004_...`` so a newer migration could take the
+    003 slot, wedging every database upgraded in that window. The recovery is
+    ``migrations/versions/20260731_003_bridge_renamed_proxy_token_revision.py``.
+
+    Renaming the *file* is fine; only the id matters. If an id genuinely has to
+    stop carrying DDL, keep the node and empty its ``upgrade()`` instead of
+    deleting it.
+
 The check is AST-based (stdlib only — no new dependency) and opens no database.
+MIG003 additionally shells out to ``git`` to read the baseline tree; if git or
+the ref is unavailable it is skipped with a note rather than failing, so the
+check never blocks on a shallow clone or an unfetched remote.
 
 Usage:
     # Check the canonical migrations/versions/ tree
@@ -52,13 +72,19 @@ Usage:
     # the migration-graph CI job)
     python3 scripts/lint/check_migration_rules.py /path/to/migrations/versions
 
+    # Compare released ids against a different baseline (default: origin/main)
+    python3 scripts/lint/check_migration_rules.py --baseline-ref origin/develop
+    python3 scripts/lint/check_migration_rules.py --skip-released-check
+
 Exit code: 1 if any violation is found, 0 otherwise.
 """
 
 from __future__ import annotations
 
 import ast
+import os
 import re
+import subprocess  # nosec: B404 - fixed git argv, no shell
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -294,6 +320,133 @@ def _build_parent_map(tree: ast.Module) -> dict[int, list[ast.AST]]:
     return parents
 
 
+# ---------------------------------------------------------------------------
+# MIG003 — released revision ids must not disappear
+# ---------------------------------------------------------------------------
+
+# Baseline the working tree's revision ids are compared against. A stale
+# baseline only ever knows about *fewer* ids, so it can miss a violation but
+# never invent one.
+DEFAULT_BASELINE_REF = os.environ.get("MIG003_BASELINE_REF", "origin/main")
+
+# Deliberately retired revision ids. Adding one here asserts that no live
+# database is stamped with it. Prefer keeping the node with an empty
+# ``upgrade()`` — that costs nothing and cannot be wrong.
+RETIRED_REVISION_IDS: frozenset[str] = frozenset()
+
+
+def _revision_id_from_source(source: str, filename: str = "<baseline>") -> str | None:
+    """Extract the module-level ``revision`` id, or None if absent/dynamic.
+
+    Handles both ``revision: str = "..."`` and ``revision = "..."``.
+    """
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return None
+
+    for node in tree.body:
+        target = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target = node.target.id
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            first = node.targets[0]
+            if isinstance(first, ast.Name):
+                target = first.id
+        if target != "revision":
+            continue
+        value = node.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+    return None
+
+
+def _git(args: list[str]) -> str | None:
+    """Run a git command from the project root; None if git/ref is unavailable."""
+    try:
+        result = subprocess.run(  # nosec: B603 - fixed argv, no shell
+            ["git", "-C", str(PROJECT_ROOT), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return result.stdout
+
+
+def _revision_ids_at_ref(ref: str) -> dict[str, str] | None:
+    """Map revision id -> path for every migration on ``ref``.
+
+    Returns None when the baseline cannot be read (no git, unknown ref,
+    shallow clone), which callers treat as "skip", not "pass".
+    """
+    listing = _git(["ls-tree", "-r", "--name-only", ref, "--", "migrations/versions"])
+    if listing is None:
+        return None
+
+    ids: dict[str, str] = {}
+    for path in listing.splitlines():
+        if not path.endswith(".py") or Path(path).name.startswith("__"):
+            continue
+        blob = _git(["show", f"{ref}:{path}"])
+        if blob is None:
+            continue
+        rev = _revision_id_from_source(blob, path)
+        if rev:
+            ids[rev] = path
+    return ids
+
+
+def check_released_revision_ids(
+    versions_dir: Path, baseline_ref: str = DEFAULT_BASELINE_REF
+) -> list[Violation]:
+    """MIG003: every revision id on ``baseline_ref`` must still exist locally."""
+    baseline = _revision_ids_at_ref(baseline_ref)
+    if baseline is None:
+        print(
+            f"MIG003: skipped (cannot read migrations from '{baseline_ref}').",
+            file=sys.stderr,
+        )
+        return []
+    if not baseline:
+        print(
+            f"MIG003: skipped ('{baseline_ref}' has no migrations to compare).",
+            file=sys.stderr,
+        )
+        return []
+
+    current: set[str] = set()
+    for f in sorted(versions_dir.glob("*.py")):
+        if f.name.startswith("__"):
+            continue
+        try:
+            rev = _revision_id_from_source(f.read_text(encoding="utf-8"), str(f))
+        except OSError:
+            continue
+        if rev:
+            current.add(rev)
+
+    violations: list[Violation] = []
+    for rev, path in sorted(baseline.items()):
+        if rev in current or rev in RETIRED_REVISION_IDS:
+            continue
+        violations.append(
+            Violation(
+                "MIG003",
+                versions_dir,
+                0,
+                f"revision id {rev!r} exists on {baseline_ref} ({path}) but not in this "
+                f"tree. Every database stamped with it will fail 'upgrade head' with "
+                f"\"Can't locate revision identified by '{rev}'\". Restore the id — "
+                f"renaming the file is fine, changing the id is not. If the DDL moved "
+                f"elsewhere, keep the id as a no-op bridge (see "
+                f"migrations/versions/20260731_003_bridge_renamed_proxy_token_revision.py).",
+            )
+        )
+    return violations
+
+
 def check_file(filepath: Path) -> list[Violation]:
     """Run all migration authoring rules on a single file."""
     try:
@@ -319,10 +472,25 @@ def check_file(filepath: Path) -> list[Violation]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = argv if argv is not None else sys.argv[1:]
+    args = list(argv if argv is not None else sys.argv[1:])
 
-    if args:
-        versions_dir = Path(args[0]).resolve()
+    skip_released = False
+    if "--skip-released-check" in args:
+        args.remove("--skip-released-check")
+        skip_released = True
+
+    baseline_ref = DEFAULT_BASELINE_REF
+    if "--baseline-ref" in args:
+        i = args.index("--baseline-ref")
+        if i + 1 >= len(args):
+            print("FAIL: --baseline-ref requires a value", file=sys.stderr)
+            return 2
+        baseline_ref = args[i + 1]
+        del args[i : i + 2]
+
+    positional = [a for a in args if not a.startswith("-")]
+    if positional:
+        versions_dir = Path(positional[0]).resolve()
     else:
         versions_dir = DEFAULT_VERSIONS_DIR
 
@@ -342,6 +510,9 @@ def main(argv: list[str] | None = None) -> int:
     for f in migration_files:
         all_violations.extend(check_file(f))
 
+    if not skip_released:
+        all_violations.extend(check_released_revision_ids(versions_dir, baseline_ref))
+
     for v in all_violations:
         print(v.format(), file=sys.stderr)
 
@@ -356,7 +527,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    print(f"OK: {len(migration_files)} migration file(s) pass MIG001/MIG002.", file=sys.stderr)
+    rules = "MIG001/MIG002" if skip_released else "MIG001/MIG002/MIG003"
+    print(f"OK: {len(migration_files)} migration file(s) pass {rules}.", file=sys.stderr)
     return 0
 
 

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -670,6 +670,41 @@ class TestGuardsOutsideAdminBlueprint:
 
         assert response.status_code == 200, response.get_data(as_text=True)
 
+    @staticmethod
+    def _reports():
+        from app.routes.compliance import compliance_bp
+
+        generator = MagicMock()
+        generator.get_saved_reports.return_value = []
+        return compliance_bp, [("app.routes.compliance.report_generator", generator)], generator
+
+    def test_saved_reports_list_rejects_another_tenant(self):
+        bp, patches, _ = self._reports()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/reports/saved?tenant_id=2", patches=patches
+        )
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_saved_reports_list_is_narrowed_for_a_tenant_admin(self):
+        """No tenant_id used to mean every tenant's reports."""
+        bp, patches, generator = self._reports()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/reports/saved", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert generator.get_saved_reports.call_args.kwargs["tenant_id"] == TENANT_A
+
+    def test_saved_reports_list_stays_global_for_platform_admin(self):
+        bp, patches, generator = self._reports()
+        response = _request_other_blueprint(
+            PLATFORM_ADMIN, bp, "/api/reports/saved", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert generator.get_saved_reports.call_args.kwargs["tenant_id"] is None
+
 
 class TestQuotaEndpointsDoNotLeakUserLists:
     """GET /admin/quota/usage returns the user list too.
@@ -710,3 +745,64 @@ class TestQuotaEndpointsDoNotLeakUserLists:
         )
 
         assert response.status_code == 403
+
+    def test_quota_health_check_rejects_another_tenant(self):
+        """The body's tenant_id was taken on trust here."""
+        response, _ = _request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/admin/quota/health-check",
+            json_body={"tenant_id": TENANT_B},
+        )
+
+        assert response.status_code == 403
+
+    def test_quota_health_check_allows_own_tenant(self):
+        response, _ = _request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/admin/quota/health-check",
+            json_body={"tenant_id": TENANT_A},
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+
+class TestOrgSyncIsNotACrossTenantWrite:
+    """A sync creates and updates users/teams in the target tenant.
+
+    Taking the body's tenant_id on trust therefore let a tenant admin reshape
+    another tenant's org tree -- a cross-tenant write, not just a read.
+    """
+
+    @pytest.mark.parametrize(
+        ("path", "service"),
+        [
+            ("/api/admin/feishu/sync", "app.services.feishu_org_sync.FeishuOrgSyncService"),
+            ("/api/admin/dingtalk/sync", "app.services.dingtalk_org_sync.DingTalkOrgSyncService"),
+        ],
+    )
+    def test_tenant_admin_cannot_sync_into_another_tenant(self, path, service):
+        with patch(service) as mock_service:
+            response, _ = _request(TENANT_A_ADMIN, "POST", path, json_body={"tenant_id": TENANT_B})
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+        mock_service.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("path", "service"),
+        [
+            ("/api/admin/feishu/sync", "app.services.feishu_org_sync.FeishuOrgSyncService"),
+            ("/api/admin/dingtalk/sync", "app.services.dingtalk_org_sync.DingTalkOrgSyncService"),
+        ],
+    )
+    def test_tenant_admin_sync_is_narrowed_to_own_tenant(self, path, service):
+        """Omitting tenant_id must not mean 'whatever the service defaults to'."""
+        with patch(service) as mock_service:
+            mock_service.return_value.sync_org.return_value = SimpleNamespace(
+                to_dict=lambda: {"ok": True}
+            )
+            response, _ = _request(TENANT_A_ADMIN, "POST", path, json_body={})
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        mock_service.return_value.sync_org.assert_called_once_with(tenant_id=TENANT_A)

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -512,6 +512,89 @@ class TestTenantlessAdminFailsClosed:
         assert repo.password_updates == []
 
 
+class TestDecoratorBranchesNotReachableFromTheRoutes:
+    """Two branches the routes cannot currently exercise.
+
+    All 7 call sites use ``<int:user_id>`` converters, so the "unusable view
+    arg" path is latent -- and an unpinned fail-closed branch is one refactor
+    away from becoming a fail-open one. Driven directly here.
+    """
+
+    @staticmethod
+    def _app_with(view_arg_name, decorated_arg="user_id"):
+        from app.auth.decorators import admin_required, same_tenant_user_required
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        @app.route(f"/probe/<{view_arg_name}>")
+        @admin_required
+        @same_tenant_user_required(arg=decorated_arg)
+        def probe(**kwargs):
+            return {"reached": True}
+
+        return app
+
+    def _call(self, app, actor, path):
+        repo = _FakeUserRepo()
+        with (
+            patch("app.auth.decorators._load_user_from_token", return_value=actor),
+            patch("app.repositories.user_repo.UserRepository", return_value=repo),
+        ):
+            return app.test_client().get(path, headers={"Authorization": "Bearer t"})
+
+    def test_view_arg_mismatch_denies_a_tenant_admin(self):
+        """The decorator names user_id; the route supplies uid."""
+        app = self._app_with("uid")
+
+        response = self._call(app, TENANT_A_ADMIN, "/probe/20")
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_non_numeric_view_arg_denies_a_tenant_admin(self):
+        app = self._app_with("user_id")
+
+        response = self._call(app, TENANT_A_ADMIN, "/probe/not-a-number")
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_view_arg_mismatch_does_not_grant_a_platform_admin_anything_new(self):
+        """Platform admins fall through -- they simply lose the audit entry."""
+        app = self._app_with("uid")
+
+        response = self._call(app, PLATFORM_ADMIN, "/probe/20")
+
+        assert response.status_code == 200
+
+
+class TestCrossTenantAccessIsAudited:
+    """The PR advertises an ADMIN_CROSS_TENANT_ACCESS entry; pin that it happens."""
+
+    def test_platform_admin_reaching_another_tenant_writes_an_audit_entry(self):
+        from app.auth.decorators import _log_cross_tenant_operation  # noqa: F401
+
+        with patch("app.auth.decorators._log_cross_tenant_operation") as mock_log:
+            response, _ = _request(PLATFORM_ADMIN, "POST", "/api/admin/users/20/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        mock_log.assert_called_once()
+        assert mock_log.call_args.kwargs["target_tenant_id"] == TENANT_B
+
+    def test_no_audit_entry_when_the_target_is_not_cross_tenant(self):
+        legacy_same_tenant = {
+            "id": 2,
+            "username": "legacy",
+            "role": "admin",
+            "tenant_id": TENANT_A,
+            "must_change_password": False,
+        }
+        with patch("app.auth.decorators._log_cross_tenant_operation") as mock_log:
+            response, _ = _request(legacy_same_tenant, "POST", "/api/admin/users/10/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        mock_log.assert_not_called()
+
+
 class _ExplodingUserRepo(_FakeUserRepo):
     """Repository whose target lookup fails, e.g. the database is unreachable."""
 
@@ -756,6 +839,33 @@ class TestQuotaEndpointsDoNotLeakUserLists:
         )
 
         assert response.status_code == 403
+
+    def test_quota_stats_sums_only_the_tenant_it_reports_against(self):
+        """Limits and the users summed against them must be the same tenant.
+
+        Scoping only the user query is not enough: a platform admin calling
+        this with no tenant_id (which is how the dashboard calls it) read
+        tenant 1's limits while summing EVERY tenant's users, producing
+        percentages over 100%.
+        """
+        response, repo = _request(PLATFORM_ADMIN, "GET", "/api/admin/quota/stats")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        body = response.get_json()
+        # USERS holds one quota-bearing user per tenant, each 100 daily tokens.
+        # Summing both tenants would double this.
+        assert body["allocated"]["daily_token"] == 100, body
+
+    def test_quota_stats_uses_the_requested_tenant_for_both_sides(self):
+        response, _ = _request(
+            PLATFORM_ADMIN,
+            "GET",
+            "/api/admin/quota/stats",
+            query_string={"tenant_id": TENANT_B},
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert response.get_json()["allocated"]["daily_token"] == 100
 
     def test_quota_health_check_allows_own_tenant(self):
         response, _ = _request(

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -17,7 +17,8 @@ but left ``admin_required`` itself boundary-free.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -135,28 +136,47 @@ class _FakeUserRepo:
         return True
 
 
-def _request(actor, method, path, *, json_body=None, repo=None, query_string=None):
+def _request(actor, method, path, *, json_body=None, repo=None, query_string=None, guard_repo=None):
     """Issue one authenticated request against a bare admin blueprint.
 
     Uses a minimal Flask app rather than ``create_app()`` so the shared
     module-level blueprint singletons are not mutated for other test modules
     (same reasoning as tests/integration/test_admin_tenant_isolation_2180.py).
+
+    ``guard_repo`` overrides only the repository the tenant guard resolves
+    through, leaving the view's own ``user_repo`` intact -- so a test can make
+    the guard's lookup fail without also breaking the endpoint underneath it.
     """
     from app.routes.admin import admin_bp
 
     repo = repo or _FakeUserRepo()
+    guard_repo = guard_repo if guard_repo is not None else repo
 
     app = Flask(__name__)
     app.config["TESTING"] = True
     app.register_blueprint(admin_bp, url_prefix="/api")
 
+    # TenantService is imported inside the view functions and talks to the
+    # tenants table; stub it so these tests need no database at all.
+    tenant_service = MagicMock()
+    tenant_service.list_tenants.return_value = [
+        SimpleNamespace(id=TENANT_A, name="tenant-a"),
+        SimpleNamespace(id=TENANT_B, name="tenant-b"),
+    ]
+    tenant_service.can_add_user.return_value = True
+    tenant_service.increment_user_count.return_value = True
+    tenant_service.decrement_user_count.return_value = True
+    tenant_service.get_tenant.return_value = SimpleNamespace(quota=SimpleNamespace(max_users=100))
+
     with (
         patch("app.auth.decorators._load_user_from_token", return_value=actor),
-        # same_tenant_user_required constructs its own repository.
-        patch("app.repositories.user_repo.UserRepository", return_value=repo),
+        # same_tenant_user_required resolves the target through _load_target_user,
+        # which constructs its own repository.
+        patch("app.repositories.user_repo.UserRepository", return_value=guard_repo),
         patch("app.routes.admin.user_repo", repo),
         patch("app.routes.admin.audit_logger"),
         patch("app.routes.admin.get_security_settings_cached", return_value=None),
+        patch("app.services.tenant_service.TenantService", return_value=tenant_service),
     ):
         client = app.test_client()
         response = client.open(
@@ -352,3 +372,50 @@ class TestTenantlessAdminFailsClosed:
 
         assert response.status_code == 403
         assert repo.password_updates == []
+
+
+class _ExplodingUserRepo(_FakeUserRepo):
+    """Repository whose target lookup fails, e.g. the database is unreachable."""
+
+    def get_user_by_id(self, user_id):
+        raise RuntimeError("database unavailable")
+
+
+class TestLookupFailureIsFailClosedForTenantAdmins:
+    """The target lookup gates access for a tenant admin, so it cannot be optional.
+
+    For a platform admin the same lookup only names the tenant in the audit
+    entry, so a failure there must not turn a permitted request into a 500 --
+    that asymmetry is deliberate.
+    """
+
+    def test_tenant_admin_denied_when_target_cannot_be_resolved(self):
+        response, repo = _request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/admin/users/10/reset-password",
+            guard_repo=_ExplodingUserRepo(),
+        )
+
+        assert response.status_code == 403
+        assert repo.password_updates == []
+
+    def test_tenant_admin_denied_for_a_user_that_does_not_exist(self):
+        """Not a 404 fall-through: api_update_user/api_delete_user have no
+        not-found branch, so 'unresolved' must never mean 'allowed'."""
+        response, repo = _request(TENANT_A_ADMIN, "DELETE", "/api/admin/users/12345")
+
+        assert response.status_code == 403
+        assert repo.deleted == []
+
+    def test_platform_admin_unaffected_by_audit_lookup_failure(self):
+        """This is the case CI caught: no database, platform admin, must still work."""
+        response, repo = _request(
+            PLATFORM_ADMIN,
+            "POST",
+            "/api/admin/users/20/reset-password",
+            guard_repo=_ExplodingUserRepo(),
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.password_updates == [20]

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -17,6 +17,7 @@ but left ``admin_required`` itself boundary-free.
 
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -186,7 +187,20 @@ def _request(actor, method, path, *, json_body=None, repo=None, query_string=Non
     tenant_service.can_add_user.return_value = True
     tenant_service.increment_user_count.return_value = True
     tenant_service.decrement_user_count.return_value = True
-    tenant_service.get_tenant.return_value = SimpleNamespace(quota=SimpleNamespace(max_users=100))
+    tenant_service.get_tenant.return_value = SimpleNamespace(
+        quota=SimpleNamespace(
+            max_users=100,
+            daily_token_limit=10**9,
+            monthly_token_limit=10**9,
+            daily_request_limit=10**9,
+            monthly_request_limit=10**9,
+        )
+    )
+
+    # The quota endpoints join per-user usage; stub the repo so these stay
+    # database-free like the rest of the module.
+    usage_repo = MagicMock()
+    usage_repo.get_combined_usage.return_value = {"tokens": 0, "requests": 0}
 
     with (
         patch("app.auth.decorators._load_user_from_token", return_value=actor),
@@ -197,6 +211,7 @@ def _request(actor, method, path, *, json_body=None, repo=None, query_string=Non
         patch("app.routes.admin.audit_logger"),
         patch("app.routes.admin.get_security_settings_cached", return_value=None),
         patch("app.services.tenant_service.TenantService", return_value=tenant_service),
+        patch("app.routes.admin.usage_repo", usage_repo),
     ):
         client = app.test_client()
         response = client.open(
@@ -476,10 +491,8 @@ class TestPrivilegeEscalation:
             },
         )
 
-        # Not 403 -- the tenant-scope guard must not fire for a platform admin.
-        # (Quota/creation may still fail on the mocked tenant service; the point
-        # here is only that authorization let it through.)
-        assert response.status_code != 403
+        assert response.status_code == 201, response.get_data(as_text=True)
+        assert [c["role"] for c in repo.created] == ["platform_admin"]
 
 
 class TestTenantlessAdminFailsClosed:
@@ -544,3 +557,156 @@ class TestLookupFailureIsFailClosedForTenantAdmins:
 
         assert response.status_code == 200, response.get_data(as_text=True)
         assert repo.password_updates == [20]
+
+
+def _request_other_blueprint(actor, blueprint, path, *, patches=()):
+    """Same as _request but for a blueprint other than admin_bp.
+
+    The guards added to compliance.py and governance.py had no coverage at all
+    -- deleting either decorator left the whole suite green -- because every
+    other test here registers only admin_bp.
+    """
+    repo = _FakeUserRepo()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(blueprint, url_prefix="/api")
+
+    with (
+        patch("app.auth.decorators._load_user_from_token", return_value=actor),
+        patch("app.repositories.user_repo.UserRepository", return_value=repo),
+    ):
+        with contextlib.ExitStack() as stack:
+            for target, replacement in patches:
+                stack.enter_context(patch(target, replacement))
+            response = app.test_client().get(path, headers={"Authorization": "Bearer test-token"})
+    return response
+
+
+class TestGuardsOutsideAdminBlueprint:
+    """compliance.py and governance.py carry the same decorator.
+
+    Neither is reachable from admin_bp, so without these the guards could be
+    deleted and nothing would fail.
+    """
+
+    @staticmethod
+    def _compliance():
+        from app.routes.compliance import compliance_bp
+
+        analyzer = MagicMock()
+        analyzer.get_user_behavior_profile.return_value = {"user_id": 20, "total_actions": 7}
+        return compliance_bp, [("app.routes.compliance._get_audit_analyzer", lambda: analyzer)]
+
+    @staticmethod
+    def _governance():
+        from app.routes.governance import governance_bp
+
+        logger_mock = MagicMock()
+        logger_mock.get_user_activity.return_value = {"user_id": 20, "actions": 7}
+        return governance_bp, [("app.routes.governance.audit_logger", logger_mock)]
+
+    def test_compliance_user_profile_denies_cross_tenant(self):
+        bp, patches = self._compliance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/20/profile", patches=patches
+        )
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_compliance_user_profile_allows_own_tenant(self):
+        bp, patches = self._compliance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/10/profile", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+    def test_compliance_user_profile_denies_platform_account_in_own_tenant(self):
+        bp, patches = self._compliance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/98/profile", patches=patches
+        )
+
+        assert response.status_code == 403
+
+    def test_compliance_user_profile_allows_platform_admin(self):
+        bp, patches = self._compliance()
+        response = _request_other_blueprint(
+            PLATFORM_ADMIN, bp, "/api/audit/user/20/profile", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+    def test_governance_user_activity_denies_cross_tenant(self):
+        bp, patches = self._governance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/20/activity", patches=patches
+        )
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_governance_user_activity_allows_own_tenant(self):
+        bp, patches = self._governance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/10/activity", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+    def test_governance_user_activity_denies_platform_account_in_own_tenant(self):
+        bp, patches = self._governance()
+        response = _request_other_blueprint(
+            TENANT_A_ADMIN, bp, "/api/audit/user/98/activity", patches=patches
+        )
+
+        assert response.status_code == 403
+
+    def test_governance_user_activity_allows_platform_admin(self):
+        bp, patches = self._governance()
+        response = _request_other_blueprint(
+            PLATFORM_ADMIN, bp, "/api/audit/user/20/activity", patches=patches
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+
+class TestQuotaEndpointsDoNotLeakUserLists:
+    """GET /admin/quota/usage returns the user list too.
+
+    Narrowing only /admin/users left cross-tenant enumeration open at a
+    sibling URL -- and this one exposes more, including each account's role,
+    which is the targeting data an attacker actually wants.
+    """
+
+    def test_quota_usage_is_narrowed_to_own_tenant(self):
+        response, _ = _request(TENANT_A_ADMIN, "GET", "/api/admin/quota/usage")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert {u.get("tenant_id") for u in response.get_json()} == {TENANT_A}
+
+    def test_quota_usage_rejects_another_tenant(self):
+        response, _ = _request(
+            TENANT_A_ADMIN,
+            "GET",
+            "/api/admin/quota/usage",
+            query_string={"tenant_id": TENANT_B},
+        )
+
+        assert response.status_code == 403
+
+    def test_quota_usage_still_global_for_platform_admin(self):
+        response, _ = _request(PLATFORM_ADMIN, "GET", "/api/admin/quota/usage")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert {u.get("tenant_id") for u in response.get_json()} == {TENANT_A, TENANT_B, None}
+
+    def test_quota_stats_rejects_another_tenant(self):
+        response, _ = _request(
+            TENANT_A_ADMIN,
+            "GET",
+            "/api/admin/quota/stats",
+            query_string={"tenant_id": TENANT_B},
+        )
+
+        assert response.status_code == 403

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -68,6 +68,26 @@ USERS: dict[int, dict] = {
         "tenant_id": None,
         "must_change_password": False,
     },
+    # A platform admin FILED UNDER tenant A. This is not an exotic row:
+    # api_create_user rejects a missing tenant_id (400), so every platform
+    # admin minted through the admin API carries some tenant, and the schema
+    # only requires a tenant for tenant_admin.
+    98: {
+        "id": 98,
+        "username": "root-in-tenant-a",
+        "email": "root-a@a.example",
+        "role": "platform_admin",
+        "tenant_id": TENANT_A,
+        "must_change_password": False,
+    },
+    97: {
+        "id": 97,
+        "username": "legacy-admin-in-tenant-a",
+        "email": "legacy-a@a.example",
+        "role": "admin",
+        "tenant_id": TENANT_A,
+        "must_change_password": False,
+    },
 }
 
 TENANT_A_ADMIN = {
@@ -236,6 +256,69 @@ class TestPasswordResetTakeover:
         assert repo.password_updates == [20]
 
 
+class TestVerticalEscalationViaSameTenantPlatformAdmin:
+    """Sharing a tenant must not make a platform admin a valid target.
+
+    A tenant-only check is purely horizontal and misses this: file a
+    platform_admin under tenant A, and tenant A's admin can reset its password
+    and read the result -- full escape, without ever granting itself a role.
+    ``reject_privilege_escalation`` does not help, because nothing is granted.
+    """
+
+    @pytest.mark.parametrize("target_id", [98, 97])
+    def test_tenant_admin_cannot_reset_a_platform_account_in_its_own_tenant(self, target_id):
+        response, repo = _request(
+            TENANT_A_ADMIN, "POST", f"/api/admin/users/{target_id}/reset-password"
+        )
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert "temporary_password" not in response.get_json()
+        assert repo.password_updates == []
+
+    @pytest.mark.parametrize(
+        ("method", "path", "body"),
+        [
+            ("PUT", "/api/admin/users/98", {"username": "pwned"}),
+            ("DELETE", "/api/admin/users/98", None),
+            ("PUT", "/api/admin/users/98/password", {"password": "NewP@ssw0rd123"}),
+            ("PUT", "/api/admin/users/98/quota", {"daily_token_quota": 999999}),
+        ],
+    )
+    def test_every_sibling_endpoint_denies_it_too(self, method, path, body):
+        response, repo = _request(TENANT_A_ADMIN, method, path, json_body=body)
+
+        assert (
+            response.status_code == 403
+        ), f"{method} {path} returned {response.status_code}: {response.get_data(as_text=True)}"
+        assert repo.updated == []
+        assert repo.deleted == []
+        assert repo.password_updates == []
+
+    def test_protection_does_not_depend_on_strict_mode(self, monkeypatch):
+        """is_platform_level_role is flag-independent on purpose.
+
+        Routing this through the strict-mode-sensitive is_platform_admin_role
+        would stop protecting legacy 'admin' rows the moment strict mode is
+        switched on -- protection must not narrow as a side effect.
+        """
+        from app.auth.permissions import reset_strict_mode_cache
+
+        reset_strict_mode_cache()
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+        try:
+            response, repo = _request(TENANT_A_ADMIN, "POST", "/api/admin/users/97/reset-password")
+            assert response.status_code == 403
+            assert repo.password_updates == []
+        finally:
+            reset_strict_mode_cache()
+
+    def test_platform_admin_may_still_manage_its_peers(self):
+        response, repo = _request(PLATFORM_ADMIN, "POST", "/api/admin/users/98/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.password_updates == [98]
+
+
 class TestOtherUserTargetedEndpoints:
     """The same gap existed on every sibling endpoint keyed by a user id."""
 
@@ -336,6 +419,58 @@ class TestPrivilegeEscalation:
 
         assert response.status_code == 403
         assert repo.updated == []
+
+    @pytest.mark.parametrize("bogus", [0, -1, "", "abc", "0"])
+    def test_unusable_tenant_id_is_rejected_not_silently_ignored(self, bogus):
+        """A value the scope guard cannot normalize returns None, which reads as
+        'no tenant requested' -- so re-reading the raw body value afterwards
+        would hand it straight to the quota check and the UPDATE.
+        """
+        response, repo = _request(
+            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": bogus}
+        )
+
+        assert response.status_code == 400, response.get_data(as_text=True)
+        assert repo.updated == []
+
+    def test_a_float_tenant_id_truncates_but_is_still_boundary_checked(self):
+        """1.9 is not 'unusable' -- _normalize_user_tenant_id truncates it to 1.
+
+        Documented rather than rejected: the truncated value goes through the
+        same comparison as any other, so it cannot cross a boundary. Here it
+        lands on the actor's own tenant and is allowed; the next case shows the
+        foreign-tenant float being denied.
+        """
+        response, repo = _request(
+            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": 1.9}
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.updated == [10]
+
+    def test_a_float_tenant_id_pointing_at_another_tenant_is_denied(self):
+        response, repo = _request(
+            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": 2.5}
+        )
+
+        assert response.status_code == 403
+        assert repo.updated == []
+
+    def test_platform_admin_also_gets_400_for_an_unusable_tenant_id(self):
+        response, repo = _request(
+            PLATFORM_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": "abc"}
+        )
+
+        assert response.status_code == 400
+        assert repo.updated == []
+
+    def test_platform_admin_can_still_move_a_user_between_tenants(self):
+        response, repo = _request(
+            PLATFORM_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": TENANT_B}
+        )
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.updated == [10]
 
     def test_platform_admin_may_still_create_platform_admins(self):
         response, repo = _request(

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -420,7 +420,7 @@ class TestPrivilegeEscalation:
         assert response.status_code == 403
         assert repo.updated == []
 
-    @pytest.mark.parametrize("bogus", [0, -1, "", "abc", "0"])
+    @pytest.mark.parametrize("bogus", [0, -1, "", "abc", "0", 1.9, 2.5, True, False])
     def test_unusable_tenant_id_is_rejected_not_silently_ignored(self, bogus):
         """A value the scope guard cannot normalize returns None, which reads as
         'no tenant requested' -- so re-reading the raw body value afterwards
@@ -433,28 +433,18 @@ class TestPrivilegeEscalation:
         assert response.status_code == 400, response.get_data(as_text=True)
         assert repo.updated == []
 
-    def test_a_float_tenant_id_truncates_but_is_still_boundary_checked(self):
-        """1.9 is not 'unusable' -- _normalize_user_tenant_id truncates it to 1.
+    def test_an_integral_float_tenant_id_is_still_accepted(self):
+        """2.0 is unambiguous, so it is honoured rather than rejected.
 
-        Documented rather than rejected: the truncated value goes through the
-        same comparison as any other, so it cannot cross a boundary. Here it
-        lands on the actor's own tenant and is allowed; the next case shows the
-        foreign-tenant float being denied.
+        Only non-integral floats and bools are refused -- those are the ones
+        that would silently land on a tenant the caller never named.
         """
         response, repo = _request(
-            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": 1.9}
+            PLATFORM_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": 2.0}
         )
 
         assert response.status_code == 200, response.get_data(as_text=True)
         assert repo.updated == [10]
-
-    def test_a_float_tenant_id_pointing_at_another_tenant_is_denied(self):
-        response, repo = _request(
-            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": 2.5}
-        )
-
-        assert response.status_code == 403
-        assert repo.updated == []
 
     def test_platform_admin_also_gets_400_for_an_unusable_tenant_id(self):
         response, repo = _request(

--- a/tests/integration/test_admin_cross_tenant_takeover.py
+++ b/tests/integration/test_admin_cross_tenant_takeover.py
@@ -1,0 +1,354 @@
+"""Tenant boundary on the admin user-management endpoints.
+
+``admin_required`` authenticates ``admin`` / ``platform_admin`` / ``tenant_admin``
+and populates ``g.tenant_id``, but never compared that tenant against the tenant
+of the resource being operated on. On ``/api/admin/users/<id>/...`` that gap was
+a full cross-tenant account takeover: a tenant admin could reset any user's
+password -- a platform admin's included -- and read the new password straight
+out of the response body.
+
+Each test below is the exploit, run against the fixed code and asserting the
+denial. ``test_..._was_the_exploit`` names spell out the attack that used to
+work.
+
+Lineage: Issue #2180 (admin-route tenant isolation), which fixed 22 endpoints
+but left ``admin_required`` itself boundary-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.security,
+    pytest.mark.regression,
+    pytest.mark.issue(2180),
+]
+
+
+# Two tenants, and one platform-level account with no tenant at all.
+TENANT_A = 1
+TENANT_B = 2
+
+USERS: dict[int, dict] = {
+    10: {
+        "id": 10,
+        "username": "alice",
+        "email": "alice@a.example",
+        "role": "user",
+        "tenant_id": TENANT_A,
+        "must_change_password": False,
+        "daily_token_quota": 100,
+        "monthly_token_quota": 1000,
+        "daily_request_quota": 10,
+        "monthly_request_quota": 100,
+    },
+    20: {
+        "id": 20,
+        "username": "bob",
+        "email": "bob@b.example",
+        "role": "user",
+        "tenant_id": TENANT_B,
+        "must_change_password": False,
+        "daily_token_quota": 100,
+        "monthly_token_quota": 1000,
+        "daily_request_quota": 10,
+        "monthly_request_quota": 100,
+    },
+    99: {
+        "id": 99,
+        "username": "root",
+        "email": "root@example",
+        "role": "platform_admin",
+        "tenant_id": None,
+        "must_change_password": False,
+    },
+}
+
+TENANT_A_ADMIN = {
+    "id": 11,
+    "username": "a-admin",
+    "role": "tenant_admin",
+    "tenant_id": TENANT_A,
+    "must_change_password": False,
+}
+PLATFORM_ADMIN = {
+    "id": 1,
+    "username": "platform",
+    "role": "platform_admin",
+    "tenant_id": None,
+    "must_change_password": False,
+}
+
+
+class _FakeUserRepo:
+    """Just enough of UserRepository for the routes under test."""
+
+    def __init__(self, users: dict[int, dict] | None = None):
+        self.users = users if users is not None else USERS
+        self.password_updates: list[int] = []
+        self.deleted: list[int] = []
+        self.updated: list[int] = []
+        self.created: list[dict] = []
+
+    def get_user_by_id(self, user_id):
+        user = self.users.get(int(user_id))
+        return dict(user) if user else None
+
+    def get_all_users(self, tenant_id=None, **kwargs):
+        return [
+            dict(u)
+            for u in self.users.values()
+            if tenant_id is None or u.get("tenant_id") == tenant_id
+        ]
+
+    def get_user_by_username(self, username):
+        return None
+
+    def get_user_by_email(self, email):
+        return None
+
+    def update_password(self, user_id, password_hash):
+        self.password_updates.append(int(user_id))
+        return True
+
+    def set_must_change_password(self, user_id, value):
+        return True
+
+    def delete_user(self, user_id):
+        self.deleted.append(int(user_id))
+        return True
+
+    def update_user(self, user_id, **kwargs):
+        self.updated.append(int(user_id))
+        return True
+
+    def create_user(self, username, email, password_hash, role, **kwargs):
+        self.created.append({"username": username, "role": role, **kwargs})
+        return 500
+
+    def update_user_quota(self, *args, **kwargs):
+        return True
+
+
+def _request(actor, method, path, *, json_body=None, repo=None, query_string=None):
+    """Issue one authenticated request against a bare admin blueprint.
+
+    Uses a minimal Flask app rather than ``create_app()`` so the shared
+    module-level blueprint singletons are not mutated for other test modules
+    (same reasoning as tests/integration/test_admin_tenant_isolation_2180.py).
+    """
+    from app.routes.admin import admin_bp
+
+    repo = repo or _FakeUserRepo()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(admin_bp, url_prefix="/api")
+
+    with (
+        patch("app.auth.decorators._load_user_from_token", return_value=actor),
+        # same_tenant_user_required constructs its own repository.
+        patch("app.repositories.user_repo.UserRepository", return_value=repo),
+        patch("app.routes.admin.user_repo", repo),
+        patch("app.routes.admin.audit_logger"),
+        patch("app.routes.admin.get_security_settings_cached", return_value=None),
+    ):
+        client = app.test_client()
+        response = client.open(
+            path,
+            method=method,
+            json=json_body,
+            query_string=query_string,
+            headers={"Authorization": "Bearer test-token"},
+        )
+    return response, repo
+
+
+class TestPasswordResetTakeover:
+    """POST /api/admin/users/<id>/reset-password."""
+
+    def test_tenant_admin_cannot_reset_other_tenants_user_was_the_exploit(self):
+        """The P0: tenant A's admin resets tenant B's user and reads the password."""
+        response, repo = _request(TENANT_A_ADMIN, "POST", "/api/admin/users/20/reset-password")
+
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert "temporary_password" not in response.get_json()
+        assert repo.password_updates == []
+
+    def test_tenant_admin_cannot_reset_platform_admin_was_the_worst_case(self):
+        """User 99 is a platform admin with tenant_id=None -- NULL is not a wildcard."""
+        response, repo = _request(TENANT_A_ADMIN, "POST", "/api/admin/users/99/reset-password")
+
+        assert response.status_code == 403
+        assert repo.password_updates == []
+
+    def test_tenant_admin_can_still_reset_own_tenants_user(self):
+        """The fix must not break the legitimate case it is wrapped around."""
+        response, repo = _request(TENANT_A_ADMIN, "POST", "/api/admin/users/10/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert response.get_json()["temporary_password"]
+        assert repo.password_updates == [10]
+
+    def test_platform_admin_keeps_cross_tenant_reach(self):
+        response, repo = _request(PLATFORM_ADMIN, "POST", "/api/admin/users/20/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.password_updates == [20]
+
+    def test_legacy_admin_keeps_cross_tenant_reach(self):
+        """Legacy 'admin' is a platform admin while strict mode is off."""
+        legacy = {
+            "id": 2,
+            "username": "legacy",
+            "role": "admin",
+            "tenant_id": TENANT_A,
+            "must_change_password": False,
+        }
+        response, repo = _request(legacy, "POST", "/api/admin/users/20/reset-password")
+
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.password_updates == [20]
+
+
+class TestOtherUserTargetedEndpoints:
+    """The same gap existed on every sibling endpoint keyed by a user id."""
+
+    @pytest.mark.parametrize(
+        ("method", "path", "body"),
+        [
+            ("PUT", "/api/admin/users/20", {"username": "pwned"}),
+            ("DELETE", "/api/admin/users/20", None),
+            ("PUT", "/api/admin/users/20/password", {"password": "NewP@ssw0rd123"}),
+            ("PUT", "/api/admin/users/20/quota", {"daily_token_quota": 999999}),
+        ],
+    )
+    def test_tenant_admin_denied_across_tenants(self, method, path, body):
+        response, repo = _request(TENANT_A_ADMIN, method, path, json_body=body)
+
+        assert (
+            response.status_code == 403
+        ), f"{method} {path} returned {response.status_code}: {response.get_data(as_text=True)}"
+        assert repo.updated == []
+        assert repo.deleted == []
+        assert repo.password_updates == []
+
+
+class TestUserEnumeration:
+    """GET /api/admin/users -- the reconnaissance step before a takeover."""
+
+    def test_tenant_admin_listing_is_narrowed_to_own_tenant(self):
+        """No tenant_id used to mean 'every tenant'."""
+        response, _ = _request(TENANT_A_ADMIN, "GET", "/api/admin/users")
+
+        assert response.status_code == 200
+        tenants = {u.get("tenant_id") for u in response.get_json()}
+        assert tenants == {TENANT_A}
+
+    def test_tenant_admin_cannot_request_another_tenants_listing(self):
+        response, _ = _request(
+            TENANT_A_ADMIN, "GET", "/api/admin/users", query_string={"tenant_id": TENANT_B}
+        )
+
+        assert response.status_code == 403
+
+    def test_platform_admin_still_sees_every_tenant(self):
+        response, _ = _request(PLATFORM_ADMIN, "GET", "/api/admin/users")
+
+        assert response.status_code == 200
+        assert {u.get("tenant_id") for u in response.get_json()} == {TENANT_A, TENANT_B, None}
+
+
+class TestPrivilegeEscalation:
+    """A tenant admin minting platform-level accounts is takeover by another route."""
+
+    def test_tenant_admin_cannot_create_platform_admin(self):
+        response, repo = _request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/admin/users",
+            json_body={
+                "username": "backdoor",
+                "email": "backdoor@a.example",
+                "password": "S0me!LongPassword",
+                "role": "platform_admin",
+                "tenant_id": TENANT_A,
+            },
+        )
+
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_create_into_another_tenant(self):
+        response, repo = _request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/admin/users",
+            json_body={
+                "username": "planted",
+                "email": "planted@b.example",
+                "password": "S0me!LongPassword",
+                "role": "user",
+                "tenant_id": TENANT_B,
+            },
+        )
+
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_promote_own_user_to_platform_admin(self):
+        response, repo = _request(
+            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"role": "platform_admin"}
+        )
+
+        assert response.status_code == 403
+        assert repo.updated == []
+
+    def test_tenant_admin_cannot_move_own_user_into_another_tenant(self):
+        response, repo = _request(
+            TENANT_A_ADMIN, "PUT", "/api/admin/users/10", json_body={"tenant_id": TENANT_B}
+        )
+
+        assert response.status_code == 403
+        assert repo.updated == []
+
+    def test_platform_admin_may_still_create_platform_admins(self):
+        response, repo = _request(
+            PLATFORM_ADMIN,
+            "POST",
+            "/api/admin/users",
+            json_body={
+                "username": "peer",
+                "email": "peer@example.com",
+                "password": "S0me!LongPassword",
+                "role": "platform_admin",
+                "tenant_id": TENANT_A,
+            },
+        )
+
+        # Not 403 -- the tenant-scope guard must not fire for a platform admin.
+        # (Quota/creation may still fail on the mocked tenant service; the point
+        # here is only that authorization let it through.)
+        assert response.status_code != 403
+
+
+class TestTenantlessAdminFailsClosed:
+    """A tenant_admin row with no tenant_id has no scope to confine to."""
+
+    def test_tenant_admin_without_tenant_id_is_denied(self):
+        broken = {
+            "id": 12,
+            "username": "no-tenant",
+            "role": "tenant_admin",
+            "tenant_id": None,
+            "must_change_password": False,
+        }
+        response, repo = _request(broken, "POST", "/api/admin/users/10/reset-password")
+
+        assert response.status_code == 403
+        assert repo.password_updates == []

--- a/tests/integration/test_admin_tenant_isolation_2180.py
+++ b/tests/integration/test_admin_tenant_isolation_2180.py
@@ -124,10 +124,52 @@ class TestMappingRulesTenantIsolation:
         from app.routes.mapping_rules import _validate_user_in_tenant
 
         with patch("app.routes.mapping_rules.user_repo") as mock_repo:
-            mock_repo.get_user_by_id.return_value = {"id": 2, "tenant_id": 1}
+            mock_repo.get_user_by_id.return_value = {"id": 2, "tenant_id": 1, "role": "user"}
 
             result = _validate_user_in_tenant(user_id=2, tenant_id=1)
             assert result is True
+
+    @pytest.mark.parametrize("platform_role", ["platform_admin", "admin"])
+    def test_tenant_admin_cannot_target_a_platform_account_in_its_own_tenant(self, platform_role):
+        """The check must be vertical as well as horizontal.
+
+        A platform-level account can carry a tenant id -- api_create_user
+        requires one, and the schema only forces tenant_admin to have it. So
+        comparing tenants alone lets a tenant admin operate on a platform admin
+        filed under its own tenant. The two tests above pass target dicts with
+        no ``role`` key, which exercises only the horizontal half.
+        """
+        from app.routes.mapping_rules import _validate_user_in_tenant
+
+        with patch("app.routes.mapping_rules.user_repo") as mock_repo:
+            mock_repo.get_user_by_id.return_value = {
+                "id": 2,
+                "tenant_id": 1,
+                "role": platform_role,
+            }
+
+            assert _validate_user_in_tenant(user_id=2, tenant_id=1) is False
+
+    def test_a_peer_tenant_admin_in_the_same_tenant_is_still_allowed(self):
+        """The vertical check must not over-reach: tenant_admin is not platform-level."""
+        from app.routes.mapping_rules import _validate_user_in_tenant
+
+        with patch("app.routes.mapping_rules.user_repo") as mock_repo:
+            mock_repo.get_user_by_id.return_value = {
+                "id": 2,
+                "tenant_id": 1,
+                "role": "tenant_admin",
+            }
+
+            assert _validate_user_in_tenant(user_id=2, tenant_id=1) is True
+
+    def test_a_target_with_no_tenant_is_denied(self):
+        from app.routes.mapping_rules import _validate_user_in_tenant
+
+        with patch("app.routes.mapping_rules.user_repo") as mock_repo:
+            mock_repo.get_user_by_id.return_value = {"id": 2, "tenant_id": None, "role": "user"}
+
+            assert _validate_user_in_tenant(user_id=2, tenant_id=1) is False
 
 
 class TestAPIKeyTenantIsolation:

--- a/tests/unit/test_check_migration_rules.py
+++ b/tests/unit/test_check_migration_rules.py
@@ -681,6 +681,12 @@ class TestMig003AgainstRealMigrations:
     """MIG003 on the committed tree, using git for real rather than stubs."""
 
     def test_committed_tree_is_clean(self):
+        # Skip when there is no baseline to compare against, rather than
+        # asserting == [] and passing on a skip -- which is exactly the
+        # "a skip must not read like a pass" defect fixed in the script.
+        if not rules._baseline_commits(rules.DEFAULT_BASELINE_REF):
+            pytest.skip(f"no git baseline for {rules.DEFAULT_BASELINE_REF} in this checkout")
+
         violations = rules.check_released_revision_ids(rules.DEFAULT_VERSIONS_DIR)
         assert (
             violations == []
@@ -816,8 +822,16 @@ class TestMig003BaselineResolutionAgainstRealGit:
 
         main gains X at B. A side branch forks at C and is merged into main, so
         main has X. feature forks from C, merges B (so feature has X too), then
-        deletes X. The bases are {B, C}; C never had X, so a single-base
-        comparison misses the deletion entirely.
+        deletes X. The merge bases are {B, C}, and only B has X.
+
+        Which of the two plain ``git merge-base`` returns is git's choice, not
+        something a test can pin -- in this fixture it happens to return B, so
+        the deletion would be caught either way here. What this test therefore
+        asserts is the property that makes the outcome independent of that
+        choice: BOTH bases are resolved, and the union of their ids is what the
+        comparison uses. Do not weaken the ``set(bases) ==`` assertion to a
+        length or membership check; it is the only thing standing between this
+        test and vacuity.
         """
         repo = self._new_repo(tmp_path / "repo")
         self._add_migration(repo, "rev_base")

--- a/tests/unit/test_check_migration_rules.py
+++ b/tests/unit/test_check_migration_rules.py
@@ -386,10 +386,34 @@ class TestMainAndDiscovery:
             """,
             name="0001_clean.py",
         )
-        rc = rules.main([str(tmp_path)])
+        # --skip-released-check: this fixture is a one-file tree, not a full
+        # migrations/versions/, so MIG003 would (correctly) report every real
+        # revision id as missing.
+        rc = rules.main([str(tmp_path), "--skip-released-check"])
         assert rc == 0
         err = capsys.readouterr().err
         assert "pass MIG001/MIG002" in err
+
+    def test_main_runs_mig003_by_default(self, tmp_path: Path, capsys):
+        """The released-id check is on unless explicitly skipped."""
+        _write_migration(
+            tmp_path,
+            """
+            revision = "rev_test"
+            down_revision = None
+
+            def upgrade():
+                pass
+            """,
+            name="0001_clean.py",
+        )
+        rc = rules.main([str(tmp_path)])
+
+        err = capsys.readouterr().err
+        # Either the baseline was readable and every real id is reported
+        # missing from this one-file tree, or it was unreadable and skipped.
+        assert ("MIG003" in err) or ("MIG003: skipped" in err)
+        assert rc in (0, 1)
 
     def test_main_fails_on_violation(self, tmp_path: Path, capsys):
         _write_migration(
@@ -446,3 +470,104 @@ class TestRealMigrationsInvariant:
         assert violations == [], "Committed migrations violate authoring rules:\n  " + "\n  ".join(
             v.format() for v in violations
         )
+
+
+# ---------------------------------------------------------------------------
+# MIG003: a revision id that shipped must never disappear
+# ---------------------------------------------------------------------------
+
+
+class TestMig003ReleasedRevisionIds:
+    """The rule that would have caught the 20260731_003 renumbering.
+
+    ``20260731_003_add_proxy_token_terminated_fields`` shipped on main, was
+    later renumbered to ``..._004_...`` so a newer migration could take the 003
+    slot, and every database stamped with the old id started failing
+    ``upgrade head`` with "Can't locate revision". Alembic keys history off the
+    id, not the filename.
+    """
+
+    def _tree(self, tmp_path: Path, ids: dict[str, str]) -> Path:
+        for name, rev in ids.items():
+            _write_migration(
+                tmp_path,
+                f"""
+                revision = "{rev}"
+                down_revision = None
+
+                def upgrade():
+                    pass
+                """,
+                name=name,
+            )
+        return tmp_path
+
+    @staticmethod
+    def _baseline(**ids: str):
+        """Stub for _revision_ids_at_ref: revision id -> path."""
+        return lambda ref: dict(ids)
+
+    def test_revision_id_parsed_from_annotated_assignment(self):
+        source = 'revision: str = "abc123"\ndown_revision: str | None = None\n'
+        assert rules._revision_id_from_source(source) == "abc123"
+
+    def test_revision_id_parsed_from_plain_assignment(self):
+        assert rules._revision_id_from_source('revision = "abc123"\n') == "abc123"
+
+    def test_revision_id_absent_returns_none(self):
+        assert rules._revision_id_from_source("x = 1\n") is None
+
+    def test_dynamic_revision_id_returns_none(self):
+        """A computed id cannot be compared statically; do not guess."""
+        assert rules._revision_id_from_source('revision = "a" + "b"\n') is None
+
+    def test_missing_baseline_id_is_reported(self, tmp_path: Path, monkeypatch):
+        tree = self._tree(tmp_path, {"new.py": "rev_b"})
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", self._baseline(rev_a="migrations/versions/old.py")
+        )
+
+        violations = rules.check_released_revision_ids(tree, "origin/main")
+
+        assert len(violations) == 1
+        assert violations[0].rule == "MIG003"
+        assert "rev_a" in violations[0].message
+
+    def test_renaming_the_file_but_keeping_the_id_passes(self, tmp_path: Path, monkeypatch):
+        """Filenames are cosmetic to Alembic; only the id is history."""
+        tree = self._tree(tmp_path, {"renamed_to_something_else.py": "rev_a"})
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", self._baseline(rev_a="migrations/versions/old.py")
+        )
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_adding_new_ids_passes(self, tmp_path: Path, monkeypatch):
+        tree = self._tree(tmp_path, {"old.py": "rev_a", "new.py": "rev_b"})
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", self._baseline(rev_a="migrations/versions/old.py")
+        )
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_retired_id_allowlist_suppresses_the_violation(self, tmp_path: Path, monkeypatch):
+        tree = self._tree(tmp_path, {"new.py": "rev_b"})
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", self._baseline(rev_a="migrations/versions/old.py")
+        )
+        monkeypatch.setattr(rules, "RETIRED_REVISION_IDS", frozenset({"rev_a"}))
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_unreadable_baseline_skips_instead_of_failing(self, tmp_path: Path, monkeypatch):
+        """A shallow clone or unfetched remote must not manufacture a failure."""
+        tree = self._tree(tmp_path, {"new.py": "rev_b"})
+        monkeypatch.setattr(rules, "_revision_ids_at_ref", lambda ref: None)
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_empty_baseline_skips(self, tmp_path: Path, monkeypatch):
+        tree = self._tree(tmp_path, {"new.py": "rev_b"})
+        monkeypatch.setattr(rules, "_revision_ids_at_ref", lambda ref: {})
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []

--- a/tests/unit/test_check_migration_rules.py
+++ b/tests/unit/test_check_migration_rules.py
@@ -517,6 +517,18 @@ class TestMig003ReleasedRevisionIds:
     id, not the filename.
     """
 
+    @pytest.fixture(autouse=True)
+    def _stub_baseline_commit(self, monkeypatch):
+        """Pin the baseline commit so these tests do not depend on git state.
+
+        check_released_revision_ids resolves merge-base(ref, HEAD) before it
+        reads any ids. CI checks out shallow and has no origin/main, so an
+        unpinned _baseline_commit returns None there, the check short-circuits
+        to "skip", and every stubbed expectation below silently passes for the
+        wrong reason. Tests that exercise _baseline_commit itself override this.
+        """
+        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "baseline_sha")
+
     def _tree(self, tmp_path: Path, ids: dict[str, str]) -> Path:
         for name, rev in ids.items():
             _write_migration(

--- a/tests/unit/test_check_migration_rules.py
+++ b/tests/unit/test_check_migration_rules.py
@@ -394,7 +394,7 @@ class TestMainAndDiscovery:
         err = capsys.readouterr().err
         assert "pass MIG001/MIG002" in err
 
-    def test_main_runs_mig003_by_default(self, tmp_path: Path, capsys):
+    def test_main_runs_mig003_by_default(self, tmp_path: Path, capsys, monkeypatch):
         """The released-id check is on unless explicitly skipped."""
         _write_migration(
             tmp_path,
@@ -407,13 +407,43 @@ class TestMainAndDiscovery:
             """,
             name="0001_clean.py",
         )
+        # Pin the baseline so the assertion does not depend on the checkout's
+        # git state -- an earlier version of this test accepted rc in (0, 1)
+        # and "MIG003 or MIG003: skipped", which no implementation could fail.
+        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "deadbeef")
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", lambda ref: {"only_on_main": "migrations/versions/m.py"}
+        )
+
         rc = rules.main([str(tmp_path)])
 
         err = capsys.readouterr().err
-        # Either the baseline was readable and every real id is reported
-        # missing from this one-file tree, or it was unreadable and skipped.
-        assert ("MIG003" in err) or ("MIG003: skipped" in err)
-        assert rc in (0, 1)
+        assert rc == 1
+        assert "MIG003" in err
+        assert "only_on_main" in err
+
+    def test_skip_flag_turns_mig003_off(self, tmp_path: Path, capsys, monkeypatch):
+        _write_migration(
+            tmp_path,
+            """
+            revision = "rev_test"
+            down_revision = None
+
+            def upgrade():
+                pass
+            """,
+            name="0001_clean.py",
+        )
+        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "deadbeef")
+        monkeypatch.setattr(
+            rules, "_revision_ids_at_ref", lambda ref: {"only_on_main": "migrations/versions/m.py"}
+        )
+
+        rc = rules.main([str(tmp_path), "--skip-released-check"])
+
+        err = capsys.readouterr().err
+        assert rc == 0
+        assert "MIG003" not in err
 
     def test_main_fails_on_violation(self, tmp_path: Path, capsys):
         _write_migration(
@@ -571,3 +601,84 @@ class TestMig003ReleasedRevisionIds:
         monkeypatch.setattr(rules, "_revision_ids_at_ref", lambda ref: {})
 
         assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_unresolvable_baseline_commit_skips(self, tmp_path: Path, monkeypatch):
+        tree = self._tree(tmp_path, {"new.py": "rev_b"})
+        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: None)
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+
+    def test_baseline_is_the_merge_base_not_the_branch_tip(self, tmp_path: Path, monkeypatch):
+        """A branch that merely lags behind main must not be failed.
+
+        Comparing against the tip of origin/main flags every migration merged
+        after the fork point as "missing", and the obvious way to silence that
+        is to add the id to RETIRED_REVISION_IDS -- exactly the mistake MIG003
+        exists to prevent. Verified by asserting the ids come from the
+        merge-base commit, not the ref.
+        """
+        tree = self._tree(tmp_path, {"forked.py": "rev_at_fork"})
+        asked_for: list[str] = []
+
+        def fake_ids(ref):
+            asked_for.append(ref)
+            # merge-base has only the forked id; the tip also has a later one.
+            return (
+                {"rev_at_fork": "m1.py"}
+                if ref == "fork_sha"
+                else {"rev_at_fork": "m1.py", "rev_merged_after_fork": "m2.py"}
+            )
+
+        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "fork_sha")
+        monkeypatch.setattr(rules, "_revision_ids_at_ref", fake_ids)
+
+        assert rules.check_released_revision_ids(tree, "origin/main") == []
+        assert asked_for == ["fork_sha"]
+
+
+class TestMig003AgainstRealMigrations:
+    """MIG003 on the committed tree, using git for real rather than stubs."""
+
+    def test_committed_tree_is_clean(self):
+        violations = rules.check_released_revision_ids(rules.DEFAULT_VERSIONS_DIR)
+        assert (
+            violations == []
+        ), "Committed migrations dropped a released revision id:\n  " + "\n  ".join(
+            v.format() for v in violations
+        )
+
+    def test_removing_a_released_migration_is_caught(self, tmp_path: Path):
+        """Copy the real tree, delete a migration that predates this branch."""
+        import shutil
+
+        victim = "20260731_004_add_proxy_token_terminated_fields.py"
+        source = rules.DEFAULT_VERSIONS_DIR / victim
+        if not source.exists():
+            pytest.skip(f"{victim} not present")
+
+        tree = tmp_path / "versions"
+        shutil.copytree(rules.DEFAULT_VERSIONS_DIR, tree)
+        (tree / victim).unlink()
+
+        violations = rules.check_released_revision_ids(tree)
+
+        if not violations:
+            pytest.skip("no git baseline available in this checkout")
+        assert any(
+            "20260731_004_add_proxy_token_terminated_fields" in v.message for v in violations
+        )
+
+    def test_renaming_only_the_file_is_allowed(self, tmp_path: Path):
+        """Alembic keys off the id; the filename is cosmetic."""
+        import shutil
+
+        victim = "20260731_004_add_proxy_token_terminated_fields.py"
+        source = rules.DEFAULT_VERSIONS_DIR / victim
+        if not source.exists():
+            pytest.skip(f"{victim} not present")
+
+        tree = tmp_path / "versions"
+        shutil.copytree(rules.DEFAULT_VERSIONS_DIR, tree)
+        (tree / victim).rename(tree / "zzz_renamed_file.py")
+
+        assert rules.check_released_revision_ids(tree) == []

--- a/tests/unit/test_check_migration_rules.py
+++ b/tests/unit/test_check_migration_rules.py
@@ -410,7 +410,7 @@ class TestMainAndDiscovery:
         # Pin the baseline so the assertion does not depend on the checkout's
         # git state -- an earlier version of this test accepted rc in (0, 1)
         # and "MIG003 or MIG003: skipped", which no implementation could fail.
-        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "deadbeef")
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: ["deadbeef"])
         monkeypatch.setattr(
             rules, "_revision_ids_at_ref", lambda ref: {"only_on_main": "migrations/versions/m.py"}
         )
@@ -434,7 +434,7 @@ class TestMainAndDiscovery:
             """,
             name="0001_clean.py",
         )
-        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "deadbeef")
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: ["deadbeef"])
         monkeypatch.setattr(
             rules, "_revision_ids_at_ref", lambda ref: {"only_on_main": "migrations/versions/m.py"}
         )
@@ -443,7 +443,36 @@ class TestMainAndDiscovery:
 
         err = capsys.readouterr().err
         assert rc == 0
-        assert "MIG003" not in err
+        assert "only_on_main" not in err, "MIG003 must not have run"
+        # The summary says so explicitly rather than implying a clean pass.
+        assert "MIG003 skipped by request" in err
+
+    def test_summary_says_when_mig003_could_not_run(self, tmp_path: Path, capsys, monkeypatch):
+        """A skip must not read like a pass.
+
+        The required `lint` lane checks out shallow with no origin/main, so
+        MIG003 skips there. Printing "pass MIG001/MIG002/MIG003" in that case
+        is how a check quietly stops being a check.
+        """
+        _write_migration(
+            tmp_path,
+            """
+            revision = "rev_test"
+            down_revision = None
+
+            def upgrade():
+                pass
+            """,
+            name="0001_clean.py",
+        )
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: [])
+
+        rc = rules.main([str(tmp_path)])
+
+        err = capsys.readouterr().err
+        assert rc == 0
+        assert "MIG003 NOT checked" in err
+        assert "pass MIG001/MIG002/MIG003." not in err
 
     def test_main_fails_on_violation(self, tmp_path: Path, capsys):
         _write_migration(
@@ -518,16 +547,16 @@ class TestMig003ReleasedRevisionIds:
     """
 
     @pytest.fixture(autouse=True)
-    def _stub_baseline_commit(self, monkeypatch):
+    def _stub_baseline_commits(self, monkeypatch):
         """Pin the baseline commit so these tests do not depend on git state.
 
         check_released_revision_ids resolves merge-base(ref, HEAD) before it
         reads any ids. CI checks out shallow and has no origin/main, so an
-        unpinned _baseline_commit returns None there, the check short-circuits
+        unpinned _baseline_commits returns empty there, the check short-circuits
         to "skip", and every stubbed expectation below silently passes for the
-        wrong reason. Tests that exercise _baseline_commit itself override this.
+        wrong reason. Tests that exercise _baseline_commits itself override this.
         """
-        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "baseline_sha")
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: ["baseline_sha"])
 
     def _tree(self, tmp_path: Path, ids: dict[str, str]) -> Path:
         for name, rev in ids.items():
@@ -616,7 +645,7 @@ class TestMig003ReleasedRevisionIds:
 
     def test_unresolvable_baseline_commit_skips(self, tmp_path: Path, monkeypatch):
         tree = self._tree(tmp_path, {"new.py": "rev_b"})
-        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: None)
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: [])
 
         assert rules.check_released_revision_ids(tree, "origin/main") == []
 
@@ -641,7 +670,7 @@ class TestMig003ReleasedRevisionIds:
                 else {"rev_at_fork": "m1.py", "rev_merged_after_fork": "m2.py"}
             )
 
-        monkeypatch.setattr(rules, "_baseline_commit", lambda ref: "fork_sha")
+        monkeypatch.setattr(rules, "_baseline_commits", lambda ref: ["fork_sha"])
         monkeypatch.setattr(rules, "_revision_ids_at_ref", fake_ids)
 
         assert rules.check_released_revision_ids(tree, "origin/main") == []
@@ -660,13 +689,21 @@ class TestMig003AgainstRealMigrations:
         )
 
     def test_removing_a_released_migration_is_caught(self, tmp_path: Path):
-        """Copy the real tree, delete a migration that predates this branch."""
+        """Copy the real tree, delete a migration that predates this branch.
+
+        Skips only when the baseline is genuinely unresolvable (CI checks out
+        shallow with no origin/main). It must NOT skip merely because no
+        violation was found -- that would let a regression to "always return
+        []" read as a pass.
+        """
         import shutil
 
         victim = "20260731_004_add_proxy_token_terminated_fields.py"
         source = rules.DEFAULT_VERSIONS_DIR / victim
         if not source.exists():
             pytest.skip(f"{victim} not present")
+        if not rules._baseline_commits(rules.DEFAULT_BASELINE_REF):
+            pytest.skip(f"no git baseline for {rules.DEFAULT_BASELINE_REF} in this checkout")
 
         tree = tmp_path / "versions"
         shutil.copytree(rules.DEFAULT_VERSIONS_DIR, tree)
@@ -674,8 +711,7 @@ class TestMig003AgainstRealMigrations:
 
         violations = rules.check_released_revision_ids(tree)
 
-        if not violations:
-            pytest.skip("no git baseline available in this checkout")
+        assert violations, "deleting a released migration must be reported"
         assert any(
             "20260731_004_add_proxy_token_terminated_fields" in v.message for v in violations
         )
@@ -688,9 +724,137 @@ class TestMig003AgainstRealMigrations:
         source = rules.DEFAULT_VERSIONS_DIR / victim
         if not source.exists():
             pytest.skip(f"{victim} not present")
+        if not rules._baseline_commits(rules.DEFAULT_BASELINE_REF):
+            pytest.skip(f"no git baseline for {rules.DEFAULT_BASELINE_REF} in this checkout")
 
         tree = tmp_path / "versions"
         shutil.copytree(rules.DEFAULT_VERSIONS_DIR, tree)
         (tree / victim).rename(tree / "zzz_renamed_file.py")
 
         assert rules.check_released_revision_ids(tree) == []
+
+
+class TestMig003BaselineResolutionAgainstRealGit:
+    """Drive _baseline_commits against synthetic repositories, unstubbed.
+
+    Every other MIG003 test monkeypatches _baseline_commits away, so reverting
+    the merge-base logic to the old tip-based version left the whole suite
+    green. These tests build real git histories and are the ones that fail if
+    that logic regresses.
+    """
+
+    @staticmethod
+    def _git(repo: Path, *args: str) -> str:
+        import subprocess
+
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    @classmethod
+    def _new_repo(cls, path: Path) -> Path:
+        import shutil
+
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+        (path / "migrations" / "versions").mkdir(parents=True)
+        cls._git(path, "init", "-q", "-b", "main")
+        cls._git(path, "config", "user.email", "t@example.com")
+        cls._git(path, "config", "user.name", "t")
+        return path
+
+    @classmethod
+    def _add_migration(cls, repo: Path, rev: str) -> None:
+        (repo / "migrations" / "versions" / f"{rev}.py").write_text(
+            f'revision = "{rev}"\ndown_revision = None\n\n\ndef upgrade():\n    pass\n',
+            encoding="utf-8",
+        )
+        cls._git(repo, "add", "-A")
+        cls._git(repo, "commit", "-qm", f"add {rev}")
+
+    def test_branch_lagging_behind_main_is_not_flagged(self, tmp_path: Path, monkeypatch):
+        """The false positive that made the tip-based baseline unusable.
+
+        A migration merged to main AFTER the fork is not this branch's to keep.
+        Flagging it invites the one fix that must never be made: adding the id
+        to RETIRED_REVISION_IDS.
+        """
+        repo = self._new_repo(tmp_path / "repo")
+        self._add_migration(repo, "rev_at_fork")
+        fork = self._git(repo, "rev-parse", "HEAD")
+
+        self._git(repo, "checkout", "-qb", "feature")
+        self._git(repo, "checkout", "-q", "main")
+        self._add_migration(repo, "rev_merged_after_fork")
+        self._git(repo, "checkout", "-q", "feature")
+
+        monkeypatch.setattr(rules, "PROJECT_ROOT", repo)
+        versions = repo / "migrations" / "versions"
+
+        assert rules._baseline_commits("main") == [fork]
+        assert rules.check_released_revision_ids(versions, "main") == []
+
+    def test_deleting_an_id_present_at_the_fork_is_caught(self, tmp_path: Path, monkeypatch):
+        repo = self._new_repo(tmp_path / "repo")
+        self._add_migration(repo, "rev_at_fork")
+        self._git(repo, "checkout", "-qb", "feature")
+
+        monkeypatch.setattr(rules, "PROJECT_ROOT", repo)
+        versions = repo / "migrations" / "versions"
+        (versions / "rev_at_fork.py").unlink()
+
+        violations = rules.check_released_revision_ids(versions, "main")
+
+        assert len(violations) == 1
+        assert "rev_at_fork" in violations[0].message
+
+    def test_criss_cross_history_uses_every_merge_base(self, tmp_path: Path, monkeypatch):
+        """Plain `git merge-base` returns ONE base; a criss-cross has several.
+
+        main gains X at B. A side branch forks at C and is merged into main, so
+        main has X. feature forks from C, merges B (so feature has X too), then
+        deletes X. The bases are {B, C}; C never had X, so a single-base
+        comparison misses the deletion entirely.
+        """
+        repo = self._new_repo(tmp_path / "repo")
+        self._add_migration(repo, "rev_base")
+
+        self._git(repo, "checkout", "-qb", "side")
+        self._add_migration(repo, "rev_on_side")
+        side = self._git(repo, "rev-parse", "HEAD")
+
+        self._git(repo, "checkout", "-q", "main")
+        self._add_migration(repo, "rev_x_on_main")
+        main_b = self._git(repo, "rev-parse", "HEAD")
+        self._git(repo, "merge", "-q", "--no-ff", "-m", "merge side", side)
+
+        self._git(repo, "checkout", "-qb", "feature", side)
+        self._git(repo, "merge", "-q", "--no-ff", "-m", "merge B", main_b)
+
+        monkeypatch.setattr(rules, "PROJECT_ROOT", repo)
+        versions = repo / "migrations" / "versions"
+
+        bases = rules._baseline_commits("main")
+        assert set(bases) == {main_b, side}, f"expected both merge bases, got {bases}"
+
+        # feature carries X via the merge; deleting it must be reported no
+        # matter which base git would have picked on its own.
+        (versions / "rev_x_on_main.py").unlink()
+        violations = rules.check_released_revision_ids(versions, "main")
+
+        assert [v for v in violations if "rev_x_on_main" in v.message], (
+            "deleting an id that exists on main must be caught even when the "
+            "arbitrarily-chosen single merge base predates it"
+        )
+
+    def test_unresolvable_ref_falls_back_and_skips(self, tmp_path: Path, monkeypatch):
+        repo = self._new_repo(tmp_path / "repo")
+        self._add_migration(repo, "rev_a")
+        monkeypatch.setattr(rules, "PROJECT_ROOT", repo)
+
+        assert rules._baseline_commits("refs/heads/nope") == []
+        versions = repo / "migrations" / "versions"
+        assert rules.check_released_revision_ids(versions, "refs/heads/nope") == []

--- a/tests/unit/test_migration_graph_released_ids.py
+++ b/tests/unit/test_migration_graph_released_ids.py
@@ -82,6 +82,24 @@ class TestOrphanedRevisionIsReachable:
         """A stuck database sits at 002's successor; the bridge must be exactly that."""
         assert graph[ORPHANED_ID]["down_revision"] == CI_REPAIR_ID
 
+    @staticmethod
+    def _effective_statements(node: ast.FunctionDef) -> list[ast.stmt]:
+        """Body statements that do something, i.e. everything but a docstring/pass.
+
+        Note what is NOT excluded: a bare ``op.add_column(...)`` parses to
+        ``ast.Expr(value=ast.Call(...))``. Filtering out every ``ast.Expr``
+        would drop exactly the DDL this check exists to catch, so only
+        ``ast.Expr`` wrapping a *constant* (the docstring) is ignored.
+        """
+        out = []
+        for stmt in node.body:
+            if isinstance(stmt, ast.Pass):
+                continue
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+                continue
+            out.append(stmt)
+        return out
+
     def test_bridge_applies_no_ddl(self, graph):
         """The DDL lives in 004. Re-applying it here would double-add columns."""
         source = graph[ORPHANED_ID]["path"].read_text(encoding="utf-8")
@@ -93,8 +111,35 @@ class TestOrphanedRevisionIsReachable:
         }
         assert set(funcs) == {"upgrade", "downgrade"}
         for name, node in funcs.items():
-            statements = [s for s in node.body if not isinstance(s, ast.Expr)] or []
-            assert not statements, f"{name}() must stay a no-op, found: {ast.dump(node)}"
+            statements = self._effective_statements(node)
+            assert not statements, (
+                f"{name}() must stay a no-op, found {len(statements)} statement(s): "
+                f"{[ast.dump(s) for s in statements]}"
+            )
+
+    def test_the_no_ddl_check_would_actually_catch_ddl(self):
+        """Guard the guard: the previous version of this check was vacuous.
+
+        It filtered out every ``ast.Expr``, which is precisely how a bare
+        ``op.add_column(...)`` call parses -- so a bridge full of DDL passed.
+        """
+        planted = ast.parse(
+            "def upgrade():\n"
+            '    """doc"""\n'
+            '    op.add_column("t", sa.Column("c"))\n'
+            '    op.execute("DROP TABLE users")\n'
+        ).body[0]
+        assert isinstance(planted, ast.FunctionDef)
+
+        assert len(self._effective_statements(planted)) == 2
+
+        empty = ast.parse('def upgrade():\n    """doc only"""\n').body[0]
+        assert isinstance(empty, ast.FunctionDef)
+        assert self._effective_statements(empty) == []
+
+        just_pass = ast.parse("def upgrade():\n    pass\n").body[0]
+        assert isinstance(just_pass, ast.FunctionDef)
+        assert self._effective_statements(just_pass) == []
 
     def test_teams_index_migration_follows_the_bridge(self, graph):
         """Ordering matters: a stuck database still needs the teams index."""

--- a/tests/unit/test_migration_graph_released_ids.py
+++ b/tests/unit/test_migration_graph_released_ids.py
@@ -170,6 +170,36 @@ class TestOrphanedRevisionIsReachable:
 
 
 class TestProxyTokenMigrationStaysIdempotent:
+    @staticmethod
+    def _unguarded_add_columns(func: ast.FunctionDef) -> list[ast.Call]:
+        """Return every ``op.add_column(...)`` NOT inside an ``if``.
+
+        Association, not counting. A previous version compared the number of
+        ``if`` nodes containing an add_column against the number of add_column
+        calls, so one extra nested ``if`` around an already-guarded call could
+        offset a second call left completely unguarded.
+        """
+        guarded: set[int] = set()
+        for node in ast.walk(func):
+            if not isinstance(node, ast.If):
+                continue
+            for descendant in ast.walk(node):
+                if (
+                    isinstance(descendant, ast.Call)
+                    and isinstance(descendant.func, ast.Attribute)
+                    and descendant.func.attr == "add_column"
+                ):
+                    guarded.add(id(descendant))
+
+        return [
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_column"
+            and id(node) not in guarded
+        ]
+
     def test_add_column_calls_are_guarded(self, graph):
         """A recovered database already has these columns from the old id.
 
@@ -194,18 +224,33 @@ class TestProxyTokenMigrationStaysIdempotent:
         ]
         assert add_columns, "expected add_column calls in upgrade()"
 
-        guarded = [
-            node
-            for node in ast.walk(upgrade)
-            if isinstance(node, ast.If)
-            and any(
-                isinstance(c, ast.Call)
-                and isinstance(c.func, ast.Attribute)
-                and c.func.attr == "add_column"
-                for c in ast.walk(node)
-            )
-        ]
-        assert len(guarded) >= len(add_columns), (
-            "every op.add_column in 20260731_004 must sit behind an existence check "
-            "-- databases recovered from the orphaned revision id already have these columns"
+        unguarded = self._unguarded_add_columns(upgrade)
+        assert not unguarded, (
+            f"{len(unguarded)} op.add_column call(s) in 20260731_004 are not behind an "
+            "existence check -- databases recovered from the orphaned revision id "
+            "already have these columns and would fail on duplicate column"
         )
+
+    def test_the_guard_check_catches_a_single_unguarded_call(self):
+        """Guard the guard: counting could be defeated by an extra nested if."""
+        mixed = ast.parse(
+            "def upgrade():\n"
+            "    if a:\n"
+            "        if b:\n"
+            '            op.add_column("t", c1)\n'
+            '    op.add_column("t", c2)\n'
+        ).body[0]
+        assert isinstance(mixed, ast.FunctionDef)
+
+        unguarded = self._unguarded_add_columns(mixed)
+        assert len(unguarded) == 1, "the bare add_column must be reported"
+
+        fully_guarded = ast.parse(
+            "def upgrade():\n"
+            "    if a:\n"
+            '        op.add_column("t", c1)\n'
+            "    if b:\n"
+            '        op.add_column("t", c2)\n'
+        ).body[0]
+        assert isinstance(fully_guarded, ast.FunctionDef)
+        assert self._unguarded_add_columns(fully_guarded) == []

--- a/tests/unit/test_migration_graph_released_ids.py
+++ b/tests/unit/test_migration_graph_released_ids.py
@@ -172,16 +172,21 @@ class TestOrphanedRevisionIsReachable:
 class TestProxyTokenMigrationStaysIdempotent:
     @staticmethod
     def _unguarded_add_columns(func: ast.FunctionDef) -> list[ast.Call]:
-        """Return every ``op.add_column(...)`` NOT inside an ``if``.
+        """Return every ``op.add_column(...)`` NOT behind a real condition.
 
         Association, not counting. A previous version compared the number of
         ``if`` nodes containing an add_column against the number of add_column
         calls, so one extra nested ``if`` around an already-guarded call could
         offset a second call left completely unguarded.
+
+        A constant test (``if True:``) does not count as a guard -- it is the
+        obvious way to neuter this check while keeping its shape.
         """
         guarded: set[int] = set()
         for node in ast.walk(func):
             if not isinstance(node, ast.If):
+                continue
+            if isinstance(node.test, ast.Constant):
                 continue
             for descendant in ast.walk(node):
                 if (
@@ -254,3 +259,12 @@ class TestProxyTokenMigrationStaysIdempotent:
         ).body[0]
         assert isinstance(fully_guarded, ast.FunctionDef)
         assert self._unguarded_add_columns(fully_guarded) == []
+
+    def test_a_constant_condition_does_not_count_as_a_guard(self):
+        """`if True:` keeps the shape while removing the protection."""
+        neutered = ast.parse('def upgrade():\n    if True:\n        op.add_column("t", c1)\n').body[
+            0
+        ]
+        assert isinstance(neutered, ast.FunctionDef)
+
+        assert len(self._unguarded_add_columns(neutered)) == 1

--- a/tests/unit/test_migration_graph_released_ids.py
+++ b/tests/unit/test_migration_graph_released_ids.py
@@ -1,0 +1,166 @@
+"""The Alembic graph must keep resolving every revision id that has shipped.
+
+``20260731_003_add_proxy_token_terminated_fields`` shipped on main (commit
+05bcca72) and was then renumbered to ``20260731_004_...`` so that
+``20260731_003_add_teams_sync_source_indexes`` could take the 003 slot. Alembic
+keys history off the revision id, so the rename deleted a node that live
+databases were already stamped with: every deployment upgraded in that window
+now fails ``upgrade head`` with ``Can't locate revision identified by
+'20260731_003_add_proxy_token_terminated_fields'`` -- and stays stuck for every
+later migration too.
+
+The recovery is a no-op bridge that re-homes the orphaned id between 002 and
+the teams-index migration. These tests pin its shape so nobody "cleans up" the
+empty migration later.
+
+Lineage: Issue #1704 (migration authoring rules).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.regression,
+    pytest.mark.issue(1704),
+]
+
+VERSIONS_DIR = Path(__file__).resolve().parent.parent.parent / "migrations" / "versions"
+
+ORPHANED_ID = "20260731_003_add_proxy_token_terminated_fields"
+TEAMS_INDEX_ID = "20260731_003_add_teams_sync_source_indexes"
+PROXY_TOKEN_ID = "20260731_004_add_proxy_token_terminated_fields"
+CI_REPAIR_ID = "20260731_002_add_ci_repair_transient_retries"
+
+
+def _module_constants(path: Path) -> dict[str, object]:
+    """Read module-level literal assignments without importing the module."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    out: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            first = node.targets[0]
+            if not isinstance(first, ast.Name):
+                continue
+            name = first.id
+        else:
+            continue
+        if isinstance(node.value, ast.Constant):
+            out[name] = node.value.value
+    return out
+
+
+@pytest.fixture(scope="module")
+def graph() -> dict[str, dict]:
+    """Map revision id -> {down_revision, path} for every committed migration."""
+    revisions: dict[str, dict] = {}
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        consts = _module_constants(path)
+        rev = consts.get("revision")
+        if isinstance(rev, str):
+            revisions[rev] = {"down_revision": consts.get("down_revision"), "path": path}
+    return revisions
+
+
+class TestOrphanedRevisionIsReachable:
+    def test_orphaned_id_exists_in_the_graph(self, graph):
+        """Without this node, every database stamped with it is wedged."""
+        assert ORPHANED_ID in graph, (
+            f"{ORPHANED_ID} shipped on main and must remain a resolvable revision. "
+            "See migrations/versions/20260731_003_bridge_renamed_proxy_token_revision.py"
+        )
+
+    def test_bridge_is_parented_to_the_revision_it_originally_followed(self, graph):
+        """A stuck database sits at 002's successor; the bridge must be exactly that."""
+        assert graph[ORPHANED_ID]["down_revision"] == CI_REPAIR_ID
+
+    def test_bridge_applies_no_ddl(self, graph):
+        """The DDL lives in 004. Re-applying it here would double-add columns."""
+        source = graph[ORPHANED_ID]["path"].read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        funcs = {
+            node.name: node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name in ("upgrade", "downgrade")
+        }
+        assert set(funcs) == {"upgrade", "downgrade"}
+        for name, node in funcs.items():
+            statements = [s for s in node.body if not isinstance(s, ast.Expr)] or []
+            assert not statements, f"{name}() must stay a no-op, found: {ast.dump(node)}"
+
+    def test_teams_index_migration_follows_the_bridge(self, graph):
+        """Ordering matters: a stuck database still needs the teams index."""
+        assert graph[TEAMS_INDEX_ID]["down_revision"] == ORPHANED_ID
+
+    def test_proxy_token_ddl_still_follows_the_teams_index(self, graph):
+        assert graph[PROXY_TOKEN_ID]["down_revision"] == TEAMS_INDEX_ID
+
+    def test_path_from_orphan_reaches_a_single_head(self, graph):
+        """Walk the chain forward and confirm it terminates in exactly one head."""
+        children: dict[object, list[str]] = {}
+        for rev, meta in graph.items():
+            children.setdefault(meta["down_revision"], []).append(rev)
+
+        current = ORPHANED_ID
+        seen = {current}
+        while True:
+            nxt = children.get(current, [])
+            assert len(nxt) <= 1, f"{current} forks into {nxt}"
+            if not nxt:
+                break
+            current = nxt[0]
+            assert current not in seen, f"cycle at {current}"
+            seen.add(current)
+
+        heads = [rev for rev in graph if rev not in children]
+        assert heads == [current], f"expected the walk to end at the single head, got {heads}"
+
+
+class TestProxyTokenMigrationStaysIdempotent:
+    def test_add_column_calls_are_guarded(self, graph):
+        """A recovered database already has these columns from the old id.
+
+        The bridge only works because 004 checks the inspector before adding;
+        drop that guard and every recovered database fails on duplicate column.
+        """
+        source = graph[PROXY_TOKEN_ID]["path"].read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        upgrade = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "upgrade"
+        )
+
+        add_columns = [
+            node
+            for node in ast.walk(upgrade)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_column"
+        ]
+        assert add_columns, "expected add_column calls in upgrade()"
+
+        guarded = [
+            node
+            for node in ast.walk(upgrade)
+            if isinstance(node, ast.If)
+            and any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Attribute)
+                and c.func.attr == "add_column"
+                for c in ast.walk(node)
+            )
+        ]
+        assert len(guarded) >= len(add_columns), (
+            "every op.add_column in 20260731_004 must sit behind an existence check "
+            "-- databases recovered from the orphaned revision id already have these columns"
+        )

--- a/tests/unit/test_platform_admin_strict_mode_wiring.py
+++ b/tests/unit/test_platform_admin_strict_mode_wiring.py
@@ -1,0 +1,160 @@
+"""OPENACE_PLATFORM_ADMIN_STRICT_MODE must actually reach the role checks.
+
+The flag shipped unwired. ``is_platform_admin_strict_mode()`` -- the only
+function that read the environment variable and populated the module cache --
+had zero production callers; every consumer went through
+``get_cached_strict_mode()``, which returned ``_PLATFORM_ADMIN_STRICT_MODE or
+False`` against a global that nothing ever set. The result was a switch that
+could not be switched: setting the variable to ``true`` changed nothing, and
+legacy ``admin`` stayed equivalent to ``platform_admin`` forever, while the
+docstring carried a four-step deployment procedure for enabling it.
+
+These tests pin the wiring itself, not just the helper's return type.
+
+Lineage: Issue #2332 (centralized platform admin checking with strict mode).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.security,
+    pytest.mark.regression,
+    pytest.mark.issue(2332),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_strict_mode_cache():
+    """Clear the process-global flag around every test.
+
+    The cache is deliberately process-lifetime in production; leaving a value
+    behind here would silently change how later tests classify the legacy
+    ``admin`` role.
+    """
+    from app.auth.permissions import reset_strict_mode_cache
+
+    reset_strict_mode_cache()
+    yield
+    reset_strict_mode_cache()
+
+
+class TestFlagIsActuallyRead:
+    def test_enabled_env_reaches_get_cached_strict_mode(self, monkeypatch):
+        """The regression: this returned False no matter what the env said."""
+        from app.auth.permissions import get_cached_strict_mode
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+
+        assert get_cached_strict_mode() is True
+
+    def test_disabled_env_is_the_default(self, monkeypatch):
+        from app.auth.permissions import get_cached_strict_mode
+
+        monkeypatch.delenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", raising=False)
+
+        assert get_cached_strict_mode() is False
+
+    @pytest.mark.parametrize("value", ["TRUE", "True", "tRuE"])
+    def test_case_insensitive(self, monkeypatch, value):
+        from app.auth.permissions import get_cached_strict_mode
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", value)
+
+        assert get_cached_strict_mode() is True
+
+    @pytest.mark.parametrize("value", ["false", "1", "yes", "on", ""])
+    def test_only_the_literal_true_enables_it(self, monkeypatch, value):
+        """Anything other than 'true' leaves the permissive default in place."""
+        from app.auth.permissions import get_cached_strict_mode
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", value)
+
+        assert get_cached_strict_mode() is False
+
+    def test_value_is_frozen_after_first_read(self, monkeypatch):
+        """A mid-flight env change must not make two requests disagree."""
+        from app.auth.permissions import get_cached_strict_mode
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+        assert get_cached_strict_mode() is True
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "false")
+        assert get_cached_strict_mode() is True
+
+
+class TestRoleChecksHonourTheFlag:
+    """The flag is only meaningful if it changes an authorization outcome."""
+
+    def test_legacy_admin_is_platform_admin_when_disabled(self, monkeypatch):
+        from app.auth.permissions import is_platform_admin_role
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "false")
+
+        assert is_platform_admin_role("admin") is True
+        assert is_platform_admin_role("platform_admin") is True
+
+    def test_legacy_admin_is_rejected_when_enabled(self, monkeypatch):
+        """This is the whole point of the flag, and it never worked."""
+        from app.auth.permissions import is_platform_admin_role
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+
+        assert is_platform_admin_role("admin") is False
+        assert is_platform_admin_role("platform_admin") is True
+
+    def test_user_model_honours_the_flag(self, monkeypatch):
+        from app.models.user import User
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+        legacy = User(id=1, username="legacy", email="l@example.com", role="admin")
+
+        assert legacy.is_platform_admin() is False
+        assert legacy.is_platform_admin(strict=False) is True
+
+    def test_non_admin_roles_are_never_platform_admin(self, monkeypatch):
+        from app.auth.permissions import is_platform_admin_role
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+
+        for role in ("user", "tenant_admin", "", None):
+            assert is_platform_admin_role(role) is False
+
+
+class TestStartupInitialization:
+    def test_init_resolves_and_freezes_the_flag(self, monkeypatch):
+        from app.auth.permissions import get_cached_strict_mode, init_platform_admin_strict_mode
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+
+        assert init_platform_admin_strict_mode() is True
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "false")
+        assert init_platform_admin_strict_mode() is True
+        assert get_cached_strict_mode() is True
+
+    def test_init_is_called_during_app_creation(self):
+        """Guards against the wiring being dropped from create_app again.
+
+        Checked statically: actually building the app opens a database and
+        would make this test depend on the local schema being current, which
+        says nothing about the flag.
+        """
+        import ast
+        import inspect
+
+        import app as app_pkg
+
+        tree = ast.parse(inspect.getsource(app_pkg.create_app))
+        called = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+
+        assert "init_platform_admin_strict_mode" in called, (
+            "create_app must call init_platform_admin_strict_mode() so the flag "
+            "is frozen and logged before the first request"
+        )

--- a/tests/unit/test_platform_admin_strict_mode_wiring.py
+++ b/tests/unit/test_platform_admin_strict_mode_wiring.py
@@ -158,3 +158,66 @@ class TestStartupInitialization:
             "create_app must call init_platform_admin_strict_mode() so the flag "
             "is frozen and logged before the first request"
         )
+        assert (
+            "warn_if_strict_mode_locks_out_legacy_admins" in called
+        ), "create_app must run the legacy-admin lockout check at startup"
+
+
+class TestLegacyAdminLockoutWarning:
+    """The flag was inert while the runbook told operators to set it.
+
+    So the deploy that finally wires it up is the deploy where every remaining
+    role='admin' account silently loses platform access. Startup must say so.
+    """
+
+    def test_no_check_when_strict_mode_is_off(self, monkeypatch):
+        from app.auth.permissions import warn_if_strict_mode_locks_out_legacy_admins
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "false")
+
+        assert warn_if_strict_mode_locks_out_legacy_admins() is None
+
+    def test_counts_and_logs_legacy_admins_when_on(self, monkeypatch, caplog):
+        import logging
+        from unittest.mock import MagicMock
+
+        from app.auth.permissions import warn_if_strict_mode_locks_out_legacy_admins
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+        db = MagicMock()
+        db.fetch_one.return_value = {"n": 3}
+        monkeypatch.setattr("app.repositories.database.Database", lambda *a, **k: db)
+
+        with caplog.at_level(logging.ERROR):
+            assert warn_if_strict_mode_locks_out_legacy_admins() == 3
+
+        assert "3 account(s) still have" in caplog.text
+
+    def test_silent_when_no_legacy_admins_remain(self, monkeypatch, caplog):
+        import logging
+        from unittest.mock import MagicMock
+
+        from app.auth.permissions import warn_if_strict_mode_locks_out_legacy_admins
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+        db = MagicMock()
+        db.fetch_one.return_value = {"n": 0}
+        monkeypatch.setattr("app.repositories.database.Database", lambda *a, **k: db)
+
+        with caplog.at_level(logging.ERROR):
+            assert warn_if_strict_mode_locks_out_legacy_admins() == 0
+
+        assert "still have" not in caplog.text
+
+    def test_unreachable_database_is_not_fatal(self, monkeypatch):
+        """Startup diagnostics must never be the thing that breaks startup."""
+        from app.auth.permissions import warn_if_strict_mode_locks_out_legacy_admins
+
+        monkeypatch.setenv("OPENACE_PLATFORM_ADMIN_STRICT_MODE", "true")
+
+        def boom(*a, **k):
+            raise RuntimeError("no database")
+
+        monkeypatch.setattr("app.repositories.database.Database", boom)
+
+        assert warn_if_strict_mode_locks_out_legacy_admins() is None


### PR DESCRIPTION
Three P0 findings from the 2026-08-13 evaluation.

## 1 — Cross-tenant account takeover

`admin_required` authenticates `admin` / `platform_admin` / `tenant_admin` and populates `g.tenant_id`, but never compared that tenant against the tenant of the resource being operated on. Concretely, any tenant admin could:

- **Reset any user's password — including a platform admin's — and read the new password straight out of the response body** (`POST /api/admin/users/<id>/reset-password`)
- Change/delete/re-quota any user in any tenant
- `GET /api/admin/users` with no `tenant_id` returned **every tenant's** users
- Promote a user to `platform_admin`, or move users across the tenant boundary

This became reachable when #2179 added `tenant_admin` to the decorator's allow-list; before that only platform-level roles could enter these endpoints.

### Fix

Three reusable primitives in `app/auth/decorators.py`, rather than a hand-written `if` per endpoint (the mode of failure there is *forgetting*, which is silent):

| Primitive | Role |
|---|---|
| `resolve_admin_tenant_scope()` | platform admin → global; tenant admin → own tenant; no usable tenant → deny |
| `same_tenant_user_required` | decorator stacked under `admin_required`; resolves the target user and compares |
| `enforce_requested_tenant_scope()` | list/create paths: naming another tenant is 403, omitting it narrows to your own |

Plus `reject_privilege_escalation()` in `app/routes/admin.py` to block a tenant admin granting `platform_admin` / `admin`.

### The check is vertical as well as horizontal

Comparing tenants alone is not enough, and the first draft of this PR got it wrong. `api_create_user` **requires** a `tenant_id` (400 without one), so every platform admin minted through the admin API carries some tenant, and the schema only constrains `tenant_admin` to have one. File a `platform_admin` under tenant A and tenant A's admin could reset its password and read it back — a full escape, with no role granted, so `reject_privilege_escalation` never fires.

So the guard also denies platform-level *targets*, via `is_platform_level_role`, which is deliberately **not** strict-mode-sensitive: routing it through `is_platform_admin_role` would drop protection for legacy `admin` rows the moment strict mode is enabled, making the stricter setting less safe.

Applied to 7 user-targeted `admin_required` endpoints; 2 more (`mapping_rules.py`) keep their existing hand-written #2180 checks, so all 9 are covered. **Platform admins keep their cross-tenant reach unchanged** — boundary crossings are now written to the audit log as `ADMIN_CROSS_TENANT_ACCESS`.

### Audit

All 95 functions carrying `@admin_required` reviewed — 92 route handlers plus 3 blueprint-wide `before_request` guards. See `docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md`. 29 carry a resource id; 23 are now tenant-aware. The 6 that are not are non-user resources (policy rules, filter rules, quota alerts, compliance reports) — not account takeover, they need per-resource owner lookups, and they are deliberately left to a follow-up PR. The note carries the worklist and flags `PUT /policy/rules/<rule_key>` as its priority item, since that one replaces another tenant's live policy rather than merely toggling it.

## 2 — `OPENACE_PLATFORM_ADMIN_STRICT_MODE` was dead code

`is_platform_admin_strict_mode()` — the only function that read the environment variable and populated the module cache — had **zero production callers**. Every consumer went through `get_cached_strict_mode()`, which returned `_PLATFORM_ADMIN_STRICT_MODE or False` against a global nothing ever set. The flag was permanently off and legacy `admin` stayed equivalent to `platform_admin` forever, while the docstring carried a four-step deployment procedure for enabling it.

```
BEFORE  OPENACE_PLATFORM_ADMIN_STRICT_MODE=true
        get_cached_strict_mode()          -> False
        is_platform_admin_role("admin")   -> True

AFTER   OPENACE_PLATFORM_ADMIN_STRICT_MODE=true
        get_cached_strict_mode()          -> True
        is_platform_admin_role("admin")   -> False
```

`get_cached_strict_mode()` now delegates to the resolver; `create_app` freezes the value at startup so the documented "cached at application startup" contract is true and the ENABLED/DISABLED line appears in the boot log. **Default behavior is unchanged** — the flag still defaults to `false`.

The docstring's step 4 pointed at `/api/system/config`, which does not exist; it now points at the startup log line, and step 1 spells out that legacy `admin` accounts must be migrated *before* enabling strict mode or they lose access.

## 3 — A released alembic revision id was renamed

`20260731_003_add_proxy_token_terminated_fields` shipped on main (commit `05bcca72`), then was renumbered to `20260731_004_...` so `20260731_003_add_teams_sync_source_indexes` could take the 003 slot. Alembic keys history off the revision **id**, not the filename, so the rename deleted a node that live databases were already stamped with. Every deployment upgraded in that window fails `upgrade head` with `Can't locate revision identified by '20260731_003_add_proxy_token_terminated_fields'` — and stays stuck for every later migration too.

### Fix

A no-op bridge re-homes the orphaned id between 002 and the teams-index migration:

```
002 -> 003 (bridge, no DDL) -> 003_teams_sync_source_indexes -> 004_proxy_token_terminated_fields
```

Renaming `_004_` back is not an option — that id has shipped too, and renaming it would strand a second set of databases the same way.

**Verified end to end on SQLite.** A database stamped with the orphaned id (built by replaying the original 003 DDL against a tree at 002, then stamping the old id) reaches head, and its schema is object-for-object identical to a freshly migrated database. The proxy-token columns are not added twice — `_004_` already guards every `add_column` behind an inspector check, and a test now pins that guard in place.

### Prevention

New **MIG003** in `scripts/lint/check_migration_rules.py`: a revision id present at this branch's fork point must still exist. Runs in pre-commit and in the `migration-graph` workflow against the pre-merged tree. `RETIRED_REVISION_IDS` is the documented escape hatch.

The baseline is `merge-base --all`, not the tip of `origin/main`, for two reasons found in review:

- **Tip** flags every migration merged to main after the fork as "missing" — it false-positived on this very branch against `20260814_002`. Worse, the obvious way to silence that is to add the id to `RETIRED_REVISION_IDS`, which is precisely the mistake the rule exists to prevent.
- **`--all`** because plain `git merge-base` returns one of several bases. In a criss-cross history, if the id was added on the branch the chosen base does not descend from, deleting it goes unnoticed.

When no baseline is resolvable (shallow clone, unfetched remote) it skips — and now **says so** in the summary line rather than reporting a pass, because the required `lint` lane checks out shallow and that is its normal case.

Tested both directions against `05bcca72` (the pre-rename baseline), and against synthetic git repositories built per-test for the lag, deletion, rename and criss-cross cases — the last of which fail if the merge-base logic is reverted.

## Verification

- **83 new tests**, all passing.
- **Run against pre-fix main (`f52b2912`)**: reverting `app/` + `scripts/lint/` + the bridge gives **39 failed + 33 errors**. Targeted hunk reverts confirm the specific claims — neutering the vertical `is_platform_level_role` branch → 7 failures; neutering the `enforce_requested_tenant_scope` 400 → 6 failures; reverting the MIG003 merge-base logic → 2 failures. The tests that still pass under a full revert are the no-regression controls (platform admin keeps reach, legacy admin keeps reach, tenant admin still acts within its own tenant).
- **CI conditions, which are stricter than a dev box.** The lanes have no database configured *and* a shallow checkout with no `origin/main`; two bugs in this PR escaped by passing locally for reasons that do not exist on the runner. Verified with both removed:
  - `pytest tests/` → **5058 passed / 0 failed** (empty SQLite)
  - same, plus `MIG003_BASELINE_REF=refs/does-not-exist` → **5056 passed / 0 failed**
  - `pytest tests/unit/` (the `compatibility-smoke` suite) → **4111 passed / 0 failed**
- pre-commit: all hooks pass.

## Review history

Two rounds of independent adversarial review, both of which found real defects that are now fixed:

- **Round 1** — the tenant check was purely horizontal, so a tenant admin could take over a `platform_admin` filed under its own tenant; `api_update_user` discarded the scope guard's return value; MIG003 false-positived on any branch lagging `origin/main`.
- **Round 2** — MIG003 had no effective test coverage (every test stubbed the resolver, so reverting it stayed green); a criss-cross git history could still hide a deleted revision id; a skipped MIG003 was logged as a pass; `test_bridge_applies_no_ddl` could not actually detect DDL; `PUT /policy/rules/<rule_key>` was missing from the follow-up worklist.

One review finding was disputed rather than applied: `require_tenant_scope()` does hand tenant admins global scope, but all three call sites discard the returned value and use it purely as a deny-gate, so it is a latent trap rather than a live leak. It is recorded as such in the dev-note.

Reviewed against issues #2180 (admin-route tenant isolation), #2332 (strict mode), #1704 (migration authoring rules). No issue is auto-closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
