### PR TITLE
feat(#2658): unify acceptance-paused user actions

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1312,32 +1312,31 @@ def get_timeline(workflow_id):
 @autonomous_bp.route("/workflows/<workflow_id>/verification_override", methods=["POST"])
 @auth_required
 def acceptance_verification_override(workflow_id):
-    """Admin override: confirm an indeterminate acceptance workflow (#2335 S6).
+    """Human override: confirm an acceptance-paused workflow (#2335 S6, #2658).
 
-    A workflow paused at ``acceptance_verification`` with
-    ``verification_status="indeterminate"`` cannot complete on its own (the
-    verifier could not reach a confident verdict and is awaiting evidence that
-    only a human can supply). An admin may inspect the merged code out of band
-    and override the verdict to ``confirmed``: this stamps ``verified_by`` with
-    the human identity, emits an audit event, posts a short report, closes the
-    issue as @open-ace-bot, and completes the workflow (resting at the
+    A workflow paused at ``acceptance_verification`` with a terminal
+    ``verification_status`` of ``"indeterminate"`` (verifier could not reach a
+    verdict) or ``"rejected"`` (verifier rejected, a human disagrees) cannot
+    complete on its own. The workflow owner or an admin may inspect the merged
+    code out of band and override the verdict to ``confirmed``: this stamps
+    ``verified_by`` with the human identity, emits an audit event, posts a
+    report (noting when a rejection was overturned), closes the issue as
+    @open-ace-bot, and completes the workflow (resting at the
     ``acceptance_verification`` phase, consistent with the confirmed terminal
-    default).
-
-    Admin-only — a non-admin (even the workflow owner) cannot override, because
-    the override bypasses the independent verifier and must be attributable to
-    a privileged actor.
+    default). The override bypasses the independent verifier, so it stays
+    attributable: ``verified_by: human-override:<username>``.
     """
-    if not User.is_admin_role(g.user_role):
-        return jsonify({"error": "Admin permission required"}), 403
-
     workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
 
+    if not User.is_admin_role(g.user_role) and workflow.get("user_id") != g.user_id:
+        return jsonify({"error": "Access denied"}), 403
+
     if workflow.get("current_phase") != "acceptance_verification":
         return jsonify({"error": "Workflow is not in the acceptance_verification phase"}), 400
-    if workflow.get("verification_status") != "indeterminate":
+    prior_status = (workflow.get("verification_status") or "").strip()
+    if prior_status not in ("indeterminate", "rejected"):
         return (
             jsonify({"error": "Override is only available for indeterminate verification status"}),
             400,
@@ -1388,8 +1387,13 @@ def acceptance_verification_override(workflow_id):
                 owner = user_repo.get_user_by_id(workflow.get("user_id")) or {}
                 system_account = owner.get("system_account")
             gh = GitHubOps(project_path, system_account=system_account)
+            override_title = (
+                "## ✅ Acceptance verified (human override — rejection overturned)"
+                if prior_status == "rejected"
+                else "## ✅ Acceptance verified (human override)"
+            )
             lines = [
-                "## ✅ Acceptance verified (human override)",
+                override_title,
                 f"**Merge SHA:** `{merge_sha}`" if merge_sha else "**Merge SHA:** _unknown_",
                 f"**Verifier:** `{verified_by}`",
             ]
@@ -1692,13 +1696,20 @@ def resume_with_feedback(workflow_id):
     if len(user_feedback) > 5000:
         return jsonify({"error": "user_feedback too long (max 5000 characters)"}), 400
 
-    # Store feedback and set to waiting (scheduler will pick up via _do_wait)
+    # Store feedback and set to waiting (scheduler will pick up via _do_wait).
+    # #2658: clear the cached acceptance merge SHA — the acceptance phase's
+    # idempotency replays a terminal verdict for the same
+    # (merge_sha, snapshot) pair, and nothing else resets it between dev
+    # rounds, so without this the next acceptance run would re-verify the OLD
+    # merge instead of the new one (stale-replay loop for both rejected and
+    # indeterminate resumes).
     _get_repo().update_workflow(
         workflow_id,
         {
             "user_feedback": user_feedback,
             "current_phase": "wait",
             "status": "waiting",
+            "verification_merge_sha": "",
         },
     )
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1335,10 +1335,25 @@ def acceptance_verification_override(workflow_id):
 
     if workflow.get("current_phase") != "acceptance_verification":
         return jsonify({"error": "Workflow is not in the acceptance_verification phase"}), 400
+    # Paused-only (#2658 review): resume-with-feedback clears the cached
+    # verification_merge_sha but keeps the prior verification_status until a
+    # new verdict lands, so a mid-verification run (status e.g. "running")
+    # still carries a stale "rejected". Overriding there would race the
+    # verifier's own writes and stamp an unknown merge SHA — require the
+    # paused state the UI already gates on.
+    if workflow.get("status") != "paused":
+        return jsonify({"error": "Workflow is not paused for human review"}), 400
     prior_status = (workflow.get("verification_status") or "").strip()
     if prior_status not in ("indeterminate", "rejected"):
         return (
-            jsonify({"error": "Override is only available for indeterminate verification status"}),
+            jsonify(
+                {
+                    "error": (
+                        "Override is only available for indeterminate or rejected "
+                        "verification status"
+                    )
+                }
+            ),
             400,
         )
 

--- a/docs/dev-notes/2658-acceptance-paused-user-actions-design.md
+++ b/docs/dev-notes/2658-acceptance-paused-user-actions-design.md
@@ -1,0 +1,78 @@
+# #2658 design: unify user actions for acceptance-paused workflows
+
+Date: 2026-08-14. Branch: `fix/2658-acceptance-paused-user-actions` (off `origin/main`).
+
+## Problem
+
+A workflow paused at `acceptance_verification` awaiting human action has
+incomplete, inconsistent exits:
+
+1. **rejected has no human-accept path.** `POST /workflows/<id>/verification_override`
+   accepts only `verification_status == "indeterminate"` (rejected → 400) and is
+   admin-only (the workflow owner gets 403). The 「标记完成」 button only shows
+   for `status == "waiting"`. A user who disagrees with the rejection cannot
+   finish the workflow and close the issue from the page; the only exit is
+   resume-with-feedback into another dev round.
+2. **indeterminate cannot resume with feedback.** The 「带反馈恢复」 button added
+   in #2641 is gated on `verification_status === 'rejected'` only.
+3. **The full verification report is not visible on the page.** Per-item
+   verdicts/evidence/rationale are posted as a GitHub issue comment; the page
+   timeline card shows only the one-line `result_summary` (first 6 failed
+   items). The report JSON already rides in the acceptance milestone's
+   `metadata` (returned by `/timeline`) but the frontend never renders it.
+   Verifier infra-exhausted pauses land as `indeterminate` and had no dedicated
+   action at all.
+
+## Decisions (user-approved 2026-08-14)
+
+- Override (人工确认验收) becomes available for **rejected AND indeterminate**,
+  to **admin OR the workflow owner** (mirroring `resume_with_feedback`).
+- Every acceptance pause that needs a human gets exactly two exits:
+  **accept** (override → confirmed → issue comment → close issue → completed)
+  or **resume with feedback** (new dev round → new merge → fresh acceptance).
+- Every such pause can view the **full report** on the page.
+
+## Backend change (single point: `app/routes/autonomous.py`)
+
+`acceptance_verification_override`:
+
+- Status guard: allow `verification_status in {"indeterminate", "rejected"}`
+  (confirmed still 400s — nothing to override; empty status 400s as before).
+- Permission: `User.is_admin_role(g.user_role) or workflow["user_id"] == g.user_id`
+  (same shape as `resume_with_feedback`). Docstring updated to reflect that the
+  human actor is the owner or an admin, and the override remains attributable
+  via the `verified_by: human-override:<username>` stamp + audit event.
+- Behavior unchanged: stamp `confirmed`, post override comment, close issue,
+  complete workflow. The override comment notes when a rejection was
+  overturned ("human override (rejected overturned)") so the issue history
+  reads honestly.
+
+Everything else is untouched: idempotency, replayed-rejected guard, close
+semantics, audit event emission.
+
+## Frontend changes (`frontend/src/components/work/WorkflowTimeline.tsx`)
+
+- `showAcceptanceOverride`: `paused && acceptance_verification && verification_status ∈ {rejected, indeterminate}`.
+- `showResumeWithFeedback`: same condition (was rejected-only).
+- New 「查看验收报告」 action on the acceptance milestone card (same pattern as
+  `canViewPlanContent`'s viewer): a modal renders the report parsed from the
+  milestone's `metadata` JSON, grouped **scope / gates / verifier**, each item
+  showing verdict badge + evidence (`ref`, `note`) + rationale. Zero API
+  changes. i18n keys ×4 locales (en/zh/ja/ko).
+
+Not done (YAGNI): manual "reject" action (the system already rejects), markDone
+semantics, new GitHub links.
+
+## Testing
+
+- Unit (`tests/unit/`, `pytest.mark.regression` + `issue(2658)`):
+  - permission matrix: owner ✓, admin ✓, unrelated user 403;
+  - rejected override succeeds (completed + `verified_by` stamp + issue close
+    called), indeterminate override still succeeds (regression);
+  - boundaries: confirmed → 400, non-acceptance phase → 400, reason > 2000 → 400.
+- E2E Playwright (`tests/e2e/work/`, headless-first per project rule, then
+  `headless=false` demo): seeded rejected + indeterminate workflows show BOTH
+  buttons and the report modal opens with per-item content; owner override on
+  the rejected seed ends at completed.
+
+No schema/migration changes.

--- a/docs/dev-notes/2658-acceptance-paused-user-actions-plan.md
+++ b/docs/dev-notes/2658-acceptance-paused-user-actions-plan.md
@@ -1,0 +1,579 @@
+# #2658 Implementation Plan: unify acceptance-paused user actions
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every acceptance-paused workflow (rejected OR indeterminate) offers its owner/admin two page exits — accept (override → close issue → completed) or resume-with-feedback — plus an in-page full verification-report viewer.
+
+**Architecture:** Single backend route change (`acceptance_verification_override`: status guard + permission), frontend gating unification in `WorkflowTimeline.tsx`, report viewer reusing the existing `viewingContent` generic modal fed by a pure formatter over `milestone.metadata` (already returned by `/timeline` — zero API change).
+
+**Tech Stack:** Flask + pytest (unittest.mock), React + TS + Bootstrap, Playwright E2E (headless-first per project rule).
+
+**Spec:** `docs/dev-notes/2658-acceptance-paused-user-actions-design.md`. Issue #2658.
+
+---
+
+### Task 1: Backend — extend `verification_override` to rejected + owner
+
+**Files:**
+- Test: `tests/unit/test_acceptance_override_2658.py` (new)
+- Modify: `app/routes/autonomous.py` (`acceptance_verification_override`, ~L1312-1445)
+- Modify: `tests/issues/2335/test_acceptance_override_route.py` (legacy opt-in lane — update semantics in place; do NOT create new files there)
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/unit/test_acceptance_override_2658.py` — mirror the fixture style of `tests/issues/2335/test_acceptance_override_route.py` (mocked repo + patched `_load_user_from_token` + patched `GitHubOps`):
+
+```python
+"""#2658: acceptance override for rejected AND indeterminate, owner+admin.
+
+Regression for the route extension: the workflow owner (not just admins) may
+override a paused acceptance verdict — confirming it, closing the issue and
+completing the workflow. Rejected verdicts are overridable; confirmed ones
+still 400; unrelated users still 403.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import create_app
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2658)]
+
+
+def _workflow_row(**overrides):
+    base = {
+        "id": 1,
+        "workflow_id": "wf-override",
+        "user_id": 7,
+        "status": "paused",
+        "current_phase": "acceptance_verification",
+        "verification_status": "rejected",
+        "verification_merge_sha": "abc123",
+        "verification_report": '{"status": "rejected"}',
+        "github_issue_number": 4242,
+        "github_pr_number": 99,
+        "project_path": "/srv/open-ace",
+        "worktree_path": "/srv/open-ace/.worktrees/wf-override",
+        "system_account": "openace",
+        "error_message": "Acceptance verification rejected; awaiting review",
+    }
+    base.update(overrides)
+    return base
+
+
+def _user_dict(user_id, role, username):
+    return {
+        "id": user_id,
+        "username": username,
+        "email": f"{username}@test.com",
+        "role": role,
+        "tenant_id": None,
+    }
+
+
+def _mock_auth(user_id=1, role="admin", username="admin"):
+    user = _user_dict(user_id, role, username)
+    return patch("app.auth.decorators._load_user_from_token", return_value=user)
+
+
+@pytest.fixture
+def app_client():
+    workflow = _workflow_row()
+    repo = MagicMock()
+    repo.get_workflow.return_value = dict(workflow)
+
+    def _update(workflow_id, updates):
+        workflow.update(updates)
+        repo.get_workflow.return_value = dict(workflow)
+        return dict(workflow)
+
+    repo.update_workflow.side_effect = _update
+    repo.create_event.return_value = {}
+
+    app = create_app({"TESTING": True})
+    with patch("app.routes.autonomous._get_repo", return_value=repo):
+        client = app.test_client()
+        client.set_cookie("session_token", "test-token")
+        yield client, repo, workflow
+
+
+def _post_override(client, body=None):
+    return client.post(
+        "/api/autonomous/workflows/wf-override/verification_override",
+        json=body or {"reason": "inspected the merged code; acceptable"},
+    )
+
+
+class TestOverridePermission:
+    def test_owner_can_override_rejected(self, app_client):
+        client, repo, _ = app_client
+        gh = MagicMock()
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=gh,
+            ),
+        ):
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = _post_override(client)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        updates = repo.update_workflow.call_args.args[1]
+        assert updates["verification_status"] == "confirmed"
+        assert updates["status"] == "completed"
+        gh.close_issue.assert_called_once_with(4242)
+        # The issue comment must record that a rejection was overturned.
+        comment = gh.add_issue_comment.call_args.args[1]
+        assert "rejection overturned" in comment
+
+    def test_owner_can_override_indeterminate(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(verification_status="indeterminate")
+        gh = MagicMock()
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=gh,
+            ),
+        ):
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = _post_override(client)
+        assert resp.status_code == 200
+        comment = gh.add_issue_comment.call_args.args[1]
+        assert "rejection overturned" not in comment
+
+    def test_admin_can_override_rejected(self, app_client):
+        client, repo, _ = app_client
+        with ExitStack() as stack, patch(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps",
+            return_value=MagicMock(),
+        ):
+            stack.enter_context(_mock_auth(user_id=1, role="admin", username="root"))
+            resp = _post_override(client)
+        assert resp.status_code == 200
+
+    def test_unrelated_user_gets_403(self, app_client):
+        client, _repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=99, role="user", username="stranger"))
+            resp = _post_override(client)
+        assert resp.status_code == 403
+
+
+class TestOverrideStatusGuard:
+    def test_confirmed_still_400(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(verification_status="confirmed")
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_wrong_phase_400(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(current_phase="development")
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_reason_over_2000_chars_400(self, app_client):
+        client, _repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client, {"reason": "x" * 2001})
+        assert resp.status_code == 400
+```
+
+Note: check whether `pytest.mark.issue` is a registered marker (`pytest.ini` / a plugin). If not registered, add the marker declaration to `pytest.ini` — first grep `tests/unit/` for an existing `pytest.mark.issue(` usage; if it exists, the marker is already registered.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_acceptance_override_2658.py -v`
+Expected: `test_owner_can_override_rejected` FAIL 403, `test_owner_can_override_indeterminate` FAIL 403, `test_admin_can_override_rejected` FAIL 400 (rejected not allowed yet). Permission/guard tests that assert old behavior unchanged (`test_unrelated_user_gets_403`, `test_confirmed_still_400`, `test_wrong_phase_400`, `test_reason_over_2000_chars_400`) may pass already — that's fine.
+
+- [ ] **Step 3: Implement the route change**
+
+In `app/routes/autonomous.py` `acceptance_verification_override`:
+
+1. Docstring: replace the admin-only paragraph with:
+
+```python
+    """Human override: confirm an acceptance-paused workflow (#2335 S6, #2658).
+
+    A workflow paused at ``acceptance_verification`` with a terminal
+    ``verification_status`` of ``"indeterminate"`` (verifier could not reach a
+    verdict) or ``"rejected"`` (verifier rejected, a human disagrees) cannot
+    complete on its own. The workflow owner or an admin may inspect the merged
+    code out of band and override the verdict to ``confirmed``: this stamps
+    ``verified_by`` with the human identity, emits an audit event, posts a
+    report (noting when a rejection was overturned), closes the issue as
+    @open-ace-bot, and completes the workflow (resting at the
+    ``acceptance_verification`` phase, consistent with the confirmed terminal
+    default). The override bypasses the independent verifier, so it stays
+    attributable: ``verified_by: human-override:<username>``.
+    """
+```
+
+2. Permission (replace the `is_admin_role` block):
+
+```python
+    if not User.is_admin_role(g.user_role) and workflow.get("user_id") != g.user_id:
+        return jsonify({"error": "Access denied"}), 403
+```
+
+3. Status guard (replace the `!= "indeterminate"` block):
+
+```python
+    prior_status = (workflow.get("verification_status") or "").strip()
+    if prior_status not in ("indeterminate", "rejected"):
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "Override is only available for indeterminate or rejected "
+                        "verification status"
+                    )
+                }
+            ),
+            400,
+        )
+```
+
+4. Comment title (in the `lines = [...]` construction): make the first line conditional:
+
+```python
+            override_title = (
+                "## ✅ Acceptance verified (human override — rejection overturned)"
+                if prior_status == "rejected"
+                else "## ✅ Acceptance verified (human override)"
+            )
+            lines = [
+                override_title,
+                f"**Merge SHA:** `{merge_sha}`" if merge_sha else "**Merge SHA:** _unknown_",
+                f"**Verifier:** `{verified_by}`",
+            ]
+```
+
+- [ ] **Step 4: Update the legacy 2335 test file in place**
+
+`tests/issues/2335/test_acceptance_override_route.py`: `test_non_admin_override_returns_403` currently patches the OWNER (user_id=7, role user) and expects 403 — that user must now succeed. Change it to an unrelated user, and add an owner-success test:
+
+```python
+def test_non_owner_non_admin_override_returns_403(app_client):
+    client, _repo, _ = app_client
+    with ExitStack() as stack:
+        for p in _mock_auth(role="user", user_id=99, username="stranger"):
+            stack.enter_context(p)
+        resp = _post_override(client)
+    assert resp.status_code == 403
+
+
+def test_owner_override_now_allowed_2658(app_client):
+    """#2658: the workflow owner (role=user, user_id matching the row) may override."""
+    client, _repo, _ = app_client
+    with (
+        ExitStack() as stack,
+        patch(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps",
+            return_value=MagicMock(),
+        ),
+    ):
+        for p in _mock_auth(role="user", user_id=7, username="owner"):
+            stack.enter_context(p)
+        resp = _post_override(client)
+    assert resp.status_code == 200
+```
+
+Also update the module docstring line "Non-admins get 403" → "Unrelated users get 403; the workflow owner may override (#2658)".
+
+- [ ] **Step 5: Run both test files**
+
+Run: `python -m pytest tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py -v`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/routes/autonomous.py tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py
+git commit -m "feat(#2658): acceptance override for rejected+indeterminate, owner+admin"
+```
+
+---
+
+### Task 2: Frontend — unified button gating + report viewer
+
+**Files:**
+- Modify: `frontend/src/components/work/WorkflowTimeline.tsx`
+- Modify: `frontend/src/i18n/index.ts`
+
+- [ ] **Step 1: Unify the gating constants**
+
+Replace (near line 705 on main):
+
+```tsx
+  // #2335 S6: admin override for a paused indeterminate acceptance workflow.
+  const showAcceptanceOverride =
+    workflow.status === 'paused' && workflow.verification_status === 'indeterminate';
+```
+
+and
+
+```tsx
+  // #2634: a REJECTED acceptance needs new developer feedback to make progress;
+  // resuming without it hits the idempotency guard and re-pauses immediately.
+  const showResumeWithFeedback =
+    workflow.status === 'paused' &&
+    workflow.current_phase === 'acceptance_verification' &&
+    workflow.verification_status === 'rejected';
+```
+
+with:
+
+```tsx
+  // #2658: every acceptance pause that needs a human offers BOTH exits —
+  // accept (override → close issue → completed; owner+admin, enforced
+  // server-side) and resume-with-feedback (new dev round → new merge → fresh
+  // acceptance). Resuming a rejected verdict without feedback hits the
+  // idempotency guard and re-pauses immediately, which is why the feedback
+  // modal is the resume path.
+  const isAcceptancePaused =
+    workflow.status === 'paused' &&
+    workflow.current_phase === 'acceptance_verification' &&
+    (workflow.verification_status === 'rejected' ||
+      workflow.verification_status === 'indeterminate');
+  const showAcceptanceOverride = isAcceptancePaused;
+  const showResumeWithFeedback = isAcceptancePaused;
+```
+
+- [ ] **Step 2: Add the report formatter (module level, next to `PLAN_CONTENT_TYPES`)**
+
+```tsx
+// #2658: render the acceptance milestone's verification report (stored in
+// milestone.metadata as JSON by the acceptance phase) as readable text for
+// the generic content viewer. Sections mirror _format_report_comment in
+// acceptance_verification.py.
+const VERDICT_TONE: Record<string, string> = {
+  confirmed: '✅',
+  rejected: '❌',
+  indeterminate: '⚠️',
+};
+
+const formatAcceptanceReport = (metadata: string): string => {
+  let report: Record<string, unknown>;
+  try {
+    report = JSON.parse(metadata) as Record<string, unknown>;
+  } catch {
+    return metadata;
+  }
+  const lines: string[] = [];
+  const status = String(report.status ?? '');
+  lines.push(`${VERDICT_TONE[status] ?? '⚠️'} ${status || 'unknown'}`);
+  if (report.merge_sha) lines.push(`Merge SHA: ${String(report.merge_sha)}`);
+  if (report.verified_by) lines.push(`Verifier: ${String(report.verified_by)}`);
+  if (report.infra_error) lines.push(`Infra error: ${String(report.infra_error)}`);
+  const sections: Array<[string, string]> = [
+    ['scope', 'Scope'],
+    ['gates', 'Gates'],
+    ['verifier', 'Verifier findings'],
+  ];
+  for (const [key, label] of sections) {
+    const items = report[key];
+    if (!Array.isArray(items) || items.length === 0) continue;
+    lines.push('', `── ${label} ──`);
+    for (const raw of items) {
+      if (!raw || typeof raw !== 'object') continue;
+      const item = raw as Record<string, unknown>;
+      const verdict = String(item.verdict ?? '');
+      const icon = VERDICT_TONE[verdict] ?? '•';
+      const tail = item.rationale ? ` — ${String(item.rationale)}` : '';
+      lines.push(`${icon} ${String(item.item ?? '')}${tail}`);
+      const evidence = item.evidence;
+      if (Array.isArray(evidence)) {
+        for (const ev of evidence) {
+          if (!ev || typeof ev !== 'object') continue;
+          const e = ev as Record<string, unknown>;
+          const note = e.note ? ` (${String(e.note)})` : '';
+          lines.push(`    ↳ ${String(e.ref ?? '')}${note}`);
+        }
+      }
+    }
+  }
+  return lines.join('\n');
+};
+```
+
+- [ ] **Step 3: Add the milestone-card button**
+
+Next to `canViewReviewContent` in the milestone render (~L1495):
+
+```tsx
+    const canViewAcceptanceReport =
+      !compact &&
+      milestone.milestone_type === 'acceptance_verification' &&
+      !!milestone.metadata?.trim();
+```
+
+And in the card actions after the `canViewReviewContent` button block (~L1733):
+
+```tsx
+                    {canViewAcceptanceReport && (
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        className="timeline-inline-btn timeline-inline-btn--warning"
+                        onClick={() =>
+                          setViewingContent({
+                            title: t('autoViewAcceptanceReportTitle', language),
+                            content: formatAcceptanceReport(mstoneMetadata(milestone)),
+                          })
+                        }
+                      >
+                        <i className="bi bi-clipboard-check me-1"></i>
+                        {t('autoViewAcceptanceReport', language)}
+                      </Button>
+                    )}
+```
+
+(If `milestone.metadata` is directly accessible at that point — it is, the map variable is `milestone` — use `milestone.metadata` inline instead of a helper: `content: formatAcceptanceReport(milestone.metadata)`.)
+
+- [ ] **Step 4: i18n keys ×4 locales**
+
+In `frontend/src/i18n/index.ts`, next to the existing `autoAcceptanceOverrideButton` entries in each of the 4 locale blocks (en/zh/ja/ko):
+
+```ts
+    autoViewAcceptanceReport: 'View acceptance report',
+    autoViewAcceptanceReportTitle: 'Acceptance verification report',
+```
+
+zh:
+
+```ts
+    autoViewAcceptanceReport: '查看验收报告',
+    autoViewAcceptanceReportTitle: '验收报告',
+```
+
+ja:
+
+```ts
+    autoViewAcceptanceReport: '受け入れレポートを表示',
+    autoViewAcceptanceReportTitle: '受け入れ検証レポート',
+```
+
+ko:
+
+```ts
+    autoViewAcceptanceReport: '승인 리포트 보기',
+    autoViewAcceptanceReportTitle: '승인 검증 리포트',
+```
+
+Also update `autoAcceptanceOverrideDesc` in each locale if its text says the action is admin-only — change to "workflow owner or admin" wording (zh: 「工作流所有者或管理员可确认验收并关闭 issue」).
+
+- [ ] **Step 5: Typecheck + build**
+
+Run: `cd frontend && npx tsc --noEmit && npm run build`
+Expected: no type errors, build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/work/WorkflowTimeline.tsx frontend/src/i18n/index.ts
+git commit -m "feat(#2658): unified acceptance-pause exits + in-page report viewer"
+```
+
+---
+
+### Task 3: E2E (Playwright, headless first — project rule)
+
+**Files:**
+- Modify: `tests/e2e/work/e2e_paused_acceptance_ui_playwright.py`
+
+- [ ] **Step 1: Extend the E2E**
+
+In the existing file (it already seeds rejected + indeterminate workflows and drives the paused tab), add:
+
+1. A milestone seed helper (the timeline API needs a milestone row so the report button renders):
+
+```python
+def seed_acceptance_milestone(repo, workflow_id: str, status: str) -> str:
+    import json as _json
+
+    report = {
+        "merge_sha": "abc123",
+        "status": status,
+        "scope": [{"item": "src/app.py", "verdict": "confirmed", "evidence": []}],
+        "gates": [],
+        "verifier": [
+            {
+                "item": "修复登录失败",
+                "verdict": "rejected",
+                "evidence": [{"ref": "tests/test_login.py:12", "note": "用例仍然失败"}],
+                "rationale": "合并后用例依旧失败",
+            }
+        ],
+    }
+    repo.create_milestone(
+        {
+            "workflow_id": workflow_id,
+            "phase": "acceptance_verification",
+            "round_number": 1,
+            "milestone_type": "acceptance_verification",
+            "status": status,
+            "title": f"Acceptance verification: {status}",
+            "result_summary": f"status={status}",
+            "metadata": _json.dumps(report, ensure_ascii=False),
+        }
+    )
+    return report
+```
+
+(Adapt to the file's existing `repo` seeding mechanism — `seed_workflow` uses the same repo object; keep the style consistent.)
+
+2. Assertions, for BOTH the rejected and indeterminate seeded workflows:
+   - 「带反馈恢复」 button visible (was rejected-only; indeterminate is the #2658 change),
+   - 「确认验收（覆盖）」 button visible (rejected is the #2658 change),
+   - open the workflow detail timeline, click 「查看验收报告」, assert the viewer modal shows the seeded item text (`修复登录失败`) and the evidence ref (`tests/test_login.py:12`).
+
+- [ ] **Step 2: Run headless until green**
+
+Run: `HEADLESS=true python scripts/run_extended_tests.py --category specific --target tests/e2e/work/e2e_paused_acceptance_ui_playwright.py --isolated-home --server auto --timeout 300`
+Expected: PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/work/e2e_paused_acceptance_ui_playwright.py
+git commit -m "test(#2658): e2e both exits on rejected+indeterminate + report viewer"
+```
+
+---
+
+### Task 4: Full verification + PR
+
+- [ ] **Step 1: Full unit suite locally**
+
+Run: `python -m pytest tests/unit/ -q`
+Expected: no new failures vs `origin/main`.
+
+- [ ] **Step 2: pre-commit on changed files (NOT --all-files — scope-guard rule)**
+
+Run: `pre-commit run --files app/routes/autonomous.py tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py frontend/src/components/work/WorkflowTimeline.tsx frontend/src/i18n/index.ts tests/e2e/work/e2e_paused_acceptance_ui_playwright.py`
+Expected: clean (watch for pyupgrade `X | None`, TC003 TYPE_CHECKING moves, black 25.1.0 formatting).
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin fix/2658-acceptance-paused-user-actions
+gh pr create --title "feat(#2658): unify acceptance-paused user actions" --body "<summary; NO closes/fixes/resolves keywords near #2658>"
+```
+
+PR body must reference the issue with "Refs #2658" only (GitHub auto-close trap).
+
+- [ ] **Step 4: Required CI green** (lint / test(3.10) / test(3.11) / test(3.12) / build) → independent review (`superpowers:requesting-code-review` on `gh pr diff`) → merge `--merge --delete-branch` → deploy hotpatch (orchestrator/routes change needs scheduler restart; frontend build+deploy + open-ace.service restart) → verify on prod.
+
+- [ ] **Step 5: headless=false demo to user** (project E2E rule step 3).

--- a/docs/dev-notes/2658-acceptance-paused-user-actions-plan.md
+++ b/docs/dev-notes/2658-acceptance-paused-user-actions-plan.md
@@ -2,22 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Every acceptance-paused workflow (rejected OR indeterminate) offers its owner/admin two page exits — accept (override → close issue → completed) or resume-with-feedback — plus an in-page full verification-report viewer.
+**Goal:** Every acceptance-paused workflow (rejected OR indeterminate) offers its owner/admin two page exits — accept (override → close issue → completed) or resume-with-feedback — plus an in-page full verification-report viewer; resume-with-feedback actually delivers a FRESH verification (stale merge-SHA cache cleared).
 
-**Architecture:** Single backend route change (`acceptance_verification_override`: status guard + permission), frontend gating unification in `WorkflowTimeline.tsx`, report viewer reusing the existing `viewingContent` generic modal fed by a pure formatter over `milestone.metadata` (already returned by `/timeline` — zero API change).
+**Architecture:** Backend route changes (`acceptance_verification_override`: status guard + permission reorder; `resume_with_feedback`: clear the verification cache), frontend gating unification in `WorkflowTimeline.tsx`, report viewer reusing the existing `viewingContent` generic modal fed by a pure formatter over `milestone.metadata` (already returned by `/timeline` — zero API change).
 
-**Tech Stack:** Flask + pytest (unittest.mock), React + TS + Bootstrap, Playwright E2E (headless-first per project rule).
+**Tech Stack:** Flask + pytest (unittest.mock), React + TS + Bootstrap + vitest, Playwright E2E (headless-first per project rule).
 
 **Spec:** `docs/dev-notes/2658-acceptance-paused-user-actions-design.md`. Issue #2658.
+**Plan review:** independent review 2026-08-14 — all findings (1 Critical, 4 Important, 5 Minor) folded in below.
 
 ---
 
-### Task 1: Backend — extend `verification_override` to rejected + owner
+### Task 1: Backend — override extension + resume-cache reset
 
 **Files:**
 - Test: `tests/unit/test_acceptance_override_2658.py` (new)
-- Modify: `app/routes/autonomous.py` (`acceptance_verification_override`, ~L1312-1445)
-- Modify: `tests/issues/2335/test_acceptance_override_route.py` (legacy opt-in lane — update semantics in place; do NOT create new files there)
+- Modify: `app/routes/autonomous.py` (`acceptance_verification_override` ~L1312-1445; `resume_with_feedback` ~L1676-1710)
+- Modify: `tests/issues/2335/test_acceptance_override_route.py` (existing file, updated IN PLACE — do not create new files under tests/issues/; note this dir runs only in the extended `category=issues` lane, never in required PR CI)
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -29,7 +30,9 @@
 Regression for the route extension: the workflow owner (not just admins) may
 override a paused acceptance verdict — confirming it, closing the issue and
 completing the workflow. Rejected verdicts are overridable; confirmed ones
-still 400; unrelated users still 403.
+still 400; unrelated users still 403. resume-with-feedback must clear the
+cached verification merge SHA so the next acceptance run re-verifies instead
+of replaying the prior verdict on a stale (merge_sha, snapshot) pair.
 """
 
 from __future__ import annotations
@@ -182,22 +185,42 @@ class TestOverrideStatusGuard:
             resp = _post_override(client)
         assert resp.status_code == 400
 
-    def test_reason_over_2000_chars_400(self, app_client):
-        client, _repo, _ = app_client
-        with ExitStack() as stack:
-            stack.enter_context(_mock_auth(user_id=1, role="admin"))
-            resp = _post_override(client, {"reason": "x" * 2001})
-        assert resp.status_code == 400
-```
 
-Note: check whether `pytest.mark.issue` is a registered marker (`pytest.ini` / a plugin). If not registered, add the marker declaration to `pytest.ini` — first grep `tests/unit/` for an existing `pytest.mark.issue(` usage; if it exists, the marker is already registered.
+class TestResumeWithFeedbackClearsVerificationCache:
+    """#2658: a fresh dev round must not replay the prior acceptance verdict.
+
+    The acceptance phase caches ``verification_merge_sha`` on the workflow and
+    its idempotency replays a terminal verdict for the same
+    (merge_sha, snapshot) pair. Nothing else ever cleared the SHA between
+    rounds, so resume-with-feedback → new dev round → new merge would still
+    re-verify the OLD merge. The route must clear the cached SHA.
+    """
+
+    def _post_feedback(self, client):
+        return client.post(
+            "/api/autonomous/workflows/wf-override/resume-with-feedback",
+            json={"user_feedback": "please also handle the edge case"},
+        )
+
+    def test_resume_clears_cached_merge_sha(self, app_client):
+        client, repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = self._post_feedback(client)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        updates = repo.update_workflow.call_args.args[1]
+        assert updates["verification_merge_sha"] == ""
+        assert updates["current_phase"] == "wait"
+        assert updates["status"] == "waiting"
+        assert updates["user_feedback"] == "please also handle the edge case"
+```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `python -m pytest tests/unit/test_acceptance_override_2658.py -v`
-Expected: `test_owner_can_override_rejected` FAIL 403, `test_owner_can_override_indeterminate` FAIL 403, `test_admin_can_override_rejected` FAIL 400 (rejected not allowed yet). Permission/guard tests that assert old behavior unchanged (`test_unrelated_user_gets_403`, `test_confirmed_still_400`, `test_wrong_phase_400`, `test_reason_over_2000_chars_400`) may pass already — that's fine.
+Expected FAILs: `test_owner_can_override_rejected` (403), `test_owner_can_override_indeterminate` (403), `test_admin_can_override_rejected` (400), `test_resume_clears_cached_merge_sha` (no `verification_merge_sha` in updates). `test_unrelated_user_gets_403` / guard tests may already pass.
 
-- [ ] **Step 3: Implement the route change**
+- [ ] **Step 3: Implement the override route change**
 
 In `app/routes/autonomous.py` `acceptance_verification_override`:
 
@@ -220,7 +243,17 @@ In `app/routes/autonomous.py` `acceptance_verification_override`:
     """
 ```
 
-2. Permission (replace the `is_admin_role` block):
+2. **Permission check MOVES after the 404** (it currently sits before
+   `get_workflow` and would raise NameError on `workflow` otherwise). Delete:
+
+```python
+    if not User.is_admin_role(g.user_role):
+        return jsonify({"error": "Admin permission required"}), 403
+```
+
+and insert right AFTER the `if not workflow: return 404` block (mirroring
+`resume_with_feedback`'s order — an unrelated user probing an unknown id now
+gets 404, consistent with every other route):
 
 ```python
     if not User.is_admin_role(g.user_role) and workflow.get("user_id") != g.user_id:
@@ -245,7 +278,7 @@ In `app/routes/autonomous.py` `acceptance_verification_override`:
         )
 ```
 
-4. Comment title (in the `lines = [...]` construction): make the first line conditional:
+4. Comment title — make the first line conditional:
 
 ```python
             override_title = (
@@ -260,9 +293,32 @@ In `app/routes/autonomous.py` `acceptance_verification_override`:
             ]
 ```
 
-- [ ] **Step 4: Update the legacy 2335 test file in place**
+- [ ] **Step 4: Implement the resume-with-feedback cache reset**
 
-`tests/issues/2335/test_acceptance_override_route.py`: `test_non_admin_override_returns_403` currently patches the OWNER (user_id=7, role user) and expects 403 — that user must now succeed. Change it to an unrelated user, and add an owner-success test:
+In `resume_with_feedback`, extend the `update_workflow` dict:
+
+```python
+    # Store feedback and set to waiting (scheduler will pick up via _do_wait).
+    # #2658: clear the cached acceptance merge SHA — the acceptance phase's
+    # idempotency replays a terminal verdict for the same
+    # (merge_sha, snapshot) pair, and nothing else resets it between dev
+    # rounds, so without this the next acceptance run would re-verify the OLD
+    # merge instead of the new one (stale-replay loop for both rejected and
+    # indeterminate resumes).
+    _get_repo().update_workflow(
+        workflow_id,
+        {
+            "user_feedback": user_feedback,
+            "current_phase": "wait",
+            "status": "waiting",
+            "verification_merge_sha": "",
+        },
+    )
+```
+
+- [ ] **Step 5: Update the legacy 2335 test file in place**
+
+`tests/issues/2335/test_acceptance_override_route.py`: `test_non_admin_override_returns_403` currently patches the OWNER (user_id=7, role user) and expects 403 — that user must now succeed. Replace it with:
 
 ```python
 def test_non_owner_non_admin_override_returns_403(app_client):
@@ -292,16 +348,16 @@ def test_owner_override_now_allowed_2658(app_client):
 
 Also update the module docstring line "Non-admins get 403" → "Unrelated users get 403; the workflow owner may override (#2658)".
 
-- [ ] **Step 5: Run both test files**
+- [ ] **Step 6: Run both test files**
 
 Run: `python -m pytest tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py -v`
 Expected: ALL PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add app/routes/autonomous.py tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py
-git commit -m "feat(#2658): acceptance override for rejected+indeterminate, owner+admin"
+git commit -m "feat(#2658): owner+admin override for rejected/indeterminate + fresh re-verify on feedback resume"
 ```
 
 ---
@@ -310,6 +366,7 @@ git commit -m "feat(#2658): acceptance override for rejected+indeterminate, owne
 
 **Files:**
 - Modify: `frontend/src/components/work/WorkflowTimeline.tsx`
+- Modify: `frontend/src/components/work/WorkflowTimeline.test.tsx` (🔴 existing vitest locks the OLD rejected-only behavior — CI runs it via `npm run test:coverage` on `frontend/**` changes)
 - Modify: `frontend/src/i18n/index.ts`
 
 - [ ] **Step 1: Unify the gating constants**
@@ -339,9 +396,12 @@ with:
   // #2658: every acceptance pause that needs a human offers BOTH exits —
   // accept (override → close issue → completed; owner+admin, enforced
   // server-side) and resume-with-feedback (new dev round → new merge → fresh
-  // acceptance). Resuming a rejected verdict without feedback hits the
-  // idempotency guard and re-pauses immediately, which is why the feedback
-  // modal is the resume path.
+  // acceptance; resuming without feedback hits the idempotency guard and
+  // re-pauses immediately, which is why the feedback modal is the resume
+  // path). The explicit current_phase check also fixes a latent bug: the old
+  // indeterminate-only gate could show the override button during a LATER dev
+  // round (verification_status is never cleared between rounds), where the
+  // server would 400.
   const isAcceptancePaused =
     workflow.status === 'paused' &&
     workflow.current_phase === 'acceptance_verification' &&
@@ -419,7 +479,20 @@ Next to `canViewReviewContent` in the milestone render (~L1495):
       !!milestone.metadata?.trim();
 ```
 
-And in the card actions after the `canViewReviewContent` button block (~L1733):
+Extend `showInlineActionGroup` (~L1581) — without this the button silently never renders on the `showForkCancel: false` render path (~L1903):
+
+```tsx
+    const showInlineActionGroup =
+      showInlineSessionButton ||
+      canViewPlanContent ||
+      canViewReviewContent ||
+      canViewAcceptanceReport ||
+      canViewChanges ||
+      canFork ||
+      canCancel;
+```
+
+Card action button, after the `canViewReviewContent` button block (~L1733) — note `milestone.metadata` is a plain `string` on the `WorkflowMilestone` type (`api/autonomous.ts:139`), used directly:
 
 ```tsx
                     {canViewAcceptanceReport && (
@@ -430,7 +503,7 @@ And in the card actions after the `canViewReviewContent` button block (~L1733):
                         onClick={() =>
                           setViewingContent({
                             title: t('autoViewAcceptanceReportTitle', language),
-                            content: formatAcceptanceReport(mstoneMetadata(milestone)),
+                            content: formatAcceptanceReport(milestone.metadata),
                           })
                         }
                       >
@@ -439,8 +512,6 @@ And in the card actions after the `canViewReviewContent` button block (~L1733):
                       </Button>
                     )}
 ```
-
-(If `milestone.metadata` is directly accessible at that point — it is, the map variable is `milestone` — use `milestone.metadata` inline instead of a helper: `content: formatAcceptanceReport(milestone.metadata)`.)
 
 - [ ] **Step 4: i18n keys ×4 locales**
 
@@ -472,17 +543,44 @@ ko:
     autoViewAcceptanceReportTitle: '승인 검증 리포트',
 ```
 
-Also update `autoAcceptanceOverrideDesc` in each locale if its text says the action is admin-only — change to "workflow owner or admin" wording (zh: 「工作流所有者或管理员可确认验收并关闭 issue」).
+**Reword `autoAcceptanceOverrideDesc`** in all 4 locales — current text only covers indeterminate ("verifier could not reach a confident verdict"); rejected means the verifier DID decide and a human disagrees:
 
-- [ ] **Step 5: Typecheck + build**
+en: `'Accept the delivered result (confirmed by human review), close the issue and complete the workflow. Available to the workflow owner or an admin.'`
+zh: `'人工确认验收通过并关闭 issue、完成工作流。工作流所有者或管理员可操作；若验收器已拒绝，此操作将推翻该拒绝。'`
+ja: `'人間の確認により受理し、issue をクローズしてワークフローを完了します。ワークフロー所有者または管理者が操作できます。検証者が拒否した場合はその判定を覆します。'`
+ko: `'사람의 확인으로 승인하고 issue를 닫아 워크플로를 완료합니다. 워크플로 소유자 또는 관리자가 실행할 수 있습니다. 검증자가 거부한 경우 해당 판정을 뒤집습니다.'`
 
-Run: `cd frontend && npx tsc --noEmit && npm run build`
-Expected: no type errors, build succeeds.
+- [ ] **Step 5: Rewrite the vitest that locks old behavior**
 
-- [ ] **Step 6: Commit**
+`frontend/src/components/work/WorkflowTimeline.test.tsx` (~L147-163): the test `shows resume-with-feedback only for rejected acceptance, not indeterminate` asserts indeterminate has NO resume button and finds the override button by its OLD title regex `/confirm acceptance and close the issue/i` — both flip. Rewrite as:
+
+```tsx
+  it('#2658 shows BOTH exits (override + resume-with-feedback) for rejected AND indeterminate acceptance pauses', () => {
+    for (const status of ['rejected', 'indeterminate'] as const) {
+      const view = renderTimeline(pausedWorkflow({ verification_status: status }));
+      // The banner button's accessible name is the help text (title -> aria-label).
+      expect(screen.getByRole('button', { name: /new development round/i })).toBeInTheDocument();
+      // Override button: accessible name is its descriptive title (reworded for
+      // #2658 — covers rejected-overturn and indeterminate alike).
+      expect(
+        screen.getByRole('button', { name: /accept the delivered result/i })
+      ).toBeInTheDocument();
+      view.unmount();
+    }
+  });
+```
+
+(Adjust the title regex to whatever the reworded `autoAcceptanceOverrideDesc` renders — the assertion and the i18n string MUST match; check other tests in the file that reference the old title text and update them too, e.g. grep the file for `confirm acceptance`.)
+
+- [ ] **Step 6: Typecheck + vitest + build**
+
+Run: `cd frontend && npx tsc --noEmit && npm run test -- --run && npm run build`
+Expected: no type errors, all vitest specs pass, build succeeds.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add frontend/src/components/work/WorkflowTimeline.tsx frontend/src/i18n/index.ts
+git add frontend/src/components/work/WorkflowTimeline.tsx frontend/src/components/work/WorkflowTimeline.test.tsx frontend/src/i18n/index.ts
 git commit -m "feat(#2658): unified acceptance-pause exits + in-page report viewer"
 ```
 
@@ -493,14 +591,12 @@ git commit -m "feat(#2658): unified acceptance-pause exits + in-page report view
 **Files:**
 - Modify: `tests/e2e/work/e2e_paused_acceptance_ui_playwright.py`
 
-- [ ] **Step 1: Extend the E2E**
+- [ ] **Step 1: Extend + FLIP the E2E**
 
-In the existing file (it already seeds rejected + indeterminate workflows and drives the paused tab), add:
-
-1. A milestone seed helper (the timeline API needs a milestone row so the report button renders):
+1. Milestone seed helper — call it INSIDE the same `app.app_context()` block the existing `seed_workflow` uses (repo calls need request/app context; mirror `seed_workflow` at ~L118):
 
 ```python
-def seed_acceptance_milestone(repo, workflow_id: str, status: str) -> str:
+def seed_acceptance_milestone(repo, workflow_id: str, status: str) -> None:
     import json as _json
 
     report = {
@@ -529,15 +625,33 @@ def seed_acceptance_milestone(repo, workflow_id: str, status: str) -> str:
             "metadata": _json.dumps(report, ensure_ascii=False),
         }
     )
-    return report
 ```
 
-(Adapt to the file's existing `repo` seeding mechanism — `seed_workflow` uses the same repo object; keep the style consistent.)
+(Keep the file's existing naming/style; `create_milestone` accepts exactly these keys — `dev_round` defaults to 1, FK matches the seeded workflow.)
 
-2. Assertions, for BOTH the rejected and indeterminate seeded workflows:
-   - 「带反馈恢复」 button visible (was rejected-only; indeterminate is the #2658 change),
-   - 「确认验收（覆盖）」 button visible (rejected is the #2658 change),
-   - open the workflow detail timeline, click 「查看验收报告」, assert the viewer modal shows the seeded item text (`修复登录失败`) and the evidence ref (`tests/test_login.py:12`).
+2. **FLIP section 3** (~L320-334): the current assertion
+`expect(page.locator(".timeline-state-banner")).not_to_contain_text("Resume with Feedback")`
+now contradicts #2658 — indeterminate MUST show the resume button. Replace with:
+
+```python
+            expect(
+                page.locator(".timeline-state-banner").get_by_text("Resume with Feedback")
+            ).to_be_visible()
+```
+
+and update the final print to `"[PASS] indeterminate workflow shows override + resume-with-feedback"`.
+
+3. NEW section 4 — report viewer, run for the rejected workflow: on the timeline, click 「View acceptance report」 and assert the viewer modal shows the seeded item + evidence:
+
+```python
+            page.get_by_role("button", name="View acceptance report").click()
+            expect(page.get_by_text("修复登录失败")).to_be_visible()
+            expect(page.get_by_text("tests/test_login.py:12")).to_be_visible()
+```
+
+(Localize the button name if the E2E drives a zh UI — follow however the existing test selects banner buttons.)
+
+Note (plan-review #7): this E2E logs in as an admin who also owns the seeds, so it cannot distinguish owner vs admin permissions — that matrix is fully covered by the unit tests in Task 1.
 
 - [ ] **Step 2: Run headless until green**
 
@@ -562,18 +676,16 @@ Expected: no new failures vs `origin/main`.
 
 - [ ] **Step 2: pre-commit on changed files (NOT --all-files — scope-guard rule)**
 
-Run: `pre-commit run --files app/routes/autonomous.py tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py frontend/src/components/work/WorkflowTimeline.tsx frontend/src/i18n/index.ts tests/e2e/work/e2e_paused_acceptance_ui_playwright.py`
+Run: `pre-commit run --files app/routes/autonomous.py tests/unit/test_acceptance_override_2658.py tests/issues/2335/test_acceptance_override_route.py frontend/src/components/work/WorkflowTimeline.tsx frontend/src/components/work/WorkflowTimeline.test.tsx frontend/src/i18n/index.ts tests/e2e/work/e2e_paused_acceptance_ui_playwright.py`
 Expected: clean (watch for pyupgrade `X | None`, TC003 TYPE_CHECKING moves, black 25.1.0 formatting).
 
 - [ ] **Step 3: Push + PR**
 
 ```bash
 git push -u origin fix/2658-acceptance-paused-user-actions
-gh pr create --title "feat(#2658): unify acceptance-paused user actions" --body "<summary; NO closes/fixes/resolves keywords near #2658>"
+gh pr create --title "feat(#2658): unify acceptance-paused user actions" --body "<summary; NO closes/fixes/resolves keywords near #2658 — 'Refs #2658' only>"
 ```
 
-PR body must reference the issue with "Refs #2658" only (GitHub auto-close trap).
-
-- [ ] **Step 4: Required CI green** (lint / test(3.10) / test(3.11) / test(3.12) / build) → independent review (`superpowers:requesting-code-review` on `gh pr diff`) → merge `--merge --delete-branch` → deploy hotpatch (orchestrator/routes change needs scheduler restart; frontend build+deploy + open-ace.service restart) → verify on prod.
+- [ ] **Step 4: Required CI green** (lint / test(3.10) / test(3.11) / test(3.12) / build + Frontend CI vitest) → independent review (`superpowers:requesting-code-review` on `gh pr diff`) → merge `--merge --delete-branch` → deploy hotpatch (routes change: cp autonomous.py + restart openace-scheduler.service AND open-ace.service; frontend build+deploy + open-ace.service restart) → verify on prod.
 
 - [ ] **Step 5: headless=false demo to user** (project E2E rule step 3).

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -7,7 +7,7 @@
 
 import { fireEvent, render, screen, within } from '@/test/utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WorkflowTimeline } from './WorkflowTimeline';
+import { WorkflowTimeline, formatAcceptanceReport } from './WorkflowTimeline';
 import type { AutonomousWorkflow } from '@/api/autonomous';
 
 const { mockResumeWithFeedbackMutate, mockAcceptanceOverrideMutate, pendingMutation } = vi.hoisted(
@@ -201,5 +201,45 @@ describe('WorkflowTimeline paused-state banner (#2634)', () => {
 
     expect(mockResumeWithFeedbackMutate).toHaveBeenCalled();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('formatAcceptanceReport (#2658)', () => {
+  it('renders per-item verdicts, rationale and evidence refs from metadata JSON', () => {
+    const report = {
+      merge_sha: 'abc123',
+      status: 'rejected',
+      verified_by: 'glm-5',
+      scope: [{ item: 'src/app.py', verdict: 'confirmed', evidence: [] }],
+      gates: [],
+      verifier: [
+        {
+          item: '修复登录失败',
+          verdict: 'rejected',
+          evidence: [{ ref: 'tests/test_login.py:12', note: '用例仍然失败' }],
+          rationale: '合并后用例依旧失败',
+        },
+      ],
+    };
+    const out = formatAcceptanceReport(JSON.stringify(report));
+    expect(out).toContain('❌ rejected');
+    expect(out).toContain('Merge SHA: abc123');
+    expect(out).toContain('── Scope ──');
+    expect(out).toContain('✅ src/app.py');
+    expect(out).toContain('❌ 修复登录失败 — 合并后用例依旧失败');
+    expect(out).toContain('↳ tests/test_login.py:12 (用例仍然失败)');
+    // Empty sections are skipped (gates omitted above).
+    expect(out).not.toContain('── Gates ──');
+  });
+
+  it('falls back to raw metadata when the JSON is malformed', () => {
+    expect(formatAcceptanceReport('not-json{')).toBe('not-json{');
+  });
+
+  it('omits optional fields gracefully', () => {
+    const out = formatAcceptanceReport(JSON.stringify({ status: 'indeterminate' }));
+    expect(out).toContain('⚠️ indeterminate');
+    expect(out).not.toContain('Merge SHA');
+    expect(out).not.toContain('Infra error');
   });
 });

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -144,22 +144,18 @@ describe('WorkflowTimeline paused-state banner (#2634)', () => {
     expect(screen.queryByRole('button', { name: /resume with feedback/i })).not.toBeInTheDocument();
   });
 
-  it('shows resume-with-feedback only for rejected acceptance, not indeterminate', () => {
-    const rejected = renderTimeline(pausedWorkflow({ verification_status: 'rejected' }));
-    // The banner button's accessible name is the help text (title -> aria-label).
-    expect(screen.getByRole('button', { name: /new development round/i })).toBeInTheDocument();
-    rejected.unmount();
-
-    // indeterminate keeps the acceptance-override button instead (#2335 S6)
-    renderTimeline(pausedWorkflow({ verification_status: 'indeterminate' }));
-    expect(
-      screen.queryByRole('button', { name: /new development round/i })
-    ).not.toBeInTheDocument();
-    // Override button: accessible name is its descriptive title (verifier could
-    // not reach a verdict → confirm acceptance and close the issue).
-    expect(
-      screen.getByRole('button', { name: /confirm acceptance and close the issue/i })
-    ).toBeInTheDocument();
+  it('#2658 shows BOTH exits (override + resume-with-feedback) for rejected AND indeterminate acceptance pauses', () => {
+    for (const status of ['rejected', 'indeterminate'] as const) {
+      const view = renderTimeline(pausedWorkflow({ verification_status: status }));
+      // The banner button's accessible name is the help text (title -> aria-label).
+      expect(screen.getByRole('button', { name: /new development round/i })).toBeInTheDocument();
+      // Override button: accessible name is its descriptive title (reworded for
+      // #2658 — covers rejected-overturn and indeterminate alike).
+      expect(
+        screen.getByRole('button', { name: /accept the delivered result/i })
+      ).toBeInTheDocument();
+      view.unmount();
+    }
   });
 
   it('opens the feedback modal, blocks empty submit, and submits valid feedback', () => {

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -122,7 +122,7 @@ const VERDICT_TONE: Record<string, string> = {
   indeterminate: '⚠️',
 };
 
-const formatAcceptanceReport = (metadata: string): string => {
+export const formatAcceptanceReport = (metadata: string): string => {
   let report: Record<string, unknown>;
   try {
     report = JSON.parse(metadata) as Record<string, unknown>;

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -111,6 +111,59 @@ const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
 // worth viewing after the run finishes (the live activity stream is run-time only).
 const PLAN_CONTENT_TYPES = ['plan_created', 'plan_refined', 'plan_finalized'];
 const REVIEW_CONTENT_TYPES = ['plan_reviewed', 'pr_reviewed', 'pr_review_summary'];
+
+// #2658: render the acceptance milestone's verification report (stored in
+// milestone.metadata as JSON by the acceptance phase) as readable text for
+// the generic content viewer. Sections mirror _format_report_comment in
+// acceptance_verification.py.
+const VERDICT_TONE: Record<string, string> = {
+  confirmed: '✅',
+  rejected: '❌',
+  indeterminate: '⚠️',
+};
+
+const formatAcceptanceReport = (metadata: string): string => {
+  let report: Record<string, unknown>;
+  try {
+    report = JSON.parse(metadata) as Record<string, unknown>;
+  } catch {
+    return metadata;
+  }
+  const lines: string[] = [];
+  const status = String(report.status ?? '');
+  lines.push(`${VERDICT_TONE[status] ?? '⚠️'} ${status || 'unknown'}`);
+  if (report.merge_sha) lines.push(`Merge SHA: ${String(report.merge_sha)}`);
+  if (report.verified_by) lines.push(`Verifier: ${String(report.verified_by)}`);
+  if (report.infra_error) lines.push(`Infra error: ${String(report.infra_error)}`);
+  const sections: Array<[string, string]> = [
+    ['scope', 'Scope'],
+    ['gates', 'Gates'],
+    ['verifier', 'Verifier findings'],
+  ];
+  for (const [key, label] of sections) {
+    const items = report[key];
+    if (!Array.isArray(items) || items.length === 0) continue;
+    lines.push('', `── ${label} ──`);
+    for (const raw of items) {
+      if (!raw || typeof raw !== 'object') continue;
+      const item = raw as Record<string, unknown>;
+      const verdict = String(item.verdict ?? '');
+      const icon = VERDICT_TONE[verdict] ?? '•';
+      const tail = item.rationale ? ` — ${String(item.rationale)}` : '';
+      lines.push(`${icon} ${String(item.item ?? '')}${tail}`);
+      const evidence = item.evidence;
+      if (Array.isArray(evidence)) {
+        for (const ev of evidence) {
+          if (!ev || typeof ev !== 'object') continue;
+          const e = ev as Record<string, unknown>;
+          const note = e.note ? ` (${String(e.note)})` : '';
+          lines.push(`    ↳ ${String(e.ref ?? '')}${note}`);
+        }
+      }
+    }
+  }
+  return lines.join('\n');
+};
 const MILESTONE_ICON_COLORS: Record<string, string> = {
   dark: 'var(--text-primary)',
   info: 'var(--color-info)',
@@ -703,9 +756,21 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         : { workflowId: workflow.workflow_id }
     );
 
-  // #2335 S6: admin override for a paused indeterminate acceptance workflow.
-  const showAcceptanceOverride =
-    workflow.status === 'paused' && workflow.verification_status === 'indeterminate';
+  // #2658: every acceptance pause that needs a human offers BOTH exits —
+  // accept (override → close issue → completed; owner+admin, enforced
+  // server-side) and resume-with-feedback (new dev round → new merge → fresh
+  // acceptance; resuming without feedback hits the idempotency guard and
+  // re-pauses immediately, which is why the feedback modal is the resume
+  // path). The explicit current_phase check also fixes a latent bug: the old
+  // indeterminate-only gate could show the override button during a LATER dev
+  // round (verification_status is never cleared between rounds), where the
+  // server would 400.
+  const isAcceptancePaused =
+    workflow.status === 'paused' &&
+    workflow.current_phase === 'acceptance_verification' &&
+    (workflow.verification_status === 'rejected' ||
+      workflow.verification_status === 'indeterminate');
+  const showAcceptanceOverride = isAcceptancePaused;
   const handleAcceptanceOverride = () => {
     const reason = window.prompt(t('autoAcceptanceOverrideReason', language));
     // window.prompt returns null when the user cancels; '' is a valid (empty) reason.
@@ -714,12 +779,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     acceptanceOverrideMutation.mutate({ workflowId: workflow.workflow_id, reason });
   };
 
-  // #2634: a REJECTED acceptance needs new developer feedback to make progress;
-  // resuming without it hits the idempotency guard and re-pauses immediately.
-  const showResumeWithFeedback =
-    workflow.status === 'paused' &&
-    workflow.current_phase === 'acceptance_verification' &&
-    workflow.verification_status === 'rejected';
+  const showResumeWithFeedback = isAcceptancePaused;
   const handleResumeFeedbackSubmit = () => {
     const feedback = resumeFeedback.trim();
     if (!feedback) return;
@@ -1500,6 +1560,12 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       !compact &&
       REVIEW_CONTENT_TYPES.includes(milestone.milestone_type) &&
       !!milestone.review_content?.trim();
+    // #2658: acceptance milestones carry the full verification report JSON in
+    // `metadata`; expose it through the generic content viewer.
+    const canViewAcceptanceReport =
+      !compact &&
+      milestone.milestone_type === 'acceptance_verification' &&
+      !!milestone.metadata?.trim();
     // progress_reported milestones render from a structured payload in the
     // viewer's UI language (system-authored structured content). Legacy
     // milestones without a payload fall back to verbatim tldr/result_summary.
@@ -1582,6 +1648,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       showInlineSessionButton ||
       canViewPlanContent ||
       canViewReviewContent ||
+      canViewAcceptanceReport ||
       canViewChanges ||
       canFork ||
       canCancel;
@@ -1745,6 +1812,22 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                       >
                         <i className="bi bi-chat-text me-1"></i>
                         {t('autoViewReview', language)}
+                      </Button>
+                    )}
+                    {canViewAcceptanceReport && (
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        className="timeline-inline-btn timeline-inline-btn--warning"
+                        onClick={() =>
+                          setViewingContent({
+                            title: t('autoViewAcceptanceReportTitle', language),
+                            content: formatAcceptanceReport(milestone.metadata),
+                          })
+                        }
+                      >
+                        <i className="bi bi-clipboard-check me-1"></i>
+                        {t('autoViewAcceptanceReport', language)}
                       </Button>
                     )}
                     {canViewReport && (

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1909,8 +1909,10 @@ export const translations: Record<Language, Translations> = {
       'This starts a NEW development round driven by your feedback. The workflow will merge again and re-run acceptance verification after the new merge.',
     autoAcceptanceOverrideTitle: 'Acceptance pending human review',
     autoAcceptanceOverrideDesc:
-      'The verifier could not reach a confident verdict. If you have reviewed the merged code, you can confirm acceptance and close the issue.',
+      'Accept the delivered result (confirmed by human review), close the issue and complete the workflow. Available to the workflow owner or an admin.',
     autoAcceptanceOverrideButton: 'Accept (override)',
+    autoViewAcceptanceReport: 'View acceptance report',
+    autoViewAcceptanceReportTitle: 'Acceptance verification report',
     autoAcceptanceOverrideConfirm:
       'Confirm acceptance on the merged code and close the issue? This action is recorded with your username.',
     autoAcceptanceOverrideReason: 'Reason (optional)',
@@ -3838,8 +3840,10 @@ export const translations: Record<Language, Translations> = {
       '这将根据你的反馈开启新一轮开发；工作流会重新合并代码并再次执行验收验证。',
     autoAcceptanceOverrideTitle: '验收待人工复核',
     autoAcceptanceOverrideDesc:
-      '验证器无法给出确定性结论。如果你已审查合并后的代码，可以确认验收并关闭 Issue。',
+      '人工确认验收通过并关闭 Issue、完成工作流。工作流所有者或管理员可操作；若验收器已拒绝，此操作将推翻该拒绝。',
     autoAcceptanceOverrideButton: '确认验收（覆盖）',
+    autoViewAcceptanceReport: '查看验收报告',
+    autoViewAcceptanceReportTitle: '验收报告',
     autoAcceptanceOverrideConfirm: '确认合并代码的验收并关闭 Issue？此操作会记录你的用户名。',
     autoAcceptanceOverrideReason: '原因（可选）',
     autoAcceptanceOverrideSuccess: '验收已确认，Issue 将被关闭。',
@@ -5539,8 +5543,10 @@ export const translations: Record<Language, Translations> = {
       'フィードバックに基づいて新しい開発ラウンドを開始します。ワークフローは再度マージし、その後承認確認を再実行します。',
     autoAcceptanceOverrideTitle: '承認確認が人間のレビューを待っています',
     autoAcceptanceOverrideDesc:
-      '検証エージェントが確定的な結論に達しませんでした。マージ済みコードを確認した場合、承認を確定して Issue をクローズできます。',
+      '人間の確認により受理し、Issue をクローズしてワークフローを完了します。ワークフロー所有者または管理者が操作できます。検証者が拒否した場合はその判定を覆します。',
     autoAcceptanceOverrideButton: '承認（オーバーライド）',
+    autoViewAcceptanceReport: '受け入れレポートを表示',
+    autoViewAcceptanceReportTitle: '受け入れ検証レポート',
     autoAcceptanceOverrideConfirm:
       'マージ済みコードの承認を確定し Issue をクローズしますか？この操作はユーザー名と共に記録されます。',
     autoAcceptanceOverrideReason: '理由（任意）',
@@ -7362,8 +7368,10 @@ export const translations: Record<Language, Translations> = {
       '피드백을 반영해 새로운 개발 라운드를 시작합니다. 워크플로는 다시 병합한 후 수락 확인을 재실행합니다.',
     autoAcceptanceOverrideTitle: '수락 확인이 사람 검토를 기다리는 중',
     autoAcceptanceOverrideDesc:
-      '검증 에이전트가 확정적인 결론에 도달하지 못했습니다. 병합된 코드를 검토했다면 수락을 확정하고 Issue를 닫을 수 있습니다.',
+      '사람의 확인으로 승인하고 Issue를 닫아 워크플로를 완료합니다. 워크플로 소유자 또는 관리자가 실행할 수 있습니다. 검증자가 거부한 경우 해당 판정을 뒤집습니다.',
     autoAcceptanceOverrideButton: '수락 (재정의)',
+    autoViewAcceptanceReport: '승인 리포트 보기',
+    autoViewAcceptanceReportTitle: '승인 검증 리포트',
     autoAcceptanceOverrideConfirm:
       '병합된 코드의 수락을 확정하고 Issue를 닫으시겠습니까? 이 작업은 사용자 이름과 함께 기록됩니다.',
     autoAcceptanceOverrideReason: '사유 (선택)',

--- a/tests/e2e/work/e2e_paused_acceptance_ui_playwright.py
+++ b/tests/e2e/work/e2e_paused_acceptance_ui_playwright.py
@@ -16,9 +16,13 @@ repository, mirroring tests/e2e/e2e_acceptance_override_playwright.py):
      submitting feedback calls POST /resume-with-feedback (payload asserted)
      and the workflow leaves "paused" (status becomes "waiting" — real
      backend transition, no route mocking).
-  3. Indeterminate workflow (verification_status=indeterminate): the
-     "Accept (override)" button is present and the resume-with-feedback
-     button is absent.
+  3. Indeterminate workflow (verification_status=indeterminate): BOTH exits
+     render — the "Accept (override)" button and the "Resume with Feedback"
+     button (#2658 unified gating; previously indeterminate had no resume
+     entry).
+  4. Rejected workflow timeline (#2658): the "View acceptance report" button
+     opens the generic content viewer with the per-item verdicts and evidence
+     refs parsed from the acceptance milestone's metadata JSON.
 
 Seeding: five workflow rows are inserted via AutonomousWorkflowRepository —
 an acceptance-paused (rejected) workflow paused >3 days ago, a quota-paused
@@ -149,6 +153,47 @@ def seed_workflow(
     return workflow_id
 
 
+def seed_acceptance_milestone(workflow_id: str, status: str) -> None:
+    """#2658: attach an acceptance milestone whose metadata carries the full
+    verification report JSON — the report viewer renders from this column."""
+    import json as _json
+
+    os.environ.setdefault("SCHEDULER_MODE", "web")
+    from app import create_app
+    from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+    report = {
+        "merge_sha": "abc123def456",
+        "status": status,
+        "verified_by": "glm-5/e2e",
+        "scope": [{"item": "src/app.py", "verdict": "confirmed", "evidence": []}],
+        "gates": [],
+        "verifier": [
+            {
+                "item": "修复登录失败",
+                "verdict": "rejected",
+                "evidence": [{"ref": "tests/test_login.py:12", "note": "用例仍然失败"}],
+                "rationale": "合并后用例依旧失败",
+            }
+        ],
+    }
+    app = create_app()
+    repo = AutonomousWorkflowRepository()
+    with app.app_context():
+        repo.create_milestone(
+            {
+                "workflow_id": workflow_id,
+                "phase": "acceptance_verification",
+                "round_number": 1,
+                "milestone_type": "acceptance_verification",
+                "status": status,
+                "title": f"Acceptance verification: {status}",
+                "result_summary": f"status={status}; not-verified: 修复登录失败",
+                "metadata": _json.dumps(report, ensure_ascii=False),
+            }
+        )
+
+
 def cleanup_previous_runs() -> None:
     """Delete workflows left by previous runs of this test (idempotent re-runs)."""
     from app import create_app
@@ -181,6 +226,7 @@ def main() -> None:
         title="E2E paused-acceptance UI #2634",
         paused_days_ago=4,
     )
+    seed_acceptance_milestone(accepted_id, "rejected")
     quota_id = seed_workflow(
         title="E2E quota-paused UI #2634",
         current_phase="developing",
@@ -317,7 +363,7 @@ def main() -> None:
             ), f"feedback not persisted: {row.get('user_feedback')!r}"
             print("[PASS] workflow left paused (status=waiting, feedback persisted)")
 
-            # ── 3. Indeterminate workflow: override present, resume absent ──
+            # ── 3. Indeterminate workflow: BOTH exits (#2658) ────────────
             page.goto(
                 f"{BASE_URL}/work/autonomous?workflow={indeterminate_id}",
                 wait_until="domcontentloaded",
@@ -327,11 +373,35 @@ def main() -> None:
             expect(
                 page.locator(".timeline-state-banner").get_by_text("Accept (override)")
             ).to_be_visible()
-            expect(page.locator(".timeline-state-banner")).not_to_contain_text(
-                "Resume with Feedback"
-            )
+            # #2658: indeterminate now also offers resume-with-feedback (was
+            # override-only before the unified gating).
+            expect(
+                page.locator(".timeline-state-banner").get_by_text(
+                    "Resume with Feedback", exact=True
+                )
+            ).to_be_visible()
             shot(page, "05-indeterminate")
-            print("[PASS] indeterminate workflow keeps override button, no resume-with-feedback")
+            print("[PASS] indeterminate workflow shows override + resume-with-feedback")
+
+            # ── 4. Rejected workflow: full report viewer (#2658) ──────────
+            page.goto(
+                f"{BASE_URL}/work/autonomous?workflow={accepted_id}",
+                wait_until="domcontentloaded",
+            )
+            pause(2)
+            report_btn = page.get_by_role("button", name="View acceptance report")
+            expect(report_btn).to_be_visible(timeout=30000)
+            report_btn.click()
+            pause(0.5)
+            # The generic content viewer shows the per-item verdicts and
+            # evidence refs parsed from the milestone's metadata JSON. Scope
+            # to the dialog — the milestone card's summary line repeats the
+            # item name outside the modal (strict-mode collision).
+            viewer = page.get_by_role("dialog")
+            expect(viewer.get_by_text("修复登录失败")).to_be_visible()
+            expect(viewer.get_by_text("tests/test_login.py:12")).to_be_visible()
+            shot(page, "06-report-viewer")
+            print("[PASS] acceptance report viewer renders per-item verdicts + evidence")
         finally:
             browser.close()
 

--- a/tests/issues/2335/test_acceptance_override_route.py
+++ b/tests/issues/2335/test_acceptance_override_route.py
@@ -3,7 +3,8 @@
 An admin may override a workflow paused at ``acceptance_verification`` with
 ``verification_status="indeterminate"``: setting it to ``confirmed`` with an
 audit trail, then closing the issue (as @open-ace-bot) and completing the
-workflow. Non-admins get 403; a non-indeterminate workflow is rejected.
+workflow. Unrelated users get 403; the workflow owner may override (#2658); a
+confirmed workflow is rejected.
 """
 
 from __future__ import annotations
@@ -125,13 +126,29 @@ def test_admin_override_confirms_indeterminate_and_closes_issue(app_client):
     assert evt["event_type"] == "acceptance_override"
 
 
-def test_non_admin_override_returns_403(app_client):
+def test_non_owner_non_admin_override_returns_403(app_client):
     client, _repo, _ = app_client
     with ExitStack() as stack:
-        for p in _mock_auth(role="user", user_id=7, username="owner"):
+        for p in _mock_auth(role="user", user_id=99, username="stranger"):
             stack.enter_context(p)
         resp = _post_override(client)
     assert resp.status_code == 403
+
+
+def test_owner_override_now_allowed_2658(app_client):
+    """#2658: the workflow owner (role=user, user_id matching the row) may override."""
+    client, _repo, _ = app_client
+    with (
+        ExitStack() as stack,
+        patch(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps",
+            return_value=MagicMock(),
+        ),
+    ):
+        for p in _mock_auth(role="user", user_id=7, username="owner"):
+            stack.enter_context(p)
+        resp = _post_override(client)
+    assert resp.status_code == 200
 
 
 def test_override_rejects_non_indeterminate_workflow(app_client):

--- a/tests/unit/test_acceptance_override_2658.py
+++ b/tests/unit/test_acceptance_override_2658.py
@@ -1,0 +1,191 @@
+"""#2658: acceptance override for rejected AND indeterminate, owner+admin.
+
+Regression for the route extension: the workflow owner (not just admins) may
+override a paused acceptance verdict — confirming it, closing the issue and
+completing the workflow. Rejected verdicts are overridable; confirmed ones
+still 400; unrelated users still 403. resume-with-feedback must clear the
+cached verification merge SHA so the next acceptance run re-verifies instead
+of replaying the prior verdict on a stale (merge_sha, snapshot) pair.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import create_app
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2658)]
+
+
+def _workflow_row(**overrides):
+    base = {
+        "id": 1,
+        "workflow_id": "wf-override",
+        "user_id": 7,
+        "status": "paused",
+        "current_phase": "acceptance_verification",
+        "verification_status": "rejected",
+        "verification_merge_sha": "abc123",
+        "verification_report": '{"status": "rejected"}',
+        "github_issue_number": 4242,
+        "github_pr_number": 99,
+        "project_path": "/srv/open-ace",
+        "worktree_path": "/srv/open-ace/.worktrees/wf-override",
+        "system_account": "openace",
+        "error_message": "Acceptance verification rejected; awaiting review",
+    }
+    base.update(overrides)
+    return base
+
+
+def _user_dict(user_id, role, username):
+    return {
+        "id": user_id,
+        "username": username,
+        "email": f"{username}@test.com",
+        "role": role,
+        "tenant_id": None,
+    }
+
+
+def _mock_auth(user_id=1, role="admin", username="admin"):
+    user = _user_dict(user_id, role, username)
+    return patch("app.auth.decorators._load_user_from_token", return_value=user)
+
+
+@pytest.fixture
+def app_client():
+    workflow = _workflow_row()
+    repo = MagicMock()
+    repo.get_workflow.return_value = dict(workflow)
+
+    def _update(workflow_id, updates):
+        workflow.update(updates)
+        repo.get_workflow.return_value = dict(workflow)
+        return dict(workflow)
+
+    repo.update_workflow.side_effect = _update
+    repo.create_event.return_value = {}
+
+    app = create_app({"TESTING": True})
+    with patch("app.routes.autonomous._get_repo", return_value=repo):
+        client = app.test_client()
+        client.set_cookie("session_token", "test-token")
+        yield client, repo, workflow
+
+
+def _post_override(client, body=None):
+    return client.post(
+        "/api/autonomous/workflows/wf-override/verification_override",
+        json=body or {"reason": "inspected the merged code; acceptable"},
+    )
+
+
+class TestOverridePermission:
+    def test_owner_can_override_rejected(self, app_client):
+        client, repo, _ = app_client
+        gh = MagicMock()
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=gh,
+            ),
+        ):
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = _post_override(client)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        updates = repo.update_workflow.call_args.args[1]
+        assert updates["verification_status"] == "confirmed"
+        assert updates["status"] == "completed"
+        gh.close_issue.assert_called_once_with(4242)
+        # The issue comment must record that a rejection was overturned.
+        comment = gh.add_issue_comment.call_args.args[1]
+        assert "rejection overturned" in comment
+
+    def test_owner_can_override_indeterminate(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(verification_status="indeterminate")
+        gh = MagicMock()
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=gh,
+            ),
+        ):
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = _post_override(client)
+        assert resp.status_code == 200
+        comment = gh.add_issue_comment.call_args.args[1]
+        assert "rejection overturned" not in comment
+
+    def test_admin_can_override_rejected(self, app_client):
+        client, repo, _ = app_client
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=MagicMock(),
+            ),
+        ):
+            stack.enter_context(_mock_auth(user_id=1, role="admin", username="root"))
+            resp = _post_override(client)
+        assert resp.status_code == 200
+
+    def test_unrelated_user_gets_403(self, app_client):
+        client, _repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=99, role="user", username="stranger"))
+            resp = _post_override(client)
+        assert resp.status_code == 403
+
+
+class TestOverrideStatusGuard:
+    def test_confirmed_still_400(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(verification_status="confirmed")
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_wrong_phase_400(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(current_phase="development")
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+
+class TestResumeWithFeedbackClearsVerificationCache:
+    """#2658: a fresh dev round must not replay the prior acceptance verdict.
+
+    The acceptance phase caches ``verification_merge_sha`` on the workflow and
+    its idempotency replays a terminal verdict for the same
+    (merge_sha, snapshot) pair. Nothing else ever cleared the SHA between
+    rounds, so resume-with-feedback → new dev round → new merge would still
+    re-verify the OLD merge. The route must clear the cached SHA.
+    """
+
+    def _post_feedback(self, client):
+        return client.post(
+            "/api/autonomous/workflows/wf-override/resume-with-feedback",
+            json={"user_feedback": "please also handle the edge case"},
+        )
+
+    def test_resume_clears_cached_merge_sha(self, app_client):
+        client, repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = self._post_feedback(client)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        updates = repo.update_workflow.call_args.args[1]
+        assert updates["verification_merge_sha"] == ""
+        assert updates["current_phase"] == "wait"
+        assert updates["status"] == "waiting"
+        assert updates["user_feedback"] == "please also handle the edge case"

--- a/tests/unit/test_acceptance_override_2658.py
+++ b/tests/unit/test_acceptance_override_2658.py
@@ -136,12 +136,26 @@ class TestOverridePermission:
             resp = _post_override(client)
         assert resp.status_code == 200
 
-    def test_unrelated_user_gets_403(self, app_client):
-        client, _repo, _ = app_client
-        with ExitStack() as stack:
+    def test_unrelated_user_gets_403_without_side_effects(self, app_client):
+        client, repo, _ = app_client
+        gh = MagicMock()
+        with (
+            ExitStack() as stack,
+            patch(
+                "app.modules.workspace.autonomous.github_ops.GitHubOps",
+                return_value=gh,
+            ) as gh_cls,
+        ):
             stack.enter_context(_mock_auth(user_id=99, role="user", username="stranger"))
             resp = _post_override(client)
         assert resp.status_code == 403
+        # The 403 must land BEFORE any side effect: no workflow mutation, no
+        # issue comment/close, no audit event (review #2659 Minor 3).
+        repo.update_workflow.assert_not_called()
+        repo.create_event.assert_not_called()
+        gh.add_issue_comment.assert_not_called()
+        gh.close_issue.assert_not_called()
+        assert gh_cls.call_count == 0  # never constructed: 403 precedes all guards
 
 
 class TestOverrideStatusGuard:
@@ -159,6 +173,32 @@ class TestOverrideStatusGuard:
         with ExitStack() as stack:
             stack.enter_context(_mock_auth(user_id=1, role="admin"))
             resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_not_paused_400(self, app_client):
+        """#2659 review: mid-verification runs carry a stale prior verdict
+        (resume-with-feedback clears the merge SHA but not verification_status)
+        — overriding there would race the verifier on an unknown merge."""
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(status="running", verification_merge_sha="")
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_empty_verification_status_400(self, app_client):
+        client, repo, _ = app_client
+        repo.get_workflow.return_value = _workflow_row(verification_status=None)
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client)
+        assert resp.status_code == 400
+
+    def test_reason_over_2000_chars_400(self, app_client):
+        client, _repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=1, role="admin"))
+            resp = _post_override(client, {"reason": "x" * 2001})
         assert resp.status_code == 400
 
 


### PR DESCRIPTION
## What

Unifies the user-facing exits for workflows paused at `acceptance_verification` awaiting human action. Refs #2658 (issue stays open until verified in prod).

### Backend (`app/routes/autonomous.py`)
- `verification_override` now accepts **rejected AND indeterminate** verdicts (previously indeterminate-only; rejected → 400). Overriding a rejection posts the issue comment titled "human override — rejection overturned" so the history reads honestly.
- Permission extended from admin-only to **workflow owner + admin** (same idiom as `resume_with_feedback`; check moved after the 404 to match). `verified_by: human-override:<username>` stamp + audit event preserved — the override stays attributable.
- `resume_with_feedback` now clears the cached `verification_merge_sha`. Root cause found in plan review: the acceptance phase's idempotency replays a terminal verdict for the same (merge_sha, snapshot) pair and **nothing ever cleared the SHA between dev rounds** — so even the #2634 rejected-resume path would have re-verified the OLD merge after a new round. Now every feedback resume gets a fresh verification.

### Frontend
- Unified gating: every acceptance pause (rejected or indeterminate) shows BOTH banner exits — 「确认验收（覆盖）」 and 「带反馈恢复」. The explicit `current_phase` check also fixes a latent bug where the old indeterminate-only gate showed the override button during a LATER dev round (server would 400).
- New 「查看验收报告」 button on acceptance milestone cards: opens the generic content viewer with per-item scope/gates/verifier verdicts + evidence refs + rationale, parsed from `milestone.metadata` (already returned by /timeline — zero API change).
- i18n ×4 locales (new report-viewer keys; override description reworded to cover rejection-overturn and owner permission).

## Testing
- `tests/unit/test_acceptance_override_2658.py` (regression + issue(2658)): permission matrix (owner ✓ / admin ✓ / stranger 403), rejected+indeterminate override success, confirmed/wrong-phase 400, feedback-resume clears cached SHA.
- `tests/issues/2335/test_acceptance_override_route.py` updated in place (owner now allowed — no new files under tests/issues/).
- `WorkflowTimeline.test.tsx`: both-exits test for rejected AND indeterminate (old rejected-only lock rewritten). Full vitest: 841 passed.
- E2E `e2e_paused_acceptance_ui_playwright.py`: indeterminate now shows resume-with-feedback (assertion flipped); new section asserts the report viewer renders per-item verdicts + evidence from seeded metadata. Headless run PASSED.

No schema/migration changes. Local full `tests/unit/` failures (dingtalk/feishu/api_key_proxy) reproduce identically on clean origin/main — environment-only, not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)