### PR TITLE
fix(tests): revive last 4 residual async e2e tests with real UI/lane fixes (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -641,14 +641,6 @@
       "summary": "AssertionError: Login failed: {\"error\":\"Invalid username or password\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
-      "issue_number": "4",
-      "nodeid": "tests/issues/4/test_conversation_history_icon.py::test_conversation_history_icon",
-      "outcome": "failure",
-      "summary": "Failed: async def functions are not natively supported."
-    },
-    {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "42",
@@ -1794,14 +1786,6 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
-      "issue_number": "79",
-      "nodeid": "tests/issues/79/test_role_filter.py::test_role_filter",
-      "outcome": "failure",
-      "summary": "Failed: async def functions are not natively supported."
-    },
-    {
-      "category": "test_body_exception",
       "exception_type": "Error",
       "issue_number": "80",
       "nodeid": "tests/issues/80/test_manage_language_dropdown.py::test_manage_language_dropdown",
@@ -1969,22 +1953,6 @@
       "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
-      "issue_number": "98",
-      "nodeid": "tests/issues/98/test_data_update.py::test_data_update",
-      "outcome": "failure",
-      "summary": "Failed: async def functions are not natively supported."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "",
-      "issue_number": "98",
-      "nodeid": "tests/issues/98/test_refresh_detailed.py::test_messages_refresh_detailed",
-      "outcome": "failure",
-      "summary": "Failed: async def functions are not natively supported."
-    },
-    {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "987",
@@ -2043,8 +2011,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-14 prune 15+5 resolved: async-def cluster — 15 revived with the pytest-asyncio marker alone (spike run 31700276891) plus 5 revived by port/env/fixture/dead-JS fixes (run 31764889447). Remaining 3 unmarked/known: 98/refresh_detailed + 79/role_filter + 4/conversation_history_icon have real UI-selector drift; 98/data_update requires PostgreSQL (issues lane is SQLite-only). Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31764889447",
+    "prune_note": "2026-08-14 prune 4 residual async entries (#2631 follow-up): the last 4 'async def not natively supported' entries were real UI/lane drift, not missing markers. Fixed per 2457-residual-plan.md (independently reviewed CLEAN): 4/history-icon login used dead input[name=] selectors + wrong seeded password; 79/role_filter checkbox ids were removed and default selection became all-3-roles (rewrote as seeded regression via upload API); 98/refresh_detailed refresh button is now icon-only data-testid=manual-refresh-button and auto-refresh moved into a dropdown; 98/data_update dropped psycopg2/host-PG setup for the lane upload API + shared must_change_password pre-clear. Seeded admin must_change_password=1 was the common blocker (modal blocks clicks; /api/messages 403). Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31780251110",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/4/test_conversation_history_icon.py
+++ b/tests/issues/4/test_conversation_history_icon.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import os
+import sqlite3
 
+import pytest
 from playwright.async_api import async_playwright
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -12,8 +14,40 @@ SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "4")
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
+def _clear_admin_password_flag():
+    """Clear must_change_password on the seeded admin (issues-lane SQLite DB).
+
+    scripts/init_db.py seeds admin with must_change_password=1, which forces a
+    non-dismissible password-change modal after login and 403
+    password_change_required on API calls. We clear the flag directly on the
+    lane DB; never complete the modal — that would change the password for
+    every sibling test logging in as admin/admin123.
+    """
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+        if "must_change_password" not in cols:
+            return
+        conn.execute("UPDATE users SET must_change_password=0 WHERE username='admin'")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
 async def test_conversation_history_icon():
-    """Test that conversation history icon is visible in sidebar."""
+    """Test that conversation history icon is visible in the manage sidebar.
+
+    Visibility assertions only — deliberately no post-login clicks, so the
+    (cleared) force-change-password modal could not block anything even if it
+    appeared: Playwright visibility checks are occlusion-insensitive.
+    """
+
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+    _clear_admin_password_flag()
 
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
@@ -26,65 +60,50 @@ async def test_conversation_history_icon():
             await page.goto(f"{BASE_URL}/login", timeout=30000)
             await page.wait_for_load_state("networkidle")
 
-            # Take screenshot of login page
             await page.screenshot(path=f"{SCREENSHOT_DIR}/01_login.png")
-            print("   Saved: 01_login.png")
 
-            # Login (assuming default admin credentials)
+            # Login with the seeded admin credentials (issue-lane default).
             print("2. Logging in...")
-            await page.fill('input[name="username"]', "admin")
-            await page.fill('input[name="password"]', "admin")
+            await page.fill("#username", "admin")
+            await page.fill("#password", "admin123")
             await page.click('button[type="submit"]')
-            await page.wait_for_load_state("networkidle")
-            await asyncio.sleep(2)  # Wait for redirect
+            await page.wait_for_url(lambda url: "/login" not in url, timeout=10000)
 
-            # Take screenshot after login
             await page.screenshot(path=f"{SCREENSHOT_DIR}/02_after_login.png")
-            print("   Saved: 02_after_login.png")
 
-            # Navigate to manage mode to see conversation history
-            print("3. Navigating to manage mode...")
+            # Navigate to the conversation-history analysis page (manage area).
+            print("3. Navigating to conversation history page...")
             await page.goto(f"{BASE_URL}/manage/analysis/conversation-history", timeout=30000)
             await page.wait_for_load_state("networkidle")
-            await asyncio.sleep(2)
 
-            # Take screenshot of conversation history page
             await page.screenshot(path=f"{SCREENSHOT_DIR}/03_conversation_history.png")
-            print("   Saved: 03_conversation_history.png")
 
-            # Check if conversation history icon is visible in sidebar
+            # The conversation-history nav item must exist in the sidebar.
             print("4. Checking conversation history icon visibility...")
-            conv_history_icon = page.locator(".bi-chat-square-text").first
-            is_visible = await conv_history_icon.is_visible()
-            print(f"   Conversation history icon visible: {is_visible}")
+            conv_history_icon = page.locator(".manage-sidebar .bi-chat-square-text").first
+            assert (
+                await conv_history_icon.is_visible()
+            ), "conversation-history icon should be visible in the manage sidebar"
 
-            if is_visible:
-                print("   ✓ PASS: Conversation history icon is visible")
-            else:
-                print("   ✗ FAIL: Conversation history icon is NOT visible")
+            # The current route's nav item must be the active one.
+            active_icon = page.locator(".manage-sidebar .nav-item.active .bi-chat-square-text")
+            assert (
+                await active_icon.count() >= 1
+            ), "active nav item should contain the conversation-history icon"
 
-            # Also check the active nav item
-            active_nav_item = page.locator(".nav-item.active .bi-chat-square-text")
-            is_active_visible = await active_nav_item.is_visible()
-            print(f"   Active conversation history icon visible: {is_active_visible}")
-
-            # Take screenshot of sidebar
-            sidebar = page.locator(".manage-sidebar")
-            await sidebar.screenshot(path=f"{SCREENSHOT_DIR}/04_sidebar.png")
+            await page.locator(".manage-sidebar").screenshot(
+                path=f"{SCREENSHOT_DIR}/04_sidebar.png"
+            )
             print("   Saved: 04_sidebar.png")
 
             print("\n✓ Test completed successfully")
 
-        except Exception as e:
-            print(f"\n✗ Test failed: {e}")
-            # Take error screenshot
+        except Exception:
             await page.screenshot(path=f"{SCREENSHOT_DIR}/error.png")
-            print("   Saved: error.png")
             raise
         finally:
             await browser.close()
 
 
 if __name__ == "__main__":
-    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
     asyncio.run(test_conversation_history_icon())

--- a/tests/issues/79/test_role_filter.py
+++ b/tests/issues/79/test_role_filter.py
@@ -4,158 +4,207 @@ Test script for Issue #79: Messages页面role过滤不生效
 
 问题：Messages页面虽然选择了User这个role，但是下面的messages没有过滤
 
-验证：
-1. 打开 Messages 页面
-2. 检查 User 角色是否默认选中
-3. 验证 API 请求是否包含 role=user 参数
-4. 验证返回的消息是否都是 user 角色
-5. 取消所有角色选择，验证显示空状态提示
+验证（对齐当前 /manage/messages 实现）：
+1. 三个 role 复选框（user/assistant/system）默认全选
+2. 只留 User → 列表里每条都是 user 角色
+3. 只留 Assistant → 每条都是 assistant 角色
+4. 全部取消 → 显示"选择角色"空状态
+
+数据通过 issues-lane 的 upload API seed（X-Upload-Auth），不依赖任何宿主机数据库。
 """
 
 import asyncio
-import sys
-from pathlib import Path
-
-# Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
-
 import os
+import sqlite3
+import uuid
+from datetime import datetime
 
-from playwright.async_api import async_playwright
+import pytest
+import requests
+from playwright.async_api import async_playwright, expect
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
+SEED_TOOL_NAME = "issue79_role_filter_test"
 
 
+def _lane_db_path():
+    return os.path.expanduser("~/.open-ace/ace.db")
+
+
+def _clear_admin_password_flag():
+    """Clear must_change_password on the seeded admin (issues-lane SQLite DB).
+
+    Otherwise the forced password-change modal blocks every Playwright click
+    and /api/messages returns 403 password_change_required. Never complete the
+    modal — that would break sibling tests' admin/admin123 logins.
+    """
+    db_path = _lane_db_path()
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+        if "must_change_password" not in cols:
+            return
+        conn.execute("UPDATE users SET must_change_password=0 WHERE username='admin'")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _cleanup_seeded_messages():
+    db_path = _lane_db_path()
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DELETE FROM daily_messages WHERE tool_name = ?", (SEED_TOOL_NAME,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _upload_seed_messages():
+    """Seed one user + one assistant + one system message for today.
+
+    Returns the marker shared by all seeded contents (kept at the start of
+    each content so it survives the 200-char truncation in the message card).
+    """
+    upload_key = os.environ.get("UPLOAD_AUTH_KEY")
+    if not upload_key:
+        pytest.skip("UPLOAD_AUTH_KEY not set (no issues-lane server spawned)")
+
+    marker = f"issue79-marker-{uuid.uuid4().hex[:8]}"
+    now = datetime.now()
+    payload = {
+        "date": now.strftime("%Y-%m-%d"),
+        "tool_name": SEED_TOOL_NAME,
+        "messages": [
+            {
+                "message_id": str(uuid.uuid4()),
+                "role": role,
+                "content": f"{marker} role={role}",
+                "tokens_used": 10,
+                "timestamp": now.isoformat(),
+                "sender_name": "issue79-seeder",
+            }
+            for role in ("user", "assistant", "system")
+        ],
+    }
+    resp = requests.post(
+        f"{BASE_URL}/api/upload/messages",
+        json=payload,
+        headers={"X-Upload-Auth": upload_key},
+        timeout=15,
+    )
+    assert resp.status_code == 200, f"seed upload failed: {resp.status_code} {resp.text[:200]}"
+    assert resp.json().get("saved_count") == 3, f"unexpected seed result: {resp.text[:200]}"
+    return marker
+
+
+async def _login(page):
+    await page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
+    await page.fill("#username", "admin")
+    await page.fill("#password", "admin123")
+    await page.click('button[type="submit"]')
+    await page.wait_for_url(lambda url: "/login" not in url, timeout=10000)
+
+
+@pytest.mark.asyncio
 async def test_role_filter():
-    """Test that role filter works correctly on Messages page."""
+    """Test that role filter works correctly on the Messages page."""
+    _clear_admin_password_flag()
+    marker = _upload_seed_messages()
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1400, "height": 900}, locale="zh-CN")
         page = await context.new_page()
 
         try:
-            # Navigate to Messages page
-            print("\n[Step 1] Navigating to Messages page...")
-            await page.goto(f"{BASE_URL}/messages", wait_until="networkidle")
-
-            # Wait for React to render
-            await asyncio.sleep(3)
-
-            # Check if we need to login
-            current_url = page.url
-            print(f"  Current URL: {current_url}")
-
-            if "/login" in current_url:
-                print("  Need to login first...")
-                # Login as admin
-                await page.fill("#username", "admin")
-                await page.fill("#password", "admin123")
-                await page.click('button[type="submit"]')
-                await page.wait_for_url("**/", timeout=10000)
-                print("  ✓ Logged in")
-                await page.goto(f"{BASE_URL}/messages", wait_until="networkidle")
-                await asyncio.sleep(2)
-
+            # Login and go straight to the messages page (/messages redirects
+            # to /manage/messages).
+            print("\n[Step 1] Login and navigate to Messages page...")
+            await _login(page)
+            await page.goto(f"{BASE_URL}/manage/messages", wait_until="networkidle")
             await page.wait_for_selector(".messages", timeout=15000)
-            print("✓ Messages page loaded")
 
-            # Check if User role checkbox is checked by default
-            print("\n[Step 2] Checking User role checkbox state...")
-            user_checkbox = page.locator("#roleUser")
-            is_checked = await user_checkbox.is_checked()
-            print(f"  User checkbox checked: {is_checked}")
-            assert is_checked, "User role should be checked by default"
-            print("✓ User role is checked by default")
+            # Role checkboxes have no ids: fixed order user/assistant/system
+            # inside .messages-filter-roles-checkboxes.
+            checkboxes = page.locator(".messages-filter-roles-checkboxes .form-check-input")
+            user_cb, assistant_cb, system_cb = (checkboxes.nth(i) for i in range(3))
 
-            # Wait for messages to load
-            print("\n[Step 3] Waiting for messages to load...")
-            await page.wait_for_selector(".message-item", timeout=10000)
-            await asyncio.sleep(2)  # Wait for API response
+            # Default: all three roles selected (current UI semantics).
+            print("[Step 2] Checking default role checkbox states...")
+            for name, cb in (("user", user_cb), ("assistant", assistant_cb), ("system", system_cb)):
+                assert await cb.is_checked(), f"{name} role should be checked by default"
 
-            # Get all visible messages and check their roles
-            print("\n[Step 4] Checking message roles...")
-            messages = await page.locator(".message-item").all()
-            print(f"  Found {len(messages)} messages")
+            # Filter down to user-only. The core #79 invariant is asserted on
+            # the badge classes themselves with auto-retry (badge classes are
+            # locale-independent), so a still-in-flight refetch cannot fake a
+            # pass — the old all-roles list still renders assistant/system
+            # badges until the filtered data lands.
+            print("[Step 3] Filtering to user-only...")
+            await assistant_cb.click()
+            await system_cb.click()
+            await expect(page.locator(".message-item .role-badge-assistant")).to_have_count(
+                0, timeout=10000
+            )
+            await expect(page.locator(".message-item .role-badge-system")).to_have_count(
+                0, timeout=10000
+            )
+            user_markers = page.locator(f'.message-item:has-text("{marker}")')
+            await expect(user_markers).to_have_count(1, timeout=10000)
 
-            if len(messages) > 0:
-                # Check each message's role badge
-                for i, msg in enumerate(messages[:10]):  # Check first 10 messages
-                    role_badge = await msg.locator(".role-badge").first.text_content()
-                    role = role_badge.strip().upper()
-                    print(f"  Message {i+1}: {role}")
-                    assert role == "USER", f"Expected USER role, got {role}"
+            # Switch to assistant-only.
+            print("[Step 4] Switching to assistant-only...")
+            await user_cb.click()
+            await assistant_cb.click()
+            await expect(page.locator(".message-item .role-badge-user")).to_have_count(
+                0, timeout=10000
+            )
+            await expect(page.locator(".message-item .role-badge-system")).to_have_count(
+                0, timeout=10000
+            )
+            assistant_markers = page.locator(f'.message-item:has-text("{marker}")')
+            await expect(assistant_markers).to_have_count(1, timeout=10000)
 
-                print(f"✓ All {min(len(messages), 10)} checked messages have USER role")
-            else:
-                print("  No messages found (may be expected if no user messages today)")
+            # Uncheck everything -> select-role empty state.
+            print("[Step 5] Unchecking all roles...")
+            await assistant_cb.click()
 
-            # Now uncheck User and check Assistant
-            print("\n[Step 5] Switching to Assistant role...")
-            await user_checkbox.click()  # Uncheck User
-            assistant_checkbox = page.locator("#roleAssistant")
-            await assistant_checkbox.click()  # Check Assistant
-
-            # Wait for messages to reload
-            await asyncio.sleep(2)
-            await page.wait_for_selector(".message-item", timeout=10000)
-
-            # Check messages are now Assistant role
-            print("\n[Step 6] Checking message roles after filter change...")
-            messages = await page.locator(".message-item").all()
-            print(f"  Found {len(messages)} messages")
-
-            if len(messages) > 0:
-                for i, msg in enumerate(messages[:10]):
-                    role_badge = await msg.locator(".role-badge").first.text_content()
-                    role = role_badge.strip().upper()
-                    print(f"  Message {i+1}: {role}")
-                    assert role == "ASSISTANT", f"Expected ASSISTANT role, got {role}"
-
-                print(f"✓ All {min(len(messages), 10)} checked messages have ASSISTANT role")
-            else:
-                print("  No messages found (may be expected if no assistant messages today)")
-
-            # Test: Uncheck all roles - should show empty state
-            print("\n[Step 7] Unchecking all roles...")
-            await assistant_checkbox.click()  # Uncheck Assistant
-
-            # Wait for empty state to appear
-            await asyncio.sleep(2)
-
-            # Check for empty state message (EmptyState component uses h5 for title)
-            print("\n[Step 8] Checking empty state when no role selected...")
-            empty_title = page.locator(".messages .text-center h5")
+            empty_title = page.locator(".messages .empty-state h5")
             await empty_title.wait_for(timeout=5000)
-            title_text = await empty_title.text_content()
-            print(f"  Empty state title: {title_text}")
+            title_text = (await empty_title.text_content()) or ""
             assert (
-                "Select Role" in title_text or "选择角色" in title_text
-            ), f"Expected 'Select Role' empty state, got '{title_text}'"
-            print("✓ Empty state shown when no role selected")
+                "选择角色" in title_text or "Select Role" in title_text
+            ), f"expected select-role empty state, got '{title_text}'"
 
-            # Take screenshot
-            screenshot_path = Path(__file__).parent.parent.parent / "screenshots/issues/79"
-            screenshot_path.mkdir(parents=True, exist_ok=True)
-            await page.screenshot(
-                path=str(screenshot_path / "role_filter_test.png"), full_page=True
+            screenshot_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "79",
+                "role_filter_test.png",
             )
-            print(f"\n✓ Screenshot saved to {screenshot_path / 'role_filter_test.png'}")
+            os.makedirs(os.path.dirname(screenshot_path), exist_ok=True)
+            await page.screenshot(path=screenshot_path, full_page=True)
 
-            print("\n" + "=" * 50)
-            print("✅ All tests passed! Role filter is working correctly.")
-            print("=" * 50)
-
-        except Exception as e:
-            print(f"\n❌ Test failed: {e}")
-            # Take screenshot on failure
-            screenshot_path = Path(__file__).parent.parent.parent / "screenshots/issues/79"
-            screenshot_path.mkdir(parents=True, exist_ok=True)
-            await page.screenshot(
-                path=str(screenshot_path / "role_filter_failure.png"), full_page=True
+            print("\n✅ Role filter regression passed.")
+        except Exception:
+            screenshot_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "79",
+                "role_filter_failure.png",
             )
+            os.makedirs(os.path.dirname(screenshot_path), exist_ok=True)
+            await page.screenshot(path=screenshot_path, full_page=True)
             raise
         finally:
             await browser.close()
+            _cleanup_seeded_messages()
 
 
 if __name__ == "__main__":

--- a/tests/issues/98/test_data_update.py
+++ b/tests/issues/98/test_data_update.py
@@ -2,213 +2,175 @@
 """
 Test for Issue #98: 刷新后数据没有变化
 
-测试内容：
-1. 获取当前消息列表
-2. 添加新消息到数据库
-3. 点击刷新按钮
-4. 检查新消息是否显示
+测试内容（对齐当前 issues lane：upload API seed + 临时端口 BASE_URL）：
+1. 登录并打开 /manage/messages
+2. 通过 /api/upload/messages（X-Upload-Auth）插入一条带唯一 marker 的今日消息
+3. 点击手动刷新按钮（React-Query invalidateQueries，无整页 reload）
+4. 断言新消息出现在列表里
 """
 
 import asyncio
-import json
 import os
+import sqlite3
+import uuid
 from datetime import datetime
 
-import psycopg2
-from playwright.async_api import async_playwright
+import pytest
+import requests
+from playwright.async_api import async_playwright, expect
 
-BASE_URL = "http://localhost:19888"
-
-
-def get_db_connection():
-    """Get database connection."""
-    config_path = os.path.expanduser("~/.open-ace/config.json")
-    with open(config_path) as f:
-        config = json.load(f)
-
-    db_config = config.get("database", {})
-    db_url = db_config.get("url")
-
-    if db_url and db_url.startswith("postgresql"):
-        conn = psycopg2.connect(db_url)
-        return conn
-    else:
-        raise ValueError("PostgreSQL database not configured")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
+SEED_TOOL_NAME = "issue98_data_update_test"
 
 
-def add_test_message():
-    """Add a test message to the database."""
-    conn = get_db_connection()
-    cursor = conn.cursor()
+def _lane_db_path():
+    return os.path.expanduser("~/.open-ace/ace.db")
 
-    # Generate unique test message
-    timestamp = datetime.now().isoformat()
-    test_content = f"TEST MESSAGE - {timestamp}"
-    import uuid
 
-    message_id = str(uuid.uuid4())
+def _clear_admin_password_flag():
+    """Clear must_change_password on the seeded admin (issues-lane SQLite DB).
 
-    cursor.execute(
-        """
-        INSERT INTO daily_messages (
-            date, tool_name, host_name, sender_name, sender_id,
-            role, content, tokens_used, input_tokens, output_tokens,
-            timestamp, model, message_id
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        RETURNING id
-    """,
-        (
-            datetime.now().strftime("%Y-%m-%d"),
-            "test_tool",
-            "test_host",
-            "test_sender",
-            "test_sender_id",
-            "user",
-            test_content,
-            100,
-            50,
-            50,
-            timestamp,
-            "test-model",
-            message_id,
-        ),
+    Otherwise the forced password-change modal blocks every Playwright click
+    and /api/messages returns 403 password_change_required. Never complete the
+    modal — that would break sibling tests' admin/admin123 logins.
+    """
+    db_path = _lane_db_path()
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+        if "must_change_password" not in cols:
+            return
+        conn.execute("UPDATE users SET must_change_password=0 WHERE username='admin'")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _cleanup_seeded_messages():
+    db_path = _lane_db_path()
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DELETE FROM daily_messages WHERE tool_name = ?", (SEED_TOOL_NAME,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def upload_test_message():
+    """Insert one user-role message for today via the lane upload API.
+
+    Returns the unique content marker (also the visible message text).
+    """
+    upload_key = os.environ.get("UPLOAD_AUTH_KEY")
+    if not upload_key:
+        pytest.skip("UPLOAD_AUTH_KEY not set (no issues-lane server spawned)")
+
+    now = datetime.now()
+    marker = f"ISSUE98-TEST-MESSAGE-{uuid.uuid4().hex[:8]}"
+    payload = {
+        "date": now.strftime("%Y-%m-%d"),
+        "tool_name": SEED_TOOL_NAME,
+        "messages": [
+            {
+                "message_id": str(uuid.uuid4()),
+                "role": "user",
+                "content": marker,
+                "tokens_used": 100,
+                "input_tokens": 50,
+                "output_tokens": 50,
+                "timestamp": now.isoformat(),
+                "sender_name": "issue98-seeder",
+            }
+        ],
+    }
+    resp = requests.post(
+        f"{BASE_URL}/api/upload/messages",
+        json=payload,
+        headers={"X-Upload-Auth": upload_key},
+        timeout=15,
     )
-
-    msg_id = cursor.fetchone()[0]
-    conn.commit()
-    conn.close()
-
-    print(f"  Added test message with ID: {msg_id}, content: {test_content[:50]}...")
-    return test_content
+    assert resp.status_code == 200, f"seed upload failed: {resp.status_code} {resp.text[:200]}"
+    assert resp.json().get("saved_count") == 1, f"unexpected seed result: {resp.text[:200]}"
+    return marker
 
 
-def delete_test_messages():
-    """Delete test messages from the database."""
-    conn = get_db_connection()
-    cursor = conn.cursor()
-
-    cursor.execute("DELETE FROM daily_messages WHERE tool_name = 'test_tool'")
-    deleted = cursor.rowcount
-
-    conn.commit()
-    conn.close()
-
-    print(f"  Deleted {deleted} test messages")
-    return deleted
-
-
+@pytest.mark.asyncio
 async def test_data_update():
-    """Test that refresh updates the data."""
+    """Test that refresh picks up newly inserted data."""
+    _clear_admin_password_flag()
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1400, "height": 900}, locale="zh-CN")
         page = await context.new_page()
 
         try:
-            # Clean up any existing test messages
-            print("\n[Setup] Cleaning up test messages...")
-            delete_test_messages()
-
-            # Step 1: Navigate to login page
-            print("\n[Step 1] Navigating to login page...")
+            # Login and open the messages page.
+            print("[Step 1] Login and navigate to Messages page...")
             await page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
-            await page.wait_for_timeout(1000)
-
-            # Step 2: Login
-            print("[Step 2] Logging in...")
             await page.fill("#username", "admin")
             await page.fill("#password", "admin123")
             await page.click('button[type="submit"]')
             await page.wait_for_url(lambda url: "/login" not in url, timeout=10000)
-            print("✓ Login successful")
 
-            # Step 3: Navigate to Messages page
-            print("\n[Step 3] Navigating to Messages page...")
             await page.goto(f"{BASE_URL}/manage/messages", wait_until="networkidle", timeout=30000)
-            await page.wait_for_timeout(2000)
-            print("✓ Messages page loaded")
-
-            # Step 4: Get current message count
-            print("\n[Step 4] Getting current message count...")
+            await page.wait_for_selector(".messages", timeout=15000)
 
             messages_before = await page.locator(".message-item").count()
-            print(f"  Messages visible before: {messages_before}")
+            print(f"[Step 2] Messages visible before: {messages_before}")
 
-            # Step 5: Add a test message
-            print("\n[Step 5] Adding test message to database...")
-            test_content = add_test_message()
+            # Insert the test message via the lane-compatible upload API.
+            print("[Step 3] Uploading test message via /api/upload/messages...")
+            marker = upload_test_message()
 
-            # Step 6: Click refresh button
-            print("\n[Step 6] Clicking refresh button...")
-            refresh_btn = page.locator('button:has-text("刷新"), button:has-text("Refresh")')
-            await refresh_btn.first.click()
-            await page.wait_for_timeout(3000)
-            print("✓ Refresh button clicked")
+            # Manual refresh (icon button; invalidates the React Query cache).
+            print("[Step 4] Clicking manual refresh button...")
+            refresh_btn = page.locator('[data-testid="manual-refresh-button"]')
+            await expect(refresh_btn).to_be_enabled(timeout=5000)
+            await refresh_btn.click()
 
-            # Step 7: Check if new message appears
-            print("\n[Step 7] Checking for new message...")
+            # The new message must appear without a page reload.
+            print("[Step 5] Verifying the new message appears...")
+            test_msg = page.locator(f'.message-item:has-text("{marker}")')
+            await expect(test_msg).to_have_count(1, timeout=15000)
+            print(f"  Test message visible: {marker}")
 
-            # Check if test message appears (search for partial content)
-            test_msg_locator = page.locator('.message-item:has-text("TEST MESSAGE")')
-            test_msg_count = await test_msg_locator.count()
-
-            if test_msg_count > 0:
-                print("  ✓ Test message found in UI!")
-            else:
-                print("  ✗ Test message NOT found in UI")
-
-                # Check current messages
-                messages_after = await page.locator(".message-item").count()
-                print(f"  Messages visible after: {messages_after}")
-
-                # Check API directly
-                print("\n  Checking API directly...")
-                api_response = await page.evaluate("""async () => {
-                    const response = await fetch('/api/messages?limit=100&role=user,assistant,system');
-                    const data = await response.json();
-                    return data;
-                }""")
-
-                if api_response and "messages" in api_response:
-                    print(f"  API returned {len(api_response['messages'])} messages")
-
-                    # Check if test message is in API response
-                    test_msg_in_api = any(
-                        msg.get("content", "").startswith("TEST MESSAGE")
-                        for msg in api_response["messages"]
-                    )
-                    print(f"  Test message in API response: {test_msg_in_api}")
-
-            # Take screenshot
-            await page.screenshot(
-                path="screenshots/issues/98/05_data_update_test.png", full_page=True
+            screenshot_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "98",
             )
-            print("  Screenshot saved: screenshots/issues/98/05_data_update_test.png")
+            os.makedirs(screenshot_dir, exist_ok=True)
+            await page.screenshot(
+                path=os.path.join(screenshot_dir, "05_data_update_test.png"), full_page=True
+            )
 
-            # Summary
-            print("\n" + "=" * 50)
-            print("Test Summary:")
-            print(f"  - Test message added: {test_content[:50]}...")
-            print(f"  - Test message found in UI: {test_msg_count > 0}")
-            print("=" * 50)
-
-        except Exception as e:
-            print(f"\n✗ Error: {e}")
+            print("\n✅ Data-update regression passed.")
+        except Exception:
             import traceback
 
             traceback.print_exc()
-            await page.screenshot(path="screenshots/issues/98/error_data_update.png")
-            print("  Error screenshot saved: screenshots/issues/98/error_data_update.png")
+            screenshot_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "98",
+                "error_data_update.png",
+            )
+            os.makedirs(os.path.dirname(screenshot_dir), exist_ok=True)
+            await page.screenshot(path=screenshot_dir)
+            raise
         finally:
-            # Clean up test messages
-            print("\n[Cleanup] Removing test messages...")
-            delete_test_messages()
-
+            # Cleanup must run even on failure: residual rows would perturb
+            # sibling tests in the same shard.
+            _cleanup_seeded_messages()
             await browser.close()
 
 
 if __name__ == "__main__":
-    import os
-
-    os.makedirs("screenshots/issues/98", exist_ok=True)
     asyncio.run(test_data_update())

--- a/tests/issues/98/test_refresh_detailed.py
+++ b/tests/issues/98/test_refresh_detailed.py
@@ -2,202 +2,151 @@
 """
 Detailed test for Issue #98: Messages 页面的 refresh 和 auto refresh 都不工作
 
-测试内容：
-1. 检查刷新按钮点击后的 isFetching 状态
-2. 检查刷新按钮的 loading 状态
-3. 检查 auto-refresh 的定时器是否正确设置
+对齐当前 /manage/messages 实现（纯图标刷新按钮 + dropdown 里的 auto-refresh 开关）：
+1. 手动刷新按钮（data-testid="manual-refresh-button"）点击后触发 /api/messages 请求
+2. 点击后按钮短暂禁用（防抖），随后恢复 enabled
+3. auto-refresh 开关存在于 dropdown 中，可开启并保持 checked
+
+60s interval 定时器触发验证默认关闭（240s/test 预算下抖动余量太薄），
+设 OPENACE_VERIFY_AUTO_REFRESH_INTERVAL=1 可开启（至多等 90s 断言一次非手动请求）。
 """
 
 import asyncio
 import os
+import sqlite3
 import time
 
 import pytest
-from playwright.async_api import async_playwright
+from playwright.async_api import async_playwright, expect
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
+def _clear_admin_password_flag():
+    """Clear must_change_password on the seeded admin (issues-lane SQLite DB).
+
+    Otherwise the forced password-change modal blocks every Playwright click
+    and /api/messages returns 403 password_change_required. Never complete the
+    modal — that would break sibling tests' admin/admin123 logins.
+    """
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+        if "must_change_password" not in cols:
+            return
+        conn.execute("UPDATE users SET must_change_password=0 WHERE username='admin'")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
 async def test_messages_refresh_detailed():
-    """Test Messages page refresh functionality in detail."""
+    """Test Messages page manual refresh + auto-refresh toggle (current UI)."""
+    verify_interval = os.environ.get("OPENACE_VERIFY_AUTO_REFRESH_INTERVAL") == "1"
+    _clear_admin_password_flag()
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1400, "height": 900}, locale="zh-CN")
         page = await context.new_page()
 
-        # Track network requests
-        api_requests = []
+        # Track /api/messages list requests (exclude /count).
+        api_requests: list[dict] = []
 
         def track_request(request):
             if "/api/messages" in request.url and "/count" not in request.url:
                 api_requests.append({"url": request.url, "time": time.time()})
-                print(f"  [API Request] {request.url}")
-
-        def track_response(response):
-            if "/api/messages" in response.url and "/count" not in response.url:
-                print(f"  [API Response] {response.url} - Status: {response.status}")
 
         page.on("request", track_request)
-        page.on("response", track_response)
 
         try:
-            # Step 1: Navigate to login page
-            print("\n[Step 1] Navigating to login page...")
+            # Login and open the messages page.
+            print("[Step 1] Login and navigate to Messages page...")
             await page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
-            await page.wait_for_timeout(1000)
-
-            # Step 2: Login
-            print("[Step 2] Logging in...")
             await page.fill("#username", "admin")
             await page.fill("#password", "admin123")
             await page.click('button[type="submit"]')
             await page.wait_for_url(lambda url: "/login" not in url, timeout=10000)
-            print("✓ Login successful")
 
-            # Step 3: Navigate to Messages page
-            print("\n[Step 3] Navigating to Messages page...")
             await page.goto(f"{BASE_URL}/manage/messages", wait_until="networkidle", timeout=30000)
-            await page.wait_for_timeout(2000)
-            print("✓ Messages page loaded")
+            await page.wait_for_selector(".messages", timeout=15000)
 
-            # Step 4: Check refresh button state
-            print("\n[Step 4] Checking refresh button state...")
-            refresh_btn = page.locator('button:has-text("刷新"), button:has-text("Refresh")')
+            # The refresh control is an icon-only button now.
+            print("[Step 2] Checking manual refresh button state...")
+            refresh_btn = page.locator('[data-testid="manual-refresh-button"]')
+            await expect(refresh_btn).to_be_visible(timeout=10000)
+            await expect(refresh_btn).to_be_enabled(timeout=5000)
 
-            # Check if button has spinner (loading state)
-            spinner = refresh_btn.locator(".spinner-border")
-            spinner_count = await spinner.count()
-            print(f"  Spinner count before click: {spinner_count}")
-
-            # Check button disabled state
-            is_disabled = await refresh_btn.first.is_disabled()
-            print(f"  Button disabled before click: {is_disabled}")
-
-            # Clear previous requests
+            # Manual click must trigger a fresh /api/messages request.
+            print("[Step 3] Clicking refresh and verifying the API request...")
             api_requests.clear()
+            await refresh_btn.click()
+            deadline = time.time() + 10
+            while time.time() < deadline and not api_requests:
+                await page.wait_for_timeout(250)
+            assert api_requests, "manual refresh button did not trigger an /api/messages request"
+            print(f"  Refresh triggered: {api_requests[0]['url']}")
 
-            # Click refresh button
-            print("  Clicking refresh button...")
-            await refresh_btn.first.click()
+            # The button debounces (disabled while refreshing), then re-enables.
+            print("[Step 4] Verifying the button re-enables after debounce...")
+            await expect(refresh_btn).to_be_enabled(timeout=5000)
 
-            # Immediately check for spinner
-            await page.wait_for_timeout(100)
-            spinner_count_after = await spinner.count()
-            print(f"  Spinner count after click (100ms): {spinner_count_after}")
+            # Auto-refresh toggle lives in the dropdown next to the button.
+            print("[Step 5] Opening settings dropdown and enabling auto-refresh...")
+            await page.locator('[data-testid="dropdown-toggle"]').click()
+            auto_refresh_switch = page.locator('[id$="-auto-refresh"]')
+            await expect(auto_refresh_switch.first).to_be_visible(timeout=5000)
+            await auto_refresh_switch.first.check()
+            assert (
+                await auto_refresh_switch.first.is_checked()
+            ), "auto-refresh switch should stay checked after enabling"
+            print("  Auto-refresh enabled and stays checked.")
 
-            # Wait for response
-            await page.wait_for_timeout(2000)
+            # Optional (env-gated): the 60s interval timer really fires a
+            # non-manual /api/messages request.
+            if verify_interval:
+                print("[Step 6] Waiting for an interval-triggered request (<=90s)...")
+                manual_count = len(api_requests)
+                deadline = time.time() + 90
+                fired = False
+                while time.time() < deadline:
+                    if len(api_requests) > manual_count:
+                        fired = True
+                        break
+                    await page.wait_for_timeout(1000)
+                assert fired, "auto-refresh interval did not trigger an /api/messages request"
+                print("  Interval-triggered request observed.")
 
-            # Check final state
-            spinner_count_final = await spinner.count()
-            print(f"  Spinner count after 2s: {spinner_count_final}")
+            screenshot_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "98",
+            )
+            os.makedirs(screenshot_dir, exist_ok=True)
+            await page.screenshot(
+                path=os.path.join(screenshot_dir, "04_detailed_test.png"), full_page=True
+            )
 
-            # Check if API request was made
-            print(f"  API requests after click: {len(api_requests)}")
-            if len(api_requests) > 0:
-                print("  ✓ Refresh button triggered API request")
-            else:
-                print("  ✗ Refresh button did NOT trigger API request")
-
-            # Step 5: Check auto-refresh toggle state
-            print("\n[Step 5] Checking auto-refresh toggle state...")
-            auto_refresh_switch = page.locator("#messagesAutoRefreshSwitch")
-
-            # Check if switch exists
-            switch_count = await auto_refresh_switch.count()
-            print(f"  Auto-refresh switch count: {switch_count}")
-
-            if switch_count > 0:
-                # Check if it's checked
-                is_checked = await auto_refresh_switch.is_checked()
-                print(f"  Auto-refresh is checked: {is_checked}")
-
-                # Get the switch's parent element
-                switch_parent = auto_refresh_switch.locator("xpath=..")
-                parent_html = await switch_parent.inner_html()
-                print(f"  Switch parent HTML: {parent_html[:200]}...")
-
-                # Check if there's a label
-                label = page.locator('label[for="messagesAutoRefreshSwitch"]')
-                label_count = await label.count()
-                print(f"  Label count: {label_count}")
-                if label_count > 0:
-                    label_text = await label.text_content()
-                    print(f"  Label text: {label_text}")
-
-            # Step 6: Test auto-refresh timing
-            print("\n[Step 6] Testing auto-refresh timing...")
-
-            # Clear previous requests
-            api_requests.clear()
-
-            # Make sure auto-refresh is on
-            is_checked = await auto_refresh_switch.is_checked()
-            if not is_checked:
-                print("  Turning on auto-refresh...")
-                await auto_refresh_switch.check()
-                await page.wait_for_timeout(500)
-
-            print("  Waiting 35 seconds for auto-refresh to trigger...")
-            start_time = time.time()
-
-            # Wait and track requests
-            await page.wait_for_timeout(35000)
-
-            end_time = time.time()
-            print(f"  Waited {end_time - start_time:.1f} seconds")
-            print(f"  API requests during wait: {len(api_requests)}")
-
-            if len(api_requests) > 0:
-                print("  ✓ Auto-refresh triggered API request(s)")
-                for req in api_requests:
-                    print(f"    - {req['url']}")
-            else:
-                print("  ✗ Auto-refresh did NOT trigger any API request")
-
-            # Step 7: Check React Query state via browser console
-            print("\n[Step 7] Checking React Query state...")
-
-            # Execute JavaScript to check React Query state
-            result = await page.evaluate("""() => {
-                // Try to find React Query devtools or state
-                const root = document.querySelector('#root');
-                if (!root) return { error: 'No root element' };
-
-                // Check if there are any pending queries
-                const pendingQueries = document.querySelectorAll('[data-query-state="pending"]');
-                const fetchingQueries = document.querySelectorAll('[data-query-state="fetching"]');
-
-                return {
-                    pendingQueries: pendingQueries.length,
-                    fetchingQueries: fetchingQueries.length,
-                };
-            }""")
-            print(f"  React Query state: {result}")
-
-            # Take final screenshot
-            await page.screenshot(path="screenshots/issues/98/04_detailed_test.png", full_page=True)
-            print("  Screenshot saved: screenshots/issues/98/04_detailed_test.png")
-
-            # Summary
-            print("\n" + "=" * 50)
-            print("Test Summary:")
-            print(f"  - Refresh button triggered API: {len(api_requests) > 0}")
-            print(f"  - Auto-refresh switch found: {switch_count > 0}")
-            print(f"  - Auto-refresh is ON: {is_checked}")
-            print("=" * 50)
-
-        except Exception as e:
-            print(f"\n✗ Error: {e}")
-            await page.screenshot(path="screenshots/issues/98/error_detailed.png")
-            print("  Error screenshot saved: screenshots/issues/98/error_detailed.png")
+            print("\n✅ Refresh regression passed.")
+        except Exception:
+            screenshot_dir = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                "screenshots",
+                "issues",
+                "98",
+                "error_detailed.png",
+            )
+            os.makedirs(os.path.dirname(screenshot_dir), exist_ok=True)
+            await page.screenshot(path=screenshot_dir)
             raise
         finally:
             await browser.close()
 
 
 if __name__ == "__main__":
-    import os
-
-    os.makedirs("screenshots/issues/98", exist_ok=True)
     asyncio.run(test_messages_refresh_detailed())


### PR DESCRIPTION
Refs #2457 (legacy issue failure baseline burn-down). Baseline 275→255 landed via #2631; this clears the last 4 deferred "async-def" entries with **real fixes** (not marker patches). Baseline 255 → 251, shrink-only.

## Root causes (all verified against current source)

- `tests/issues/4/test_conversation_history_icon.py` — login filled `input[name=...]` (login form uses `#username`/`#password` only) and password `admin` (seeded is `admin123`); also screenshot dir was only created under `__main__`. The target selectors themselves did NOT drift (`/manage/analysis/conversation-history`, `.manage-sidebar`, `.bi-chat-square-text`, `.nav-item.active` all current).
- `tests/issues/79/test_role_filter.py` — `#roleUser`/`#roleAssistant` ids no longer exist (id-less checkboxes in `.messages-filter-roles-checkboxes`, order user/assistant/system); default selection changed from user-only to all-3-roles; empty lane DB meant `.message-item` never rendered and assertions were vacuous.
- `tests/issues/98/test_refresh_detailed.py` — refresh button is now icon-only `[data-testid="manual-refresh-button"]` (no 刷新 text → old locator matched nothing → 30s timeout, the previously observed failure); auto-refresh switch moved into a dropdown (`dropdown-toggle`, id `*-auto-refresh`), no more `#messagesAutoRefreshSwitch`; the old 35s wait mismatched the current 60s interval.
- `tests/issues/98/test_data_update.py` — psycopg2 + host `~/.open-ace/config.json` PG URL vs the issues lane's isolated home + SQLite + ephemeral port; hardcoded BASE_URL; swallowed exceptions with print-only "assertions".

## Common blocker found by independent plan review (round 1, CRITICAL)

Seeded admin has `must_change_password=1` (init_db.py:145): login triggers a non-dismissible ForceChangePasswordModal (blocks all Playwright click actionability) and `/api/messages` returns 403 `password_change_required`. All 4 tests now pre-clear the flag directly on the lane SQLite DB (`UPDATE users SET must_change_password=0`). The modal is **never completed** — that would change the password for every sibling test logging in as admin/admin123 in the same shard.

## What each test now does

- **4**: correct login; visibility-only assertions (occlusion-insensitive, deliberately no post-login clicks).
- **79**: seeds user+assistant+system messages for today via `POST /api/upload/messages` (`X-Upload-Auth` from the lane env, same env dict as the pytest subprocess); asserts all-3 default-checked; filters to user-only/assistant-only asserting badge-class counts go to 0 + marker-scoped count == 1 (auto-retry `expect`, locale-independent); unchecks all → select-role empty state. Cleanup in `finally` (sqlite DELETE by tool_name).
- **98a (refresh_detailed)**: manual click triggers `/api/messages` (network capture, real assert); button re-enables via `to_be_enabled(timeout=5000)`; auto-refresh toggle opens in dropdown, checks and stays checked. The 60s interval-timer verification is env-gated (`OPENACE_VERIFY_AUTO_REFRESH_INTERVAL=1`, ≤90s) — off by default (240s/test budget too thin).
- **98b (data_update)**: seeds via the upload API (date=today, uuid4 message_id, explicit ISO timestamp), clicks manual refresh (React-Query invalidate path, no reload), asserts the marker `.message-item` appears; failures re-raise; cleanup in `finally`.

## Evidence

- Plan reviewed by independent agent: round 1 NOT CLEAN (5 objections incl. the must_change_password CRITICAL, live-server verified) → revised → round 2 CLEAN.
- Local lane run (`--isolated-home`, 3 dirs): **14/14 passed** including all 4 target nodeids executed for real (71s).
- Controlled negative tests on the comparator: stale resolved entry kept → exit 1; unknown new failure → exit 1 (fail-closed confirmed).
- Full 4-shard lane validation on this branch: run 31795877644 — `known=251, new=0, resolved=0, changed=0, collection_errors=0, invalid=0, exit_code=0` (verified from the `legacy-issue-diff.json` artifact).

## Intentionally out of scope

517/716/740/1395/584/165/1329 clusters (per #2457 directive); comparator/quarantine/nightly semantics unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>