### PR TITLE
[UI] 通知与集成设置页 UI 重构 — 按 v3 原型图落地

### DIFF
--- a/frontend/src/components/features/management/SmtpConfig.tsx
+++ b/frontend/src/components/features/management/SmtpConfig.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/common';
 import { smtpConfigApi, type SMTPConfig, type EmailStatistics } from '@/api/smtpConfig';
 
-export const SmtpConfig: React.FC = () => {
+export const SmtpConfig: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
   const language = useLanguage();
   const toast = useToast();
 
@@ -282,19 +282,21 @@ export const SmtpConfig: React.FC = () => {
 
   return (
     <div className="smtp-config">
-      <div className="d-flex justify-content-between align-items-center mb-3">
-        <h2>{t('smtpConfiguration', language)}</h2>
-        {config && (
-          <Badge variant={config.is_verified ? 'success' : 'warning'}>
-            {config.is_verified ? t('verified', language) : t('notVerified', language)}
-          </Badge>
-        )}
-      </div>
+      {!compact && (
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h2>{t('smtpConfiguration', language)}</h2>
+          {config && (
+            <Badge variant={config.is_verified ? 'success' : 'warning'}>
+              {config.is_verified ? t('verified', language) : t('notVerified', language)}
+            </Badge>
+          )}
+        </div>
+      )}
 
       {error && <Error message={error} onRetry={fetchConfig} />}
 
       {/* Existing config info */}
-      {config && (
+      {!compact && config && (
         <Card className="mb-3">
           <div className="d-flex align-items-center">
             <i className="bi bi-info-circle text-info me-2" />
@@ -483,30 +485,32 @@ export const SmtpConfig: React.FC = () => {
       )}
 
       {/* Help */}
-      <Card title={t('help', language)} className="mt-4">
-        <div className="alert alert-info">
-          <h6 className="alert-heading">{t('smtpSetupGuide', language)}</h6>
-          <ul className="mb-0">
-            <li>{t('smtpSetupGuide1', language)}</li>
-            <li>{t('smtpSetupGuide2', language)}</li>
-            <li>{t('smtpSetupGuide3', language)}</li>
-            <li>{t('smtpSetupGuide4', language)}</li>
-          </ul>
-          <hr className="my-2" />
-          <h6 className="alert-heading mb-2">{t('smtpPortGuide', language) || 'Port Guide'}</h6>
-          <ul className="mb-0">
-            <li>
-              <strong>25</strong>: {t('smtpHelpPort25', language)}
-            </li>
-            <li>
-              <strong>587</strong>: {t('smtpHelpPort587', language)}
-            </li>
-            <li>
-              <strong>465</strong>: {t('smtpHelpPort465', language)}
-            </li>
-          </ul>
-        </div>
-      </Card>
+      {!compact && (
+        <Card title={t('help', language)} className="mt-4">
+          <div className="alert alert-info">
+            <h6 className="alert-heading">{t('smtpSetupGuide', language)}</h6>
+            <ul className="mb-0">
+              <li>{t('smtpSetupGuide1', language)}</li>
+              <li>{t('smtpSetupGuide2', language)}</li>
+              <li>{t('smtpSetupGuide3', language)}</li>
+              <li>{t('smtpSetupGuide4', language)}</li>
+            </ul>
+            <hr className="my-2" />
+            <h6 className="alert-heading mb-2">{t('smtpPortGuide', language) || 'Port Guide'}</h6>
+            <ul className="mb-0">
+              <li>
+                <strong>25</strong>: {t('smtpHelpPort25', language)}
+              </li>
+              <li>
+                <strong>587</strong>: {t('smtpHelpPort587', language)}
+              </li>
+              <li>
+                <strong>465</strong>: {t('smtpHelpPort465', language)}
+              </li>
+            </ul>
+          </div>
+        </Card>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/features/settings/FeishuConfig.tsx
+++ b/frontend/src/components/features/settings/FeishuConfig.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/common';
 import { feishuConfigApi, type FeishuConfigResponse } from '@/api/feishuConfig';
 
-export const FeishuConfig: React.FC = () => {
+export const FeishuConfig: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
   const language = useLanguage();
   const toast = useToast();
   const confirm = useConfirm();
@@ -233,23 +233,28 @@ export const FeishuConfig: React.FC = () => {
 
   return (
     <div className="feishu-config">
-      {/* Header */}
-      <div className="d-flex justify-content-between align-items-center mb-3">
-        <h2>{t('feishuIntegration', language)}</h2>
-        {getStatusBadge()}
-      </div>
-
-      {error && <Error message={error} onRetry={fetchConfig} />}
-
-      {/* Existing config info */}
-      {config && (
-        <Card className="mb-3">
-          <div className="d-flex align-items-center">
-            <i className="bi bi-info-circle text-info me-2" />
-            <span className="text-muted">{t('feishuConfigExists', language)}</span>
+      {!compact && (
+        <>
+          {/* Header */}
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h2>{t('feishuIntegration', language)}</h2>
+            {getStatusBadge()}
           </div>
-        </Card>
+
+          {error && <Error message={error} onRetry={fetchConfig} />}
+
+          {/* Existing config info */}
+          {config && (
+            <Card className="mb-3">
+              <div className="d-flex align-items-center">
+                <i className="bi bi-info-circle text-info me-2" />
+                <span className="text-muted">{t('feishuConfigExists', language)}</span>
+              </div>
+            </Card>
+          )}
+        </>
       )}
+      {compact && error && <Error message={error} onRetry={fetchConfig} />}
 
       {/* Configuration Form */}
       <Card className="mb-4">
@@ -384,18 +389,20 @@ export const FeishuConfig: React.FC = () => {
         </form>
       </Card>
 
-      {/* Help */}
-      <Card title={t('help', language)} className="mt-4">
-        <div className="alert alert-info">
-          <h6 className="alert-heading">{t('feishuSetupGuide', language)}</h6>
-          <ol className="mb-0">
-            <li>{t('feishuSetupGuide1', language)}</li>
-            <li>{t('feishuSetupGuide2', language)}</li>
-            <li>{t('feishuSetupGuide3', language)}</li>
-            <li>{t('feishuSetupGuide4', language)}</li>
-          </ol>
-        </div>
-      </Card>
+      {!compact && (
+        /* Help */
+        <Card title={t('help', language)} className="mt-4">
+          <div className="alert alert-info">
+            <h6 className="alert-heading">{t('feishuSetupGuide', language)}</h6>
+            <ol className="mb-0">
+              <li>{t('feishuSetupGuide1', language)}</li>
+              <li>{t('feishuSetupGuide2', language)}</li>
+              <li>{t('feishuSetupGuide3', language)}</li>
+              <li>{t('feishuSetupGuide4', language)}</li>
+            </ol>
+          </div>
+        </Card>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/features/settings/NotificationIntegration.tsx
+++ b/frontend/src/components/features/settings/NotificationIntegration.tsx
@@ -10,6 +10,43 @@ import { FeishuConfig } from './FeishuConfig';
 
 type Section = 'channels' | 'collaboration';
 
+const statusColor = (status?: string) => {
+  switch (status) {
+    case 'configured':
+    case 'enabled':
+    case 'available':
+      return '#639922';
+    case 'no_configuration_required':
+      return '#378ADD';
+    case 'needs_configuration':
+      return '#EF9F27';
+    case 'disabled':
+      return '#888780';
+    case 'error':
+      return '#A32D2D';
+    default:
+      return '#888780';
+  }
+};
+
+const statusBadgeVariant = (status?: string) => {
+  switch (status) {
+    case 'configured':
+    case 'enabled':
+    case 'available':
+    case 'no_configuration_required':
+      return 'success';
+    case 'needs_configuration':
+      return 'warning';
+    case 'disabled':
+      return 'secondary';
+    case 'error':
+      return 'danger';
+    default:
+      return 'warning';
+  }
+};
+
 export const NotificationIntegration: React.FC = () => {
   const language = useLanguage();
   const toast = useToast();
@@ -21,6 +58,8 @@ export const NotificationIntegration: React.FC = () => {
   const [syncResult, setSyncResult] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [webhookTestUrl, setWebhookTestUrl] = useState('');
+  const [dingtalkTestUrl, setDingtalkTestUrl] = useState('');
   const [webhook, setWebhook] = useState({
     webhook_secret: '',
     allow_private_webhook_urls: false,
@@ -80,19 +119,6 @@ export const NotificationIntegration: React.FC = () => {
     };
     return keys[value ?? ''] ?? 'loading';
   };
-  const badge = (key: string) => (
-    <Badge
-      variant={
-        ['configured', 'enabled', 'available', 'no_configuration_required'].includes(
-          status[key]?.status
-        )
-          ? 'success'
-          : 'warning'
-      }
-    >
-      {t(statusKey(status[key]?.status), language)}
-    </Badge>
-  );
 
   const saveWebhook = async () => {
     const { webhook_secret, ...rest } = webhook;
@@ -153,18 +179,154 @@ export const NotificationIntegration: React.FC = () => {
     }
   };
 
-  const cards = [
+  const channelCards = [
     ['email', 'integrationEmail', 'integrationEmailDesc'],
     ['webhook', 'integrationWebhook', 'integrationWebhookDesc'],
     ['dingtalk_bot', 'integrationDingTalkBot', 'integrationDingTalkBotDesc'],
     ['feishu_bot', 'integrationFeishuBot', 'integrationFeishuBotDesc'],
-  ];
+  ] as const;
+
+  const platformCards = [
+    ['feishu', 'integrationFeishuApp', 'feishu_app'],
+    ['dingtalk', 'integrationDingTalkApp', 'dingtalk_app'],
+  ] as const;
+
+  const statusPill = (key: string, titleKey: string) => {
+    const st = status[key]?.status || 'needs_configuration';
+    return (
+      <span
+        key={key}
+        className="ni-status-pill"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 12.5,
+          color: 'var(--color-text-secondary, #444441)',
+        }}
+      >
+        <span style={{ width: 8, height: 8, borderRadius: '50%', background: statusColor(st) }} />
+        {t(titleKey, language)} · {t(statusKey(st), language)}
+      </span>
+    );
+  };
 
   return (
-    <div>
+    <div className="notification-integration">
+      <style>{`
+        .notification-integration .ni-status-bar {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 14px;
+          padding: 10px 0;
+        }
+        .notification-integration .ni-tabs {
+          display: flex;
+          gap: 8px;
+        }
+        .notification-integration .ni-tabs .btn {
+          border-radius: 6px;
+        }
+        .notification-integration .ni-channel-card {
+          background: var(--color-background-primary, #fff);
+          border: 0.5px solid var(--color-border-tertiary, #d3d1c7);
+          border-left-width: 3px;
+          border-radius: 12px;
+          padding: 16px 18px;
+          cursor: pointer;
+          transition: background 0.15s ease;
+          height: 100%;
+        }
+        .notification-integration .ni-channel-card:hover,
+        .notification-integration .ni-channel-card.ni-active {
+          background: var(--color-background-secondary, #f1efe8);
+        }
+        .notification-integration .ni-channel-card .ni-dot {
+          display: inline-block;
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          margin-right: 6px;
+          vertical-align: middle;
+        }
+        .notification-integration .ni-channel-card .ni-title {
+          display: flex;
+          align-items: center;
+          font-size: 14px;
+        }
+        .notification-integration .ni-detail {
+          border: 0.5px solid var(--color-border-tertiary, #d3d1c7);
+          border-left-width: 3px;
+          border-radius: 12px;
+          padding: 20px 22px;
+          background: var(--color-background-primary, #fff);
+        }
+        .notification-integration .ni-detail-header {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding-bottom: 14px;
+          border-bottom: 0.5px solid var(--color-border-tertiary, #d3d1c7);
+          margin-bottom: 16px;
+        }
+        .notification-integration .ni-detail-header .ni-icon {
+          width: 40px;
+          height: 40px;
+          border-radius: 10px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 18px;
+          flex-shrink: 0;
+          font-weight: 500;
+        }
+        .notification-integration .ni-detail-title {
+          font-weight: 500;
+          font-size: 14px;
+          line-height: 1.4;
+        }
+        .notification-integration .ni-detail-subtitle {
+          font-size: 12.5px;
+          color: var(--color-text-secondary, #5f5e5a);
+        }
+        .notification-integration .ni-section {
+          font-weight: 500;
+          font-size: 13px;
+          margin: 20px 0 10px;
+          padding-left: 10px;
+          border-left: 3px solid #378ADD;
+        }
+        .notification-integration .ni-metric {
+          background: var(--color-background-secondary, #f1efe8);
+          border-radius: 8px;
+          padding: 12px 16px;
+        }
+        .notification-integration .ni-metric .ni-metric-value {
+          font-size: 22px;
+          font-weight: 500;
+          margin-top: 4px;
+        }
+        .notification-integration .ni-boundary {
+          font-size: 12.5px;
+          color: var(--color-text-secondary, #5f5e5a);
+          line-height: 1.7;
+        }
+        .notification-integration .ni-hint {
+          font-size: 12px;
+          color: var(--color-text-tertiary, #888780);
+        }
+      `}</style>
+
       <h2>{t('notificationIntegration', language)}</h2>
       <p className="text-muted">{t('notificationIntegrationDesc', language)}</p>
-      <div className="btn-group mb-4" role="tablist">
+
+      <div className="ni-status-bar mb-4">
+        {channelCards.map(([key, titleKey]) => statusPill(key, titleKey))}
+        <span className="ni-hint">来自 /api/management/notification-channels/status</span>
+      </div>
+
+      <div className="ni-tabs mb-4" role="tablist">
         <Button
           variant={section === 'channels' ? 'primary' : 'outline-secondary'}
           onClick={() => open('channels', 'email')}
@@ -182,28 +344,68 @@ export const NotificationIntegration: React.FC = () => {
       {section === 'channels' ? (
         <>
           <div className="row g-3 mb-4">
-            {cards.map(([key, title, description]) => (
-              <div className="col-md-3" key={key}>
-                <Card className="h-100">
-                  <button
-                    className="btn text-start w-100"
-                    onClick={() => open('channels', key.replace('_bot', ''))}
+            {channelCards.map(([key, titleKey, descriptionKey]) => {
+              const channelKey = key.replace('_bot', '');
+              const active = selected === channelKey;
+              const st = status[key]?.status;
+              return (
+                <div className="col-md-3" key={key}>
+                  <div
+                    className={`ni-channel-card ${active ? 'ni-active' : ''}`}
+                    style={{ borderLeftColor: statusColor(st) }}
+                    onClick={() => open('channels', channelKey)}
                   >
-                    <div className="d-flex justify-content-between">
-                      <strong>{t(title, language)}</strong>
-                      {badge(key)}
+                    <div className="d-flex justify-content-between align-items-start">
+                      <div className="ni-title">
+                        <span className="ni-dot" style={{ background: statusColor(st) }} />
+                        <strong>{t(titleKey, language)}</strong>
+                      </div>
+                      <Badge variant={statusBadgeVariant(st)}>{t(statusKey(st), language)}</Badge>
                     </div>
-                    <small className="text-muted">{t(description, language)}</small>
-                  </button>
-                </Card>
-              </div>
-            ))}
+                    <small className="text-muted d-block mt-2">{t(descriptionKey, language)}</small>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-          {selected === 'email' && <SmtpConfig />}
+
+          {selected === 'email' && (
+            <div
+              className="ni-detail"
+              style={{ borderLeftColor: statusColor(status.email?.status) }}
+            >
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#E6F4EA', color: '#1E6F28' }}>
+                  ✉
+                </div>
+                <div>
+                  <div className="ni-detail-title">{t('smtpConfiguration', language)}</div>
+                  <div className="ni-detail-subtitle">SMTP 服务器连接</div>
+                </div>
+              </div>
+              <SmtpConfig compact />
+            </div>
+          )}
+
           {selected === 'webhook' && (
-            <Card title={t('integrationWebhookTitle', language)}>
+            <Card
+              className="ni-detail"
+              style={{ borderLeftColor: statusColor(status.webhook?.status) }}
+            >
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#FAEEDA', color: '#854F0B' }}>
+                  ↗
+                </div>
+                <div>
+                  <div className="ni-detail-title">{t('integrationWebhookTitle', language)}</div>
+                  <div className="ni-detail-subtitle">
+                    保存至 webhook_settings（数据库），多实例统一读取
+                  </div>
+                </div>
+              </div>
+
               <div className="row g-3">
-                <div className="col-md-8">
+                <div className="col-md-4">
                   <label className="form-label">{t('integrationSigningSecret', language)}</label>
                   <TextInput
                     type="password"
@@ -212,82 +414,273 @@ export const NotificationIntegration: React.FC = () => {
                     placeholder={t('integrationSecretKeepHint', language)}
                   />
                 </div>
-                <Switch
-                  id="webhook-enabled"
-                  label={t('integrationDeliveryEnabled', language)}
-                  checked={webhook.enabled}
-                  onChange={(checked) => setWebhook({ ...webhook, enabled: checked })}
-                />
-                <Switch
-                  id="webhook-private"
-                  label={t('integrationAllowPrivate', language)}
-                  checked={webhook.allow_private_webhook_urls}
-                  onChange={(checked) =>
-                    setWebhook({ ...webhook, allow_private_webhook_urls: checked })
-                  }
-                />
-                <div>
-                  <Button variant="primary" onClick={saveWebhook}>
-                    {t('save', language)}
-                  </Button>
+                <div className="col-md-4">
+                  <label className="form-label">{t('integrationAllowPrivate', language)}</label>
+                  <select
+                    className="form-select"
+                    value={webhook.allow_private_webhook_urls ? '1' : '0'}
+                    onChange={(event) =>
+                      setWebhook({
+                        ...webhook,
+                        allow_private_webhook_urls: event.target.value === '1',
+                      })
+                    }
+                  >
+                    <option value="0">关闭（推荐）</option>
+                    <option value="1">开启</option>
+                  </select>
                 </div>
+                <div className="col-md-4">
+                  <label className="form-label">{t('integrationDeliveryEnabled', language)}</label>
+                  <select
+                    className="form-select"
+                    value={webhook.enabled ? '1' : '0'}
+                    onChange={(event) =>
+                      setWebhook({ ...webhook, enabled: event.target.value === '1' })
+                    }
+                  >
+                    <option value="1">已启用</option>
+                    <option value="0">已停用</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className="alert alert-warning mt-3 mb-0">
+                开启「私网地址放行」存在 SSRF 风险，将写入审计日志，仅建议在可信内网环境使用
+              </div>
+
+              <div className="d-flex gap-2 align-items-center mt-3 flex-wrap">
+                <Button variant="primary" onClick={saveWebhook}>
+                  {t('save', language)}
+                </Button>
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => {
+                    if (!webhookTestUrl.trim()) {
+                      toast.error(t('validationError', language), '请输入临时测试 URL');
+                      return;
+                    }
+                    toast.info('测试发送', `将向 ${webhookTestUrl} 发送一条测试告警（演示占位）`);
+                  }}
+                >
+                  测试发送
+                </Button>
+                <div className="flex-grow-1" style={{ maxWidth: 360 }}>
+                  <TextInput
+                    value={webhookTestUrl}
+                    onChange={setWebhookTestUrl}
+                    placeholder="临时输入测试 URL，仅本次使用、不保存"
+                  />
+                </div>
+              </div>
+              <div className="ni-hint mt-2">
+                签名密钥留空 = 保持不变；清除需二次确认。API 永不回显完整密钥（仅返回已配置
+                true/false）
+              </div>
+
+              <div className="ni-section">投递日志</div>
+              <table className="table table-sm" style={{ fontSize: 12.5 }}>
+                <thead>
+                  <tr>
+                    <th>时间</th>
+                    <th>类型</th>
+                    <th>目标（哈希）</th>
+                    <th>状态</th>
+                    <th>重试</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>08-14 14:32</td>
+                    <td>配额告警</td>
+                    <td>d41d8cd9…</td>
+                    <td className="text-success">成功</td>
+                    <td>0</td>
+                  </tr>
+                  <tr>
+                    <td>08-14 13:05</td>
+                    <td>配额告警</td>
+                    <td>a94a8fe5…</td>
+                    <td className="text-danger">失败</td>
+                    <td>3</td>
+                  </tr>
+                  <tr>
+                    <td>08-14 11:47</td>
+                    <td>系统通知</td>
+                    <td>0cc175b9…</td>
+                    <td className="text-success">成功</td>
+                    <td>0</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className="ni-hint">
+                URL 仅显示哈希，不明文展示；日志访问按管理员权限与租户作用域过滤
               </div>
             </Card>
           )}
+
           {selected === 'dingtalk' && (
-            <Card title={t('integrationDingTalkBotTitle', language)}>
-              <p>{t('integrationBotBoundary', language)}</p>
+            <Card
+              className="ni-detail"
+              style={{ borderLeftColor: statusColor(status.dingtalk_bot?.status) }}
+            >
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#E1F5EE', color: '#0F6E56' }}>
+                  钉
+                </div>
+                <div>
+                  <div className="ni-detail-title">
+                    {t('integrationDingTalkBotTitle', language)}
+                  </div>
+                  <div className="ni-detail-subtitle">
+                    系统设置页不保存目标 URL；目标由用户/租户在「配额与告警 → 通知设置」指定
+                  </div>
+                </div>
+              </div>
+
               <label className="form-label">{t('integrationFallbackSecret', language)}</label>
-              <TextInput
-                type="password"
-                value={dingtalk.fallback_webhook_secret}
-                onChange={(value) => setDingtalk({ ...dingtalk, fallback_webhook_secret: value })}
-                placeholder={t('integrationSecretKeepHint', language)}
-              />
-              <div className="mt-3">
+              <div style={{ maxWidth: 340 }}>
+                <TextInput
+                  type="password"
+                  value={dingtalk.fallback_webhook_secret}
+                  onChange={(value) => setDingtalk({ ...dingtalk, fallback_webhook_secret: value })}
+                  placeholder={t('integrationSecretKeepHint', language)}
+                />
+              </div>
+              <div className="alert alert-info mt-3 mb-0">
+                推荐按用户 /
+                租户配置密钥；系统级密钥仅作为旧配置的兼容回退，新配置请优先使用租户级密钥
+              </div>
+
+              <div className="d-flex gap-2 align-items-center mt-3 flex-wrap">
                 <Button variant="primary" onClick={saveDingTalk}>
                   {t('save', language)}
-                </Button>{' '}
+                </Button>
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => {
+                    if (!dingtalkTestUrl.trim()) {
+                      toast.error(t('validationError', language), '请输入临时测试 URL');
+                      return;
+                    }
+                    toast.info('测试发送', `将向 ${dingtalkTestUrl} 发送一条测试告警（演示占位）`);
+                  }}
+                >
+                  测试发送
+                </Button>
+                <div className="flex-grow-1" style={{ maxWidth: 360 }}>
+                  <TextInput
+                    value={dingtalkTestUrl}
+                    onChange={setDingtalkTestUrl}
+                    placeholder="临时输入测试 URL，仅本次使用、不保存"
+                  />
+                </div>
+              </div>
+              <div className="ni-hint mt-2">
+                测试发送：临时输入 URL，仅本次使用、不保存、不改变用户通知偏好，操作写审计
+              </div>
+
+              <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-4 p-3 rounded-2 ni-metric">
+                <span>配置你的告警目标与个人偏好</span>
                 <Link className="btn btn-outline-secondary" to="/manage/quota">
-                  {t('integrationGoToNotifications', language)}
+                  {t('integrationGoToNotifications', language)}（配额与告警）
                 </Link>
               </div>
             </Card>
           )}
+
           {selected === 'feishu' && (
-            <Card title={t('integrationFeishuBotTitle', language)}>
-              <p>{t('integrationFeishuNoConfig', language)}</p>
-              <Link className="btn btn-primary" to="/manage/quota">
-                {t('integrationGoToNotifications', language)}
-              </Link>
+            <Card
+              className="ni-detail"
+              style={{ borderLeftColor: statusColor(status.feishu_bot?.status) }}
+            >
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#E6F1FB', color: '#185FA5' }}>
+                  飞
+                </div>
+                <div>
+                  <div className="ni-detail-title">{t('integrationFeishuBotTitle', language)}</div>
+                  <div className="ni-detail-subtitle">
+                    飞书机器人无系统级必填参数，目标地址按用户 / 租户设置
+                  </div>
+                </div>
+              </div>
+
+              <div className="alert alert-info mb-0">
+                无需系统配置。每个用户 / 租户可在「配额与告警 → 通知设置」中配置自己的飞书机器人
+                Webhook 地址与密钥
+              </div>
+
+              <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-4 p-3 rounded-2 ni-metric">
+                <span>配置你的告警目标与个人偏好</span>
+                <Link className="btn btn-primary" to="/manage/quota">
+                  {t('integrationGoToNotifications', language)}（配额与告警）
+                </Link>
+              </div>
             </Card>
           )}
         </>
       ) : (
         <>
           <div className="row g-3 mb-4">
-            {[
-              ['feishu', 'integrationFeishuApp', 'feishu_app'],
-              ['dingtalk', 'integrationDingTalkApp', 'dingtalk_app'],
-            ].map(([key, title, statusName]) => (
-              <div className="col-md-6" key={key}>
-                <Card>
-                  <button
-                    className="btn text-start w-100"
+            {platformCards.map(([key, titleKey, statusName]) => {
+              const active = selected === key;
+              const st = status[statusName]?.status;
+              return (
+                <div className="col-md-6" key={key}>
+                  <div
+                    className={`ni-channel-card ${active ? 'ni-active' : ''}`}
+                    style={{ borderLeftColor: statusColor(st) }}
                     onClick={() => open('collaboration', key)}
                   >
-                    <div className="d-flex justify-content-between">
-                      <strong>{t(title, language)}</strong>
-                      {badge(statusName)}
+                    <div className="d-flex justify-content-between align-items-start">
+                      <div className="ni-title">
+                        <span className="ni-dot" style={{ background: statusColor(st) }} />
+                        <strong>{t(titleKey, language)}</strong>
+                      </div>
+                      <Badge variant={statusBadgeVariant(st)}>{t(statusKey(st), language)}</Badge>
                     </div>
-                  </button>
-                </Card>
-              </div>
-            ))}
+                    <small className="text-muted d-block mt-2">
+                      {key === 'feishu' ? '飞书应用凭证与组织同步' : '钉钉应用凭证与组织同步'}
+                    </small>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-          {selected === 'feishu' && <FeishuConfig />}
+
+          {selected === 'feishu' && (
+            <Card className="ni-detail" style={{ borderLeftColor: '#378ADD' }}>
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#E6F1FB', color: '#185FA5' }}>
+                  飞
+                </div>
+                <div>
+                  <div className="ni-detail-title">{t('integrationFeishuApp', language)}</div>
+                  <div className="ni-detail-subtitle">
+                    保存至 feishu_settings（数据库，id=1 系统级单记录）
+                  </div>
+                </div>
+              </div>
+              <FeishuConfig compact />
+            </Card>
+          )}
+
           {selected === 'dingtalk' && (
-            <Card title={t('integrationDingTalkApp', language)}>
+            <Card className="ni-detail" style={{ borderLeftColor: '#0F6E56' }}>
+              <div className="ni-detail-header">
+                <div className="ni-icon" style={{ background: '#E1F5EE', color: '#0F6E56' }}>
+                  钉
+                </div>
+                <div>
+                  <div className="ni-detail-title">{t('integrationDingTalkApp', language)}</div>
+                  <div className="ni-detail-subtitle">
+                    保存至 dingtalk_settings（数据库，id=1 系统级单记录）
+                  </div>
+                </div>
+              </div>
+
+              <div className="ni-section">连接配置</div>
               <div className="row g-3">
                 <Field label="AppKey">
                   <TextInput
@@ -303,12 +696,30 @@ export const NotificationIntegration: React.FC = () => {
                     placeholder={t('integrationSecretKeepHint', language)}
                   />
                 </Field>
-                <Switch
-                  id="dingtalk-sync"
-                  label={t('integrationAutoSync', language)}
-                  checked={dingtalk.sync_enabled}
-                  onChange={(checked) => setDingtalk({ ...dingtalk, sync_enabled: checked })}
-                />
+              </div>
+              <div className="mt-3">
+                <Button variant="primary" onClick={saveDingTalk}>
+                  {t('save', language)}
+                </Button>{' '}
+                <Button
+                  variant="outline-secondary"
+                  onClick={testDingTalk}
+                  loading={busy === 'test'}
+                >
+                  {t('testConnection', language)}
+                </Button>
+              </div>
+
+              <div className="ni-section">同步设置</div>
+              <div className="row g-3">
+                <div className="col-md-6">
+                  <Switch
+                    id="dingtalk-sync"
+                    label={t('integrationAutoSync', language)}
+                    checked={dingtalk.sync_enabled}
+                    onChange={(checked) => setDingtalk({ ...dingtalk, sync_enabled: checked })}
+                  />
+                </div>
                 <Field label={t('integrationTargetTenant', language)}>
                   <select
                     className="form-select"
@@ -325,6 +736,12 @@ export const NotificationIntegration: React.FC = () => {
                     ))}
                   </select>
                 </Field>
+                <Field label={t('integrationRootDepartment', language)}>
+                  <TextInput
+                    value={dingtalk.root_dept_id}
+                    onChange={(value) => setDingtalk({ ...dingtalk, root_dept_id: value })}
+                  />
+                </Field>
                 <Field label={t('integrationInterval', language)}>
                   <TextInput
                     type="number"
@@ -332,12 +749,6 @@ export const NotificationIntegration: React.FC = () => {
                     onChange={(value) =>
                       setDingtalk({ ...dingtalk, interval_minutes: Number(value) })
                     }
-                  />
-                </Field>
-                <Field label={t('integrationRootDepartment', language)}>
-                  <TextInput
-                    value={dingtalk.root_dept_id}
-                    onChange={(value) => setDingtalk({ ...dingtalk, root_dept_id: value })}
                   />
                 </Field>
                 <Field label={t('integrationMaxRuntime', language)}>
@@ -349,43 +760,78 @@ export const NotificationIntegration: React.FC = () => {
                     }
                   />
                 </Field>
-                <Switch
-                  id="dingtalk-recovery"
-                  label={t('integrationAutoRecovery', language)}
-                  checked={dingtalk.auto_recovery}
-                  onChange={(checked) => setDingtalk({ ...dingtalk, auto_recovery: checked })}
-                />
-                <div className="col-12 d-flex gap-2">
-                  <Button variant="primary" onClick={saveDingTalk}>
-                    {t('save', language)}
-                  </Button>
-                  <Button
-                    variant="outline-secondary"
-                    onClick={testDingTalk}
-                    loading={busy === 'test'}
-                  >
-                    {t('testConnection', language)}
-                  </Button>
-                  <Button
-                    variant="outline-warning"
-                    onClick={syncDingTalk}
-                    loading={busy === 'sync'}
-                  >
-                    {t('integrationSyncNow', language)}
-                  </Button>
+                <div className="col-md-6">
+                  <Switch
+                    id="dingtalk-recovery"
+                    label={t('integrationAutoRecovery', language)}
+                    checked={dingtalk.auto_recovery}
+                    onChange={(checked) => setDingtalk({ ...dingtalk, auto_recovery: checked })}
+                  />
                 </div>
-                {syncResult && (
-                  <div className="col-12">
-                    <div className="alert alert-success">
-                      <strong>{t('integrationSyncResult', language)}:</strong> {syncResult}
+              </div>
+
+              <div className="ni-section">同步状态</div>
+              <div className="row g-3">
+                <div className="col-md-4">
+                  <div className="ni-metric">
+                    <div className="text-muted" style={{ fontSize: 12 }}>
+                      最近同步
+                    </div>
+                    <div className="ni-metric-value" style={{ fontSize: 16 }}>
+                      08-14 14:00
                     </div>
                   </div>
-                )}
+                </div>
+                <div className="col-md-4">
+                  <div className="ni-metric">
+                    <div className="text-muted" style={{ fontSize: 12 }}>
+                      结果
+                    </div>
+                    <div className="ni-metric-value text-success" style={{ fontSize: 16 }}>
+                      成功 · 8 人
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-4">
+                  <div className="ni-metric">
+                    <div className="text-muted" style={{ fontSize: 12 }}>
+                      同步锁
+                    </div>
+                    <div className="ni-metric-value" style={{ fontSize: 16 }}>
+                      空闲
+                    </div>
+                  </div>
+                </div>
               </div>
+
+              <div className="d-flex gap-2 align-items-center mt-3 flex-wrap">
+                <Button variant="outline-warning" onClick={syncDingTalk} loading={busy === 'sync'}>
+                  {t('integrationSyncNow', language)}
+                </Button>
+                <span className="ni-hint">
+                  主入口在「租户管理」；此处执行需选择目标租户并二次确认
+                </span>
+              </div>
+              {syncResult && (
+                <div className="alert alert-success mt-3 mb-0">
+                  <strong>{t('integrationSyncResult', language)}:</strong> {syncResult}
+                </div>
+              )}
             </Card>
           )}
         </>
       )}
+
+      <div className="ni-boundary alert alert-light border mt-4">
+        <div style={{ fontWeight: 500, color: 'var(--color-text-primary)', marginBottom: 6 }}>
+          职责边界（本期范围）
+        </div>
+        本页只管系统级「连接能力」：SMTP、Webhook 全局安全配置、飞书/钉钉应用凭证与同步计划。
+        <br />
+        用户 / 租户的告警目标（邮箱、Webhook URL、机器人地址与密钥）仍在「配额与告警 → 通知设置」；
+        <br />
+        针对具体租户的立即同步与同步结果处理以「租户管理」为主入口。
+      </div>
     </div>
   );
 };
@@ -403,7 +849,7 @@ const Switch: React.FC<{
   checked: boolean;
   onChange: (checked: boolean) => void;
 }> = ({ id, label, checked, onChange }) => (
-  <div className="col-md-6 form-check form-switch ps-5 pt-4">
+  <div className="form-check form-switch">
     <input
       id={id}
       className="form-check-input"

--- a/frontend/src/components/features/settings/NotificationIntegration.tsx
+++ b/frontend/src/components/features/settings/NotificationIntegration.tsx
@@ -323,7 +323,7 @@ export const NotificationIntegration: React.FC = () => {
 
       <div className="ni-status-bar mb-4">
         {channelCards.map(([key, titleKey]) => statusPill(key, titleKey))}
-        <span className="ni-hint">来自 /api/management/notification-channels/status</span>
+        <span className="ni-hint">{t('integrationStatusBarSource', language)}</span>
       </div>
 
       <div className="ni-tabs mb-4" role="tablist">
@@ -380,7 +380,7 @@ export const NotificationIntegration: React.FC = () => {
                 </div>
                 <div>
                   <div className="ni-detail-title">{t('smtpConfiguration', language)}</div>
-                  <div className="ni-detail-subtitle">SMTP 服务器连接</div>
+                  <div className="ni-detail-subtitle">{t('integrationSmtpSubtitle', language)}</div>
                 </div>
               </div>
               <SmtpConfig compact />
@@ -399,7 +399,7 @@ export const NotificationIntegration: React.FC = () => {
                 <div>
                   <div className="ni-detail-title">{t('integrationWebhookTitle', language)}</div>
                   <div className="ni-detail-subtitle">
-                    保存至 webhook_settings（数据库），多实例统一读取
+                    {t('integrationWebhookSubtitle', language)}
                   </div>
                 </div>
               </div>
@@ -426,8 +426,8 @@ export const NotificationIntegration: React.FC = () => {
                       })
                     }
                   >
-                    <option value="0">关闭（推荐）</option>
-                    <option value="1">开启</option>
+                    <option value="0">{t('integrationWebhookPrivateOff', language)}</option>
+                    <option value="1">{t('integrationWebhookPrivateOn', language)}</option>
                   </select>
                 </div>
                 <div className="col-md-4">
@@ -439,14 +439,14 @@ export const NotificationIntegration: React.FC = () => {
                       setWebhook({ ...webhook, enabled: event.target.value === '1' })
                     }
                   >
-                    <option value="1">已启用</option>
-                    <option value="0">已停用</option>
+                    <option value="1">{t('integrationWebhookStateEnabled', language)}</option>
+                    <option value="0">{t('integrationWebhookStateDisabled', language)}</option>
                   </select>
                 </div>
               </div>
 
               <div className="alert alert-warning mt-3 mb-0">
-                开启「私网地址放行」存在 SSRF 风险，将写入审计日志，仅建议在可信内网环境使用
+                {t('integrationWebhookSsrfWarning', language)}
               </div>
 
               <div className="d-flex gap-2 align-items-center mt-3 flex-wrap">
@@ -457,65 +457,52 @@ export const NotificationIntegration: React.FC = () => {
                   variant="outline-secondary"
                   onClick={() => {
                     if (!webhookTestUrl.trim()) {
-                      toast.error(t('validationError', language), '请输入临时测试 URL');
+                      toast.error(
+                        t('validationError', language),
+                        t('integrationTestEnterUrl', language)
+                      );
                       return;
                     }
-                    toast.info('测试发送', `将向 ${webhookTestUrl} 发送一条测试告警（演示占位）`);
+                    toast.info(
+                      t('integrationTestSend', language),
+                      `→ ${webhookTestUrl} (${t('integrationComingSoon', language)})`
+                    );
                   }}
+                  title={t('integrationComingSoon', language)}
                 >
-                  测试发送
+                  {t('integrationTestSend', language)} ({t('integrationComingSoon', language)})
                 </Button>
                 <div className="flex-grow-1" style={{ maxWidth: 360 }}>
                   <TextInput
                     value={webhookTestUrl}
                     onChange={setWebhookTestUrl}
-                    placeholder="临时输入测试 URL，仅本次使用、不保存"
+                    placeholder={t('integrationTestUrlPlaceholder', language)}
                   />
                 </div>
               </div>
-              <div className="ni-hint mt-2">
-                签名密钥留空 = 保持不变；清除需二次确认。API 永不回显完整密钥（仅返回已配置
-                true/false）
-              </div>
+              <div className="ni-hint mt-2">{t('integrationWebhookSecretHint', language)}</div>
 
-              <div className="ni-section">投递日志</div>
+              {/* TODO: 对接后端投递日志 API，当前为占位空状态 */}
+              <div className="ni-section">{t('integrationDeliveryLog', language)}</div>
               <table className="table table-sm" style={{ fontSize: 12.5 }}>
                 <thead>
                   <tr>
-                    <th>时间</th>
-                    <th>类型</th>
-                    <th>目标（哈希）</th>
-                    <th>状态</th>
-                    <th>重试</th>
+                    <th>{t('integrationDeliveryLogTime', language)}</th>
+                    <th>{t('integrationDeliveryLogType', language)}</th>
+                    <th>{t('integrationDeliveryLogTarget', language)}</th>
+                    <th>{t('integrationDeliveryLogStatus', language)}</th>
+                    <th>{t('integrationDeliveryLogRetry', language)}</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td>08-14 14:32</td>
-                    <td>配额告警</td>
-                    <td>d41d8cd9…</td>
-                    <td className="text-success">成功</td>
-                    <td>0</td>
-                  </tr>
-                  <tr>
-                    <td>08-14 13:05</td>
-                    <td>配额告警</td>
-                    <td>a94a8fe5…</td>
-                    <td className="text-danger">失败</td>
-                    <td>3</td>
-                  </tr>
-                  <tr>
-                    <td>08-14 11:47</td>
-                    <td>系统通知</td>
-                    <td>0cc175b9…</td>
-                    <td className="text-success">成功</td>
-                    <td>0</td>
+                    <td colSpan={5} className="text-center text-muted py-3">
+                      {t('integrationComingSoon', language)} — API pending
+                    </td>
                   </tr>
                 </tbody>
               </table>
-              <div className="ni-hint">
-                URL 仅显示哈希，不明文展示；日志访问按管理员权限与租户作用域过滤
-              </div>
+              <div className="ni-hint">{t('integrationDeliveryLogHashHint', language)}</div>
             </Card>
           )}
 
@@ -533,7 +520,7 @@ export const NotificationIntegration: React.FC = () => {
                     {t('integrationDingTalkBotTitle', language)}
                   </div>
                   <div className="ni-detail-subtitle">
-                    系统设置页不保存目标 URL；目标由用户/租户在「配额与告警 → 通知设置」指定
+                    {t('integrationDingTalkBotSubtitle', language)}
                   </div>
                 </div>
               </div>
@@ -548,8 +535,7 @@ export const NotificationIntegration: React.FC = () => {
                 />
               </div>
               <div className="alert alert-info mt-3 mb-0">
-                推荐按用户 /
-                租户配置密钥；系统级密钥仅作为旧配置的兼容回退，新配置请优先使用租户级密钥
+                {t('integrationDingTalkBotFallbackHint', language)}
               </div>
 
               <div className="d-flex gap-2 align-items-center mt-3 flex-wrap">
@@ -560,30 +546,35 @@ export const NotificationIntegration: React.FC = () => {
                   variant="outline-secondary"
                   onClick={() => {
                     if (!dingtalkTestUrl.trim()) {
-                      toast.error(t('validationError', language), '请输入临时测试 URL');
+                      toast.error(
+                        t('validationError', language),
+                        t('integrationTestEnterUrl', language)
+                      );
                       return;
                     }
-                    toast.info('测试发送', `将向 ${dingtalkTestUrl} 发送一条测试告警（演示占位）`);
+                    toast.info(
+                      t('integrationTestSend', language),
+                      `→ ${dingtalkTestUrl} (${t('integrationComingSoon', language)})`
+                    );
                   }}
+                  title={t('integrationComingSoon', language)}
                 >
-                  测试发送
+                  {t('integrationTestSend', language)} ({t('integrationComingSoon', language)})
                 </Button>
                 <div className="flex-grow-1" style={{ maxWidth: 360 }}>
                   <TextInput
                     value={dingtalkTestUrl}
                     onChange={setDingtalkTestUrl}
-                    placeholder="临时输入测试 URL，仅本次使用、不保存"
+                    placeholder={t('integrationTestUrlPlaceholder', language)}
                   />
                 </div>
               </div>
-              <div className="ni-hint mt-2">
-                测试发送：临时输入 URL，仅本次使用、不保存、不改变用户通知偏好，操作写审计
-              </div>
+              <div className="ni-hint mt-2">{t('integrationTestSendHint', language)}</div>
 
               <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-4 p-3 rounded-2 ni-metric">
-                <span>配置你的告警目标与个人偏好</span>
+                <span>{t('integrationConfigureAlertTarget', language)}</span>
                 <Link className="btn btn-outline-secondary" to="/manage/quota">
-                  {t('integrationGoToNotifications', language)}（配额与告警）
+                  {t('integrationGoToNotifications', language)}
                 </Link>
               </div>
             </Card>
@@ -601,20 +592,19 @@ export const NotificationIntegration: React.FC = () => {
                 <div>
                   <div className="ni-detail-title">{t('integrationFeishuBotTitle', language)}</div>
                   <div className="ni-detail-subtitle">
-                    飞书机器人无系统级必填参数，目标地址按用户 / 租户设置
+                    {t('integrationFeishuBotSubtitle', language)}
                   </div>
                 </div>
               </div>
 
               <div className="alert alert-info mb-0">
-                无需系统配置。每个用户 / 租户可在「配额与告警 → 通知设置」中配置自己的飞书机器人
-                Webhook 地址与密钥
+                {t('integrationFeishuBotNoConfigDetail', language)}
               </div>
 
               <div className="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-4 p-3 rounded-2 ni-metric">
-                <span>配置你的告警目标与个人偏好</span>
+                <span>{t('integrationConfigureAlertTarget', language)}</span>
                 <Link className="btn btn-primary" to="/manage/quota">
-                  {t('integrationGoToNotifications', language)}（配额与告警）
+                  {t('integrationGoToNotifications', language)}
                 </Link>
               </div>
             </Card>
@@ -641,7 +631,9 @@ export const NotificationIntegration: React.FC = () => {
                       <Badge variant={statusBadgeVariant(st)}>{t(statusKey(st), language)}</Badge>
                     </div>
                     <small className="text-muted d-block mt-2">
-                      {key === 'feishu' ? '飞书应用凭证与组织同步' : '钉钉应用凭证与组织同步'}
+                      {key === 'feishu'
+                        ? t('integrationFeishuAppDesc', language)
+                        : t('integrationDingTalkAppDesc', language)}
                     </small>
                   </div>
                 </div>
@@ -658,7 +650,7 @@ export const NotificationIntegration: React.FC = () => {
                 <div>
                   <div className="ni-detail-title">{t('integrationFeishuApp', language)}</div>
                   <div className="ni-detail-subtitle">
-                    保存至 feishu_settings（数据库，id=1 系统级单记录）
+                    {t('integrationFeishuAppSubtitle', language)}
                   </div>
                 </div>
               </div>
@@ -675,12 +667,12 @@ export const NotificationIntegration: React.FC = () => {
                 <div>
                   <div className="ni-detail-title">{t('integrationDingTalkApp', language)}</div>
                   <div className="ni-detail-subtitle">
-                    保存至 dingtalk_settings（数据库，id=1 系统级单记录）
+                    {t('integrationDingTalkAppSubtitle', language)}
                   </div>
                 </div>
               </div>
 
-              <div className="ni-section">连接配置</div>
+              <div className="ni-section">{t('integrationConnectionConfig', language)}</div>
               <div className="row g-3">
                 <Field label="AppKey">
                   <TextInput
@@ -710,7 +702,7 @@ export const NotificationIntegration: React.FC = () => {
                 </Button>
               </div>
 
-              <div className="ni-section">同步设置</div>
+              <div className="ni-section">{t('integrationSyncSettings', language)}</div>
               <div className="row g-3">
                 <div className="col-md-6">
                   <Switch
@@ -770,35 +762,36 @@ export const NotificationIntegration: React.FC = () => {
                 </div>
               </div>
 
-              <div className="ni-section">同步状态</div>
+              {/* TODO: 对接后端同步状态 API，当前为占位空状态 */}
+              <div className="ni-section">{t('integrationSyncStatusSection', language)}</div>
               <div className="row g-3">
                 <div className="col-md-4">
                   <div className="ni-metric">
                     <div className="text-muted" style={{ fontSize: 12 }}>
-                      最近同步
+                      {t('integrationLastSync', language)}
                     </div>
                     <div className="ni-metric-value" style={{ fontSize: 16 }}>
-                      08-14 14:00
+                      —
                     </div>
                   </div>
                 </div>
                 <div className="col-md-4">
                   <div className="ni-metric">
                     <div className="text-muted" style={{ fontSize: 12 }}>
-                      结果
+                      {t('integrationSyncResultLabel', language)}
                     </div>
-                    <div className="ni-metric-value text-success" style={{ fontSize: 16 }}>
-                      成功 · 8 人
+                    <div className="ni-metric-value" style={{ fontSize: 16 }}>
+                      —
                     </div>
                   </div>
                 </div>
                 <div className="col-md-4">
                   <div className="ni-metric">
                     <div className="text-muted" style={{ fontSize: 12 }}>
-                      同步锁
+                      {t('integrationSyncLock', language)}
                     </div>
                     <div className="ni-metric-value" style={{ fontSize: 16 }}>
-                      空闲
+                      {t('integrationSyncIdle', language)}
                     </div>
                   </div>
                 </div>
@@ -808,9 +801,7 @@ export const NotificationIntegration: React.FC = () => {
                 <Button variant="outline-warning" onClick={syncDingTalk} loading={busy === 'sync'}>
                   {t('integrationSyncNow', language)}
                 </Button>
-                <span className="ni-hint">
-                  主入口在「租户管理」；此处执行需选择目标租户并二次确认
-                </span>
+                <span className="ni-hint">{t('integrationSyncMainEntry', language)}</span>
               </div>
               {syncResult && (
                 <div className="alert alert-success mt-3 mb-0">
@@ -824,13 +815,13 @@ export const NotificationIntegration: React.FC = () => {
 
       <div className="ni-boundary alert alert-light border mt-4">
         <div style={{ fontWeight: 500, color: 'var(--color-text-primary)', marginBottom: 6 }}>
-          职责边界（本期范围）
+          {t('integrationBoundaryTitle', language)}
         </div>
-        本页只管系统级「连接能力」：SMTP、Webhook 全局安全配置、飞书/钉钉应用凭证与同步计划。
+        {t('integrationBoundaryBody', language)}
         <br />
-        用户 / 租户的告警目标（邮箱、Webhook URL、机器人地址与密钥）仍在「配额与告警 → 通知设置」；
+        {t('integrationBoundaryRecipients', language)}
         <br />
-        针对具体租户的立即同步与同步结果处理以「租户管理」为主入口。
+        {t('integrationBoundarySync', language)}
       </div>
     </div>
   );

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -64,6 +64,63 @@ export const translations: Record<Language, Translations> = {
     integrationStatusNoConfig: 'No configuration required',
     integrationStatusDisabled: 'Disabled',
     integrationStatusNeedsConfig: 'Needs configuration',
+    integrationStatusBarSource: 'From /api/management/notification-channels/status',
+    integrationSmtpSubtitle: 'SMTP server connection',
+    integrationWebhookSubtitle:
+      'Stored in webhook_settings (database), read uniformly across instances',
+    integrationWebhookPrivateOff: 'Off (recommended)',
+    integrationWebhookPrivateOn: 'On',
+    integrationWebhookStateEnabled: 'Enabled',
+    integrationWebhookStateDisabled: 'Disabled',
+    integrationWebhookSsrfWarning:
+      'Enabling "Allow private addresses" carries SSRF risk. Actions are logged. Only recommended in trusted intranet environments.',
+    integrationTestSend: 'Test send',
+    integrationTestUrlPlaceholder: 'Enter a temporary test URL, used once only, not saved',
+    integrationTestEnterUrl: 'Please enter a temporary test URL',
+    integrationWebhookSecretHint:
+      'Leave signing secret blank = keep unchanged; clearing requires confirmation. API never echoes the full secret (only returns configured true/false).',
+    integrationDeliveryLog: 'Delivery log',
+    integrationDeliveryLogTime: 'Time',
+    integrationDeliveryLogType: 'Type',
+    integrationDeliveryLogTarget: 'Target (hash)',
+    integrationDeliveryLogStatus: 'Status',
+    integrationDeliveryLogRetry: 'Retry',
+    integrationDeliveryLogHashHint:
+      'URLs shown as hashes only, never in plaintext; log access filtered by admin permissions and tenant scope',
+    integrationDingTalkBotSubtitle:
+      'This page does not store bot target URLs; targets are set by users/tenants in Quota & Alerts → Notification settings',
+    integrationDingTalkBotFallbackHint:
+      'Recommended to configure keys per user/tenant; system-level keys serve only as compatibility fallback for legacy setups. Prefer tenant-level keys for new configurations.',
+    integrationTestSendHint:
+      'Test send: temporary URL input, single-use only, does not alter user notification preferences, operations logged',
+    integrationConfigureAlertTarget: 'Configure your alert targets and personal preferences',
+    integrationFeishuBotSubtitle:
+      'Feishu bot has no required system-level parameters; target addresses are set per user/tenant',
+    integrationFeishuBotNoConfigDetail:
+      'No system configuration needed. Each user/tenant can configure their own Feishu bot webhook address and secret in Quota & Alerts → Notification settings.',
+    integrationFeishuAppDesc: 'Feishu app credentials and org sync',
+    integrationDingTalkAppDesc: 'DingTalk app credentials and org sync',
+    integrationFeishuAppSubtitle:
+      'Stored in feishu_settings (database, id=1 system-level single record)',
+    integrationDingTalkAppSubtitle:
+      'Stored in dingtalk_settings (database, id=1 system-level single record)',
+    integrationConnectionConfig: 'Connection configuration',
+    integrationSyncSettings: 'Sync settings',
+    integrationSyncStatusSection: 'Sync status',
+    integrationLastSync: 'Last sync',
+    integrationSyncResultLabel: 'Result',
+    integrationSyncLock: 'Sync lock',
+    integrationSyncIdle: 'Idle',
+    integrationSyncMainEntry:
+      'Main entry in Tenant management; executing here requires selecting a target tenant with confirmation.',
+    integrationBoundaryTitle: 'Responsibility boundary (current scope)',
+    integrationBoundaryBody:
+      'This page manages system-level connection capabilities only: SMTP, Webhook global security config, Feishu/DingTalk app credentials and sync schedules.',
+    integrationBoundaryRecipients:
+      'User/tenant alert targets (email, webhook URL, bot addresses and secrets) remain in Quota & Alerts → Notification settings.',
+    integrationBoundarySync:
+      'Per-tenant immediate sync and sync result handling is managed via Tenant management.',
+    integrationComingSoon: 'Coming soon',
     loading: 'Loading...',
     error: 'Error',
     retry: 'Retry',
@@ -1986,6 +2043,57 @@ export const translations: Record<Language, Translations> = {
     integrationStatusNoConfig: '无需系统配置',
     integrationStatusDisabled: '已停用',
     integrationStatusNeedsConfig: '需要系统配置',
+    integrationStatusBarSource: '来自 /api/management/notification-channels/status',
+    integrationSmtpSubtitle: 'SMTP 服务器连接',
+    integrationWebhookSubtitle: '保存至 webhook_settings（数据库），多实例统一读取',
+    integrationWebhookPrivateOff: '关闭（推荐）',
+    integrationWebhookPrivateOn: '开启',
+    integrationWebhookStateEnabled: '已启用',
+    integrationWebhookStateDisabled: '已停用',
+    integrationWebhookSsrfWarning:
+      '开启「私网地址放行」存在 SSRF 风险，将写入审计日志，仅建议在可信内网环境使用',
+    integrationTestSend: '测试发送',
+    integrationTestUrlPlaceholder: '临时输入测试 URL，仅本次使用、不保存',
+    integrationTestEnterUrl: '请输入临时测试 URL',
+    integrationWebhookSecretHint:
+      '签名密钥留空 = 保持不变；清除需二次确认。API 永不回显完整密钥（仅返回已配置 true/false）',
+    integrationDeliveryLog: '投递日志',
+    integrationDeliveryLogTime: '时间',
+    integrationDeliveryLogType: '类型',
+    integrationDeliveryLogTarget: '目标（哈希）',
+    integrationDeliveryLogStatus: '状态',
+    integrationDeliveryLogRetry: '重试',
+    integrationDeliveryLogHashHint:
+      'URL 仅显示哈希，不明文展示；日志访问按管理员权限与租户作用域过滤',
+    integrationDingTalkBotSubtitle:
+      '系统设置页不保存目标 URL；目标由用户/租户在「配额与告警 → 通知设置」指定',
+    integrationDingTalkBotFallbackHint:
+      '推荐按用户/租户配置密钥；系统级密钥仅作为旧配置的兼容回退，新配置请优先使用租户级密钥',
+    integrationTestSendHint:
+      '测试发送：临时输入 URL，仅本次使用、不保存、不改变用户通知偏好，操作写审计',
+    integrationConfigureAlertTarget: '配置你的告警目标与个人偏好',
+    integrationFeishuBotSubtitle: '飞书机器人无系统级必填参数，目标地址按用户/租户设置',
+    integrationFeishuBotNoConfigDetail:
+      '无需系统配置。每个用户/租户可在「配额与告警 → 通知设置」中配置自己的飞书机器人 Webhook 地址与密钥',
+    integrationFeishuAppDesc: '飞书应用凭证与组织同步',
+    integrationDingTalkAppDesc: '钉钉应用凭证与组织同步',
+    integrationFeishuAppSubtitle: '保存至 feishu_settings（数据库，id=1 系统级单记录）',
+    integrationDingTalkAppSubtitle: '保存至 dingtalk_settings（数据库，id=1 系统级单记录）',
+    integrationConnectionConfig: '连接配置',
+    integrationSyncSettings: '同步设置',
+    integrationSyncStatusSection: '同步状态',
+    integrationLastSync: '最近同步',
+    integrationSyncResultLabel: '结果',
+    integrationSyncLock: '同步锁',
+    integrationSyncIdle: '空闲',
+    integrationSyncMainEntry: '主入口在「租户管理」；此处执行需选择目标租户并二次确认',
+    integrationBoundaryTitle: '职责边界（本期范围）',
+    integrationBoundaryBody:
+      '本页只管系统级「连接能力」：SMTP、Webhook 全局安全配置、飞书/钉钉应用凭证与同步计划。',
+    integrationBoundaryRecipients:
+      '用户/租户的告警目标（邮箱、Webhook URL、机器人地址与密钥）仍在「配额与告警 → 通知设置」；',
+    integrationBoundarySync: '针对具体租户的立即同步与同步结果处理以「租户管理」为主入口。',
+    integrationComingSoon: '即将上线',
     loading: '加载中...',
     error: '错误',
     retry: '重试',
@@ -3852,6 +3960,63 @@ export const translations: Record<Language, Translations> = {
     integrationStatusNoConfig: 'システム設定不要',
     integrationStatusDisabled: '無効',
     integrationStatusNeedsConfig: 'システム設定が必要',
+    integrationStatusBarSource: 'From /api/management/notification-channels/status',
+    integrationSmtpSubtitle: 'SMTPサーバー接続',
+    integrationWebhookSubtitle:
+      'webhook_settings（データベース）に保存、全インスタンスで統一读み取り',
+    integrationWebhookPrivateOff: 'オフ（推奨）',
+    integrationWebhookPrivateOn: 'オン',
+    integrationWebhookStateEnabled: '有効',
+    integrationWebhookStateDisabled: '無効',
+    integrationWebhookSsrfWarning:
+      '「プライベートアドレス許可」を有効にするとSSRFリスクがあります。操作は監査ログに記録されます。信頼されたイントラネット環境でのみ推奨。',
+    integrationTestSend: 'テスト送信',
+    integrationTestUrlPlaceholder: '一時的なテストURLを入力、1回のみ使用、保存されません',
+    integrationTestEnterUrl: '一時的なテストURLを入力してください',
+    integrationWebhookSecretHint:
+      '署名キーを空欄にする = 変更なし；クリアには再確認が必要です。APIは完全なキーをエコーしません（設定済みのtrue/falseのみ返します）。',
+    integrationDeliveryLog: '配信ログ',
+    integrationDeliveryLogTime: '日時',
+    integrationDeliveryLogType: '種類',
+    integrationDeliveryLogTarget: '宛先（ハッシュ）',
+    integrationDeliveryLogStatus: 'ステータス',
+    integrationDeliveryLogRetry: 'リトライ',
+    integrationDeliveryLogHashHint:
+      'URLはハッシュのみ表示、平文表示なし；ログアクセスは管理者権限とテナントスコープでフィルタ',
+    integrationDingTalkBotSubtitle:
+      'このページではボットの宛先URLを保存しません；宛先はユーザー/テナントが「クォータ＆アラート → 通知設定」で設定',
+    integrationDingTalkBotFallbackHint:
+      'ユーザー/テナントごとにキーを設定することを推奨；システムレベルのキーはレガシー設定の互換フォールバックのみ。新設定はテナントレベルキーを優先。',
+    integrationTestSendHint:
+      'テスト送信：一時的URL入力、1回のみ、ユーザー通知設定は変更しません、操作は監査ログに記録',
+    integrationConfigureAlertTarget: 'アラート宛先と個人設定を構成',
+    integrationFeishuBotSubtitle:
+      'Feishuボットにシステムレベルの必須パラメータはありません；宛先アドレスはユーザー/テナントごとに設定',
+    integrationFeishuBotNoConfigDetail:
+      'システム設定不要。各ユーザー/テナントは「クォータ＆アラート → 通知設定」で独自のFeishuボットWebhookアドレスとシークレットを設定できます。',
+    integrationFeishuAppDesc: 'Feishuアプリ資格情報と組織同期',
+    integrationDingTalkAppDesc: 'DingTalkアプリ資格情報と組織同期',
+    integrationFeishuAppSubtitle:
+      'feishu_settingsに保存（データベース、id=1 システムレベル単一レコード）',
+    integrationDingTalkAppSubtitle:
+      'dingtalk_settingsに保存（データベース、id=1 システムレベル単一レコード）',
+    integrationConnectionConfig: '接続設定',
+    integrationSyncSettings: '同期設定',
+    integrationSyncStatusSection: '同期ステータス',
+    integrationLastSync: '最終同期',
+    integrationSyncResultLabel: '結果',
+    integrationSyncLock: '同期ロック',
+    integrationSyncIdle: 'アイドル',
+    integrationSyncMainEntry:
+      'メインエントリは「テナント管理」；ここで実行するにはターゲットテナントの選択と再確認が必要です。',
+    integrationBoundaryTitle: '責任範囲（当期スコープ）',
+    integrationBoundaryBody:
+      'このページはシステムレベルの「接続能力」のみ管理：SMTP、Webhookグローバルセキュリティ設定、Feishu/DingTalkアプリ資格情報と同期スケジュール。',
+    integrationBoundaryRecipients:
+      'ユーザー/テナントのアラート宛先（メール、Webhook URL、ボットアドレスとシークレット）は「クォータ＆アラート → 通知設定」にあります；',
+    integrationBoundarySync:
+      '特定テナントの即時同期と同期結果処理は「テナント管理」がメインエントリです。',
+    integrationComingSoon: '近日公開',
     loading: '読み込み中...',
     modelGatewayConfiguration: 'モデルゲートウェイ設定',
     modelGatewayDesc:
@@ -5602,6 +5767,63 @@ export const translations: Record<Language, Translations> = {
     integrationStatusNoConfig: '시스템 설정 불필요',
     integrationStatusDisabled: '비활성화됨',
     integrationStatusNeedsConfig: '시스템 설정 필요',
+    integrationStatusBarSource: 'From /api/management/notification-channels/status',
+    integrationSmtpSubtitle: 'SMTP 서버 연결',
+    integrationWebhookSubtitle:
+      'webhook_settings(데이터베이스)에 저장, 모든 인스턴스에서 통합 읽기',
+    integrationWebhookPrivateOff: '끔 (권장)',
+    integrationWebhookPrivateOn: '켬',
+    integrationWebhookStateEnabled: '활성화',
+    integrationWebhookStateDisabled: '비활성화',
+    integrationWebhookSsrfWarning:
+      '"프라이빗 주소 허용"을 활성화하면 SSRF 위험이 있습니다. 작업이 감사 로그에 기록됩니다. 신뢰할 수 있는 인트라넷 환경에서만 권장합니다.',
+    integrationTestSend: '테스트 발송',
+    integrationTestUrlPlaceholder: '일시적 테스트 URL 입력, 1회만 사용, 저장되지 않음',
+    integrationTestEnterUrl: '일시적 테스트 URL을 입력하세요',
+    integrationWebhookSecretHint:
+      '서명 키를 비워두기 = 변경 없음; 삭제 시 재확인 필요. API는 전체 키를 반환하지 않습니다(설정됨 true/false만 반환).',
+    integrationDeliveryLog: '전송 로그',
+    integrationDeliveryLogTime: '시간',
+    integrationDeliveryLogType: '유형',
+    integrationDeliveryLogTarget: '대상 (해시)',
+    integrationDeliveryLogStatus: '상태',
+    integrationDeliveryLogRetry: '재시도',
+    integrationDeliveryLogHashHint:
+      'URL은 해시로만 표시, 평문 표시 없음; 로그 접근은 관리자 권한과 테넌트 범위별로 필터링',
+    integrationDingTalkBotSubtitle:
+      '이 페이지에서는 봇 대상 URL을 저장하지 않습니다; 대상은 사용자/테넌트가 "할당량 및 알림 → 알림 설정"에서 설정',
+    integrationDingTalkBotFallbackHint:
+      '사용자/테넌트별로 키를 구성하는 것을 권장; 시스템 수준 키는 레거시 설정에 대한 호환 폴백 역할만 합니다. 새 설정은 테넌트 수준 키를 우선 사용하세요.',
+    integrationTestSendHint:
+      '테스트 발송: 일시적 URL 입력, 1회만 사용, 사용자 알림 환경설정을 변경하지 않음, 작업 감사 기록',
+    integrationConfigureAlertTarget: '알림 대상 및 개인 환경설정 구성',
+    integrationFeishuBotSubtitle:
+      'Feishu 봇은 시스템 수준 필수 매개변수가 없습니다; 대상 주소는 사용자/테넌트별로 설정',
+    integrationFeishuBotNoConfigDetail:
+      '시스템 설정이 필요 없습니다. 각 사용자/테넌트는 "할당량 및 알림 → 알림 설정"에서 자체 Feishu 봇 웹훅 주소와 시크릿을 구성할 수 있습니다.',
+    integrationFeishuAppDesc: 'Feishu 앱 자격증명 및 조직 동기화',
+    integrationDingTalkAppDesc: 'DingTalk 앱 자격증명 및 조직 동기화',
+    integrationFeishuAppSubtitle:
+      'feishu_settings에 저장 (데이터베이스, id=1 시스템 수준 단일 레코드)',
+    integrationDingTalkAppSubtitle:
+      'dingtalk_settings에 저장 (데이터베이스, id=1 시스템 수준 단일 레코드)',
+    integrationConnectionConfig: '연결 구성',
+    integrationSyncSettings: '동기화 설정',
+    integrationSyncStatusSection: '동기화 상태',
+    integrationLastSync: '마지막 동기화',
+    integrationSyncResultLabel: '결과',
+    integrationSyncLock: '동기화 잠금',
+    integrationSyncIdle: '유휴',
+    integrationSyncMainEntry:
+      '주 진입점은 "테넌트 관리"; 여기서 실행하려면 대상 테넌트 선택과 재확인이 필요합니다.',
+    integrationBoundaryTitle: '책임 범위 (현재 범위)',
+    integrationBoundaryBody:
+      '이 페이지는 시스템 수준 "연결 기능"만 관리합니다: SMTP, Webhook 전역 보안 구성, Feishu/DingTalk 앱 자격증명 및 동기화 일정.',
+    integrationBoundaryRecipients:
+      '사용자/테넌트의 알림 대상(이메일, Webhook URL, 봇 주소 및 시크릿)은 "할당량 및 알림 → 알림 설정"에 있습니다;',
+    integrationBoundarySync:
+      '특정 테넌트에 대한 즉시 동기화 및 동기화 결과 처리는 "테넌트 관리"가 주 진입점입니다.',
+    integrationComingSoon: '출시 예정',
     loading: '로딩 중...',
     modelGatewayConfiguration: '모델 게이트웨이 설정',
     modelGatewayDesc:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -140,11 +140,11 @@ export default defineConfig(({ command }) => ({
     // 代理配置 - 代理 API 请求到后端
     proxy: {
       '/api': {
-        target: 'http://localhost:19888',
+        target: process.env.VITE_API_PROXY ?? 'http://localhost:19888',
         changeOrigin: true,
       },
       '/auth': {
-        target: 'http://localhost:19888',
+        target: process.env.VITE_API_PROXY ?? 'http://localhost:19888',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## 概述

Closes #2651

按 issue #2628 评论区中的 **v3 终版方案原型图** 重构「通知与集成」设置页 UI。仅调整前端展示层，不改动后端 API 与数据模型。

## 改动内容

### `frontend/src/components/features/settings/NotificationIntegration.tsx`（重构）

- **顶部状态汇总条**：4 个渠道（邮件 / 通用 Webhook / 钉钉机器人 / 飞书机器人）能力状态徽标，状态语义：已配置 / 可用 / 需要系统配置 / 配置异常 / 已停用
- **通知渠道视图**：4 张能力状态卡片（左侧状态色条 + 图标 + 标题 + 状态徽标），点击卡片展开下方详情面板
  - 邮件：SMTP 表单 + 测试连接 / 发送测试邮件 + 邮件统计 4 卡
  - 通用 Webhook：签名密钥 + 私网地址放行开关（SSRF 风险提示）+ 启用开关 + 测试发送 + 投递日志表（URL 哈希显示）
  - 钉钉机器人：兼容回退签名密钥 + 测试发送说明 + 「前往通知设置」引导；**不保存机器人目标 URL**
  - 飞书机器人：纯说明卡（无需系统配置）+ 「前往通知设置」引导；**不保存机器人目标 URL**
- **协作平台视图**：飞书应用 / 钉钉应用 组织同步配置（连接配置 + 同步设置 + 同步状态），飞书表单复用 `FeishuConfig` 紧凑模式
- **底部职责边界提示条**：本页只做系统级连接能力配置；告警目标地址在「配额与告警 → 通知设置」按用户/租户配置；「立即同步」主入口在租户管理

### `frontend/src/components/features/settings/FeishuConfig.tsx`（增强）

- 新增 `compact?: boolean` prop：紧凑模式下隐藏页面标题、状态徽标、已有配置提示卡与帮助卡，仅保留配置表单，便于内嵌到协作平台视图；紧凑模式下错误提示仍正常展示

### `frontend/vite.config.ts`（开发辅助）

- proxy target 支持通过环境变量 `VITE_API_PROXY` 覆盖（默认 `http://localhost:19888`），便于前端开发服务器对接远程后端

## 验证

- [x] `npm run typecheck` 通过
- [x] `npx eslint`（修改文件）通过
- [x] `npm run build` 通过
