### PR TITLE
fix: TESTING guard + agent env scrub for SCHEDULER_MODE (ghost scheduler pause)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -806,7 +806,13 @@ def create_app(config=None):
     # - "web" or unset: Do NOT start schedulers (web worker)
     # Development mode (server.py) starts both web and scheduler
     scheduler_mode = os.environ.get("SCHEDULER_MODE", "web")
-    if scheduler_mode == "scheduler":
+    # TESTING guard (class-2, 2026-08-15): a test process must never start
+    # real schedulers — they operate on the real DB (orphan-kill advancing
+    # workflows, ghost-pausing rows). Tests that need a scheduler call
+    # init_autonomous_scheduler() directly.
+    if scheduler_mode == "scheduler" and app.config.get("TESTING"):
+        logger.info("Background services skipped (TESTING mode)")
+    elif scheduler_mode == "scheduler":
         start_background_services()
         logger.info("Background services started (SCHEDULER_MODE=scheduler)")
     else:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1448,6 +1448,11 @@ class AutonomousAgentRunner:
         # convergence command. Never let a service-level SKIP leak into a
         # normal autonomous agent and silently suppress repository hooks.
         env.pop("SKIP", None)
+        # Process topology must not leak into agent subprocesses: the agent's
+        # pytest run would start real schedulers inside the test process
+        # (TESTING guard covers create_app; this keeps topology out entirely so
+        # non-TESTING create_app calls are safe too). (class-2, 2026-08-15)
+        env.pop("SCHEDULER_MODE", None)
         env["GH_CONFIG_DIR"] = "/var/empty/openace-autonomous-gh"
         env["GIT_TERMINAL_PROMPT"] = "0"
         env["PATH"] = guard_bin + os.pathsep + env.get("PATH", "")

--- a/docs/superpowers/plans/2026-08-15-testing-scheduler-guard.md
+++ b/docs/superpowers/plans/2026-08-15-testing-scheduler-guard.md
@@ -213,6 +213,7 @@ psql -d ace_repro -tc "select status, paused_at from autonomous_workflows"
 ```
 
 Expected: `developing | `（未被暂停）——修复前同场景必 paused。
+（注意：本场景只验证层①；层②由 Task 2 单测覆盖——双 create_app 均为 TESTING 路径。）
 
 - [ ] **Step 3: 本地相关单测回归**
 
@@ -233,7 +234,7 @@ dropdb ace_repro
 ### Task 4: PR 与合并
 
 - [ ] 建 GitHub issue（ghost-pause 事故记录，含调用栈证据）
-- [ ] push 分支、开 PR（正文含事故摘要；**不用** `Closes #N` 关键词以外的自动关闭陷阱措辞——如需关 issue 用显式 `Fixes #N`）
+- [ ] push 分支、开 PR（正文含事故摘要；如需关联 issue 用显式 `Fixes #N`，其余措辞避免无意触发 GitHub auto-close）
 - [ ] 独立 agent 审查 `gh pr diff`（requesting-code-review 流程）至 CLEAN
 - [ ] 等 5 个 required checks 全绿（lint / test(3.10/3.11/3.12) / build）
 - [ ] `gh pr merge <N> --merge --delete-branch`

--- a/docs/superpowers/plans/2026-08-15-testing-scheduler-guard.md
+++ b/docs/superpowers/plans/2026-08-15-testing-scheduler-guard.md
@@ -1,0 +1,245 @@
+# TESTING Scheduler Guard 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 堵死「测试进程内启动真 scheduler 幽灵操作真实 DB」这一 class-2 事故类：`create_app` 在 TESTING 下硬禁后台服务 + agent 子进程 env 剔除 `SCHEDULER_MODE`。
+
+**Architecture:** 双层防御。层①（主修）在 `app/__init__.py` 的 background-services 分支加 `TESTING` 守卫——无论环境变量从哪来，测试进程都不再起 scheduler。层②（纵深）在 `agent_runner._build_agent_env` 剔除 `SCHEDULER_MODE`，使进程拓扑不随 agent 子进程泄漏（保护非 TESTING 的 create_app 调用）。
+
+**Tech Stack:** Flask `create_app` 工厂、pytest（unittest.mock patch）。
+
+**Spec:** `docs/superpowers/specs/2026-08-15-testing-scheduler-guard-design.md`
+
+---
+
+### Task 1: create_app TESTING 守卫（层①）
+
+**Files:**
+- Test: `tests/unit/test_app_testing_scheduler_guard.py`（新建）
+- Modify: `app/__init__.py:808-813`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/unit/test_app_testing_scheduler_guard.py`：
+
+```python
+"""TESTING 模式必须禁启后台服务（class-2 幽灵暂停事故，2026-08-15）。
+
+背景：server 以 SCHEDULER_MODE=scheduler 启动时，agent 子进程继承该变量；
+agent 在 worktree 内跑 pytest 时，fixture 的 create_app({"TESTING": True})
+会在测试进程内启动真实 AutonomousScheduler，对真实 DB 执行孤儿清理/推进，
+把 server 正在驱动的工作流 kill+paused。守卫：TESTING 下硬禁。
+"""
+
+from unittest.mock import patch
+
+from app import create_app
+
+
+def test_testing_mode_skips_background_services():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({"TESTING": True})
+
+    mock_sbs.assert_not_called()
+
+
+def test_scheduler_mode_still_starts_services_when_not_testing():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({"TESTING": False})
+
+    mock_sbs.assert_called_once()
+```
+
+- [ ] **Step 2: 跑测试确认失败（红）**
+
+Run: `python3 -m pytest tests/unit/test_app_testing_scheduler_guard.py -v`
+Expected: `test_testing_mode_skips_background_services` FAIL
+（`AssertionError: Expected 'start_background_services' to not have been called`）；
+`test_scheduler_mode_still_starts_services_when_not_testing` PASS（对照，守卫不误伤正路径）。
+
+- [ ] **Step 3: 最小实现**
+
+`app/__init__.py:806-813` 当前：
+
+```python
+    scheduler_mode = os.environ.get("SCHEDULER_MODE", "web")
+    if scheduler_mode == "scheduler":
+        start_background_services()
+        logger.info("Background services started (SCHEDULER_MODE=scheduler)")
+    else:
+        logger.info("Background services NOT started (SCHEDULER_MODE=%s)", scheduler_mode)
+```
+
+改为：
+
+```python
+    scheduler_mode = os.environ.get("SCHEDULER_MODE", "web")
+    # TESTING guard (class-2, 2026-08-15): a test process must never start
+    # real schedulers — they operate on the real DB (orphan-kill advancing
+    # workflows, ghost-pausing rows). Tests that need a scheduler call
+    # init_autonomous_scheduler() directly.
+    if scheduler_mode == "scheduler" and app.config.get("TESTING"):
+        logger.info("Background services skipped (TESTING mode)")
+    elif scheduler_mode == "scheduler":
+        start_background_services()
+        logger.info("Background services started (SCHEDULER_MODE=scheduler)")
+    else:
+        logger.info("Background services NOT started (SCHEDULER_MODE=%s)", scheduler_mode)
+```
+
+- [ ] **Step 4: 跑测试确认通过（绿）**
+
+Run: `python3 -m pytest tests/unit/test_app_testing_scheduler_guard.py -v`
+Expected: 2 passed。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_app_testing_scheduler_guard.py app/__init__.py
+git commit -m "fix: create_app hard-skips background services under TESTING"
+```
+
+---
+
+### Task 2: agent env 剔除 SCHEDULER_MODE（层②）
+
+**Files:**
+- Test: `tests/unit/test_autonomous_ci_guardrails.py`（扩展，模式复用同文件 `test_agent_environment_binds_python_and_git_guards`）
+- Modify: `app/modules/workspace/autonomous/agent_runner.py:1448`（`env.pop("SKIP", None)` 旁）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tests/unit/test_autonomous_ci_guardrails.py` 的
+`test_agent_environment_binds_python_and_git_guards` 之后新增：
+
+```python
+def test_agent_env_scrubs_scheduler_mode(monkeypatch, tmp_path):
+    """进程拓扑不得泄漏进 agent 子进程（class-2 幽灵暂停，2026-08-15）。
+
+    agent 继承 SCHEDULER_MODE=scheduler 后，其在 worktree 内运行的
+    pytest 会在测试进程内启动真 scheduler（TESTING 守卫之外的路径）。"""
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    monkeypatch.setenv("SCHEDULER_MODE", "scheduler")
+
+    adapter = MagicMock()
+    adapter.get_env_vars.return_value = {}
+    env = agent_runner.AutonomousAgentRunner._build_agent_env(
+        adapter,
+        "claude-code",
+        None,
+        "session",
+        "",
+        [sys.executable],
+    )
+
+    assert "SCHEDULER_MODE" not in env
+```
+
+（文件顶部已 import `MagicMock`/`sys`——若无则补。）
+
+- [ ] **Step 2: 跑测试确认失败（红）**
+
+Run: `python3 -m pytest tests/unit/test_autonomous_ci_guardrails.py::test_agent_env_scrubs_scheduler_mode -v`
+Expected: FAIL（`AssertionError: assert 'SCHEDULER_MODE' not in {...}`）。
+
+- [ ] **Step 3: 最小实现**
+
+`app/modules/workspace/autonomous/agent_runner.py`，在
+`env.pop("SKIP", None)`（约 :1448，注释块 "Never let a service-level
+SKIP leak..." 之后）紧接着加：
+
+```python
+    env.pop("SKIP", None)
+    # Process topology must not leak into agent subprocesses: the agent's
+    # pytest run would start real schedulers inside the test process
+    # (TESTING guard covers create_app; this keeps topology out entirely so
+    # non-TESTING create_app calls are safe too). (class-2, 2026-08-15)
+    env.pop("SCHEDULER_MODE", None)
+```
+
+- [ ] **Step 4: 跑测试确认通过（绿）**
+
+Run: `python3 -m pytest tests/unit/test_autonomous_ci_guardrails.py::test_agent_env_scrubs_scheduler_mode tests/unit/test_autonomous_ci_guardrails.py::test_agent_environment_binds_python_and_git_guards -v`
+Expected: 2 passed（新测试绿 + 既有相邻测试不回归）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_autonomous_ci_guardrails.py app/modules/workspace/autonomous/agent_runner.py
+git commit -m "fix: scrub SCHEDULER_MODE from agent subprocess env"
+```
+
+---
+
+### Task 3: 端到端复验（scratch 复现脚本转阴性）
+
+**Files:** 无代码改动；复用 `ace_repro` scratch 库与双 create_app 场景。
+
+- [ ] **Step 1: 重置假工作流**
+
+```bash
+psql -d ace_repro -qc "update autonomous_workflows set status='developing', paused_at=NULL, sandbox_state=NULL, agent_pid=NULL where workflow_id like '11111111%'"
+```
+
+- [ ] **Step 2: 跑修复后的双 create_app 场景**
+
+```bash
+DATABASE_URL=postgresql://rhuang@localhost/ace_repro SCHEDULER_MODE=scheduler \
+OPENACE_SECURITY_MODE=development SECRET_KEY=$(python3 -c "print('a'*48)") \
+OPENACE_ENCRYPTION_KEY=$(python3 -c "print('b'*64)") python3 - <<'EOF'
+import time
+from app import create_app
+app1 = create_app({'TESTING': True})
+time.sleep(15)
+app2 = create_app({'TESTING': True})
+time.sleep(10)
+print('DONE')
+EOF
+psql -d ace_repro -tc "select status, paused_at from autonomous_workflows"
+```
+
+Expected: `developing | `（未被暂停）——修复前同场景必 paused。
+
+- [ ] **Step 3: 本地相关单测回归**
+
+```bash
+python3 -m pytest tests/unit/test_app_testing_scheduler_guard.py tests/unit/test_autonomous_ci_guardrails.py tests/unit/test_scheduler_guard.py -q
+```
+
+Expected: 全部 passed（含 scheduler_guard 既有 20+ 用例）。
+
+- [ ] **Step 4: 清理 scratch 库**
+
+```bash
+dropdb ace_repro
+```
+
+---
+
+### Task 4: PR 与合并
+
+- [ ] 建 GitHub issue（ghost-pause 事故记录，含调用栈证据）
+- [ ] push 分支、开 PR（正文含事故摘要；**不用** `Closes #N` 关键词以外的自动关闭陷阱措辞——如需关 issue 用显式 `Fixes #N`）
+- [ ] 独立 agent 审查 `gh pr diff`（requesting-code-review 流程）至 CLEAN
+- [ ] 等 5 个 required checks 全绿（lint / test(3.10/3.11/3.12) / build）
+- [ ] `gh pr merge <N> --merge --delete-branch`
+
+### Task 5: 部署与重置（本机）
+
+- [ ] 合并后重启本机 server（`SCHEDULER_MODE=scheduler` + `generated-secrets.env`，从 main 最新代码）
+- [ ] 恢复 #2667（paused）与 reset #2491（failed，第一类测试失败 → pickup 状态 + 清 retry 计数 + 恢复 worktree_path）
+- [ ] 观察 agent 跑 pytest 后工作流不再被幽灵暂停（监控 cron 持续跟踪）

--- a/docs/superpowers/specs/2026-08-15-testing-scheduler-guard-design.md
+++ b/docs/superpowers/specs/2026-08-15-testing-scheduler-guard-design.md
@@ -52,7 +52,7 @@ create_app({'TESTING': True})
 `init_autonomous_scheduler()`（现有 test_scheduler_guard 等即如此），
 不提供逃生门环境变量。
 
-### 改动 2（纵深）：`agent_runner.py::_build_env` 剔除 SCHEDULER_MODE
+### 改动 2（纵深）：`agent_runner.py::_build_agent_env` 剔除 SCHEDULER_MODE
 
 在现有 `env.pop("SKIP", None)`（同样是"服务级 env 不进 agent"的先例）
 旁增加 `env.pop("SCHEDULER_MODE", None)`，注释说明：进程拓扑不得泄漏进

--- a/docs/superpowers/specs/2026-08-15-testing-scheduler-guard-design.md
+++ b/docs/superpowers/specs/2026-08-15-testing-scheduler-guard-design.md
@@ -1,0 +1,88 @@
+# Design: TESTING 模式禁启后台服务 + agent 子进程剔除 SCHEDULER_MODE
+
+日期：2026-08-15 · 类别：class-2（自主系统自身 bug）· 状态：已批准
+
+## 事故背景
+
+本地 dev server 以 `SCHEDULER_MODE=scheduler` 启动后，自主工作流的 agent
+在 worktree 内运行 pytest。agent 子进程继承了该环境变量，测试 fixture 调
+`create_app({"TESTING": True})` 时 `app/__init__.py` 的 scheduler 启动逻辑
+只看 `SCHEDULER_MODE`、不看 `TESTING`，导致测试进程内启动了真实的
+AutonomousScheduler，直接操作真实 dev DB：
+
+- `_cleanup_orphan_processes()` 把 server 进程正在使用的 agent_pid 视为
+  孤儿（本进程不认识），`killpg` 杀掉真实 agent，并将工作流重置为
+  `paused`（写入签名：`status=paused` + `paused_at` + `agent_pid=None` +
+  空 `error_message`，无任何 workflow 事件）；
+- 测试进程的 scheduler 还会推进真实工作流、自行 spawn agent。
+
+两次实锤（均 +1 秒时间耦合于 agent 的 pytest 启动）：
+
+1. #2491（05ad9f56）：16:44:06Z agent 运行
+   `pytest tests/unit/test_acceptance_override_2658.py` → 16:44:07 工作流被暂停；
+2. #2667（29f6df76）：01:49:51Z agent 运行
+   `pytest tests/unit/test_autonomous_models_route_2667.py` → 01:49:52 被暂停。
+
+完整调用栈（scratch 库复现 + repo 层仪表捕获）：
+
+```
+create_app({'TESTING': True})
+ └→ start_background_services()            # app/__init__.py:997
+     └→ init_autonomous_scheduler()        # autonomous_scheduler.py:1432
+         └→ _cleanup_orphan_processes()    # autonomous_scheduler.py:1142
+             └→ repo.update_workflow({'agent_pid': None, 'agent_session_id': '',
+                                      'status': 'paused', 'paused_at': now})
+```
+
+既有旁证：三个 e2e 文件顶部各自 `os.environ.setdefault("SCHEDULER_MODE",
+"web")` 打过同款补丁——坑已知但从未在源头堵住。
+
+## 修复设计（双层防御）
+
+### 改动 1（主修）：`app/__init__.py` TESTING 硬禁
+
+`create_app` 的 background-services 启动分支增加 `TESTING` 守卫：
+
+- `SCHEDULER_MODE=scheduler` 且 `app.config["TESTING"]` 为真 → **跳过**
+  `start_background_services()`，打 INFO 日志
+  `Background services skipped (TESTING mode)`；
+- 非 TESTING 行为完全不变。
+
+**硬禁无例外**（用户拍板）：需要测 scheduler 的单测直接调
+`init_autonomous_scheduler()`（现有 test_scheduler_guard 等即如此），
+不提供逃生门环境变量。
+
+### 改动 2（纵深）：`agent_runner.py::_build_env` 剔除 SCHEDULER_MODE
+
+在现有 `env.pop("SKIP", None)`（同样是"服务级 env 不进 agent"的先例）
+旁增加 `env.pop("SCHEDULER_MODE", None)`，注释说明：进程拓扑不得泄漏进
+agent 子进程——agent 运行 pytest 时会在测试进程内 create_app；层①只保护
+TESTING 路径，本层保证非 TESTING 的 create_app 调用（脚本/CLI）同样安全。
+
+只剔 `SCHEDULER_MODE` 一个变量。`OPENACE_SECURITY_MODE` 等 agent 运行时
+需要的语义不扩大剔除范围（YAGNI）。
+
+## 测试计划（TDD）
+
+1. **失败测试 ①**：`patch.dict(os.environ, {"SCHEDULER_MODE": "scheduler"})`
+   下 `create_app({"TESTING": True})` → 断言 `start_background_services`
+   未被调用（mock 断言）；
+2. **失败测试 ②**：agent env 构建（`_build_env` 等价路径）→ 断言产物中
+   无 `SCHEDULER_MODE` 键；
+3. **对照断言**：非 TESTING + `SCHEDULER_MODE=scheduler` 仍正常启动
+   （守卫不误伤正路径）；
+4. 回归：`tests/unit/test_scheduler_guard.py` 等现有单测全绿。
+
+## 验收
+
+- 上述测试转绿；
+- scratch-DB 复现脚本（双 create_app 场景）在修复后**不再**暂停假工作流；
+- 本地 server 重启部署后，恢复/重置 #2491、#2667，agent 再跑 pytest 不再
+  出现幽灵暂停。
+
+## 明确不做
+
+- 不删除 e2e 文件顶部的 `SCHEDULER_MODE=web` setdefault（它们管的是
+  子进程 server，与本守卫职责不同）；
+- 不引入逃生门 env；
+- 不重构 env 构建结构。

--- a/tests/unit/test_app_testing_scheduler_guard.py
+++ b/tests/unit/test_app_testing_scheduler_guard.py
@@ -8,7 +8,11 @@ agent 在 worktree 内跑 pytest 时，fixture 的 create_app({"TESTING": True})
 
 from unittest.mock import patch
 
+import pytest
+
 from app import create_app
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2680)]
 
 
 def test_testing_mode_skips_background_services():

--- a/tests/unit/test_app_testing_scheduler_guard.py
+++ b/tests/unit/test_app_testing_scheduler_guard.py
@@ -1,0 +1,31 @@
+"""TESTING 模式必须禁启后台服务（class-2 幽灵暂停事故，2026-08-15）。
+
+背景：server 以 SCHEDULER_MODE=scheduler 启动时，agent 子进程继承该变量；
+agent 在 worktree 内跑 pytest 时，fixture 的 create_app({"TESTING": True})
+会在测试进程内启动真实 AutonomousScheduler，对真实 DB 执行孤儿清理/推进，
+把 server 正在驱动的工作流 kill+paused。守卫：TESTING 下硬禁。
+"""
+
+from unittest.mock import patch
+
+from app import create_app
+
+
+def test_testing_mode_skips_background_services():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({"TESTING": True})
+
+    mock_sbs.assert_not_called()
+
+
+def test_scheduler_mode_still_starts_services_when_not_testing():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({"TESTING": False})
+
+    mock_sbs.assert_called_once()

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -324,6 +324,8 @@ def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
     assert "SKIP" not in env
 
 
+@pytest.mark.regression
+@pytest.mark.issue(2680)
 def test_agent_env_scrubs_scheduler_mode(monkeypatch, tmp_path):
     """进程拓扑不得泄漏进 agent 子进程（class-2 幽灵暂停，2026-08-15）。
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -324,6 +324,36 @@ def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
     assert "SKIP" not in env
 
 
+def test_agent_env_scrubs_scheduler_mode(monkeypatch, tmp_path):
+    """进程拓扑不得泄漏进 agent 子进程（class-2 幽灵暂停，2026-08-15）。
+
+    agent 继承 SCHEDULER_MODE=scheduler 后，其在 worktree 内运行的
+    pytest 会在测试进程内启动真 scheduler（TESTING 守卫之外的路径）。"""
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    monkeypatch.setenv("SCHEDULER_MODE", "scheduler")
+
+    adapter = MagicMock()
+    adapter.get_env_vars.return_value = {}
+    env = agent_runner.AutonomousAgentRunner._build_agent_env(
+        adapter,
+        "claude-code",
+        None,
+        "session",
+        "",
+        [sys.executable],
+    )
+
+    assert "SCHEDULER_MODE" not in env
+
+
 def test_agent_guard_bin_falls_back_to_source_when_install_is_incomplete(monkeypatch, tmp_path):
     from pathlib import Path
 


### PR DESCRIPTION
Fixes #2680

## 事故摘要

dev server 以 `SCHEDULER_MODE=scheduler` 启动后，agent 子进程继承该变量；agent 在 worktree 内跑 pytest 时，fixture 的 `create_app({"TESTING": True})` 因守卫缺失在**测试进程内启动真实 AutonomousScheduler**，其孤儿清理把 server 正在驱动的 agent killpg 杀掉并把工作流重置为 paused（无声：空 error_message、零事件）。两次实锤均为 agent 启动 pytest 后 +1 秒被暂停（#2491 / #2667 工作流，本机 2026-08-14/15）。完整查因、scratch 库复现与调用栈见 issue #2680。

## 修复（双层防御）

| 层 | 位置 | 内容 |
|---|---|---|
| 主修 | `app/__init__.py` | `TESTING=True` 时硬禁 `start_background_services()`，无例外；需要 scheduler 的单测直接调 `init_autonomous_scheduler()` |
| 纵深 | `agent_runner.py::_build_agent_env` | `env.pop("SCHEDULER_MODE", None)`（复用既有 `env.pop("SKIP")` 的"服务级 env 不进 agent"先例），进程拓扑不再泄漏进 agent 子进程 |

## 测试

- 新增 `tests/unit/test_app_testing_scheduler_guard.py`：TESTING 跳过 + 非 TESTING 正常启动（对照）双锁定
- 新增 `test_agent_env_scrubs_scheduler_mode`（guardrails 套件）：agent env 无 SCHEDULER_MODE
- 全部标 `@pytest.mark.regression` + `issue(2680)`
- 端到端阴性：scratch 库双 create_app 场景（修复前必 paused）修复后保持 developing；`test_scheduler_guard` / `test_autonomous_ci_guardrails` 全绿（112 passed）

## 明确不做（spec 锁定）

- 不删 e2e 文件顶部的 `SCHEDULER_MODE=web` setdefault（管子进程 server，职责不同）
- 不引入逃生门 env；不扩大 env 剔除清单（`ANTHROPIC_AUTH_TOKEN` 剥离缺口与 `DATABASE_URL` 泄漏已在 #2680 记为跟进项）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
