### PR TITLE
fix(#2663): test-phase retry must re-execute tests (fresh session + explicit retry instructions)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10214,14 +10214,20 @@ class AutonomousOrchestrator:
         # anything — the evidence gate only recognizes fresh output, so every
         # retry lands inconclusive until exhaustion. Switch to a FRESH session
         # (the test prompt is self-contained: plan + changed files + scopes)
-        # and state the retry obligation explicitly.
+        # and state the retry obligation explicitly. Covers both retry
+        # counters: test_retries (inconclusive/failed/requirer) and
+        # skip_retries (agent reported TEST_STATUS: skipped) — both leave a
+        # prior round in the resumed session that the agent would cite.
         test_retries_before = int(wf.get("test_retries", 0) or 0)
+        skip_retries_before = int(wf.get("skip_retries", 0) or 0)
+        retry_round = max(test_retries_before, skip_retries_before)
         test_session_line = "test"
-        if test_retries_before > 0:
+        if retry_round > 0:
             test_session_line = "fresh"
             test_prompt += (
                 "## 重试指令\n"
-                f"上一轮验证未通过证据门（第 {test_retries_before} 次重试：未捕获到可识别的新测试输出）。"
+                f"这是第 {retry_round} 次重试：上一轮的验证结果未被采信"
+                "（未捕获到可识别的新测试输出，或结果不可用/被跳过）。"
                 "本轮必须：\n"
                 "1. 重新执行验证矩阵中的测试命令，并在回复中包含每条命令的原始输出；\n"
                 "2. 不得引用之前回合的结果作为本轮验证证据；\n"

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10209,6 +10209,24 @@ class AutonomousOrchestrator:
             AUTONOMOUS_CONTEXT + "请基于最终方案和本轮实际改动，设计并执行一份定向验证矩阵。"
             "如果有失败，修复问题并重新测试。确保必测项全部通过后再结束。\n\n"
         )
+        # #2663: on a retry, resuming the test session lets the agent cite the
+        # prior round's results ("已在前面回合完成验证") instead of re-running
+        # anything — the evidence gate only recognizes fresh output, so every
+        # retry lands inconclusive until exhaustion. Switch to a FRESH session
+        # (the test prompt is self-contained: plan + changed files + scopes)
+        # and state the retry obligation explicitly.
+        test_retries_before = int(wf.get("test_retries", 0) or 0)
+        test_session_line = "test"
+        if test_retries_before > 0:
+            test_session_line = "fresh"
+            test_prompt += (
+                "## 重试指令\n"
+                f"上一轮验证未通过证据门（第 {test_retries_before} 次重试：未捕获到可识别的新测试输出）。"
+                "本轮必须：\n"
+                "1. 重新执行验证矩阵中的测试命令，并在回复中包含每条命令的原始输出；\n"
+                "2. 不得引用之前回合的结果作为本轮验证证据；\n"
+                "3. 如果确认测试无法执行，在回复末尾单独一行输出 `TEST_STATUS: skipped` 并说明原因。\n\n"
+            )
         if issue_number:
             test_prompt += (
                 f"## 关联 Issue\n"
@@ -10264,7 +10282,7 @@ class AutonomousOrchestrator:
             remote_machine_id=wf.get("remote_machine_id"),
             permission_mode=wf.get("permission_mode", "auto-edit"),
             allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(wf.get("cli_tool", "claude-code"), []),
-            session_line="test",
+            session_line=test_session_line,
             milestone_id=test_ms.get("milestone_id", ""),
         )
 

--- a/docs/dev-notes/2660-test-retry-fresh-session-design.md
+++ b/docs/dev-notes/2660-test-retry-fresh-session-design.md
@@ -1,0 +1,46 @@
+# Design: test-evidence retry must force a fresh-session re-execution (#2590 follow-up)
+
+Date: 2026-08-14. Issue: tracked under #2590's workflow failure (new issue to be filed as #2660).
+
+## Root cause (verified against session JSONL + milestones)
+
+`_run_test_phase` dispatches the test agent with `session_line="test"`, which
+**resumes the same CLI session across retries**. The dev agent already ran
+tests during development, so on a retry it answers by citing prior-round
+results ("所有必测项已在前面回合完成验证" — sometimes with an empty response)
+instead of executing anything new. The evidence gate only recognizes output
+produced in the current attempt → verdict `inconclusive` on every retry →
+MAX_TEST_RETRIES(2) exhausted → workflow failed. Deployed fixes don't cover
+this: Fix A carries forward a prior *verdict* (here the prior attempt is also
+inconclusive), Fix B's fresh-retry only fires on success+0-token+empty.
+
+## Decision (user-approved): fresh session + explicit retry instructions
+
+On a test-phase retry (`test_retries > 0` when `_run_test_phase` dispatches):
+
+1. **Dispatch `session_line="fresh"`** instead of `"test"`. An unregistered
+   line resolves to `(new uuid, None, resume=False)` — a brand-new session.
+   The test prompt is self-contained (final plan ≤4000 chars, changed files,
+   verification scopes, repo conventions), so nothing critical is lost, and
+   structurally there is no prior round in context to cite.
+2. **Append a retry block to the prompt**: 上一轮验证未通过证据门（未捕获
+   可识别的新测试输出）。本轮必须重新执行验证矩阵的命令并在回复中包含
+   每条命令的原始输出；不得引用之前回合的结果作为本轮验证证据。
+
+First run (test_retries==0) is unchanged (resume is desirable there: the dev
+session has the freshest mental context of what changed).
+
+## Files
+
+- `app/modules/workspace/autonomous/orchestrator.py` — `_run_test_phase` only.
+- `tests/unit/test_test_retry_fresh_dispatch.py` — new regression tests.
+
+## Testing
+
+Unit tests (mock `_run_agent`, call `_run_test_phase`, assert the passed
+`session_line` and prompt content):
+- first run (test_retries=0): `session_line="test"`, no retry block;
+- retry (test_retries>=1): `session_line="fresh"`, prompt contains the
+  retry-instruction block.
+
+No schema changes. E2E not required (no frontend change).

--- a/tests/unit/test_test_retry_fresh_dispatch.py
+++ b/tests/unit/test_test_retry_fresh_dispatch.py
@@ -1,0 +1,135 @@
+"""#2663: a test-phase retry must re-execute tests, not cite prior rounds.
+
+``_run_test_phase`` dispatches with ``session_line="test"``, resuming the SAME
+CLI session across retries. The dev agent already ran tests during
+development, so on a retry it answers by citing prior-round results instead of
+executing anything new — the evidence gate (correctly) sees no fresh output
+and the workflow burns every retry on ``inconclusive`` (#2590's workflow, two
+occurrences, the second after all empty-result fixes were deployed).
+
+Fix under test: on a retry (``test_retries > 0``) the dispatch switches to
+``session_line="fresh"`` (no prior round in context to cite) and the prompt
+gains an explicit retry-instruction block demanding fresh execution with raw
+output. The first run (``test_retries == 0``) keeps resuming the test line —
+the dev session's context is valuable there.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2663)]
+
+_STRUCTURED = (
+    "app.modules.workspace.autonomous.orchestrator."
+    "AutonomousOrchestrator._compute_structured_test_verdict"
+)
+_PASSING_TOOL = "app.modules.workspace.autonomous.orchestrator._has_passing_test_tool_result"
+_TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
+
+RETRY_BLOCK_MARKER = "上一轮验证未通过证据门"
+
+
+def _workflow(**overrides):
+    base = {
+        "workflow_id": "wf-2663",
+        "user_id": 1,
+        "title": "T",
+        "status": "developing",
+        "requirements_text": "r",
+        "project_path": "/tmp/p",
+        "worktree_path": "/tmp/p",
+        "workspace_type": "local",
+        "cli_tool": "claude-code",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "new-branch",
+        "current_phase": "development",
+        "dev_round": 1,
+        "current_round": 1,
+        "github_issue_number": 2663,
+        "test_retries": 0,
+        "skip_retries": 0,
+        "dev_retries_on_test_fail": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _dispatch(test_retries: int) -> dict:
+    """Drive ``_run_test_phase`` once; return the ``_run_agent`` kwargs."""
+    from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
+    from app.modules.workspace.autonomous.models import AgentTaskResult
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    wf = _workflow(test_retries=test_retries)
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as repo_cls,
+    ):
+        repo = MagicMock()
+        repo.get_workflow.return_value = wf
+        repo.list_milestones.return_value = []
+        repo.create_milestone.return_value = {"milestone_id": "ms-cur", "workflow_id": "wf-2663"}
+        repo.update_workflow.return_value = wf
+        repo.update_milestone.return_value = {}
+        repo.create_event.return_value = {"id": 1}
+        repo_cls.return_value = repo
+        orch = AutonomousOrchestrator("wf-2663")
+    orch.repo = repo
+    orch.emitter = MagicMock()
+    orch._gh = MagicMock()
+    orch._gh.has_uncommitted_changes.return_value = False
+
+    text = "TEST_STATUS: PASSED\n2 passed"
+    result = AgentTaskResult(
+        session_id="sess",
+        response_text=text,
+        visible_response_text=text,
+        success=True,
+        tool_calls=[{"tool": {"name": "Bash", "input": {"command": "python -m pytest tests/ -q"}}}],
+    )
+    orch._update_workflow = lambda p: None
+    orch._post_github_comment = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-cur"})
+    orch._find_or_create_milestone = MagicMock(return_value={"milestone_id": "ms-cur"})
+    orch._run_agent = MagicMock(return_value=result)
+    orch._accumulate_tokens = MagicMock()
+    orch._runtime_environment_gate = MagicMock(return_value="")
+    orch._build_test_execution_context = MagicMock(return_value=("", []))
+    orch._project_runtime_contract = MagicMock(return_value="")
+    orch._artifact_visible_text = MagicMock(return_value=text)
+    orch._artifact_text = MagicMock(return_value=text)
+    orch._shadow_compare_evidence = MagicMock()
+    orch._emit_structured_test_fallback = MagicMock()
+    orch._apply_test_evidence_requirer = MagicMock(return_value=("shadow", []))
+    orch._validate_test_report_format = MagicMock(return_value=(True, ""))
+
+    with (
+        patch(_STRUCTURED, return_value=(ExecutionVerdict.PASSED, [], "scripted")),
+        patch(_PASSING_TOOL, return_value=True),
+        patch(_TEST_REPO) as test_repo_cls,
+    ):
+        test_repo_cls.return_value.query_by_milestone.return_value = []
+        orch._run_test_phase(wf, 1, orch._gh)
+    return orch._run_agent.call_args.kwargs
+
+
+def test_first_run_resumes_test_line_without_retry_block():
+    kwargs = _dispatch(test_retries=0)
+    assert kwargs["session_line"] == "test"
+    assert RETRY_BLOCK_MARKER not in kwargs["prompt"]
+
+
+def test_retry_dispatches_fresh_session_with_retry_instructions():
+    kwargs = _dispatch(test_retries=1)
+    assert kwargs["session_line"] == "fresh"
+    prompt = kwargs["prompt"]
+    assert RETRY_BLOCK_MARKER in prompt
+    # The instruction must demand re-execution and forbid citing prior rounds.
+    assert "重新执行" in prompt
+    assert "不得引用之前回合" in prompt

--- a/tests/unit/test_test_retry_fresh_dispatch.py
+++ b/tests/unit/test_test_retry_fresh_dispatch.py
@@ -29,7 +29,8 @@ _STRUCTURED = (
 _PASSING_TOOL = "app.modules.workspace.autonomous.orchestrator._has_passing_test_tool_result"
 _TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
 
-RETRY_BLOCK_MARKER = "上一轮验证未通过证据门"
+RETRY_BLOCK_MARKER = "这是第"
+RETRY_BLOCK_TAIL = "次重试：上一轮的验证结果未被采信"
 
 
 def _workflow(**overrides):
@@ -58,13 +59,13 @@ def _workflow(**overrides):
     return base
 
 
-def _dispatch(test_retries: int) -> dict:
+def _dispatch(**overrides) -> dict:
     """Drive ``_run_test_phase`` once; return the ``_run_agent`` kwargs."""
     from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
     from app.modules.workspace.autonomous.models import AgentTaskResult
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
-    wf = _workflow(test_retries=test_retries)
+    wf = _workflow(**overrides)
     with (
         patch("app.modules.workspace.autonomous.orchestrator.Database"),
         patch(
@@ -129,7 +130,21 @@ def test_retry_dispatches_fresh_session_with_retry_instructions():
     kwargs = _dispatch(test_retries=1)
     assert kwargs["session_line"] == "fresh"
     prompt = kwargs["prompt"]
-    assert RETRY_BLOCK_MARKER in prompt
+    assert f"{RETRY_BLOCK_MARKER} 1 {RETRY_BLOCK_TAIL}" in prompt
     # The instruction must demand re-execution and forbid citing prior rounds.
     assert "重新执行" in prompt
     assert "不得引用之前回合" in prompt
+
+
+def test_second_retry_also_fresh():
+    kwargs = _dispatch(test_retries=2)
+    assert kwargs["session_line"] == "fresh"
+    assert f"{RETRY_BLOCK_MARKER} 2 {RETRY_BLOCK_TAIL}" in kwargs["prompt"]
+
+
+def test_skip_retry_also_fresh():
+    """skip_retries (agent reported TEST_STATUS: skipped) shares the same
+    cite-prior-round failure mode — its one retry must also run fresh."""
+    kwargs = _dispatch(test_retries=0, skip_retries=1)
+    assert kwargs["session_line"] == "fresh"
+    assert f"{RETRY_BLOCK_MARKER} 1 {RETRY_BLOCK_TAIL}" in kwargs["prompt"]


### PR DESCRIPTION
## What

Refs #2663 (issue stays open until verified on a real retry).

### Root cause (verified against prod session JSONL + milestones)
`_run_test_phase` dispatches `session_line="test"`, resuming the SAME CLI session across retries. The dev agent already ran tests during development, so on retry it cites prior-round results ("所有必测项已在前面回合完成验证", one response even empty) instead of executing anything new. The evidence gate only recognizes current-attempt output → every retry `inconclusive` → MAX_TEST_RETRIES exhausted → workflow failed (#2590's workflow, two occurrences, the second after resume-noop fresh-retry / result-text fallback / verdict carry-forward were all deployed — none cover a non-empty prose answer).

### Fix
On a retry (`test_retries > 0` OR `skip_retries > 0`):
- dispatch `session_line="fresh"` — registered one-shot line (`_resolve_session_line` → new uuid, resume=False), so there is structurally no prior round in context to cite. The test prompt is self-contained (final plan ≤4000 chars + changed files + scopes + repo conventions from DB, not from session history). The stable `test_session_id` line is untouched (fresh lines don't overwrite it) and the retry session links to the current `tests_run` milestone.
- append a retry-instruction block: 重新执行验证矩阵命令并附原始输出；不得引用之前回合结果；确实无法执行则输出 `TEST_STATUS: skipped`.

First run (`test_retries == 0 && skip_retries == 0`) is unchanged — resume is desirable there.

## Testing
`tests/unit/test_test_retry_fresh_dispatch.py` (regression + issue(2663), drives `_run_test_phase` with mocked `_run_agent`): first run resumes `test` line without retry block; retry (1st and 2nd) dispatches `fresh` with the instruction block; skip-retry path also fresh. All adjacent suites green (60 passed incl. carry-forward #2590 Option A + requirer + 2376 gate flags).

Independent review verdict: Ready to PR (0 Critical/Important; minors folded in: generic retry wording, skip_retries coverage, boundary tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)