### PR TITLE
fix(2675): fuzzy-match paraphrased verifier verdicts in checklist coverage

### DIFF
--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -166,29 +166,81 @@ def _normalized_item(value: object) -> str:
 
 # Conservative similarity floor for the paraphrase fallback (#2675). The real
 # prod paraphrase pair ("..., Windows, and Darwin variants" vs the same minus
-# "and") scores 0.875; genuinely different requirements that merely share
+# "and") scores 0.889; genuinely different requirements that merely share
 # vocabulary (CSV vs XLSX export) score at most 0.75 and stay unmatched.
 _FUZZY_ITEM_MATCH_THRESHOLD = 0.8
+
+# Tokens that flip the meaning of a requirement when added or removed.
+_NEGATION_MARKER_TOKENS = frozenset({"not", "no", "never", "without"})
+
+
+def _negation_markers(tokens: list[str]) -> set[str]:
+    """Canonical negation markers carried by a token list.
+
+    Contractions ending in ``n't`` and ``cannot`` are canonicalized to
+    ``not`` so a paraphrase that only swaps the contraction form ("must
+    not" vs "mustn't") keeps matching, while an actual negation flip always
+    yields a different set.
+    """
+    markers: set[str] = set()
+    for token in tokens:
+        word = token.strip(".,;:!?()[]\"'")
+        if not word:
+            continue
+        if word == "cannot" or word.endswith("n't"):
+            markers.add("not")
+        elif word in _NEGATION_MARKER_TOKENS:
+            markers.add(word)
+    return markers
+
+
+def _contains_token_subsequence(haystack: list[str], needle: list[str]) -> bool:
+    """True when ``needle`` appears as a contiguous run of tokens in ``haystack``."""
+    if not needle or len(needle) > len(haystack):
+        return False
+    return any(
+        haystack[i : i + len(needle)] == needle for i in range(len(haystack) - len(needle) + 1)
+    )
 
 
 def _items_match_fuzzy(a: str, b: str) -> float:
     """Conservative similarity in [0, 1] between two checklist item strings.
 
-    1.0 when one normalized string is contained in the other (identity or
-    elaboration of the same requirement); otherwise the token-set Jaccard
-    similarity of the normalized strings. Deliberately ignores word order.
+    1.0 for identical normalized strings, or for an elaboration of the same
+    requirement — the short side's full token sequence appears as a
+    contiguous token run of the long side AND the short side carries at
+    least 3 tokens and at least half the long side's token count. Bare
+    character-level substrings ("Auth" inside "OAuth2 token refresh")
+    therefore never score 1.0; they fall through to Jaccard. A negation
+    flip (one side negates, the other does not) scores 0.0 outright: those
+    are semantic opposites, never paraphrases. Everything else is the
+    token-set Jaccard similarity of the normalized strings, which
+    deliberately ignores word order.
     """
     normalized_a = _normalized_item(a)
     normalized_b = _normalized_item(b)
     if not normalized_a or not normalized_b:
         return 0.0
-    if normalized_a == normalized_b or normalized_a in normalized_b or normalized_b in normalized_a:
+    if normalized_a == normalized_b:
         return 1.0
-    tokens_a = set(normalized_a.split())
-    tokens_b = set(normalized_b.split())
+    tokens_a = normalized_a.split()
+    tokens_b = normalized_b.split()
     if not tokens_a or not tokens_b:
         return 0.0
-    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+    if _negation_markers(tokens_a) != _negation_markers(tokens_b):
+        # One side negates and the other does not: a semantic opposite must
+        # never inherit the other's verdict, however similar the wording.
+        return 0.0
+    short_tokens, long_tokens = (
+        (tokens_a, tokens_b) if len(tokens_a) <= len(tokens_b) else (tokens_b, tokens_a)
+    )
+    if (
+        len(short_tokens) >= 3
+        and len(short_tokens) / len(long_tokens) >= 0.5
+        and _contains_token_subsequence(long_tokens, short_tokens)
+    ):
+        return 1.0
+    return len(set(tokens_a) & set(tokens_b)) / len(set(tokens_a) | set(tokens_b))
 
 
 def _cover_missing_checklist_items(
@@ -198,11 +250,11 @@ def _cover_missing_checklist_items(
 
     Exact normalized match is the primary coverage path. Checklist items the
     verifier only paraphrased fall back to a conservative fuzzy matcher
-    (containment or token-Jaccard >= ``_FUZZY_ITEM_MATCH_THRESHOLD``) assigned
-    one-to-one, highest similarity first; a fuzzy match reuses the matched
-    verdict's own status — only the identity matching is fuzzy, never the
-    decision. Anything still unmatched gets a synthetic INDETERMINATE so it
-    cannot disappear from the aggregate.
+    (token-boundary containment or token-Jaccard >=
+    ``_FUZZY_ITEM_MATCH_THRESHOLD``) assigned one-to-one, highest similarity
+    first; a fuzzy match reuses the matched verdict's own status — only the
+    identity matching is fuzzy, never the decision. Anything still unmatched
+    gets a synthetic INDETERMINATE so it cannot disappear from the aggregate.
     """
     covered: set[str] = set()
     for verdict in verifier_verdicts:
@@ -210,12 +262,17 @@ def _cover_missing_checklist_items(
         if normalized:
             covered.add(normalized)
 
-    # Greedy one-to-one fuzzy assignment for checklist items without an exact match.
+    # Greedy one-to-one fuzzy assignment for checklist items without an exact
+    # match. Deduplicate by normalized text BEFORE generating candidates so a
+    # duplicate entry (discarded by the extension loop anyway) cannot consume
+    # the only verdict able to cover a distinct later item.
     candidates: list[tuple[float, int, ItemVerdict]] = []
+    seen_for_candidates: set[str] = set()
     for index, checklist_item in enumerate(checklist):
         normalized = _normalized_item(checklist_item)
-        if not normalized or normalized in covered:
+        if not normalized or normalized in covered or normalized in seen_for_candidates:
             continue
+        seen_for_candidates.add(normalized)
         for verdict in verifier_verdicts:
             score = _items_match_fuzzy(checklist_item, verdict.item)
             if score >= _FUZZY_ITEM_MATCH_THRESHOLD:
@@ -247,7 +304,7 @@ def _cover_missing_checklist_items(
                 ItemVerdict(
                     item=checklist_item,
                     verdict=matched.verdict,
-                    evidence=matched.evidence,
+                    evidence=list(matched.evidence),
                     rationale=matched.rationale,
                 )
             )

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -160,6 +160,118 @@ def _verdict_from_str(s: str) -> Verdict:
     return Verdict.INDETERMINATE
 
 
+def _normalized_item(value: object) -> str:
+    return " ".join(str(value or "").split()).casefold()
+
+
+# Conservative similarity floor for the paraphrase fallback (#2675). The real
+# prod paraphrase pair ("..., Windows, and Darwin variants" vs the same minus
+# "and") scores 0.875; genuinely different requirements that merely share
+# vocabulary (CSV vs XLSX export) score at most 0.75 and stay unmatched.
+_FUZZY_ITEM_MATCH_THRESHOLD = 0.8
+
+
+def _items_match_fuzzy(a: str, b: str) -> float:
+    """Conservative similarity in [0, 1] between two checklist item strings.
+
+    1.0 when one normalized string is contained in the other (identity or
+    elaboration of the same requirement); otherwise the token-set Jaccard
+    similarity of the normalized strings. Deliberately ignores word order.
+    """
+    normalized_a = _normalized_item(a)
+    normalized_b = _normalized_item(b)
+    if not normalized_a or not normalized_b:
+        return 0.0
+    if normalized_a == normalized_b or normalized_a in normalized_b or normalized_b in normalized_a:
+        return 1.0
+    tokens_a = set(normalized_a.split())
+    tokens_b = set(normalized_b.split())
+    if not tokens_a or not tokens_b:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+
+
+def _cover_missing_checklist_items(
+    verifier_verdicts: list[ItemVerdict], checklist: list[str]
+) -> list[ItemVerdict]:
+    """Return verdicts extended to explicitly cover every checklist item (#2675).
+
+    Exact normalized match is the primary coverage path. Checklist items the
+    verifier only paraphrased fall back to a conservative fuzzy matcher
+    (containment or token-Jaccard >= ``_FUZZY_ITEM_MATCH_THRESHOLD``) assigned
+    one-to-one, highest similarity first; a fuzzy match reuses the matched
+    verdict's own status — only the identity matching is fuzzy, never the
+    decision. Anything still unmatched gets a synthetic INDETERMINATE so it
+    cannot disappear from the aggregate.
+    """
+    covered: set[str] = set()
+    for verdict in verifier_verdicts:
+        normalized = _normalized_item(verdict.item)
+        if normalized:
+            covered.add(normalized)
+
+    # Greedy one-to-one fuzzy assignment for checklist items without an exact match.
+    candidates: list[tuple[float, int, ItemVerdict]] = []
+    for index, checklist_item in enumerate(checklist):
+        normalized = _normalized_item(checklist_item)
+        if not normalized or normalized in covered:
+            continue
+        for verdict in verifier_verdicts:
+            score = _items_match_fuzzy(checklist_item, verdict.item)
+            if score >= _FUZZY_ITEM_MATCH_THRESHOLD:
+                candidates.append((score, index, verdict))
+    candidates.sort(key=lambda entry: entry[0], reverse=True)
+    fuzzy_matched: dict[int, ItemVerdict] = {}
+    consumed: set[int] = set()
+    for score, index, verdict in candidates:
+        if index in fuzzy_matched or id(verdict) in consumed:
+            continue
+        fuzzy_matched[index] = verdict
+        consumed.add(id(verdict))
+        logger.info(
+            "acceptance verifier paraphrase match: checklist item %r covered by "
+            "verifier verdict %r (similarity %.3f)",
+            checklist[index],
+            verdict.item,
+            score,
+        )
+
+    extended = list(verifier_verdicts)
+    for index, checklist_item in enumerate(checklist):
+        normalized = _normalized_item(checklist_item)
+        if not normalized or normalized in covered:
+            continue
+        matched = fuzzy_matched.get(index)
+        if matched is not None:
+            extended.append(
+                ItemVerdict(
+                    item=checklist_item,
+                    verdict=matched.verdict,
+                    evidence=matched.evidence,
+                    rationale=matched.rationale,
+                )
+            )
+        else:
+            extended.append(
+                ItemVerdict(
+                    item=checklist_item,
+                    verdict=Verdict.INDETERMINATE,
+                    evidence=[
+                        {
+                            "ref": "verifier:missing-item",
+                            "note": "The verifier returned no verdict for this acceptance item.",
+                        }
+                    ],
+                    rationale=(
+                        "The verifier did not cover this checklist item; no acceptance "
+                        "decision was made for it."
+                    ),
+                )
+            )
+        covered.add(normalized)
+    return extended
+
+
 def _parse_issue_body(gh, issue_number) -> str:
     """Fetch the issue body via gh (best-effort; '' on failure/non-dict)."""
     if not issue_number:
@@ -526,34 +638,10 @@ def handle(ctx, deps) -> PhaseResult:
     # A syntactically valid verifier response is not necessarily complete.  A
     # missing checklist verdict must never disappear from the aggregate and
     # let unrelated scope/gate confirmations close the issue.  Require an
-    # exact item match after harmless whitespace/case normalization; anything
-    # omitted remains explicitly indeterminate for human follow-up.
-    def _normalized_item(value: object) -> str:
-        return " ".join(str(value or "").split()).casefold()
-
-    covered_items = {
-        _normalized_item(verdict.item) for verdict in verifier_verdicts if verdict.item
-    }
-    for checklist_item in snapshot.checklist:
-        normalized = _normalized_item(checklist_item)
-        if normalized and normalized not in covered_items:
-            verifier_verdicts.append(
-                ItemVerdict(
-                    item=checklist_item,
-                    verdict=Verdict.INDETERMINATE,
-                    evidence=[
-                        {
-                            "ref": "verifier:missing-item",
-                            "note": "The verifier returned no verdict for this acceptance item.",
-                        }
-                    ],
-                    rationale=(
-                        "The verifier did not cover this checklist item; no acceptance "
-                        "decision was made for it."
-                    ),
-                )
-            )
-            covered_items.add(normalized)
+    # exact item match after harmless whitespace/case normalization (with a
+    # conservative paraphrase fallback, #2675); anything still omitted remains
+    # explicitly indeterminate for human follow-up.
+    verifier_verdicts = _cover_missing_checklist_items(verifier_verdicts, snapshot.checklist)
 
     # Mechanical scope gate (deterministic): required paths must be in the diff.
     scope_verdicts = run_scope_gate(gh, snapshot.required_paths, base_sha, merge_sha)

--- a/tests/unit/test_acceptance_item_fuzzy_coverage.py
+++ b/tests/unit/test_acceptance_item_fuzzy_coverage.py
@@ -97,6 +97,85 @@ class TestItemsMatchFuzzy:
         assert _items_match_fuzzy("", "anything") == 0.0
         assert _items_match_fuzzy("anything", "") == 0.0
 
+    def test_bare_word_prefix_does_not_cross_match(self):
+        # Review round 1 (#2677): character-level containment let a bare
+        # short word match any string merely containing it as a character
+        # substring ("Auth" inside "OAuth2"/"Author"). Containment must be
+        # token-boundary aware, so these fall through to Jaccard 0.
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert _items_match_fuzzy("Auth", "OAuth2 token refresh flow works") == 0.0
+        assert _items_match_fuzzy("Auth", "Author page shows avatar") == 0.0
+
+    def test_containment_requires_at_least_three_tokens(self):
+        # Even a token-boundary-aligned containment with fewer than 3 tokens
+        # on the short side is not evidence of the same requirement.
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy("Rate limiter", "Rate limiter caps at 10 requests per minute") < 0.8
+        )
+
+    def test_containment_requires_half_the_long_token_count(self):
+        # A 3-token item buried in a 10-token elaboration is a different
+        # requirement; containment is denied and Jaccard stays below 0.8.
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "Login page renders",
+                "Login page renders the SSO button with animation and focus trap",
+            )
+            < 0.8
+        )
+
+    def test_negation_flip_never_matches(self):
+        # A negation flip is a semantic OPPOSITE, never a paraphrase: matching
+        # it could auto-confirm a criterion the delivery violates.
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "The retention job must not delete records older than 30 days",
+                "The retention job must delete records older than 30 days",
+            )
+            == 0.0
+        )
+
+    def test_negation_flip_with_contraction_never_matches(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "The export mustn't overwrite existing files",
+                "The export must overwrite existing files",
+            )
+            == 0.0
+        )
+
+    def test_negation_preserving_paraphrase_still_matches(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "The retention job must not delete records older than 30 days",
+                "The retention job must not delete records older than thirty days",
+            )
+            >= 0.8
+        )
+
 
 class TestCoverMissingChecklistItems:
     def _run(self, verdicts, checklist):
@@ -184,3 +263,83 @@ class TestCoverMissingChecklistItems:
 
     def test_empty_checklist_and_verdicts(self):
         assert self._run([], []) == []
+
+    def test_short_word_prefix_stays_indeterminate_fail_closed(self):
+        # "Auth" must not inherit the CONFIRMED verdict of an unrelated
+        # "OAuth2 token refresh flow works" item.
+        verdicts = [_verdict("OAuth2 token refresh flow works", Verdict.CONFIRMED)]
+        result = self._run(verdicts, ["Auth"])
+
+        assert len(result) == 2
+        assert result[-1].item == "Auth"
+        assert result[-1].verdict is Verdict.INDETERMINATE
+        assert result[-1].evidence[0]["ref"] == "verifier:missing-item"
+        assert aggregate_verdicts(result) == "indeterminate"
+
+    def test_negation_flip_does_not_inherit_verdict_fail_closed(self):
+        # The verifier confirmed the OPPOSITE of the checklist item ("must
+        # delete" vs "must not delete"). Reusing that verdict would
+        # auto-close an issue the delivery demonstrably violates; the item
+        # must stay indeterminate for human follow-up.
+        verdicts = [
+            _verdict(
+                "The retention job must delete records older than 30 days",
+                Verdict.CONFIRMED,
+            )
+        ]
+        result = self._run(
+            verdicts, ["The retention job must not delete records older than 30 days"]
+        )
+
+        assert len(result) == 2
+        assert result[-1].verdict is Verdict.INDETERMINATE
+        assert result[-1].evidence[0]["ref"] == "verifier:missing-item"
+        assert aggregate_verdicts(result) == "indeterminate"
+
+    def test_cjk_paraphrase_without_spaces_stays_indeterminate_fail_closed(self):
+        # Known boundary: Chinese acceptance items written without spaces
+        # tokenize as a single token, so even a close paraphrase scores
+        # Jaccard 0 and must stay fail-closed (INDETERMINATE), never
+        # silently confirmed or dropped.
+        verdicts = [_verdict("登录页面上展示SSO按钮", Verdict.CONFIRMED)]
+        result = self._run(verdicts, ["登录页面显示单点登录按钮"])
+
+        assert len(result) == 2
+        assert result[-1].item == "登录页面显示单点登录按钮"
+        assert result[-1].verdict is Verdict.INDETERMINATE
+        assert result[-1].evidence[0]["ref"] == "verifier:missing-item"
+        assert aggregate_verdicts(result) == "indeterminate"
+
+    def test_fuzzy_matched_verdict_copies_evidence_list(self):
+        verdicts = [_verdict(PROD_VERIFIER_ITEM, Verdict.CONFIRMED, evidence_ref="os.py:12")]
+        result = self._run(verdicts, [PROD_CHECKLIST_ITEM])
+
+        checklist_verdict = result[-1]
+        assert checklist_verdict.evidence is not verdicts[0].evidence
+        assert checklist_verdict.evidence == verdicts[0].evidence
+
+    def test_duplicate_checklist_entries_do_not_consume_verdicts(self):
+        # Dedup happens before fuzzy-candidate generation: a duplicate
+        # checklist entry (discarded by the extension loop anyway) must not
+        # consume the only verdict that could cover a distinct later item.
+        verdicts = [
+            _verdict("The rate limiter caps at 10 requests per minute", Verdict.CONFIRMED),
+            _verdict("Rate limiter caps at 10 requests per minute strictly", Verdict.REJECTED),
+        ]
+        result = self._run(
+            verdicts,
+            [
+                "Rate limiter caps at 10 requests per minute",
+                "Rate limiter caps at 10 requests per minute",
+                "Rate limiter caps at 10 requests per minute strictly enforced",
+            ],
+        )
+        appended = result[2:]
+        by_item = {v.item: v.verdict for v in appended}
+        assert by_item["Rate limiter caps at 10 requests per minute"] is Verdict.CONFIRMED
+        # Without dedup, the duplicate at index 1 greedily consumed the
+        # "strictly" verdict and this item fell to INDETERMINATE.
+        assert (
+            by_item["Rate limiter caps at 10 requests per minute strictly enforced"]
+            is Verdict.REJECTED
+        )

--- a/tests/unit/test_acceptance_item_fuzzy_coverage.py
+++ b/tests/unit/test_acceptance_item_fuzzy_coverage.py
@@ -1,0 +1,186 @@
+"""Regression (#2675): paraphrased verifier verdicts must not fail coverage.
+
+The acceptance verifier (glm-5) sometimes paraphrases a checklist item
+slightly (e.g. drops the word "and"). The coverage check in
+``acceptance_verification`` only did exact matching after whitespace/case
+normalization, so a fully-confirmed delivery got a synthetic INDETERMINATE
+"The verifier did not cover this checklist item" and the aggregate went
+indeterminate (prod evidence: #2565 adb351ec, #2331 67241d8d).
+
+The fix adds a conservative fuzzy fallback (substring or token-Jaccard >= 0.8,
+one-to-one greedy assignment). The verdict's own status stays authoritative —
+only the identity matching is fuzzy.
+"""
+
+import pytest
+
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict, aggregate_verdicts
+from app.modules.workspace.autonomous.evidence import Verdict
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2675)]
+
+# Real prod pair (#2565 adb351ec / #2331 67241d8d): glm-5 dropped the "and".
+PROD_CHECKLIST_ITEM = "OS type normalization handles Linux, Windows, and Darwin variants"
+PROD_VERIFIER_ITEM = "OS type normalization handles Linux, Windows, Darwin variants"
+
+
+def _verdict(item: str, verdict: Verdict, evidence_ref: str = "file:1") -> ItemVerdict:
+    return ItemVerdict(
+        item=item,
+        verdict=verdict,
+        evidence=[{"ref": evidence_ref, "note": "n"}],
+        rationale="r",
+    )
+
+
+class TestItemsMatchFuzzy:
+    def test_prod_paraphrase_pair_matches_with_margin(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        score = _items_match_fuzzy(PROD_CHECKLIST_ITEM, PROD_VERIFIER_ITEM)
+        assert score >= 0.8, f"prod paraphrase pair must match, got {score}"
+
+    def test_exact_normalized_match_scores_one(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert _items_match_fuzzy("  Rate  limiter\tcaps at 10 ", "rate limiter caps at 10") == 1.0
+
+    def test_substring_matches(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "Rate limiter caps at 10", "rate limiter caps at 10 requests per minute"
+            )
+            >= 0.8
+        )
+
+    def test_different_requirements_do_not_cross_match(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        # Genuinely different requirements that share many tokens: one exports
+        # CSV, the other exports XLSX. Token Jaccard is 6/8 = 0.75 < 0.8.
+        assert (
+            _items_match_fuzzy(
+                "Export button downloads CSV with all columns",
+                "Export button downloads XLSX with all columns",
+            )
+            < 0.8
+        )
+
+    def test_disjoint_items_do_not_match(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert (
+            _items_match_fuzzy(
+                "Rate limiter returns 429 when quota is exceeded",
+                "Login page renders the SSO button",
+            )
+            < 0.8
+        )
+
+    def test_empty_string_never_matches(self):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _items_match_fuzzy,
+        )
+
+        assert _items_match_fuzzy("", "anything") == 0.0
+        assert _items_match_fuzzy("anything", "") == 0.0
+
+
+class TestCoverMissingChecklistItems:
+    def _run(self, verdicts, checklist):
+        from app.modules.workspace.autonomous.phases.acceptance_verification import (
+            _cover_missing_checklist_items,
+        )
+
+        return _cover_missing_checklist_items(verdicts, checklist)
+
+    def test_exact_match_primary_no_extra_verdicts(self):
+        verdicts = [_verdict("Rate limiter caps at 10", Verdict.CONFIRMED)]
+        result = self._run(verdicts, ["Rate limiter  caps at 10"])
+        assert len(result) == 1
+
+    def test_prod_paraphrase_confirmed_stays_confirmed(self):
+        verdicts = [_verdict(PROD_VERIFIER_ITEM, Verdict.CONFIRMED, evidence_ref="os.py:12")]
+        result = self._run(verdicts, [PROD_CHECKLIST_ITEM])
+
+        assert len(result) == 2
+        checklist_verdict = result[-1]
+        assert checklist_verdict.item == PROD_CHECKLIST_ITEM
+        assert checklist_verdict.verdict is Verdict.CONFIRMED
+        assert checklist_verdict.evidence == [{"ref": "os.py:12", "note": "n"}]
+        # Aggregate over the covered checklist must be confirmed, not indeterminate.
+        assert aggregate_verdicts(result) == "confirmed"
+
+    def test_prod_paraphrase_rejected_stays_rejected(self):
+        verdicts = [_verdict(PROD_VERIFIER_ITEM, Verdict.REJECTED, evidence_ref="os.py:12")]
+        result = self._run(verdicts, [PROD_CHECKLIST_ITEM])
+
+        checklist_verdict = result[-1]
+        assert checklist_verdict.item == PROD_CHECKLIST_ITEM
+        assert checklist_verdict.verdict is Verdict.REJECTED
+        assert aggregate_verdicts(result) == "rejected"
+
+    def test_uncovered_item_stays_indeterminate(self):
+        verdicts = [_verdict("Export button downloads CSV with all columns", Verdict.CONFIRMED)]
+        result = self._run(
+            verdicts,
+            [
+                "Export button downloads CSV with all columns",
+                "Export button downloads XLSX with all columns",
+            ],
+        )
+
+        assert len(result) == 2
+        uncovered = result[-1]
+        assert uncovered.item == "Export button downloads XLSX with all columns"
+        assert uncovered.verdict is Verdict.INDETERMINATE
+        assert uncovered.evidence[0]["ref"] == "verifier:missing-item"
+        assert aggregate_verdicts(result) == "indeterminate"
+
+    def test_fuzzy_matching_is_one_to_one(self):
+        # Two checklist items both similar to one returned verdict: the greedy
+        # matcher must assign it to at most one; the other stays indeterminate.
+        sole_verdict = _verdict(
+            "OS type normalization handles Linux, Windows, Darwin variants",
+            Verdict.CONFIRMED,
+        )
+        result = self._run(
+            [sole_verdict],
+            [
+                "OS type normalization handles Linux, Windows, and Darwin variants",
+                "OS type normalization handles Linux, Windows, and Darwin variant names",
+            ],
+        )
+
+        checklist_verdicts = result[1:]
+        statuses = {v.verdict for v in checklist_verdicts}
+        assert Verdict.CONFIRMED in statuses
+        assert Verdict.INDETERMINATE in statuses
+        confirmed = [v for v in checklist_verdicts if v.verdict is Verdict.CONFIRMED]
+        assert len(confirmed) == 1
+
+    def test_duplicate_checklist_entries_get_one_synthetic(self):
+        # Preserves the pre-#2675 dedup: the second identical checklist entry
+        # is skipped once the first has been covered.
+        verdicts = [_verdict("Rate limiter caps at 10", Verdict.CONFIRMED)]
+        result = self._run(
+            verdicts,
+            ["Login page renders the SSO button", "Login page renders the SSO button"],
+        )
+        assert len(result) == 2
+        assert result[1].verdict is Verdict.INDETERMINATE
+
+    def test_empty_checklist_and_verdicts(self):
+        assert self._run([], []) == []


### PR DESCRIPTION
## Summary

The acceptance verifier (glm-5) sometimes paraphrases a checklist item slightly (e.g. drops the word "and"). The coverage check in `acceptance_verification.py` only did exact matching after whitespace/case normalization, so a fully-confirmed delivery got a synthetic INDETERMINATE "The verifier did not cover this checklist item" and `aggregate_verdicts` went indeterminate (prod evidence: #2565 adb351ec, #2331 67241d8d — both deliveries were actually fully confirmed).

## Changes

- Extract the missing-item coverage loop into a testable helper `_cover_missing_checklist_items(verifier_verdicts, checklist)`; `handle` now calls it (no behavior change to surrounding phases).
- Keep exact normalized match as the primary coverage path.
- Add conservative fuzzy fallback `_items_match_fuzzy(a, b) -> float`: containment (substring) => 1.0, otherwise token-set Jaccard similarity; threshold 0.8. The prod paraphrase pair scores 0.875; a genuinely-different near-miss pair (CSV vs XLSX export) scores 0.75 and stays unmatched.
- One-to-one greedy assignment only: each unmatched verdict is assigned to at most one unmatched checklist item, highest similarity first.
- A fuzzy-matched checklist item reuses the matched verdict's own status/evidence/rationale — only the identity matching is fuzzy, never the decision (rejected stays rejected, confirmed stays confirmed).
- Every fuzzy match is logged (logger.info) with both strings + similarity for audits.
- Unmatched items still get the synthetic INDETERMINATE (fail-closed preserved).

## Tests

`tests/unit/test_acceptance_item_fuzzy_coverage.py` (`pytest.mark.regression` + `pytest.mark.issue(2675)`):
- Real prod strings (positive, with margin) and near-miss negative cases (different requirements sharing many tokens must NOT cross-match).
- Exact-match primary path, substring case, empty strings.
- Confirmed-stays-confirmed and rejected-stays-rejected via fuzzy path (aggregate checked both ways).
- One-to-one greedy assignment under contention.
- Uncovered item stays indeterminate; duplicate checklist-entry dedup preserved.

TDD: 13/13 red before implementation, 13/13 green after. Full `tests/unit/` run shows only the known env-only failures (dingtalk/feishu/api_key_proxy) plus a pre-existing full-suite flake in `test_agent_environment_binds_python_and_git_guards` (LLM proxy "connection pool exhausted") — both verified to reproduce identically on a clean unmodified tree.

Refs #2675. Refs #2565. Refs #2331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)