### PR TITLE
fix(#2668): count-less exit-0 pass (lint) can no longer defuse a parsed test failure

### DIFF
--- a/app/modules/workspace/autonomous/command_evidence/test_verdict.py
+++ b/app/modules/workspace/autonomous/command_evidence/test_verdict.py
@@ -65,7 +65,7 @@ def _command_key(evidence: TestExecutionEvidence) -> tuple:
 
 def _latest_state(
     authoritative: list[tuple[int, TestExecutionEvidence]],
-) -> dict[tuple, tuple[str, _PytestScope | None, int]]:
+) -> dict[tuple, tuple[str, _PytestScope | None, int, TestExecutionEvidence]]:
     """Reduce to the latest verdict/scope/order per normalized command.
 
     ``authoritative`` is ordered by execution (the caller passes evidences in
@@ -75,9 +75,10 @@ def _latest_state(
 
     The scope is read per evidence, not gated on a run-level framework string
     (#2376 D4): a pytest evidence carries its own ``coverage_scope`` even when
-    the project as a whole infers ``"mixed"``.
+    the project as a whole infers ``"mixed"``. The evidence itself rides along
+    so coverer selection can apply ``_has_test_semantics`` (#2665).
     """
-    latest: dict[tuple, tuple[str, _PytestScope | None, int]] = {}
+    latest: dict[tuple, tuple[str, _PytestScope | None, int, TestExecutionEvidence]] = {}
     for order, evidence in authoritative:
         key = _command_key(evidence)
         scope = (
@@ -85,8 +86,31 @@ def _latest_state(
         )
         previous = latest.get(key)
         if previous is None or order > previous[2]:
-            latest[key] = (evidence.verdict, scope, order)
+            latest[key] = (evidence.verdict, scope, order, evidence)
     return latest
+
+
+def _has_test_semantics(evidence: TestExecutionEvidence) -> bool:
+    """Whether the evidence structurally proves a TEST command ran.
+
+    True when the parse produced pytest scope/counts/selectors, or came from
+    a framework parser that only fires on framework-specific output
+    (jest/go_test/cargo). False for the exit-0 fallbacks — ``_parse_generic``
+    on any clean command and ``_parse_pytest``'s exit-0-unparseable-output
+    arm — which yield a count-less, scope-less MEDIUM pass indistinguishable
+    from lint/format commands (pre-commit/black/ruff).
+    """
+    if evidence.parser in ("jest", "go_test", "cargo"):
+        return True
+    return (
+        evidence.coverage_scope is not None
+        or evidence.collected is not None
+        or evidence.passed is not None
+        or evidence.failed is not None
+        or evidence.skipped is not None
+        or evidence.errors is not None
+        or bool(evidence.selectors)
+    )
 
 
 def _classify_failures(authoritative: list[tuple[int, TestExecutionEvidence]]) -> str:
@@ -116,17 +140,17 @@ def _classify_failures(authoritative: list[tuple[int, TestExecutionEvidence]]) -
     """
     latest = _latest_state(authoritative)
     passing = [
-        (scope, order)
-        for verdict, scope, order in latest.values()
+        (scope, order, evidence)
+        for verdict, scope, order, evidence in latest.values()
         if verdict == ExecutionVerdict.PASSED.value
     ]
     result = "none"
-    for verdict, failed_scope, order in latest.values():
+    for verdict, failed_scope, order, failed_evidence in latest.values():
         if verdict == ExecutionVerdict.PASSED.value:
             continue
         covered = False
         undecidable = False
-        for passing_scope, passing_order in passing:
+        for passing_scope, passing_order, passing_evidence in passing:
             if passing_order <= order:
                 continue
             if _pytest_scope_covers(passing_scope, failed_scope):
@@ -134,8 +158,20 @@ def _classify_failures(authoritative: list[tuple[int, TestExecutionEvidence]]) -
                 break
             # Both scopes known means non-coverage was *decided* (a targeted
             # pass genuinely does not clear a failed broader run — #1967). Only
-            # a missing scope on either side leaves it undecidable.
+            # a missing scope on either side leaves it undecidable…
             if passing_scope is None or failed_scope is None:
+                # …unless the failure is structurally a TEST failure (parsed
+                # scope/counts) while the passing command carries no test
+                # semantics at all (#2665). pre-commit/black/ruff exit-0 pass
+                # through the same fallback arms, and letting them soften a
+                # decisive pytest "3 failed, 24 passed" into "uncertain" →
+                # INCONCLUSIVE spun #2590's workflow in retry loops instead of
+                # the tests-failed → dev-fix loop. Both-generic runs (bash
+                # exit-code scripts) keep the #2376 PR-2 deferral.
+                if _has_test_semantics(failed_evidence) and not _has_test_semantics(
+                    passing_evidence
+                ):
+                    continue
                 undecidable = True
         if covered:
             continue

--- a/app/modules/workspace/autonomous/command_evidence/test_verdict.py
+++ b/app/modules/workspace/autonomous/command_evidence/test_verdict.py
@@ -20,6 +20,9 @@ evidence instead of the raw ``event_log``:
   *undecidable*, not a failure: with no scope to compare, a later pass yields
   INCONCLUSIVE so the heuristic decides. Decided non-coverage (both pytest
   scopes known, the later pass narrower) still yields FAILED (#2376 PR-2).
+  #2665 carve-out: a later pass carrying no test semantics at all (count-less
+  scope-less exit-0 — lint/format) cannot make a structurally-parsed test
+  failure undecidable; see ``_has_test_semantics``.
 
 Input source of truth: ``TestExecutionEvidence`` rows, never agent prose.
 """
@@ -93,15 +96,19 @@ def _latest_state(
 def _has_test_semantics(evidence: TestExecutionEvidence) -> bool:
     """Whether the evidence structurally proves a TEST command ran.
 
-    True when the parse produced pytest scope/counts/selectors, or came from
-    a framework parser that only fires on framework-specific output
-    (jest/go_test/cargo). False for the exit-0 fallbacks — ``_parse_generic``
-    on any clean command and ``_parse_pytest``'s exit-0-unparseable-output
-    arm — which yield a count-less, scope-less MEDIUM pass indistinguishable
-    from lint/format commands (pre-commit/black/ruff).
+    True only when the parse produced pytest scope/counts/selectors or parsed
+    framework counts (jest/cargo set ``passed``; go never records counts).
+    False for the exit-0 fallback arms — ``_parse_generic`` on any clean
+    command, ``_parse_pytest``'s exit-0-unparseable-output arm (which claims
+    ``parser="pytest"``!), and the framework parsers' own exit-0 arms on
+    non-test invocations of the same tool family (``go vet``/``go build``,
+    ``cargo clippy``/``cargo fmt``) — all of which yield a count-less,
+    scope-less MEDIUM pass indistinguishable from lint/format commands
+    (#2665). The paired guard in ``_classify_failures`` still preserves the
+    #2376 deferral when the failing side is equally unstructured (a pure
+    ``go test`` fail + ``go test`` pass pair carries no counts on either
+    side, so neither has test semantics and the defer stands).
     """
-    if evidence.parser in ("jest", "go_test", "cargo"):
-        return True
     return (
         evidence.coverage_scope is not None
         or evidence.collected is not None

--- a/tests/unit/test_test_verdict.py
+++ b/tests/unit/test_test_verdict.py
@@ -26,6 +26,8 @@ def _te(
     selectors: list[str] | None = None,
     context: str = _CTX,
     framework: str = "python",
+    passed: int | None = None,
+    failed: int | None = None,
 ) -> TestExecutionEvidence:
     """Build a TestExecutionEvidence with an explicit scope for verdict tests."""
     coverage_scope = None
@@ -38,6 +40,8 @@ def _te(
         parser_confidence=confidence,
         selectors=selectors or [],
         coverage_scope=coverage_scope,
+        passed=passed,
+        failed=failed,
     )
 
 
@@ -147,11 +151,68 @@ def test_non_pytest_cross_command_pass_is_undecidable_not_a_failure():
     # flow for every non-pytest runner. Decided non-coverage (both scopes known,
     # pytest) still yields FAILED — see
     # test_targeted_pass_does_not_cover_failed_full_suite_1967.
+    # (Counts made explicit post-#2665: a pass that never parsed any test
+    # output has no test semantics at all — see
+    # test_lint_pass_after_pytest_failure_stays_failed_2665.)
     evidences = [
-        _te("c1", ExecutionVerdict.FAILED.value, framework="javascript"),
-        _te("c2", ExecutionVerdict.PASSED.value, framework="javascript"),
+        _te("c1", ExecutionVerdict.FAILED.value, framework="javascript", passed=2, failed=1),
+        _te("c2", ExecutionVerdict.PASSED.value, framework="javascript", passed=3),
     ]
     assert not _run_failed(evidences, "javascript")
+    assert compute_run_verdict(evidences) is ExecutionVerdict.INCONCLUSIVE
+
+
+def _lint_pass(command_id: str) -> TestExecutionEvidence:
+    """A generic exit-0 command (pre-commit/black/ruff style).
+
+    ``_parse_generic`` marks a clean exit-0 MEDIUM PASSED with NO counts and
+    NO coverage scope — the shape of a lint/format command, which carries no
+    test semantics (#2665).
+    """
+    return TestExecutionEvidence(
+        command_id=command_id,
+        framework="python",
+        verdict=ExecutionVerdict.PASSED.value,
+        parser_confidence=ParserConfidence.MEDIUM.value,
+        parser="generic",
+        selectors=[],
+        coverage_scope=None,
+    )
+
+
+def test_lint_pass_after_pytest_failure_stays_failed_2665():
+    # pre-commit/black/ruff exiting 0 after a DECISIVE pytest failure (3
+    # failed, 24 passed) must not defuse the verdict. Before #2665 the bare
+    # generic pass's None scope hit the undecidable branch ("uncertain" →
+    # INCONCLUSIVE), so the workflow retried forever instead of entering the
+    # productive tests-failed → dev-fix loop (#2590's workflow, verified
+    # against prod evidence rows).
+    evidences = [
+        _te("t1", ExecutionVerdict.PASSED.value, selectors=["tests/x.py::test_a"]),
+        _te("t2", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+        _lint_pass("lint1"),
+    ]
+    assert compute_run_verdict(evidences) is ExecutionVerdict.FAILED
+
+
+def test_counted_generic_pass_after_failure_stays_uncertain_2665():
+    # A generic pass WITH parsed counts (an unmodeled test framework rerun)
+    # keeps the #2376 PR-2 undecidable semantics — only count-less/scope-less
+    # generic passes are stripped of coverer status.
+    counted = TestExecutionEvidence(
+        command_id="g1",
+        framework="javascript",
+        verdict=ExecutionVerdict.PASSED.value,
+        parser_confidence=ParserConfidence.MEDIUM.value,
+        parser="generic",
+        selectors=[],
+        coverage_scope=None,
+        passed=5,
+    )
+    evidences = [
+        _te("t1", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+        counted,
+    ]
     assert compute_run_verdict(evidences) is ExecutionVerdict.INCONCLUSIVE
 
 

--- a/tests/unit/test_test_verdict.py
+++ b/tests/unit/test_test_verdict.py
@@ -162,19 +162,22 @@ def test_non_pytest_cross_command_pass_is_undecidable_not_a_failure():
     assert compute_run_verdict(evidences) is ExecutionVerdict.INCONCLUSIVE
 
 
-def _lint_pass(command_id: str) -> TestExecutionEvidence:
-    """A generic exit-0 command (pre-commit/black/ruff style).
+def _lint_pass(command_id: str, *, parser: str = "pytest") -> TestExecutionEvidence:
+    """A count-less exit-0 lint/format command (pre-commit/black/ruff style).
 
-    ``_parse_generic`` marks a clean exit-0 MEDIUM PASSED with NO counts and
-    NO coverage scope — the shape of a lint/format command, which carries no
-    test semantics (#2665).
+    In a python-hinted project these route through ``_parse_pytest`` whose
+    exit-0-unparseable arm emits ``parser="pytest"`` with NO counts and NO
+    coverage scope (the ACTUAL prod shape of #2665's evidence rows);
+    ``_parse_generic``'s exit-0 arm is the parser="generic" twin. Lock BOTH
+    shapes — a future "pytest parser ⇒ has test semantics" shortcut must not
+    silently reintroduce the bug.
     """
     return TestExecutionEvidence(
         command_id=command_id,
         framework="python",
         verdict=ExecutionVerdict.PASSED.value,
         parser_confidence=ParserConfidence.MEDIUM.value,
-        parser="generic",
+        parser=parser,
         selectors=[],
         coverage_scope=None,
     )
@@ -183,28 +186,45 @@ def _lint_pass(command_id: str) -> TestExecutionEvidence:
 def test_lint_pass_after_pytest_failure_stays_failed_2665():
     # pre-commit/black/ruff exiting 0 after a DECISIVE pytest failure (3
     # failed, 24 passed) must not defuse the verdict. Before #2665 the bare
-    # generic pass's None scope hit the undecidable branch ("uncertain" →
+    # pass's None scope hit the undecidable branch ("uncertain" →
     # INCONCLUSIVE), so the workflow retried forever instead of entering the
     # productive tests-failed → dev-fix loop (#2590's workflow, verified
-    # against prod evidence rows).
+    # against prod evidence rows). Both lint shapes locked: parser="pytest"
+    # (the real prod shape via _parse_pytest's exit-0 arm) and "generic".
+    for parser in ("pytest", "generic"):
+        evidences = [
+            _te("t1", ExecutionVerdict.PASSED.value, selectors=["tests/x.py::test_a"]),
+            _te("t2", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+            _lint_pass("lint1", parser=parser),
+        ]
+        assert compute_run_verdict(evidences) is ExecutionVerdict.FAILED, parser
+
+
+def test_rerun_with_truncated_output_after_failure_is_failed_2665():
+    # Documented trade-off: a legitimate fix-then-rerun whose passing rerun is
+    # count-less AND scope-less (truncated output_excerpt ate the only summary
+    # line, or an unmodeled wrapper like `make test`) is now FAILED where it
+    # previously deferred to the heuristic. The evidence is indistinguishable
+    # from a lint command, so decisive beats deferred — the failure routes the
+    # workflow into the dev-fix loop, which re-runs tests anyway.
     evidences = [
-        _te("t1", ExecutionVerdict.PASSED.value, selectors=["tests/x.py::test_a"]),
-        _te("t2", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
-        _lint_pass("lint1"),
+        _te("t1", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+        _lint_pass("rerun"),
     ]
     assert compute_run_verdict(evidences) is ExecutionVerdict.FAILED
 
 
-def test_counted_generic_pass_after_failure_stays_uncertain_2665():
-    # A generic pass WITH parsed counts (an unmodeled test framework rerun)
-    # keeps the #2376 PR-2 undecidable semantics — only count-less/scope-less
-    # generic passes are stripped of coverer status.
+def test_counted_pass_after_failure_stays_uncertain_2665():
+    # A pass WITH parsed framework counts (reachable shape: _parse_cargo on a
+    # "test result: ok. 5 passed" rerun) keeps the #2376 PR-2 undecidable
+    # semantics — only count-less/scope-less passes are stripped of coverer
+    # status.
     counted = TestExecutionEvidence(
         command_id="g1",
-        framework="javascript",
+        framework="rust",
         verdict=ExecutionVerdict.PASSED.value,
-        parser_confidence=ParserConfidence.MEDIUM.value,
-        parser="generic",
+        parser_confidence=ParserConfidence.HIGH.value,
+        parser="cargo",
         selectors=[],
         coverage_scope=None,
         passed=5,
@@ -214,6 +234,28 @@ def test_counted_generic_pass_after_failure_stays_uncertain_2665():
         counted,
     ]
     assert compute_run_verdict(evidences) is ExecutionVerdict.INCONCLUSIVE
+
+
+def test_go_vet_pass_after_go_test_failure_does_not_defuse_2665():
+    # Framework parsers' exit-0 arms are NOT test semantics: `go vet` (or
+    # `cargo clippy`) exiting 0 after a go/cargo test failure must not soften
+    # the failure. The failing go evidence is itself count-less (no test
+    # semantics), so the defer survives only between two STRUCTURED pairs —
+    # here the failure is structured (pytest counts) and the vet pass is not.
+    vet_pass = TestExecutionEvidence(
+        command_id="v1",
+        framework="go",
+        verdict=ExecutionVerdict.PASSED.value,
+        parser_confidence=ParserConfidence.MEDIUM.value,
+        parser="go_test",
+        selectors=[],
+        coverage_scope=None,
+    )
+    evidences = [
+        _te("t1", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+        vet_pass,
+    ]
+    assert compute_run_verdict(evidences) is ExecutionVerdict.FAILED
 
 
 def test_restricted_pass_does_not_cover_earlier_failure():


### PR DESCRIPTION
## What

Refs #2668 (issue stays open until verified on a real run).

### Root cause (prod evidence rows + local parser replay, #2590's workflow)
pre-commit/black/ruff (exit 0) classify as scope-less count-less MEDIUM PASSED via `_parse_generic`'s exit-0 arm AND `_parse_pytest`'s exit-0-unparseable arm (which claims `parser="pytest"`). In `_classify_failures`, such a pass after a decisive pytest FAILED (`3 failed, 24 passed`, scope=file) hits the undecidable branch → "uncertain" → INCONCLUSIVE → the workflow spins retry loops instead of entering the tests-failed → dev-fix loop. Same shape pre-existing for `go vet`/`cargo clippy` via the framework parsers' exit-0 arms.

### Fix
`_has_test_semantics(evidence)`: True iff pytest scope/counts/selectors or parsed framework counts. In the undecidable branch, a passing command WITHOUT test semantics cannot soften a failure WITH test semantics (skip → failure stays decisive). Both-unstructured pairs (bash exit-code scripts, pure go-test fail+pass) keep the #2376 PR-2 deferral — `test_non_python_cross_command_pass_is_undecidable_not_failed` passes unchanged.

Documented trade-off (named test): a legitimate fix-then-rerun whose passing rerun is count-less AND scope-less (truncated output, unmodeled wrapper) is now FAILED instead of deferred — evidence-indistinguishable from lint; the dev-fix loop re-runs tests anyway.

## Testing
`tests/unit/test_test_verdict.py`: lint-after-failure → FAILED for BOTH parser shapes ("pytest" prod shape + "generic"); counted pass keeps uncertain; `go vet` pass after structured failure → FAILED; truncated-rerun trade-off named. All adjacent suites green: 448 passed (verdict + requirer + carry-forward + 2376 + 2046).

Independent review: 3 Important (prod-shape test, go/cargo docstring claim, trade-off documentation) + minors all folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)