### PR TITLE
fix: implement file change parser for detecting file/folder operations (#2589)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -3897,6 +3897,25 @@ class AutonomousAgentRunner:
                     )
                     if getattr(stored, "_was_inserted", False):
                         persisted_count += 1
+
+                    # Extract file changes from tool_use events (Issue #2589)
+                    try:
+                        from scripts.shared.file_change_parser import extract_file_changes
+                        changes = extract_file_changes(
+                            {"name": event.get("tool_name"), "input": tool_input},
+                            self.project_path,
+                        )
+                        if changes:
+                            self.session_manager.append_transcript_message(
+                                session_id=session_id,
+                                role="assistant",
+                                content="",
+                                metadata={"content_blocks": [{"type": "file_change", "changes": changes, "status": "accepted"}]},
+                                milestone_id=milestone_id,
+                                source="file_change_parser",
+                            )
+                    except Exception as e:
+                        logger.debug(f"Failed to extract file changes: {e}")
             if final_assistant:
                 assistant_content = pick_best_artifact_text(
                     final_assistant.get("text", ""),

--- a/scripts/shared/file_change_parser.py
+++ b/scripts/shared/file_change_parser.py
@@ -5,11 +5,260 @@ Issue #8: Qwen CLI emits tool_use blocks for file operations (mkdir/mv/cp/rm,
 write_file/edit) without corresponding file_change blocks. This module extracts
 file change information from tool_use blocks for the frontend file-change panel.
 
-This is a placeholder implementation. The full implementation will be added
-in a follow-up change.
+Issue #2589: File change panel configuration for detecting file/folder operations.
 """
 
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Protocol
+else:
+    Protocol = object  # type: ignore[misc, assignment]
+
+logger = logging.getLogger(__name__)
+
 __all__ = ["append_file_change_blocks", "extract_file_changes"]
+
+
+@dataclass
+class FileChangeRecord:
+    """Represents a single file/folder change detected from a tool_use block."""
+
+    path: str
+    change_type: str  # 'add' | 'modify' | 'delete'
+
+
+class FileChangeParser(Protocol):
+    """Protocol for file change parsers."""
+
+    def can_parse(self, tool_name: str, tool_input: dict) -> bool:
+        """Check if this parser can handle the given tool invocation."""
+        ...
+
+    def parse(self, tool_name: str, tool_input: dict, project_path: str) -> list[FileChangeRecord]:
+        """Extract file changes from the tool invocation."""
+        ...
+
+
+class MkdirParser:
+    """Parser for mkdir commands."""
+
+    def can_parse(self, tool_name: str, tool_input: dict) -> bool:
+        if tool_name != "Bash":
+            return False
+        command = tool_input.get("command", "")
+        return "mkdir" in command
+
+    def parse(self, tool_name: str, tool_input: dict, project_path: str) -> list[FileChangeRecord]:
+        """Extract paths from mkdir command."""
+        command = tool_input.get("command", "")
+        records: list[FileChangeRecord] = []
+
+        try:
+            # Parse mkdir command to extract paths
+            paths = self._extract_mkdir_paths(command)
+            for path in paths:
+                abs_path = self._resolve_path(path, project_path)
+                if abs_path and self._is_safe_path(abs_path, project_path):
+                    records.append(FileChangeRecord(path=abs_path, change_type="add"))
+        except Exception as e:
+            logger.warning(f"Failed to parse mkdir command '{command[:50]}...': {e}")
+
+        return records
+
+    def _extract_mkdir_paths(self, command: str) -> list[str]:
+        """Extract path arguments from mkdir command."""
+        paths: list[str] = []
+
+        # Remove mkdir and flags, extract path arguments
+        # Handle: mkdir foo, mkdir -p foo/bar, mkdir "path with spaces"
+        try:
+            # Simple regex approach for common cases
+            # Match mkdir followed by optional flags and then paths
+            mkdir_pattern = r"mkdir\s+(?:-[pvPm]+\s+)*(.+?)(?:\s*;|\s*&&|\s*\|\||$)"
+            match = re.search(mkdir_pattern, command, re.IGNORECASE)
+            if not match:
+                return paths
+
+            args_str = match.group(1).strip()
+
+            # Split by spaces, respecting quotes
+            try:
+                parts = shlex.split(args_str)
+            except ValueError:
+                # Fallback to simple split if shlex fails
+                parts = args_str.split()
+
+            for part in parts:
+                # Skip flags
+                if part.startswith("-"):
+                    continue
+                paths.append(part)
+        except Exception as e:
+            logger.debug(f"Error extracting mkdir paths: {e}")
+
+        return paths
+
+    def _resolve_path(self, path: str, project_path: str) -> str | None:
+        """Resolve relative path to absolute path."""
+        if not path:
+            return None
+
+        try:
+            path = os.path.expanduser(path)
+            path = os.path.expandvars(path)
+
+            if os.path.isabs(path):
+                return os.path.normpath(path)
+
+            return os.path.normpath(os.path.join(project_path, path))
+        except Exception as e:
+            logger.debug(f"Error resolving path '{path}': {e}")
+            return None
+
+    def _is_safe_path(self, path: str, project_path: str) -> bool:
+        """Verify path is within project directory (prevent path traversal)."""
+        try:
+            abs_path = os.path.realpath(path)
+            abs_project = os.path.realpath(project_path)
+
+            # Path must be within project directory
+            return abs_path.startswith(abs_project + os.sep) or abs_path == abs_project
+        except Exception:
+            return False
+
+
+class WriteFileParser:
+    """Parser for write_file tool."""
+
+    def can_parse(self, tool_name: str, tool_input: dict) -> bool:
+        return tool_name in ("write_file", "WriteFile")
+
+    def parse(self, tool_name: str, tool_input: dict, project_path: str) -> list[FileChangeRecord]:
+        file_path = tool_input.get("file_path", "")
+        if not file_path:
+            return []
+
+        abs_path = self._resolve_path(file_path, project_path)
+        if not abs_path or not self._is_safe_path(abs_path, project_path):
+            return []
+
+        return [FileChangeRecord(path=abs_path, change_type="add")]
+
+    def _resolve_path(self, path: str, project_path: str) -> str | None:
+        if not path:
+            return None
+        try:
+            path = os.path.expanduser(path)
+            path = os.path.expandvars(path)
+            if os.path.isabs(path):
+                return os.path.normpath(path)
+            return os.path.normpath(os.path.join(project_path, path))
+        except Exception:
+            return None
+
+    def _is_safe_path(self, path: str, project_path: str) -> bool:
+        try:
+            abs_path = os.path.realpath(path)
+            abs_project = os.path.realpath(project_path)
+            return abs_path.startswith(abs_project + os.sep) or abs_path == abs_project
+        except Exception:
+            return False
+
+
+class EditParser:
+    """Parser for edit tool."""
+
+    def can_parse(self, tool_name: str, tool_input: dict) -> bool:
+        return tool_name == "edit"
+
+    def parse(self, tool_name: str, tool_input: dict, project_path: str) -> list[FileChangeRecord]:
+        file_path = tool_input.get("file_path", "")
+        if not file_path:
+            return []
+
+        abs_path = self._resolve_path(file_path, project_path)
+        if not abs_path or not self._is_safe_path(abs_path, project_path):
+            return []
+
+        return [FileChangeRecord(path=abs_path, change_type="modify")]
+
+    def _resolve_path(self, path: str, project_path: str) -> str | None:
+        if not path:
+            return None
+        try:
+            path = os.path.expanduser(path)
+            path = os.path.expandvars(path)
+            if os.path.isabs(path):
+                return os.path.normpath(path)
+            return os.path.normpath(os.path.join(project_path, path))
+        except Exception:
+            return None
+
+    def _is_safe_path(self, path: str, project_path: str) -> bool:
+        try:
+            abs_path = os.path.realpath(path)
+            abs_project = os.path.realpath(project_path)
+            return abs_path.startswith(abs_project + os.sep) or abs_path == abs_project
+        except Exception:
+            return False
+
+
+# Registered parsers (P0: mkdir, write_file, edit)
+_PARSERS: list[FileChangeParser] = [
+    MkdirParser(),
+    WriteFileParser(),
+    EditParser(),
+]
+
+
+def extract_file_changes(tool_use_block: dict, project_path: str) -> list[dict] | None:
+    """Extract file change records from a tool_use block.
+
+    Args:
+        tool_use_block: A tool_use content block with 'name' and 'input' keys.
+        project_path: The project root path for resolving relative paths.
+
+    Returns:
+        List of file_change records (dict with 'path' and 'change_type'),
+        or None if no file changes detected.
+    """
+    if not tool_use_block:
+        return None
+
+    tool_name = tool_use_block.get("name", "")
+    tool_input = tool_use_block.get("input", {})
+
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+
+    all_records: list[FileChangeRecord] = []
+
+    for parser in _PARSERS:
+        try:
+            if parser.can_parse(tool_name, tool_input):
+                records = parser.parse(tool_name, tool_input, project_path)
+                all_records.extend(records)
+        except Exception as e:
+            logger.warning(f"Parser {parser.__class__.__name__} failed: {e}")
+            continue
+
+    if not all_records:
+        return None
+
+    # Convert to dict format expected by frontend
+    return [
+        {"path": r.path, "change_type": r.change_type}
+        for r in all_records
+    ]
 
 
 def append_file_change_blocks(blocks: list[dict]) -> None:
@@ -19,28 +268,9 @@ def append_file_change_blocks(blocks: list[dict]) -> None:
         blocks: List of content blocks to augment (modified in place).
 
     Note:
-        This is a placeholder. The full implementation will parse tool_use
-        blocks for shell commands (mkdir/mv/cp/rm) and native file tools
-        (write_file/edit) to generate synthetic file_change blocks.
+        This function is kept for backward compatibility.
+        Prefer using extract_file_changes() directly.
     """
-    # Placeholder: no-op for now
-    # TODO(Issue #8): implement file_change block extraction
+    # This is now a no-op placeholder
+    # The actual implementation is in agent_runner integration
     pass
-
-
-def extract_file_changes(tool_use_block: dict) -> list[dict] | None:
-    """Extract file change records from a tool_use block.
-
-    Args:
-        tool_use_block: A tool_use content block.
-
-    Returns:
-        List of file_change records, or None if not applicable.
-
-    Note:
-        This is a placeholder. The full implementation will parse tool_use
-        blocks to identify file operations and generate change records.
-    """
-    # Placeholder: return None for now
-    # TODO(Issue #8): implement file_change extraction
-    return None

--- a/tests/unit/test_file_change_parser.py
+++ b/tests/unit/test_file_change_parser.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for file change parser.
+
+Issue #2589: File change panel configuration for detecting file/folder operations.
+"""
+
+
+from scripts.shared.file_change_parser import (
+    extract_file_changes,
+    MkdirParser,
+    WriteFileParser,
+    EditParser,
+    FileChangeRecord,
+)
+
+
+class TestMkdirParser:
+    """Tests for MkdirParser."""
+
+    def test_can_parse_bash_mkdir(self):
+        """Test can_parse returns True for Bash tool with mkdir command."""
+        parser = MkdirParser()
+        assert parser.can_parse("Bash", {"command": "mkdir foo"}) is True
+        assert parser.can_parse("Bash", {"command": "mkdir -p foo/bar"}) is True
+
+    def test_cannot_parse_other_tools(self):
+        """Test can_parse returns False for non-Bash tools."""
+        parser = MkdirParser()
+        assert parser.can_parse("WriteFile", {"file_path": "foo.txt"}) is False
+        assert parser.can_parse("Bash", {"command": "ls -la"}) is False
+
+    def test_parse_simple_mkdir(self):
+        """Test parsing simple mkdir command."""
+        parser = MkdirParser()
+        records = parser.parse("Bash", {"command": "mkdir foo"}, "/project")
+        assert len(records) == 1
+        assert records[0].path.endswith("foo")
+        assert records[0].change_type == "add"
+
+    def test_parse_mkdir_with_flag(self):
+        """Test parsing mkdir with -p flag."""
+        parser = MkdirParser()
+        records = parser.parse("Bash", {"command": "mkdir -p foo/bar"}, "/project")
+        assert len(records) == 1
+        assert "foo/bar" in records[0].path
+
+    def test_parse_mkdir_with_quotes(self):
+        """Test parsing mkdir with quoted path."""
+        parser = MkdirParser()
+        records = parser.parse("Bash", {"command": "mkdir 'path with spaces'"}, "/project")
+        assert len(records) == 1
+        assert "path with spaces" in records[0].path
+
+    def test_path_traversal_blocked(self):
+        """Test path traversal is blocked."""
+        parser = MkdirParser()
+        records = parser.parse("Bash", {"command": "mkdir ../../../etc/passwd"}, "/project")
+        # Path should be rejected due to safety check
+        assert len(records) == 0
+
+
+class TestWriteFileParser:
+    """Tests for WriteFileParser."""
+
+    def test_can_parse_write_file(self):
+        """Test can_parse returns True for write_file tool."""
+        parser = WriteFileParser()
+        assert parser.can_parse("write_file", {}) is True
+        assert parser.can_parse("WriteFile", {}) is True
+
+    def test_cannot_parse_other_tools(self):
+        """Test can_parse returns False for other tools."""
+        parser = WriteFileParser()
+        assert parser.can_parse("Bash", {}) is False
+        assert parser.can_parse("edit", {}) is False
+
+    def test_parse_write_file(self):
+        """Test parsing write_file tool."""
+        parser = WriteFileParser()
+        records = parser.parse(
+            "write_file",
+            {"file_path": "/project/foo.txt"},
+            "/project"
+        )
+        assert len(records) == 1
+        assert records[0].change_type == "add"
+
+    def test_parse_relative_path(self):
+        """Test parsing relative path."""
+        parser = WriteFileParser()
+        records = parser.parse(
+            "write_file",
+            {"file_path": "src/main.py"},
+            "/project"
+        )
+        assert len(records) == 1
+        assert records[0].path.endswith("src/main.py")
+
+
+class TestEditParser:
+    """Tests for EditParser."""
+
+    def test_can_parse_edit(self):
+        """Test can_parse returns True for edit tool."""
+        parser = EditParser()
+        assert parser.can_parse("edit", {}) is True
+
+    def test_cannot_parse_other_tools(self):
+        """Test can_parse returns False for other tools."""
+        parser = EditParser()
+        assert parser.can_parse("write_file", {}) is False
+
+    def test_parse_edit(self):
+        """Test parsing edit tool."""
+        parser = EditParser()
+        records = parser.parse(
+            "edit",
+            {"file_path": "/project/foo.txt"},
+            "/project"
+        )
+        assert len(records) == 1
+        assert records[0].change_type == "modify"
+
+
+class TestExtractFileChanges:
+    """Tests for extract_file_changes function."""
+
+    def test_extract_from_mkdir(self):
+        """Test extracting file changes from mkdir tool_use."""
+        result = extract_file_changes(
+            {"name": "Bash", "input": {"command": "mkdir foo"}},
+            "/project"
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["change_type"] == "add"
+
+    def test_extract_from_write_file(self):
+        """Test extracting file changes from write_file tool_use."""
+        result = extract_file_changes(
+            {"name": "write_file", "input": {"file_path": "foo.txt"}},
+            "/project"
+        )
+        assert result is not None
+        assert result[0]["change_type"] == "add"
+
+    def test_extract_from_edit(self):
+        """Test extracting file changes from edit tool_use."""
+        result = extract_file_changes(
+            {"name": "edit", "input": {"file_path": "foo.txt"}},
+            "/project"
+        )
+        assert result is not None
+        assert result[0]["change_type"] == "modify"
+
+    def test_no_changes_for_unsupported_tool(self):
+        """Test returns None for unsupported tools."""
+        result = extract_file_changes(
+            {"name": "Bash", "input": {"command": "ls -la"}},
+            "/project"
+        )
+        assert result is None
+
+    def test_empty_input(self):
+        """Test handles empty input gracefully."""
+        result = extract_file_changes({}, "/project")
+        assert result is None


### PR DESCRIPTION
## Summary

This PR implements the file change parser to detect file/folder operations from tool_use blocks.

## Changes

### Core Implementation
- **scripts/shared/file_change_parser.py**: Implement file change parser
  - MkdirParser: Parse mkdir commands
  - WriteFileParser: Parse write_file tool
  - EditParser: Parse edit tool
  - extract_file_changes(): Extract file changes from tool_use blocks

### Integration
- **app/modules/workspace/autonomous/agent_runner.py**: Integrate file change extraction
  - Call extract_file_changes() after tool_use event handling
  - Generate file_change blocks for frontend rendering

### Tests
- **tests/unit/test_file_change_parser.py**: Unit tests for all parsers

## How It Works

1. When agent executes a tool (mkdir, write_file, edit), the tool_use event is logged
2. After persisting the tool message, extract_file_changes() parses the tool input
3. If file changes are detected, a file_change block is appended to the transcript
4. Frontend receives the file_change block via WebSocket and displays it in the file change panel

## Test Results

All parser tests pass:
- MkdirParser: parses mkdir commands correctly
- WriteFileParser: parses write_file tool correctly
- EditParser: parses edit tool correctly
- Path safety: blocks path traversal attacks

Fixes #2589

Generated with Qwen Code