### PR TITLE
fix: 文件列表项添加点击下载功能 (#2598)

### DIFF
--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -239,7 +239,6 @@ describe('LocalDirectoryBrowser', () => {
     });
   });
 
-
   it('downloads a file when clicking the file list item', async () => {
     const blob = new Blob(['content'], { type: 'text/plain' });
     downloadFileMock.mockResolvedValue(blob);

--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -286,7 +286,7 @@ describe('LocalDirectoryBrowser', () => {
     });
 
     const fileItem = screen.getByText('slow.txt').closest('li')!;
-    
+
     fireEvent.click(fileItem);
     await waitFor(() => {
       expect(downloadFileMock).toHaveBeenCalledTimes(1);
@@ -294,7 +294,7 @@ describe('LocalDirectoryBrowser', () => {
 
     fireEvent.click(fileItem);
     await new Promise((r) => setTimeout(r, 100));
-    
+
     expect(downloadFileMock).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -239,6 +239,65 @@ describe('LocalDirectoryBrowser', () => {
     });
   });
 
+
+  it('downloads a file when clicking the file list item', async () => {
+    const blob = new Blob(['content'], { type: 'text/plain' });
+    downloadFileMock.mockResolvedValue(blob);
+    browseDirectoryMock.mockResolvedValue(
+      browseResponse({
+        files: [{ name: 'report.txt', path: '/home/alice/report.txt', size: 7, is_readable: true }],
+      })
+    );
+
+    render(
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} enableFileActions />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('report.txt')).toBeInTheDocument();
+    });
+
+    // Click the file list item (not the download button)
+    const fileItem = screen.getByText('report.txt').closest('li');
+    fireEvent.click(fileItem!);
+
+    await waitFor(() => {
+      expect(downloadFileMock).toHaveBeenCalledWith('/home/alice/report.txt');
+    });
+    await waitFor(() => {
+      expect(downloadBlobMock).toHaveBeenCalledWith(blob, 'report.txt');
+    });
+  });
+
+  it('does not trigger download again when clicking file item during download', async () => {
+    downloadFileMock.mockImplementation(() => new Promise((r) => setTimeout(r, 1000)));
+    browseDirectoryMock.mockResolvedValue(
+      browseResponse({
+        files: [{ name: 'slow.txt', path: '/home/alice/slow.txt', size: 7, is_readable: true }],
+      })
+    );
+
+    render(
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} enableFileActions />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('slow.txt')).toBeInTheDocument();
+    });
+
+    const fileItem = screen.getByText('slow.txt').closest('li')!;
+    
+    fireEvent.click(fileItem);
+    await waitFor(() => {
+      expect(downloadFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(fileItem);
+    await new Promise((r) => setTimeout(r, 100));
+    
+    expect(downloadFileMock).toHaveBeenCalledTimes(1);
+  });
+
   it('hides delete button when directory is not writable', async () => {
     browseDirectoryMock.mockResolvedValue(
       browseResponse({

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -829,6 +829,8 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                   <li
                     key={file.path}
                     className="list-group-item file-list-item d-flex justify-content-between align-items-center"
+                    onClick={() => void handleDownload(file)}
+                    style={{ cursor: 'pointer' }}
                   >
                     <div className="text-truncate">
                       <i
@@ -841,7 +843,7 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                         {formatBytes(file.size)}
                       </span>
                     </div>
-                    <div className="file-actions btn-group">
+                    <div className="file-actions btn-group" onClick={(e) => e.stopPropagation()}>
                       <button
                         type="button"
                         className="btn btn-sm btn-outline-secondary"

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -829,8 +829,16 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                   <li
                     key={file.path}
                     className="list-group-item file-list-item d-flex justify-content-between align-items-center"
-                    onClick={() => void handleDownload(file)}
-                    style={{ cursor: 'pointer' }}
+                    onClick={() => {
+                      if (downloadingPath === file.path) return;
+                      void handleDownload(file);
+                    }}
+                    style={{ cursor: downloadingPath === file.path ? 'wait' : 'pointer' }}
+                    title={
+                      file.is_readable
+                        ? t('clickToDownload', language) || 'Click to download'
+                        : t('fileNotReadable', language) || 'No read permission'
+                    }
                   >
                     <div className="text-truncate">
                       <i


### PR DESCRIPTION
Closes #2598

## 修复内容
- 文件列表项添加 onClick 事件处理
- 点击文件触发下载功能
- 添加事件冒泡防护（stopPropagation）

## 技术实现
- 在 `<li>` 元素添加 `onClick={() => void handleDownload(file)}`
- 添加 `style={{ cursor: 'pointer' }}` 提供视觉反馈
- 在按钮容器添加 `onClick={(e) => e.stopPropagation()}` 防止事件冒泡

## 测试
- 前端类型检查通过
- 前端 lint 通过（只有警告，无错误）
- 单元测试全部通过（25 tests）

Generated with Qwen Code (4-shotted by Qwen-Coder)