### PR TITLE
fix: inject OPENACE_SECURITY_MODE into systemd service units

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2910,7 +2910,7 @@ configure_scheduler_service() {
     web_unit=$(systemctl show open-ace.service -p FragmentPath --value 2>/dev/null)
     [ -n "$web_unit" ] && [ -f "$web_unit" ] || web_unit="/etc/systemd/system/open-ace.service"
 
-    local cs_user cs_group cs_path cs_python cs_home cs_secret cs_workspace
+    local cs_user cs_group cs_path cs_python cs_home cs_secret cs_workspace cs_security_mode
     cs_user=$(grep '^User=' "$web_unit" | tail -1 | cut -d= -f2)
     cs_group=$(grep '^Group=' "$web_unit" | tail -1 | cut -d= -f2)
     cs_path=$(grep '^WorkingDirectory=' "$web_unit" | tail -1 | cut -d= -f2)
@@ -2920,6 +2920,9 @@ configure_scheduler_service() {
     cs_secret=$(grep '^Environment=SECRET_KEY=' "$web_unit" | tail -1 | cut -d= -f3)
     cs_workspace=$(grep '^Environment=WORKSPACE_BASE_DIR=' "$web_unit" | tail -1 | cut -d= -f3)
     cs_home=$(grep '^Environment=HOME=' "$web_unit" | tail -1 | cut -d= -f3)
+    # Issue #2654: Inherit OPENACE_SECURITY_MODE from the web service unit
+    cs_security_mode=$(grep '^Environment=OPENACE_SECURITY_MODE=' "$web_unit" | tail -1 | cut -d= -f3)
+    [ -n "$cs_security_mode" ] || cs_security_mode="production"
     [ -n "$cs_group" ] || cs_group=$(id -gn "$cs_user" 2>/dev/null || echo "$cs_user")
     [ -n "$cs_home" ] || cs_home=$(getent passwd "$cs_user" | cut -d: -f6)
     [ -n "$cs_workspace" ] || cs_workspace="/home"
@@ -2932,6 +2935,7 @@ configure_scheduler_service() {
         -e "s|__HOME__|$cs_home|g" \
         -e "s|__SECRET_KEY__|$cs_secret|g" \
         -e "s|__WORKSPACE_BASE_DIR__|$cs_workspace|g" \
+        -e "s|__SECURITY_MODE__|$cs_security_mode|g" \
         "$scheduler_template" > "$scheduler_file" || {
         print_warning "Failed to render $scheduler_file; scheduler service not updated"
         return 1
@@ -3030,6 +3034,11 @@ install_systemd_service() {
     local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
     print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption"
 
+    # Issue #2654: OPENACE_SECURITY_MODE is required by create_app() in
+    # production-capable paths (systemd, Docker, K8s). Default to production
+    # for systemd deployments; can be overridden via environment variable.
+    local security_mode="${OPENACE_SECURITY_MODE:-production}"
+
     # Create service file from template
     print_info "Creating systemd service file..."
     sed -e "s|__USER__|$user|g" \
@@ -3042,6 +3051,7 @@ install_systemd_service() {
         -e "s|__SECRET_KEY__|$secret_key|g" \
         -e "s|__OPENACE_ENCRYPTION_KEY__|$enc_key|g" \
         -e "s|__WORKSPACE_BASE_DIR__|$WORKSPACE_BASE_DIR|g" \
+        -e "s|__SECURITY_MODE__|$security_mode|g" \
         "$service_template" > "$service_file"
 
     if [ $? -ne 0 ]; then
@@ -3150,6 +3160,9 @@ install_systemd_service_remote() {
     local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
     print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption"
 
+    # Issue #2654: OPENACE_SECURITY_MODE required by create_app()
+    local security_mode="${OPENACE_SECURITY_MODE:-production}"
+
     # Generate service file content locally using sed
     local service_content=$(sed -e "s|__USER__|$user|g" \
         -e "s|__GROUP__|$group|g" \
@@ -3161,6 +3174,7 @@ install_systemd_service_remote() {
         -e "s|__SECRET_KEY__|$secret_key|g" \
         -e "s|__OPENACE_ENCRYPTION_KEY__|$enc_key|g" \
         -e "s|__WORKSPACE_BASE_DIR__|$WORKSPACE_BASE_DIR|g" \
+        -e "s|__SECURITY_MODE__|$security_mode|g" \
         "$service_template")
 
     # If multi-user workspace mode is enabled, allow sudo (set NoNewPrivileges=false)
@@ -4070,6 +4084,17 @@ install_local() {
                 local enc_key="${OPENACE_ENCRYPTION_KEY:-$current_secret}"
                 sed -i "/^Environment=SECRET_KEY=/a Environment=OPENACE_ENCRYPTION_KEY=$enc_key" "$service_file"
                 print_info "Initialized OPENACE_ENCRYPTION_KEY from the existing encryption secret (Issue #2626)"
+            fi
+
+            # Issue #2654: Inject OPENACE_SECURITY_MODE if missing (PR #2446 follow-up)
+            # create_app() requires this env var in production-capable paths (systemd).
+            # Existing service files created before PR #2446 won't have it.
+            local has_security_mode=$(grep -q "^Environment=OPENACE_SECURITY_MODE=" "$service_file" 2>/dev/null && echo "yes" || echo "no")
+            if [ "$has_security_mode" = "no" ]; then
+                local security_mode="${OPENACE_SECURITY_MODE:-production}"
+                print_warning "Adding missing OPENACE_SECURITY_MODE to systemd service..."
+                sed -i "/^Environment=WORKSPACE_BASE_DIR=/a Environment=OPENACE_SECURITY_MODE=$security_mode" "$service_file"
+                print_info "Set OPENACE_SECURITY_MODE=$security_mode (Issue #2654)"
             fi
         fi
 

--- a/scripts/open-ace.service
+++ b/scripts/open-ace.service
@@ -21,6 +21,7 @@ Environment=HOME=__HOME__
 Environment=SECRET_KEY=__SECRET_KEY__
 Environment=OPENACE_ENCRYPTION_KEY=__OPENACE_ENCRYPTION_KEY__
 Environment=WORKSPACE_BASE_DIR=__WORKSPACE_BASE_DIR__
+Environment=OPENACE_SECURITY_MODE=__SECURITY_MODE__
 
 # Secrets (OPENACE_ENCRYPTION_KEY; encrypts API keys / SMTP passwords). The web
 # service must share the SAME key as the scheduler worker (openace-scheduler.

--- a/scripts/openace-scheduler.service
+++ b/scripts/openace-scheduler.service
@@ -24,6 +24,7 @@ Environment=SCHEDULER_MODE=scheduler
 Environment=HOME=__HOME__
 Environment=SECRET_KEY=__SECRET_KEY__
 Environment=WORKSPACE_BASE_DIR=__WORKSPACE_BASE_DIR__
+Environment=OPENACE_SECURITY_MODE=__SECURITY_MODE__
 
 # Secrets (OPENACE_ENCRYPTION_KEY at minimum; encrypts API keys / SMTP
 # passwords). The leading '-' makes the file OPTIONAL: installs without it

--- a/server.py
+++ b/server.py
@@ -53,7 +53,7 @@ _security_mode = os.environ.get("OPENACE_SECURITY_MODE", "").strip()
 if not _security_mode:
     _is_prod_capable = (
         os.path.isdir("/run/systemd/system")  # systemd
-        or os.environ.get("KUBERNETES_SERVICE_HOST") is not None  # K8s
+        or bool(os.environ.get("KUBERNETES_SERVICE_HOST"))  # K8s
         or os.environ.get("FLASK_ENV") == "production"
     )
     if not _is_prod_capable:

--- a/server.py
+++ b/server.py
@@ -44,6 +44,26 @@ secret_key = get_secret_key()
 if secret_key:
     os.environ["SECRET_KEY"] = secret_key
 
+# Issue #2331/#2654: Set OPENACE_SECURITY_MODE fallback at module level (before
+# create_app) so it applies in both gunicorn and __main__ paths.  In production-
+# capable environments (systemd, Docker, K8s) the service unit or entrypoint
+# must set OPENACE_SECURITY_MODE explicitly; the development fallback only
+# triggers when none of those production indicators are present.
+_security_mode = os.environ.get("OPENACE_SECURITY_MODE", "").strip()
+if not _security_mode:
+    _is_prod_capable = (
+        os.path.isdir("/run/systemd/system")  # systemd
+        or os.environ.get("KUBERNETES_SERVICE_HOST") is not None  # K8s
+        or os.environ.get("FLASK_ENV") == "production"
+    )
+    if not _is_prod_capable:
+        print("=" * 60)
+        print("  LOCAL DEVELOPMENT MODE")
+        print("  Setting OPENACE_SECURITY_MODE=development")
+        print("  For production: set OPENACE_SECURITY_MODE explicitly")
+        print("=" * 60)
+        os.environ["OPENACE_SECURITY_MODE"] = "development"
+
 # Create the Flask application using the factory
 from app import create_app
 
@@ -55,18 +75,9 @@ from app.repositories.database import DB_PATH, get_database_url, is_postgresql
 from scripts.shared.config import WEB_HOST, WEB_PORT
 
 if __name__ == "__main__":
-    # Issue #2331: Local development mode injection
-    # If OPENACE_SECURITY_MODE is not set or empty, inject development mode
-    # This allows local development without explicit configuration
-    current_mode = os.environ.get("OPENACE_SECURITY_MODE", "").strip()
-    if not current_mode:
-        print("=" * 60)
-        print("  LOCAL DEVELOPMENT MODE")
-        print("  Setting OPENACE_SECURITY_MODE=development")
-        print("  For production: set OPENACE_SECURITY_MODE explicitly")
-        print("=" * 60)
-        os.environ["OPENACE_SECURITY_MODE"] = "development"
-    # else: respect explicit mode (allows testing production mode locally)
+    # OPENACE_SECURITY_MODE fallback is now set at module level (before
+    # create_app) to cover both gunicorn and direct execution paths.
+    # See Issue #2654 for details.
 
     print(f"Starting Open ACE on {WEB_HOST}:{WEB_PORT}")
     if is_postgresql():


### PR DESCRIPTION
## Problem

PR #2446 (Issue #2331) added `require_explicit_mode()` to `create_app()`, which raises `RuntimeError` in production-capable paths (systemd, Docker, K8s) when `OPENACE_SECURITY_MODE` is not set. However, the systemd/package deployment path was not updated — the env var was missing from service templates, install/upgrade scripts, and `server.py`'s fallback was in the wrong code path.

This caused all systemd/package deployments to fail on upgrade with:
```
[FAIL] open-ace.service did not become ready on port 5000
```

## Root Cause

| Layer | Issue | File |
|-------|-------|------|
| systemd service template | Missing `Environment=OPENACE_SECURITY_MODE=...` | `scripts/open-ace.service` |
| scheduler service template | Same omission | `scripts/openace-scheduler.service` |
| Install script (fresh) | `install_systemd_service()` and `install_systemd_service_remote()` don't substitute `__SECURITY_MODE__` | `install.sh` |
| Install script (upgrade) | Phase 1 config fix doesn't detect/inject missing `OPENACE_SECURITY_MODE` | `install.sh` |
| Scheduler config | `configure_scheduler_service()` doesn't inherit `OPENACE_SECURITY_MODE` from web unit | `install.sh` |
| `server.py` | Development fallback was inside `if __name__ == "__main__":` — executes AFTER `create_app()` at module level (line 50), so gunicorn path never hits it | `server.py` |

Docker path had `docker-entrypoint.sh` adaptation, but systemd/package path was completely missed.

## Fix

1. **Service templates**: Add `Environment=OPENACE_SECURITY_MODE=__SECURITY_MODE__` to both `open-ace.service` and `openace-scheduler.service`
2. **Fresh install** (local + remote): Substitute `__SECURITY_MODE__` (default: `production`)
3. **Upgrade**: Detect missing `OPENACE_SECURITY_MODE` in existing service file and inject it
4. **Scheduler config**: Inherit `OPENACE_SECURITY_MODE` from the web service unit
5. **`server.py`**: Move development fallback to module level (before `create_app()`), gated by non-production-path check (no systemd, no K8s, no `FLASK_ENV=production`)

## Testing

- Relevant unit tests pass (206 passed, only Windows-unrelated failures)
- Security mode enforcement tests pass
- Service template renders correctly with `__SECURITY_MODE__` substitution

Closes #2654