### PR TITLE
fix(#2590): route exhausted structured test failures into a dev-repair round

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2081,6 +2081,22 @@ def _cleanup_backoff_time(attempts: int) -> str:
     return (datetime.now(timezone.utc) + timedelta(seconds=delay)).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _head_tail_excerpt(text: str, limit: int = 6000) -> str:
+    """Truncate ``text`` preserving BOTH ends (#2590).
+
+    Test-report tails carry the failure summary (short summary lines, exit
+    status) while the head carries the command/context — a head-only cut
+    discards exactly the part a dev-repair round needs. Split the budget
+    roughly 2:1 head:tail (test output front-loads verbose tracebacks; the
+    actionable summary at the end is usually short).
+    """
+    if len(text) <= limit:
+        return text
+    head = max(limit * 2 // 3, 1)
+    tail = max(limit - head - len("\n…[truncated]…\n"), 1)
+    return f"{text[:head]}\n…[truncated]…\n{text[-tail:]}"
+
+
 try:
     MAX_AUTONOMOUS_CHANGED_FILES = int(os.environ.get("AUTONOMOUS_MAX_CHANGED_FILES", "60"))
 except ValueError:
@@ -6328,7 +6344,7 @@ class AutonomousOrchestrator:
             lines.append("- （本轮无结构化失败行，失败详情见下方测试报告摘录）")
         lines.append("")
         lines.append("### 测试阶段报告摘录（截断至 6000 字符）")
-        lines.append((test_summary or "")[:6000])
+        lines.append(_head_tail_excerpt(test_summary or "", 6000))
         return "\n".join(lines)
 
     def _emit_structured_test_fallback(
@@ -10838,8 +10854,13 @@ class AutonomousOrchestrator:
                             # counter left exhausted, the new round's first
                             # inconclusive/FAILED would skip test retries
                             # entirely and burn a dev round on a run the test
-                            # agent could have settled itself.
+                            # agent could have settled itself. skip_retries
+                            # too: phases/development.py skips the dev agent
+                            # when test_retries > 0 OR skip_retries > 0, so a
+                            # stale skip_retries=1 would burn BOTH repair
+                            # retries without ever invoking the dev agent.
                             "test_retries": 0,
+                            "skip_retries": 0,
                             "user_feedback": feedback,
                         }
                     )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6290,6 +6290,47 @@ class AutonomousOrchestrator:
             logger.debug("prior verdict carry-forward failed: %s", e)
             return ExecutionVerdict.NOT_RUN, f"carry-forward failed: {e}"
 
+    def _structured_failure_repair_feedback(
+        self, structured_reason: str, evidences: list, test_summary: str
+    ) -> str:
+        """Build the #2590 dev-repair round's failure context (user_feedback).
+
+        The test retries re-ran the failing tests but never routed the output
+        back into development; this payload does. Composed from the structured
+        per-command verdicts (framework + counts) plus an excerpt of the test
+        agent's report — the structured rows keep counts, not excerpts, so the
+        raw failing output only survives in the report text. Persisted on the
+        workflow as ``user_feedback`` because the dev prompt already surfaces
+        that field (``_get_user_feedback_prompt``) and clears it after the
+        round, so no new plumbing is needed.
+        """
+        lines = [
+            "#2590 测试修复轮：测试重试已耗尽，且结构化证据判定测试命令真实失败"
+            f"（{structured_reason}）。",
+            "请先根据以下失败信息修复测试或修复被测试暴露的产品代码，"
+            "再重新执行验证；不得跳过测试或改写断言来让测试通过。",
+        ]
+        failed_lines = []
+        for evidence in evidences or []:
+            if getattr(evidence, "verdict", "") != ExecutionVerdict.FAILED.value:
+                continue
+            counts = f"passed={evidence.passed}, failed={evidence.failed}"
+            if evidence.errors:
+                counts += f", errors={evidence.errors}"
+            failed_lines.append(
+                f"- 失败的测试命令证据（framework={evidence.framework or 'unknown'}，{counts}）"
+            )
+        if failed_lines:
+            lines.extend(failed_lines)
+        else:
+            # Carry-forward (#2590 Option A) leaves the current milestone's
+            # evidence list empty — the verdict came from the prior milestone.
+            lines.append("- （本轮无结构化失败行，失败详情见下方测试报告摘录）")
+        lines.append("")
+        lines.append("### 测试阶段报告摘录（截断至 6000 字符）")
+        lines.append((test_summary or "")[:6000])
+        return "\n".join(lines)
+
     def _emit_structured_test_fallback(
         self,
         verdict: ExecutionVerdict,
@@ -10759,6 +10800,61 @@ class AutonomousOrchestrator:
             test_retries = int(wf.get("test_retries", 0) or 0) + 1
             if test_retries <= MAX_TEST_RETRIES:
                 self._update_workflow({"test_retries": test_retries})
+                return
+            # #2590: a decisive structured FAILED at test-retry exhaustion is a
+            # fixable defect, not an evidence gap. The retries (fresh sessions
+            # since #2663) only re-ran the same failing tests — nobody routed
+            # the failure output back into development, so the workflow went
+            # terminal without a single repair attempt. An inconclusive run
+            # keeps the terminal path below (nothing actionable to hand a dev
+            # round); a structured FAILED enters a dev-repair round exactly
+            # like Situation B ([UNFIXABLE]): same dev_retries_on_test_fail
+            # counter and cap, one dev_round bump, and the failing output
+            # persisted as user_feedback so the dev prompt
+            # (_get_user_feedback_prompt) starts from "these tests failed
+            # with this output, fix them" instead of a blank slate.
+            if structured_verdict == ExecutionVerdict.FAILED:
+                dev_retries = int(wf.get("dev_retries_on_test_fail", 0) or 0) + 1
+                if dev_retries <= MAX_DEV_RETRIES_ON_TEST_FAIL:
+                    logger.warning(
+                        "Structured test failures survived %d test retries, starting "
+                        "dev-repair round %d (retry %d/%d)",
+                        MAX_TEST_RETRIES,
+                        dev_round + 1,
+                        dev_retries,
+                        MAX_DEV_RETRIES_ON_TEST_FAIL,
+                    )
+                    prior_feedback = (wf.get("user_feedback") or "").strip()
+                    feedback = self._structured_failure_repair_feedback(
+                        structured_reason, _structured_evidences, test_summary
+                    )
+                    if prior_feedback:
+                        feedback = f"{prior_feedback}\n\n{feedback}"
+                    self._update_workflow(
+                        {
+                            "dev_round": dev_round + 1,
+                            "dev_retries_on_test_fail": dev_retries,
+                            # Fresh test budget for the repaired code: with the
+                            # counter left exhausted, the new round's first
+                            # inconclusive/FAILED would skip test retries
+                            # entirely and burn a dev round on a run the test
+                            # agent could have settled itself.
+                            "test_retries": 0,
+                            "user_feedback": feedback,
+                        }
+                    )
+                    return
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": (
+                            f"Tests failed: structured evidence reports a failing test "
+                            f"command, and no conclusive passing rerun superseded it "
+                            f"(after {MAX_TEST_RETRIES} test retries and "
+                            f"{MAX_DEV_RETRIES_ON_TEST_FAIL} dev-repair retries)"
+                        ),
+                    }
+                )
                 return
             self._update_workflow({"status": "failed", "error_message": message})
             return

--- a/tests/unit/test_prior_milestone_verdict_carryforward.py
+++ b/tests/unit/test_prior_milestone_verdict_carryforward.py
@@ -385,6 +385,74 @@ def test_structured_failed_at_retry_exhaustion_enters_dev_repair_round():
     assert not any(p.get("status") == "failed" for p in patches), patches
 
 
+def test_dev_repair_round_resets_skip_retries_too():
+    """The dev-repair bump must clear ``skip_retries`` alongside
+    ``test_retries``: phases/development.py skips the dev agent when
+    ``test_retries > 0 OR skip_retries > 0``, so a stale ``skip_retries=1``
+    (e.g. a skipped-tests retry earlier in the same round) would make BOTH
+    repair retries test-only re-runs — the dev agent is never invoked and the
+    failures can never be fixed."""
+    wf = _workflow(test_retries=2, skip_retries=1, dev_retries_on_test_fail=0)
+    orch, _ = _orchestrator(wf)
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.FAILED,
+        text="=== 3 failed, 243 passed in 30.12s ===",
+        tool_pass=False,
+        evidences=[_failed_evidence()],
+    )
+    dev_bumps = [p for p in patches if "dev_round" in p]
+    assert dev_bumps, f"expected a dev-repair round, got {patches}"
+    bump = dev_bumps[0]
+    assert bump.get("skip_retries") == 0, (
+        "stale skip_retries=1 keeps the dev agent skipped on the repair " f"round: {bump}"
+    )
+    assert bump.get("test_retries") == 0, bump
+
+
+def test_structured_failed_before_retry_exhaustion_retries_tests_first():
+    """Boundary: a structured FAILED with retries remaining (test_retries=1 <
+    MAX_TEST_RETRIES=2) takes the plain test-retry path — bump test_retries,
+    no dev_round, no user_feedback. The dev-repair round is reserved for
+    exhaustion; jumping early would waste dev rounds on flakes the test agent
+    can settle itself."""
+    wf = _workflow(test_retries=1, dev_retries_on_test_fail=0)
+    orch, _ = _orchestrator(wf)
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.FAILED,
+        text="=== 3 failed, 243 passed in 30.12s ===",
+        tool_pass=False,
+        evidences=[_failed_evidence()],
+    )
+    retry_bumps = [p for p in patches if "test_retries" in p]
+    assert retry_bumps, f"expected a test retry, got {patches}"
+    assert retry_bumps[0].get("test_retries") == 2, retry_bumps[0]
+    assert not any("dev_round" in p for p in patches), patches
+    assert not any("user_feedback" in p for p in patches), patches
+    assert not any(p.get("status") == "failed" for p in patches), patches
+
+
+def test_repair_feedback_excerpt_preserves_tail():
+    """The report excerpt must be tail-preserving: pytest-style output puts the
+    actionable summary (short summary of failures) at the END — a head-only
+    cut at 6000 chars discards exactly what the dev round needs. The excerpt
+    keeps head+tail with a truncation marker between."""
+    from app.modules.workspace.autonomous.orchestrator import _head_tail_excerpt
+
+    long_report = "A" * 4000 + "B" * 3000 + "SHORT SUMMARY: test_click FAILED\n"
+    excerpt = _head_tail_excerpt(long_report, 6000)
+    assert "SHORT SUMMARY: test_click FAILED" in excerpt, "tail content must survive truncation"
+    assert excerpt.startswith("A" * 10), "head content must survive truncation"
+    assert "…[truncated]…" in excerpt
+    # Short reports pass through untouched.
+    assert _head_tail_excerpt("short", 6000) == "short"
+
+
 def test_structured_failed_dev_retries_exhausted_is_terminal():
     """(b) dev-repair retries ALSO exhausted with structured FAILED → terminal
     failed, and the message mentions both counters."""

--- a/tests/unit/test_prior_milestone_verdict_carryforward.py
+++ b/tests/unit/test_prior_milestone_verdict_carryforward.py
@@ -92,13 +92,24 @@ def _orchestrator(wf):
         return orch, repo
 
 
-def _run(orch, wf, *, verdict, text, tool_pass, prior_evidences=None, prior_milestones=None):
+def _run(
+    orch,
+    wf,
+    *,
+    verdict,
+    text,
+    tool_pass,
+    prior_evidences=None,
+    prior_milestones=None,
+    evidences=None,
+):
     """Drive _run_test_phase with a scripted structured verdict + agent output.
 
     ``prior_evidences`` sets what the prior milestone's test-evidence repo
     returns (used by carry-forward). ``prior_milestones`` sets what
     ``list_milestones`` returns so the carry-forward can find the prior test
-    milestone.
+    milestone. ``evidences`` sets the CURRENT milestone's structured evidence
+    rows (the second element of ``_compute_structured_test_verdict``).
     """
     result = AgentTaskResult(
         session_id="sess",
@@ -125,7 +136,7 @@ def _run(orch, wf, *, verdict, text, tool_pass, prior_evidences=None, prior_mile
     orch.repo.list_milestones.return_value = prior_milestones or []
 
     with (
-        patch(_STRUCTURED, return_value=(verdict, [], "scripted")),
+        patch(_STRUCTURED, return_value=(verdict, evidences or [], "scripted")),
         patch(_PASSING_TOOL, return_value=tool_pass),
         patch(_TEST_REPO) as _test_repo_cls,
     ):
@@ -322,3 +333,95 @@ def test_carry_forward_only_on_retry():
     assert (
         "structured evidence reports a failing test command" not in comment
     ), "carry-forward must not fire on test_retries=0"
+
+
+# --- #2590 Option A: exhausted structured FAILED routes into a dev-repair round
+
+
+def _failed_evidence():
+    return TestExecutionEvidence(
+        command_id="c-fail",
+        verdict=ExecutionVerdict.FAILED.value,
+        framework="python",
+        parser_confidence="high",
+        passed=243,
+        failed=3,
+    )
+
+
+def test_structured_failed_at_retry_exhaustion_enters_dev_repair_round():
+    """(a) test retries exhausted + decisive structured FAILED → dev-repair
+    round (same counter/cap as Situation B), NOT terminal failed; the failing
+    output rides in ``user_feedback`` so the dev prompt starts from it."""
+    wf = _workflow(test_retries=2, dev_retries_on_test_fail=0)
+    orch, _ = _orchestrator(wf)
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.FAILED,
+        text=(
+            "=== 3 failed, 243 passed in 30.12s ===\n"
+            "FAILED tests/unit/test_widget.py::test_click"
+        ),
+        tool_pass=False,
+        evidences=[_failed_evidence()],
+    )
+    dev_bumps = [p for p in patches if "dev_round" in p]
+    assert dev_bumps, f"expected a dev-repair round, got {patches}"
+    bump = dev_bumps[0]
+    assert bump.get("dev_round") == 2
+    assert bump.get("dev_retries_on_test_fail") == 1
+    # The repaired code gets a fresh test-phase budget: with test_retries left
+    # exhausted, the new round's first FAILED would skip test retries entirely
+    # and burn a dev round on a run the test agent could have settled itself.
+    assert bump.get("test_retries") == 0
+    feedback = bump.get("user_feedback") or ""
+    # The structured failure summary (counts) and the test report excerpt
+    # (raw failing output) must both reach the dev round.
+    assert "failed=3" in feedback, feedback
+    assert "tests/unit/test_widget.py::test_click" in feedback, feedback
+    # Workflow stays developing — no terminal failure.
+    assert not any(p.get("status") == "failed" for p in patches), patches
+
+
+def test_structured_failed_dev_retries_exhausted_is_terminal():
+    """(b) dev-repair retries ALSO exhausted with structured FAILED → terminal
+    failed, and the message mentions both counters."""
+    wf = _workflow(test_retries=2, dev_retries_on_test_fail=2)
+    orch, _ = _orchestrator(wf)
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.FAILED,
+        text="=== 3 failed, 243 passed in 30.12s ===",
+        tool_pass=False,
+        evidences=[_failed_evidence()],
+    )
+    failures = [p for p in patches if p.get("status") == "failed"]
+    assert failures, f"expected terminal failure, got {patches}"
+    message = failures[0].get("error_message", "")
+    assert "test retries" in message, message
+    assert "dev" in message, message
+    assert not any("dev_round" in p for p in patches), patches
+
+
+def test_inconclusive_at_retry_exhaustion_keeps_terminal_path():
+    """(c) inconclusive exhaustion is unchanged: terminal failed, no dev round,
+    no user_feedback written — there is no actionable failure to hand over."""
+    wf = _workflow(test_retries=2)
+    orch, _ = _orchestrator(wf)
+
+    patches, orch = _run(
+        orch,
+        wf,
+        verdict=ExecutionVerdict.NOT_RUN,
+        text="=== AssertionError ===",
+        tool_pass=False,
+    )
+    failures = [p for p in patches if p.get("status") == "failed"]
+    assert failures, f"expected terminal failure, got {patches}"
+    assert failures[0].get("error_message", "").startswith("Test execution is inconclusive")
+    assert not any("dev_round" in p for p in patches), patches
+    assert not any("user_feedback" in p for p in patches), patches


### PR DESCRIPTION
## What

When the test-phase structured verdict was a decisive FAILED, the routing burned `MAX_TEST_RETRIES`(2) re-running the test phase (fresh sessions since #2663) and then went terminal `failed` — the failing tests were never routed back into development. The only path to a dev round was the agent declaring `[UNFIXABLE]` (Situation B). Observed on #2590's workflow 9f2ac698.

## Change (approved 方案 A)

In `_run_test_phase`'s inconclusive branch, at **test-retry exhaustion**:

- **structured FAILED** → enter a dev-repair round exactly like Situation B: reuse the `dev_retries_on_test_fail` counter and `MAX_DEV_RETRIES_ON_TEST_FAIL` cap, increment `dev_round`, and reset `test_retries` so the repaired code gets a fresh test budget (with the counter left exhausted, the new round's first FAILED would skip test retries entirely and burn a dev round on a run the test agent could have settled itself).
- The failing output is persisted as `user_feedback` — the field the dev prompt already surfaces via `_get_user_feedback_prompt` (and clears after the round): structured per-command failure counts (`_structured_failure_repair_feedback`) plus the test report excerpt (truncated to 6000 chars, the file's idiom), so the dev agent starts from "these tests failed with this output, fix them".
- **dev retries also exhausted** with structured FAILED → terminal `failed` whose message names both counters.
- **Inconclusive at exhaustion** keeps the existing terminal path unchanged (nothing actionable to hand a dev round).

## Tests (TDD)

Extended the `_run_test_phase` harness in `tests/unit/test_prior_milestone_verdict_carryforward.py` (same file/issue-tag as the #2590 Option A carry-forward work):

- (a) structured FAILED + test retries exhausted → `dev_round` 1→2, `dev_retries_on_test_fail` 0→1, `test_retries` reset to 0, `user_feedback` contains the failing counts (`failed=3`) and the raw failing-test excerpt, workflow NOT terminal failed. Red before the fix (went straight to `status=failed`), green after.
- (b) dev retries exhausted too → terminal `failed`, message mentions both counters, no dev round.
- (c) inconclusive exhaustion → unchanged terminal path ("Test execution is inconclusive..."), no dev round, no `user_feedback` write.

## Verification

- Targeted: `test_test_verdict.py test_prior_milestone_verdict_carryforward.py test_test_evidence_requirer.py test_test_retry_fresh_dispatch.py` — 73 passed.
- Full `tests/unit/ -q`: 4141 passed; failures are the known env-only set on clean main (dingtalk/feishu/api_key_proxy) plus one inter-test flake (`test_autonomous_ci_guardrails.py::test_agent_environment_binds_python_and_git_guards`) that passes in isolation on both this branch and clean main.
- pre-commit on changed files only: all Passed (black/isort/ruff/mypy/bandit/pydocstyle).

Refs #2590

🤖 Generated with [Claude Code](https://claude.com/claude-code)