### PR TITLE
fix(remote): sqlite3.Row indexing + un-shadow agent _http_send 401 handling (#2457)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -1080,8 +1080,10 @@ class RemoteAgentManager:
         if is_revoked:
             return False
 
-        # Issue #2499: Check pending_revoke status
-        pending_revoke = row.get("pending_revoke")
+        # Issue #2499: Check pending_revoke status.
+        # Raw-cursor rows are sqlite3.Row on SQLite (no .get) and
+        # RealDictRow on PostgreSQL (.get works) — index uniformly.
+        pending_revoke = row["pending_revoke"]
         if is_postgresql():
             pending_revoke = bool(pending_revoke) if pending_revoke is not None else False
         else:
@@ -1089,7 +1091,7 @@ class RemoteAgentManager:
 
         if pending_revoke:
             # Check if temporarily valid (within timeout window)
-            is_temporarily_valid = row.get("is_temporarily_valid")
+            is_temporarily_valid = row["is_temporarily_valid"]
             if is_postgresql():
                 is_temporarily_valid = (
                     bool(is_temporarily_valid) if is_temporarily_valid is not None else False
@@ -1287,7 +1289,7 @@ class RemoteAgentManager:
                     (machine_id,),
                 )
                 row = cursor.fetchone()
-                if row and row.get("token_revoke_timeout"):
+                if row and row["token_revoke_timeout"]:
                     timeout = int(row["token_revoke_timeout"])
                     # Clamp to valid range
                     return max(MIN_TOKEN_REVOKE_TIMEOUT, min(timeout, MAX_TOKEN_REVOKE_TIMEOUT))

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -483,18 +483,23 @@ class RemoteAgent:
                 except Exception as e:
                     logger.error("Error handling command: %s", e)
 
-    def _http_send(self, message: dict[str, Any]) -> dict[str, Any] | None:
+    def _http_send(
+        self, message: dict[str, Any], headers: dict[str, str] | None = None
+    ) -> dict[str, Any] | None:
         """
         POST a message to the server's HTTP fallback endpoint.
 
         Returns the parsed JSON response or None on failure.
         Sets self._token_revoked = True on 401 responses.
+
+        ``headers`` overrides the default Content-Type + Bearer auth headers
+        (used by the confirmation mechanism, issue #2499).
         """
         url = f"{self.config.server_url}/api/remote/agent/message"
-        headers = {"Content-Type": "application/json"}
-
-        if self.config.agent_token:
-            headers["Authorization"] = f"Bearer {self.config.agent_token}"
+        if headers is None:
+            headers = {"Content-Type": "application/json"}
+            if self.config.agent_token:
+                headers["Authorization"] = f"Bearer {self.config.agent_token}"
 
         try:
             resp = requests.post(
@@ -903,7 +908,7 @@ class RemoteAgent:
                     "new_token_hash": new_token[:8],  # For audit only
                 }
 
-                response = self._http_send(payload, headers=headers)
+                response = self._http_send_with_custom_headers(payload, headers=headers)
 
                 if response and response.get("success"):
                     logger.info(
@@ -1131,25 +1136,15 @@ class RemoteAgent:
         except Exception as e:
             logger.warning("Failed to sync token version from server: %s", e)
 
-    def _http_send(
-        self, data: dict[str, Any], headers: dict[str, str] | None = None
+    def _http_send_with_custom_headers(
+        self, data: dict[str, Any], headers: dict[str, str]
     ) -> dict | None:
-        """Send HTTP message to server with optional custom headers.
+        """Send HTTP message with explicit headers (no auth auto-injection).
 
-        Issue #2499: Extracted for reuse by confirmation mechanism.
-
-        Args:
-            data: Message payload to send.
-            headers: Optional custom headers (default: use agent_token).
-
-        Returns:
-            Response dict or None on failure.
+        Issue #2499: used by the confirmation mechanism, which supplies its
+        own auth headers. Regular sends (including 401 → _token_revoked
+        handling) go through _http_send.
         """
-        if headers is None:
-            headers = {}
-            if self.config.agent_token:
-                headers["Authorization"] = f"Bearer {self.config.agent_token}"
-
         url = f"{self.config.server_url}/api/remote/agent/message"
 
         try:

--- a/tests/issues/1140/test_zcode_dev_mode_and_session.py
+++ b/tests/issues/1140/test_zcode_dev_mode_and_session.py
@@ -29,7 +29,11 @@ _REMOTE_AGENT_DIR = os.path.normpath(
 
 
 def test_zcode_adapter_maps_yolo_correctly():
-    """The yolo permission_mode must map to zcode --mode yolo."""
+    """The bypass permission_mode must map to zcode --mode yolo.
+
+    Issue #2591 removed the bare "yolo" key from the mode map (default is now
+    "build"); full-autonomy is requested via "bypass"/"full-auto".
+    """
     if _REMOTE_AGENT_DIR not in sys.path:
         sys.path.insert(0, _REMOTE_AGENT_DIR)
     from cli_adapters.zcode import ZCodeAdapter
@@ -39,7 +43,7 @@ def test_zcode_adapter_maps_yolo_correctly():
         "test-sid",
         "/tmp/proj",
         "glm-5.2",
-        permission_mode="yolo",
+        permission_mode="bypass",
     )
     assert "--mode" in args
     idx = args.index("--mode")
@@ -162,7 +166,11 @@ def test_session_line_updates_even_on_resume():
     source = inspect.getsource(AutonomousOrchestrator._run_agent)
     # The old buggy condition was: `if field and not resume and not ...`
     # The fix removes the `not resume` guard so resume also updates.
-    assert "not resume" not in source, (
+    # Match the bare `not resume` token (word boundary) — later code legitimately
+    # contains `not resume_target`, a different variable in the retry path.
+    import re
+
+    assert not re.search(r"\bnot resume\b(?!_)", source), (
         "_run_agent must not skip session line update on resume — "
         "see #525 where dev resumed a dead planning session forever"
     )

--- a/tests/issues/1891/test_usage_report_auth.py
+++ b/tests/issues/1891/test_usage_report_auth.py
@@ -503,8 +503,10 @@ class TestValidRequests:
         # Old token works
         assert manager.validate_agent_token(old_token, machine_id) is True
 
-        # Rotate
-        new_result = manager.rotate_agent_token(machine_id, rotated_by=1)
+        # Rotate (immediate/emergency mode: default rotation is delayed since
+        # #2499 — the old token stays valid inside its revoke window, which
+        # would not satisfy "old token no longer works")
+        new_result = manager.rotate_agent_token(machine_id, rotated_by=1, immediate=True)
         assert new_result is not None
         new_token = new_result["new_token"]
 

--- a/tests/issues/754/test_remote_agent_identity_e2e.py
+++ b/tests/issues/754/test_remote_agent_identity_e2e.py
@@ -172,8 +172,10 @@ class TestScenario05_TokenRotation:
         # Old token works
         assert manager.validate_agent_token(old_token, "machine-005") is True
 
-        # Rotate
-        new_result = manager.rotate_agent_token("machine-005", rotated_by=1)
+        # Rotate (immediate/emergency mode: default rotation is delayed since
+        # #2499 — the old token stays valid inside its revoke window, which
+        # would not satisfy "invalidates the old token")
+        new_result = manager.rotate_agent_token("machine-005", rotated_by=1, immediate=True)
         assert new_result is not None
 
         # Old token no longer works


### PR DESCRIPTION
Refs #2457. Unblocks the 517-cluster PR: its full-lane validation run surfaced 24 new failures that all reproduce on clean main (introduced by #2629 and #2614 between the last two clean baseline runs).

## Product bugs (from #2629)

1. **`sqlite3.Row` has no `.get`** — `validate_agent_token` and `_get_token_revoke_timeout` called `row.get(...)` on raw-cursor rows. PG cursors return `RealDictRow` (has `.get`), SQLite returns `sqlite3.Row` (doesn't) — agent-token validation crashed on every SQLite deployment. Same class of bug as #2259/#2261 and the #2608 cluster. Fixed with index access (columns are always selected).
2. **Second `_http_send` shadowed the first** — #2629 added a 2-arg `_http_send` for the confirmation mechanism later in the class, silently replacing the original: the shadow lacks the **401 → `_token_revoked`** handling, so agents kept reconnecting forever after token revocation (exactly the behavior #883's test guards). Merged into one definition (2-arg signature, original defaults + 401 handling); the confirmation caller now uses the renamed `_http_send_with_custom_headers`.

## Test-side drift

- 1891/754 rotation tests asserted pre-#2499 immediate revocation; default rotation is now **delayed** (old token valid inside its revoke window by design). Both use `immediate=True` where the test's point is old-token invalidation.
- 1140: `permission_mode="yolo"` key was removed by #2591 (now `"bypass"`); the #525 static assertion false-positived on the unrelated `not resume_target` variable — now a word-boundary match.

## Evidence

- All 24 failures reproduce on clean main `aa265909` (A/B via worktree).
- After fix: lane run of 1891,754,883,1140 = **86/86 pass**; `tests/unit/test_token_rotation_2499.py` still **17/17**.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>