### PR TITLE
fix(#2674): restore cross-user mkdir whitelist (MKDIR_SAFE) in sudoers generators

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1485,11 +1485,18 @@ Cmnd_Alias GH_SAFE = \
 
 # 【安全加固 Issue #2334】OPENACE_UTILS 收紧
 # 移除 git/gh 通配（改用 GIT_SAFE/GH_SAFE），消除 runas 漂移
-# 移除 mkdir（改用 openace-mkdir wrapper）
+# 移除 root-runas mkdir（改用 openace-mkdir wrapper）
 # 保留低风险只读命令：test, ls, stat, id, find
 # find 是只读操作，DAC 已保护敏感目录
 # 【Issue #2334】runas 使用 (ALL) 以支持 github_ops 跨用户工具调用
 Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr/bin/id *, /usr/bin/find *
+
+# 【Issue #2674】跨用户 mkdir：github_ops.create_verification_worktree_dir 发
+# 'sudo -u <account> mkdir -p -- <path>' / 'mkdir -m 700 -- <path>'（裸 mkdir，
+# 非 openace-mkdir wrapper——wrapper 仅 (root) runas 且产生 root 属主目录，
+# 而 verifier worktree 必须由执行 git 的身份持有）。sudo 按调用方 PATH 解析
+# 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
+Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
 # 【安全加固 Issue #2181】删除 AI CLI 通配规则
 # 原 OPENACE_CLI 已删除，所有 AI CLI 启动必须通过 openace-run-as --isolated
@@ -1509,8 +1516,11 @@ open-ace ALL=(ALL) NOPASSWD: GIT_SAFE
 openace ALL=(ALL) NOPASSWD: GIT_SAFE
 open-ace ALL=(ALL) NOPASSWD: GH_SAFE
 openace ALL=(ALL) NOPASSWD: GH_SAFE
+# 【Issue #2674】跨用户 mkdir：github_ops verifier worktree 目录创建
+open-ace ALL=(ALL) NOPASSWD: MKDIR_SAFE
+openace ALL=(ALL) NOPASSWD: MKDIR_SAFE
 # 【Issue #2334】OPENACE_UTILS 收紧：git/gh 已迁移到 GIT_SAFE/GH_SAFE
-# 保留低风险只读工具：test, ls, stat, mkdir, id, find
+# 保留低风险只读工具：test, ls, stat, id, find（跨用户 mkdir 由 MKDIR_SAFE 承接）
 # 注意：runas 保持 (ALL) 以支持 github_ops 等跨用户工具调用
 open-ace ALL=(ALL) NOPASSWD: OPENACE_UTILS
 openace ALL=(ALL) NOPASSWD: OPENACE_UTILS

--- a/scripts/generate-sudoers.sh
+++ b/scripts/generate-sudoers.sh
@@ -250,10 +250,17 @@ Cmnd_Alias GH_SAFE = \\
 
 # 【安全加固 Issue #2334】OPENACE_UTILS 收紧
 # 移除 git/gh 通配（改用 GIT_SAFE/GH_SAFE）
-# 移除 mkdir（改用 openace-mkdir wrapper）
+# 移除 root-runas mkdir（改用 openace-mkdir wrapper）
 # 保留低风险只读命令：test, ls, stat, id, find
 # find 是只读操作，DAC 已保护敏感目录
 Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr/bin/id *, /usr/bin/find *
+
+# 【Issue #2674】跨用户 mkdir：github_ops.create_verification_worktree_dir 发
+# 'sudo -u <account> mkdir -p -- <path>' / 'mkdir -m 700 -- <path>'（裸 mkdir，
+# 非 openace-mkdir wrapper——wrapper 仅 (root) runas 且产生 root 属主目录，
+# 而 verifier worktree 必须由执行 git 的身份持有）。sudo 按调用方 PATH 解析
+# 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
+Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
 # ============================================================================
 # 用户权限配置
@@ -263,6 +270,8 @@ Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr
 # These allow github_ops to run git/gh as system_account
 ${RUN_USER} ALL=(ALL) NOPASSWD: GIT_SAFE
 ${RUN_USER} ALL=(ALL) NOPASSWD: GH_SAFE
+# 【Issue #2674】跨用户 mkdir：github_ops verifier worktree 目录创建
+${RUN_USER} ALL=(ALL) NOPASSWD: MKDIR_SAFE
 
 # WebUI launcher - wrapper required (no fallback per Issue #2334)
 ${WEBUI_RULES}

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2358,7 +2358,8 @@ $run_user ALL=(root) NOPASSWD: $python_bin $script_path *"
     # `sudo -u <system_account>` 跨用户执行（#1395），无法改走
     # openace-run-as --isolated（reject owner==target / env -i 剥凭据 /
     # credentialless 账户模型）；fs.py/projects.py/autonomous.py 的跨用户
-    # test/ls/stat/mkdir 同理。#2181 曾把这里从 (ALL) 收紧为 (root)，部署后
+    # test/ls/stat 同理（跨用户 mkdir 由 MKDIR_SAFE 承接，Issue #2674）。
+    # #2181 曾把这里从 (ALL) 收紧为 (root)，部署后
     # 所有 system_account≠openace 的工作流在 preparation `git fetch` 处全挂。
     # 仅还 runas 目标；#2181 的 agent CLI 隔离（run-as --isolated）、移除
     # cat/chown/useradd/rm、env_keep 收紧均保留。
@@ -2411,9 +2412,11 @@ ${webui_local_rule}"
 ${utility_rule}"
 
     # 【Issue #2334】添加 GIT_SAFE 和 GH_SAFE 规则（(ALL) runas）
+    # 【Issue #2674】添加 MKDIR_SAFE 跨用户 mkdir 规则（(ALL) runas）
     current_user_rules="${current_user_rules}
 $run_user ALL=(ALL) NOPASSWD: GIT_SAFE
-$run_user ALL=(ALL) NOPASSWD: GH_SAFE"
+$run_user ALL=(ALL) NOPASSWD: GH_SAFE
+$run_user ALL=(ALL) NOPASSWD: MKDIR_SAFE"
 
     # Add security wrapper rules if any
     if [ -n "$security_wrapper_rules" ]; then
@@ -2577,11 +2580,18 @@ Cmnd_Alias GH_SAFE = \\
 
 # 【安全加固 Issue #2334】OPENACE_UTILS 收紧
 # 移除 git/gh 通配（改用 GIT_SAFE/GH_SAFE），消除 runas 漂移
-# 移除 mkdir（改用 openace-mkdir wrapper）
+# 移除 root-runas mkdir（改用 openace-mkdir wrapper）
 # 保留低风险只读命令：test, ls, stat, id, find
 # find 是只读操作，DAC 已保护敏感目录
 # 【Issue #2334】runas 使用 (ALL) 以支持 github_ops 跨用户工具调用
 Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr/bin/id *, /usr/bin/find *
+
+# 【Issue #2674】跨用户 mkdir：github_ops.create_verification_worktree_dir 发
+# 'sudo -u <account> mkdir -p -- <path>' / 'mkdir -m 700 -- <path>'（裸 mkdir，
+# 非 openace-mkdir wrapper——wrapper 仅 (root) runas 且产生 root 属主目录，
+# 而 verifier worktree 必须由执行 git 的身份持有）。sudo 按调用方 PATH 解析
+# 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
+Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
 # 【安全加固 Issue #2181】安全 wrapper 规则
 # 以下 wrapper 替代原通配命令，内部验证参数安全性
@@ -2665,6 +2675,19 @@ ${line}"
         if ! grep -q "Cmnd_Alias OPENACE_UTILS" "$sudoers_file" 2>/dev/null || \
            ! grep -E "Cmnd_Alias OPENACE_UTILS.*chown" "$sudoers_file" 2>/dev/null; then
             print_warning "Sudoers missing OPENACE_UTILS Cmnd_Alias or chown command"
+            need_update=true
+        fi
+
+        # 【修复 Issue #2674】Check cross-user mkdir rule (MKDIR_SAFE).
+        # github_ops.create_verification_worktree_dir emits
+        # 'sudo -u <account> mkdir ...' (bare mkdir), which the (root)-runas
+        # openace-mkdir wrapper cannot cover. Without this probe an
+        # incremental upgrade (all earlier checks pass) would keep the old
+        # sudoers and every acceptance verifier checkout dies with
+        # "sudo: a password is required" -> "merged-main checkout failed".
+        if ! grep -q "Cmnd_Alias MKDIR_SAFE" "$sudoers_file" 2>/dev/null || \
+           ! grep -E "^${run_user} ALL=\(ALL\) NOPASSWD: MKDIR_SAFE" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing MKDIR_SAFE cross-user mkdir rule for user '$run_user'"
             need_update=true
         fi
 

--- a/tests/unit/test_sudoers_hardening.py
+++ b/tests/unit/test_sudoers_hardening.py
@@ -748,6 +748,130 @@ class TestGithubOpsCommandShapeCoverage:
         )
 
 
+class TestMkdirShapeCoverage:
+    """Issue #2674: cross-user mkdir whitelist must match github_ops shape.
+
+    github_ops.create_verification_worktree_dir emits
+    ``sudo -u <account> mkdir -p -- <path>`` and ``mkdir -m 700 -- <path>``
+    (bare mkdir, NOT the openace-mkdir wrapper: the wrapper is (root)-runas
+    and creates root-owned directories, while the verifier worktree must be
+    owned by the identity that runs git). The #2334 tightening removed mkdir
+    from the sudoers generators in favor of that wrapper, so after prod
+    regenerated sudoers every acceptance verifier checkout died with
+    "sudo: a password is required" -> "merged-main checkout failed" (#2674).
+    These tests lock the MKDIR_SAFE entries that cover the emitted shape in
+    all three generators and fail loudly if github_ops changes its mkdir
+    construction without updating them.
+    """
+
+    # The cross-user mkdir entries (as they appear in the generator sources).
+    # sudo resolves the bare ``mkdir`` argv through the invoking user's PATH,
+    # so both /usr/bin/mkdir and /bin/mkdir resolutions must be whitelisted.
+    MKDIR_ENTRIES = [
+        "/usr/bin/mkdir *",
+        "/bin/mkdir *",
+    ]
+
+    GENERATOR_FILES = [
+        ("scripts/generate-sudoers.sh", GENERATE_SUDOERS_SH),
+        ("scripts/install-central/package-method/install.sh", INSTALL_SH),
+        ("docker-entrypoint.sh", DOCKER_ENTRYPOINT),
+    ]
+
+    @pytest.mark.issue(2674)
+    @pytest.mark.parametrize("entry", MKDIR_ENTRIES)
+    @pytest.mark.parametrize(
+        "label,path",
+        GENERATOR_FILES,
+        ids=[label for label, _ in GENERATOR_FILES],
+    )
+    def test_mkdir_entries_present_in_all_generators(self, entry, label, path):
+        """All three generators must carry both mkdir whitelist entries."""
+        assert entry in _extract_cmnd_alias(path.read_text(), "MKDIR_SAFE"), (
+            f"{label} is missing the MKDIR_SAFE entry {entry!r}; "
+            f"github_ops.create_verification_worktree_dir emits "
+            f"'sudo -u <account> mkdir ...' (bare mkdir, not the (root)-runas "
+            f"openace-mkdir wrapper), so cross-user verifier worktree creation "
+            f"is rejected by sudoers (Issue #2674). Keep the three generators "
+            f"consistent."
+        )
+
+    @pytest.mark.issue(2674)
+    @pytest.mark.parametrize(
+        "label,path",
+        GENERATOR_FILES,
+        ids=[label for label, _ in GENERATOR_FILES],
+    )
+    def test_mkdir_safe_has_all_runas_in_all_generators(self, label, path):
+        """MKDIR_SAFE user rules must use (ALL) runas for cross-user mkdir."""
+        targets = _get_runas_for_alias(path.read_text(), "MKDIR_SAFE")
+        assert targets, (
+            f"No MKDIR_SAFE user-rule found in {label}; cross-user "
+            f"'sudo -u <owner> mkdir' cannot match a (root)-runas rule "
+            f"(Issue #2674)"
+        )
+        assert "ALL" in targets, (
+            f"MKDIR_SAFE runas is {targets!r} in {label}; must be (ALL) for "
+            f"github_ops cross-user mkdir (Issue #2674)"
+        )
+
+    @pytest.mark.issue(2674)
+    def test_generated_sudoers_matches_verifier_mkdir_shapes(self):
+        """Verifier mkdir shapes must fnmatch the generated MKDIR_SAFE entries."""
+        result = subprocess.run(
+            ["bash", str(GENERATE_SUDOERS_SH), "--dry-run", "--output", "/dev/null"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Generator failed: {result.stderr}"
+        content = result.stdout
+
+        targets = _get_runas_for_alias(content, "MKDIR_SAFE")
+        assert targets and "ALL" in targets, (
+            f"Generated sudoers MKDIR_SAFE runas is {targets!r}; must be (ALL) "
+            f"for github_ops cross-user mkdir (Issue #2674)"
+        )
+
+        entries = [
+            re.sub(r"^\S*/mkdir\s+", "", cmd) for cmd in _extract_cmnd_alias(content, "MKDIR_SAFE")
+        ]
+        real_shapes = [
+            # create_verification_worktree_dir: worktrees root
+            "-p -- /srv/repos/x/.worktrees",
+            # unique verifier child dir
+            "-m 700 -- /srv/repos/x/.worktrees/verify-deadbeef",
+        ]
+        for shape in real_shapes:
+            matching = [e for e in entries if fnmatch.fnmatch(shape, e)]
+            assert matching, (
+                f"create_verification_worktree_dir sudo-path command "
+                f"{shape!r} matches no MKDIR_SAFE entry; cross-user verifier "
+                f"worktree creation would be rejected by sudoers "
+                f"(Issue #2674). MKDIR_SAFE entries: {entries!r}"
+            )
+
+    @pytest.mark.issue(2674)
+    def test_github_ops_mkdir_construction_locked(self):
+        """Drift lock: github_ops must keep the bare cross-user mkdir shape.
+
+        Deliberately brittle source-grep, mirroring the #2635 prefix locks.
+        If github_ops.create_verification_worktree_dir stops emitting
+        ``sudo -u <account> mkdir ...`` (e.g. switches to the openace-mkdir
+        wrapper), the MKDIR_SAFE entries added for #2674 silently stop
+        matching — or the wrapper's (root) runas rejects the call. Fail here
+        with a pointer to the entries.
+        """
+        text = GITHUB_OPS_PY.read_text()
+        assert 'cmd = ["sudo", "-u", account, "mkdir", *args]' in text, (
+            "github_ops.create_verification_worktree_dir no longer emits "
+            "'sudo -u <account> mkdir ...'; the MKDIR_SAFE entries "
+            "'/usr/bin/mkdir *' and '/bin/mkdir *' under (ALL) runas "
+            "(scripts/generate-sudoers.sh, scripts/install-central/"
+            "package-method/install.sh, docker-entrypoint.sh) must be "
+            "updated in lockstep (Issue #2674)"
+        )
+
+
 class TestSudoersDrift:
     """Tests for Docker/Package sudoers drift detection."""
 


### PR DESCRIPTION
## Summary

Class-2 fix for sudoers/code drift reported in issue #2674 (Refs #2674 — issue stays open for the coordinator).

**Root cause (verified on prod):** the installer regenerated sudoers from main on 2026-08-14 23:12; the #2334 tightening had removed mkdir from the sudoers generators in favor of the `openace-mkdir` wrapper, but `github_ops.create_verification_worktree_dir` still emits `sudo -u <account> mkdir -p -- <path>` (bare mkdir). The whitelist only had the wrapper under `(root)` runas, so every acceptance verifier checkout died with `sudo: 需要密码` -> `merged-main checkout failed` (#2565, #2331 verifiers exhausted their retries).

**Fix (simplest consistent option per approved design — restore plain mkdir whitelist):**

- `github_ops.py` is unchanged: it keeps emitting bare cross-user mkdir (the wrapper is `(root)`-runas and creates root-owned dirs, while the verifier worktree must be owned by the identity that runs git).
- All three generators (`scripts/generate-sudoers.sh`, `scripts/install-central/package-method/install.sh`, `docker-entrypoint.sh`) now carry a dedicated alias + user rule, same style as the #2639 GIT_SAFE entries:
  - `Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *` (both PATH resolutions)
  - `<service-user> ALL=(ALL) NOPASSWD: MKDIR_SAFE`
- `install.sh` gains an incremental-upgrade probe: without it, an in-place upgrade whose earlier checks all pass would keep the old sudoers file and the mkdir rule would never land — exactly the drift that bit prod.
- Stale comments updated (the "移除 mkdir（改用 openace-mkdir wrapper）" notes now distinguish root-runas mkdir, which the wrapper covers, from cross-user mkdir, which MKDIR_SAFE covers).

**Drift-lock:** `tests/unit/test_sudoers_hardening.py` gains `TestMkdirShapeCoverage` (marked `issue(2674)` + regression + security via module marker):
1. both mkdir entries present in all three generators;
2. MKDIR_SAFE user rules use `(ALL)` runas in all three;
3. dry-run generator output fnmatches the real emitted shapes (`-p -- <root>`, `-m 700 -- <root>/verify-<hex>`);
4. brittle source-grep locking `cmd = ["sudo", "-u", account, "mkdir", *args]` in github_ops, mirroring the #2635 prefix locks.

Out of scope (tracked separately): the node_modules shim `sudo -u <owner> bash -c` denial is #2650; the wrapper runas/ownership workstream is unchanged.

## Test evidence

- TDD red: `TestMkdirShapeCoverage` — 10 failed before the generator changes.
- Green: `python -m pytest tests/unit/test_sudoers_hardening.py -q` -> **57 passed** (46 pre-existing + 11 new).
- `bash -n` passes on all three shell files; generator `--dry-run` output shows `Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *` and `open-ace ALL=(ALL) NOPASSWD: MKDIR_SAFE`.
- Full suite `python -m pytest tests/unit/ -q` -> 4162 passed, 14 failed + 3 errors. All 14/3 failures reproduce identically on a pristine `origin/main` worktree (dingtalk/feishu/api_key_proxy/api_key sqlite_row env failures, plus `test_autonomous_ci_guardrails::test_agent_environment_binds_python_and_git_guards`, a pre-existing order-dependent flake that passes in isolation and with its neighbor files on both main and this branch).
- `pre-commit run --files <4 changed files>` -> all Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)