### PR TITLE
fix: repair misclassified initial platform admin

### DIFF
--- a/migrations/versions/20260814_003_repair_initial_platform_admin.py
+++ b/migrations/versions/20260814_003_repair_initial_platform_admin.py
@@ -1,0 +1,68 @@
+"""Repair initial platform admins misclassified by an earlier migration.
+
+Revision ID: 20260814_003
+Revises: 20260814_002
+
+Issue: #2661
+
+The original form of ``20260810_001`` classified legacy admins with a
+``tenant_id`` as tenant admins before protecting the initial platform admin.
+Editing that already-applied revision cannot repair existing installations, so
+this forward migration restores only accounts that can be proven to be initial
+platform administrators.
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260814_003"
+down_revision = "20260814_002"
+branch_labels = None
+depends_on = None
+
+
+def _get_initial_platform_admins() -> list[str]:
+    """Return explicitly configured initial platform administrator usernames."""
+    configured = os.environ.get("OPENACE_INITIAL_PLATFORM_ADMINS", "")
+    return [username.strip() for username in configured.split(",") if username.strip()]
+
+
+def _repair_misclassified_initial_admins(
+    connection: sa.engine.Connection, usernames: list[str]
+) -> int:
+    """Restore provable initial admins without changing ordinary tenant admins."""
+    params: dict[str, object] = {}
+    proof_conditions = ["id = 1"]
+
+    if usernames:
+        placeholders = []
+        for index, username in enumerate(usernames):
+            parameter = f"initial_admin_{index}"
+            params[parameter] = username
+            placeholders.append(f":{parameter}")
+        proof_conditions.append(f"username IN ({','.join(placeholders)})")
+
+    result = connection.execute(
+        sa.text(f"""
+            UPDATE users
+            SET role = 'platform_admin'
+            WHERE role = 'tenant_admin'
+              AND ({' OR '.join(proof_conditions)})
+        """),
+        params,
+    )
+    return int(result.rowcount or 0)
+
+
+def upgrade() -> None:
+    _repair_misclassified_initial_admins(op.get_bind(), _get_initial_platform_admins())
+
+
+def downgrade() -> None:
+    # Reverting would remove platform access without enough information to
+    # distinguish repaired accounts from legitimate platform administrators.
+    pass

--- a/tests/integration/test_repair_initial_platform_admin_migration_2661.py
+++ b/tests/integration/test_repair_initial_platform_admin_migration_2661.py
@@ -29,9 +29,7 @@ def connection():
 
 @pytest.fixture
 def migration():
-    return importlib.import_module(
-        "migrations.versions.20260814_003_repair_initial_platform_admin"
-    )
+    return importlib.import_module("migrations.versions.20260814_003_repair_initial_platform_admin")
 
 
 def _insert_user(connection, user_id: int, username: str, role: str, tenant_id: int | None):

--- a/tests/integration/test_repair_initial_platform_admin_migration_2661.py
+++ b/tests/integration/test_repair_initial_platform_admin_migration_2661.py
@@ -1,0 +1,97 @@
+"""Regression tests for the forward repair of misclassified initial admins."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+
+pytestmark = [pytest.mark.integration, pytest.mark.issue(2661)]
+
+
+@pytest.fixture
+def connection():
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("""
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE,
+                role TEXT NOT NULL,
+                tenant_id INTEGER
+            )
+        """))
+    with engine.connect() as conn:
+        yield conn
+    engine.dispose()
+
+
+@pytest.fixture
+def migration():
+    return importlib.import_module(
+        "migrations.versions.20260814_003_repair_initial_platform_admin"
+    )
+
+
+def _insert_user(connection, user_id: int, username: str, role: str, tenant_id: int | None):
+    connection.execute(
+        sa.text("""
+            INSERT INTO users (id, username, role, tenant_id)
+            VALUES (:id, :username, :role, :tenant_id)
+        """),
+        {"id": user_id, "username": username, "role": role, "tenant_id": tenant_id},
+    )
+    connection.commit()
+
+
+def _role(connection, user_id: int) -> str:
+    return connection.execute(
+        sa.text("SELECT role FROM users WHERE id = :id"), {"id": user_id}
+    ).scalar_one()
+
+
+def test_repairs_initial_user_misclassified_as_tenant_admin(connection, migration):
+    _insert_user(connection, 1, "initial", "tenant_admin", 1)
+
+    repaired = migration._repair_misclassified_initial_admins(connection, [])
+    connection.commit()
+
+    assert repaired == 1
+    assert _role(connection, 1) == "platform_admin"
+
+
+def test_does_not_promote_ordinary_tenant_admin(connection, migration):
+    _insert_user(connection, 2, "tenant-owner", "tenant_admin", 1)
+
+    repaired = migration._repair_misclassified_initial_admins(connection, [])
+    connection.commit()
+
+    assert repaired == 0
+    assert _role(connection, 2) == "tenant_admin"
+
+
+def test_repairs_explicitly_configured_initial_admin(connection, migration):
+    _insert_user(connection, 2, "known-initial", "tenant_admin", 1)
+
+    repaired = migration._repair_misclassified_initial_admins(connection, ["known-initial"])
+    connection.commit()
+
+    assert repaired == 1
+    assert _role(connection, 2) == "platform_admin"
+
+
+def test_is_noop_for_already_correct_platform_admin(connection, migration):
+    _insert_user(connection, 1, "initial", "platform_admin", 1)
+
+    repaired = migration._repair_misclassified_initial_admins(connection, [])
+    connection.commit()
+
+    assert repaired == 0
+    assert _role(connection, 1) == "platform_admin"
+
+
+def test_reads_trimmed_nonempty_whitelist(monkeypatch, migration):
+    monkeypatch.setenv("OPENACE_INITIAL_PLATFORM_ADMINS", " first, ,second ")
+
+    assert migration._get_initial_platform_admins() == ["first", "second"]


### PR DESCRIPTION
## What changed

- add a new forward Alembic migration after `20260814_002`
- repair only provable initial platform administrators that an earlier form of `20260810_001` may have classified as `tenant_admin`
- support the existing `id=1` heuristic and `OPENACE_INITIAL_PLATFORM_ADMINS` whitelist
- leave ordinary tenant administrators and already-correct platform administrators unchanged
- add focused upgrade-path regression coverage

## Why

The classification order was fixed by editing an existing migration, but installations that had already applied that Alembic revision never reran it. Their persisted initial administrator role therefore remained incorrect after a normal upgrade.

This forward migration repairs affected installations without requiring manual database edits.

## Impact

Initial platform administrators affected by the historical migration regain access to platform-only tenant management after upgrading. Ordinary tenant administrators are not promoted.

## Validation

- `pytest tests/integration/test_admin_role_migration_2332.py tests/integration/test_repair_initial_platform_admin_migration_2661.py -q`: 22 passed, 2 skipped
- new regression file: 5 passed
- Ruff checks passed
- `git diff --check` passed

Fixes #2661