### PR TITLE
fix(#2673): bounded fallback for PRs with zero check-runs (event delivery gap)

### DIFF
--- a/app/modules/workspace/autonomous/constants.py
+++ b/app/modules/workspace/autonomous/constants.py
@@ -153,6 +153,13 @@ _TRANSIENT_ORCHESTRATOR_KEYWORDS = [
     "fetch first",
     "non-fast-forward",
     "[rejected]",
+    # Issue #2673: a PR head reporting zero check-runs after a mechanical
+    # close+reopen retrigger means GitHub dropped the branch's event delivery
+    # entirely (no push/synchronize/check-run events). That is transient
+    # infrastructure, not a code failure — advance()'s Layer-2 retry makes the
+    # stall visible (error_message + bounded retries) instead of a silent
+    # wait-spin.
+    "zero check-runs",
 ]
 
 

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1075,6 +1075,28 @@ class GitHubOps:
         logger.info("Reopened issue #%s", number)
         return {"number": number}
 
+    def close_pr(self, number: int) -> dict:
+        """Close a PR (api_only → service-user/bot identity).
+
+        Issue #2673: mechanical CI retrigger — closing and reopening a PR
+        re-delivers the ``pull_request`` ``closed``/``reopened`` events when
+        GitHub dropped the push/synchronize events for the head (zero
+        check-runs). This is a CI nudge, not a code/PR-content change.
+        """
+        self._run_gh(["pr", "close", str(number)], api_only=True)
+        logger.info("Closed PR #%s", number)
+        return {"number": number}
+
+    def reopen_pr(self, number: int) -> dict:
+        """Reopen a PR (api_only → service-user/bot identity).
+
+        Issue #2673: second half of the mechanical CI retrigger — see
+        :meth:`close_pr`.
+        """
+        self._run_gh(["pr", "reopen", str(number)], api_only=True)
+        logger.info("Reopened PR #%s", number)
+        return {"number": number}
+
     def list_issue_comments(self, number: int, since: str | None = None) -> list:
         """List every issue comment, optionally since a timestamp.
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1758,14 +1758,49 @@ CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 # the workflow is marked failed for manual intervention.
 TRANSIENT_RETRY_MAX = 6
 
-# Issue #2673: how many consecutive scheduler cycles a check-gated PR's head
-# must report ZERO check-runs before the mechanical retrigger (PR close+reopen)
-# fires. ~2 cycles (each ≥30s apart in practice) avoids racing slow CI
-# provisioning right after a push.
-ZERO_CHECK_RUNS_RETRIGGER_CYCLES = 2
+# Issue #2673: bounded mechanical fallback for a check-gated PR whose head
+# reports ZERO check-runs (GitHub dropped the branch's event delivery).
+# Timing model: the scheduler hot loop is ``self._stop_event.wait(10)`` with
+# no per-phase backoff, so consecutive merge cycles can arrive ~10s apart
+# (especially right after the sync_failed_pr_with_main fresh-push retry). A
+# pure cycle counter would therefore terminally retrigger/escalate a
+# slow-CI-provisioning head within a couple of minutes — a regression vs.
+# the old (recoverable) spin. The PRIMARY gate is thus the WALL-CLOCK
+# observation floor below, persisted per head SHA as ``first_seen_at`` in the
+# tracker milestone; the cycle count is only a secondary debounce on top of
+# it (retrigger requires floor elapsed AND cycles ≥ RETRIGGER_CYCLES).
+ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR = 1200  # seconds (20 minutes)
+ZERO_CHECK_RUNS_RETRIGGER_CYCLES = 2  # secondary signal; floor must ALSO elapse
+# Partial-state cap (#2673 review): after a successful close whose reopen
+# failed, total reopen attempts before the closed-PR state escalates visibly.
+ZERO_CHECK_RUNS_REOPEN_RETRY_MAX = 2
 
 # _TRANSIENT_ORCHESTRATOR_KEYWORDS + _is_transient_git_error moved to
 # constants.py (shared with phases/pr_review.py); re-imported above.
+
+
+def _utcnow() -> datetime:
+    """Patchable UTC clock for the #2673 zero-check-runs state machine.
+
+    Tests freeze this to make the wall-clock observation floor
+    (``ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR``) deterministic.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso_utc(value) -> datetime | None:
+    """Best-effort parse of an ISO timestamp from tracker metadata (#2673).
+
+    Naive timestamps are interpreted as UTC; unparsable/missing values
+    return None so callers can fall back to a conservative default.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
 
 
 # GitHub rejects comment bodies longer than 65536 chars. Agent output (plan /
@@ -8006,15 +8041,26 @@ class AutonomousOrchestrator:
         advance() resets it on every clean retry) and keyed on the verified
         head SHA so a new push starts a fresh observation window:
 
-        - zero-checks cycle 1..N-1: record the observation, defer (retry);
-        - cycle N (``ZERO_CHECK_RUNS_RETRIGGER_CYCLES``): mechanically
-          retrigger event delivery via PR close+reopen (a CI nudge, not a
-          code/PR-content change), audit it (milestone + event), defer one
-          more cycle so the reopened events can provision CI;
-        - any later zero-checks cycle: raise a transient-classified
+        - zero-check cycles BEFORE the wall-clock observation floor
+          (``ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR``, measured from the persisted
+          ``first_seen_at``): record the observation, defer (retry). The
+          scheduler hot loop (``_stop_event.wait(10)``) has no per-phase
+          backoff, so cycles alone cannot distinguish a slow-CI-provisioning
+          head from an event-delivery gap — only elapsed time can;
+        - floor elapsed AND ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` cycles
+          observed: mechanically retrigger event delivery via PR close+reopen
+          (a CI nudge, not a code/PR-content change), audit it (milestone +
+          event), then wait out a fresh floor so the reopened events can
+          provision CI. If the reopen half fails after a successful close,
+          a ``reopen_pending`` tracker state makes the next cycle RETRY the
+          reopen (bounded by ``ZERO_CHECK_RUNS_REOPEN_RETRY_MAX``) instead of
+          the closed-PR guard permanently skipping while the PR stays closed;
+        - retrigger completed and its own observation floor elapsed with
+          still-zero check-runs: raise a transient-classified
           ``GitHubOpsError`` ("zero check-runs") so advance()'s existing
           Layer-2 machinery makes the stall VISIBLE (error_message + bounded
-          retries, then a diagnosable failure) instead of silent spinning.
+          retries, then a diagnosable failure) instead of silent spinning,
+          and close the tracker milestone (status failed).
 
         Returns True when the merge cycle should defer to the next scheduler
         cycle. Returns False when the fallback does not apply (check-runs
@@ -8053,35 +8099,173 @@ class AutonomousOrchestrator:
         if not required_contexts:
             return False
 
-        tracker, meta = self._load_zero_check_runs_tracker()
+        tracker, meta, load_ok = self._load_zero_check_runs_tracker()
+        if not load_ok:
+            # The tracker state is unobservable — recording now would create
+            # a SECOND in_progress tracker while the (unread) first one stays
+            # orphaned in the timeline. Defer without recording; the next
+            # cycle re-reads the tracker.
+            logger.warning(
+                "Workflow %s PR #%s: zero-check-runs tracker unobservable; "
+                "deferring without recording to avoid a duplicate tracker",
+                self._workflow_id[:8],
+                pr_number,
+            )
+            return True
+
+        now = _utcnow()
         if tracker is not None and meta.get("head_sha") == head:
             cycles = int(meta.get("cycles") or 0)
             retriggered = bool(meta.get("retriggered"))
+            reopen_pending = bool(meta.get("reopen_pending"))
+            reopen_attempts = int(meta.get("reopen_attempts") or 0)
+            # A pre-floor tracker (no first_seen_at) restarts the observation
+            # floor from now — never retrigger/escalate EARLY.
+            first_seen = _parse_iso_utc(meta.get("first_seen_at")) or now
+            # A retriggered tracker missing retriggered_at falls back to
+            # first_seen (always earlier) — the conservative direction.
+            retriggered_at = _parse_iso_utc(meta.get("retriggered_at")) or first_seen
         else:
             # No tracker, or the head moved (new push): fresh window.
             cycles = 0
             retriggered = False
+            reopen_pending = False
+            reopen_attempts = 0
+            first_seen = now
+            retriggered_at = now
         cycles += 1
+        floor_elapsed = (now - first_seen).total_seconds() >= ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR
+        record = {
+            "head_sha": head,
+            "cycles": cycles,
+            "first_seen_at": first_seen.isoformat(),
+            "retriggered": retriggered,
+            "retriggered_at": retriggered_at.isoformat() if retriggered else "",
+            "reopen_pending": reopen_pending,
+            "reopen_attempts": reopen_attempts,
+        }
+
+        if reopen_pending:
+            # A previous cycle closed the PR but the reopen half failed: the
+            # PR is sitting CLOSED with a half-fired retrigger. Retry the
+            # reopen (bounded) instead of letting the closed-PR guard skip
+            # the retrigger forever (#2673 review: partial state).
+            try:
+                pr_state = str((gh.get_pr(pr_number) or {}).get("state") or "").lower()
+            except GitHubOpsError:
+                logger.warning(
+                    "Workflow %s PR #%s: could not read PR state before the "
+                    "zero-check-runs reopen retry; deferring to next cycle",
+                    self._workflow_id[:8],
+                    pr_number,
+                )
+                return True
+            if pr_state == "open":
+                # Reopened out-of-band (manual, or the earlier failure was
+                # spurious): the retrigger is complete — start its floor.
+                record["reopen_pending"] = False
+                record["retriggered"] = True
+                record["retriggered_at"] = now.isoformat()
+                self._record_zero_check_runs_tracker(tracker, record, pr_number=pr_number)
+                logger.info(
+                    "Workflow %s PR #%s: reopen-pending resolved (PR is open "
+                    "again); zero-check-runs retrigger considered complete",
+                    self._workflow_id[:8],
+                    pr_number,
+                )
+                return True
+            if reopen_attempts >= ZERO_CHECK_RUNS_REOPEN_RETRY_MAX:
+                err = GitHubOpsError(
+                    f"PR #{pr_number} head {head} reports zero check-runs and "
+                    f"stays closed: reopen failed after {reopen_attempts} "
+                    f"attempts — GitHub event delivery gap on this branch; "
+                    f"treating as transient infrastructure"
+                )
+                self._finalize_zero_check_runs_tracker(tracker, "failed", str(err))
+                logger.error(
+                    "Workflow %s PR #%s: zero-check-runs reopen retry "
+                    "exhausted (head=%s, attempts=%d) — escalating as "
+                    "transient infrastructure",
+                    self._workflow_id[:8],
+                    pr_number,
+                    head,
+                    reopen_attempts,
+                )
+                raise err
+            try:
+                gh.reopen_pr(pr_number)
+            except GitHubOpsError as exc:
+                record["reopen_attempts"] = reopen_attempts + 1
+                self._record_zero_check_runs_tracker(
+                    tracker, record, pr_number=pr_number, error_message=str(exc)
+                )
+                logger.warning(
+                    "Workflow %s PR #%s: zero-check-runs reopen retry %d "
+                    "failed (%s); deferring to next cycle",
+                    self._workflow_id[:8],
+                    pr_number,
+                    reopen_attempts + 1,
+                    exc,
+                )
+                return True
+            record["reopen_pending"] = False
+            record["retriggered"] = True
+            record["retriggered_at"] = now.isoformat()
+            record["reopen_attempts"] = reopen_attempts + 1
+            self._record_zero_check_runs_tracker(
+                tracker,
+                record,
+                pr_number=pr_number,
+                summary=(
+                    f"Retriggered CI via PR close+reopen " f"(reopen retry {reopen_attempts + 1})"
+                ),
+            )
+            self._emit(
+                "zero_check_runs_retrigger",
+                {
+                    "pr_number": pr_number,
+                    "head_sha": head,
+                    "cycles": cycles,
+                    "action": "reopen_retry",
+                },
+            )
+            logger.warning(
+                "Workflow %s PR #%s: zero-check-runs reopen retry succeeded "
+                "(head=%s) — event delivery retriggered (issue #2673)",
+                self._workflow_id[:8],
+                pr_number,
+                head,
+            )
+            return True
 
         if retriggered:
-            # The close+reopen retrigger already fired (cycle N) and at least
-            # one further cycle has elapsed — GitHub still reports zero
-            # check-runs for this head. Escalate as transient infrastructure
-            # (keyword-matched in _TRANSIENT_ORCHESTRATOR_KEYWORDS) so
-            # advance() retries with backoff and finally fails visibly.
+            if (now - retriggered_at).total_seconds() < ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR:
+                # The retrigger fired but its own observation floor has not
+                # elapsed yet — CI provisioning after the reopened events
+                # takes time. Keep observing, do not escalate.
+                self._record_zero_check_runs_tracker(tracker, record, pr_number=pr_number)
+                logger.info(
+                    "Workflow %s PR #%s: zero check-runs after the retrigger "
+                    "(head=%s, cycle=%d) — within the observation floor, "
+                    "deferring",
+                    self._workflow_id[:8],
+                    pr_number,
+                    head,
+                    cycles,
+                )
+                return True
+            # The close+reopen retrigger fired and its observation floor
+            # elapsed — GitHub still reports zero check-runs for this head.
+            # Escalate as transient infrastructure (keyword-matched in
+            # _TRANSIENT_ORCHESTRATOR_KEYWORDS) so advance() retries with
+            # backoff and finally fails visibly; close the tracker so no
+            # in_progress orphan remains.
             err = GitHubOpsError(
                 f"PR #{pr_number} head {head} reports zero check-runs after a "
                 f"close+reopen retrigger — GitHub event delivery gap on this "
                 f"branch; treating as transient infrastructure"
             )
-            self._record_zero_check_runs_tracker(
-                tracker,
-                head,
-                cycles,
-                retriggered=True,
-                pr_number=pr_number,
-                error_message=str(err),
-            )
+            self._finalize_zero_check_runs_tracker(tracker, "failed", str(err))
             logger.error(
                 "Workflow %s PR #%s: zero check-runs persisted past the "
                 "mechanical retrigger (head=%s, cycle=%d) — escalating as "
@@ -8093,10 +8277,11 @@ class AutonomousOrchestrator:
             )
             raise err
 
-        if cycles >= ZERO_CHECK_RUNS_RETRIGGER_CYCLES:
-            # Threshold reached: nudge event delivery via close+reopen. Only
-            # meaningful on an open PR — a closed one falls through to the
-            # legacy merge path (its rejection handles it).
+        if floor_elapsed and cycles >= ZERO_CHECK_RUNS_RETRIGGER_CYCLES:
+            # Observation floor elapsed AND enough cycles observed: nudge
+            # event delivery via close+reopen. Only meaningful on an open PR
+            # — a closed one falls through to the legacy merge path (its
+            # rejection handles it).
             try:
                 pr_state = str((gh.get_pr(pr_number) or {}).get("state") or "").lower()
             except GitHubOpsError:
@@ -8116,12 +8301,32 @@ class AutonomousOrchestrator:
                 )
                 return False
             gh.close_pr(pr_number)
-            gh.reopen_pr(pr_number)
+            try:
+                gh.reopen_pr(pr_number)
+            except GitHubOpsError as exc:
+                # Partial state: the close succeeded but the reopen failed —
+                # the PR is now CLOSED. Record reopen_pending so the next
+                # cycle retries the reopen instead of the closed-PR guard
+                # permanently skipping the retrigger (#2673 review).
+                record["reopen_pending"] = True
+                record["reopen_attempts"] = 1
+                self._record_zero_check_runs_tracker(
+                    tracker, record, pr_number=pr_number, error_message=str(exc)
+                )
+                logger.warning(
+                    "Workflow %s PR #%s: zero-check-runs retrigger closed the "
+                    "PR but the reopen failed (%s) — reopen_pending recorded, "
+                    "retrying next cycle",
+                    self._workflow_id[:8],
+                    pr_number,
+                    exc,
+                )
+                return True
+            record["retriggered"] = True
+            record["retriggered_at"] = now.isoformat()
             self._record_zero_check_runs_tracker(
                 tracker,
-                head,
-                cycles,
-                retriggered=True,
+                record,
                 pr_number=pr_number,
                 summary=f"Retriggered CI via PR close+reopen (cycle {cycles})",
             )
@@ -8136,33 +8341,40 @@ class AutonomousOrchestrator:
             )
             logger.warning(
                 "Workflow %s PR #%s: head %s has had zero check-runs for %d "
-                "consecutive cycles — mechanically retriggered event delivery "
-                "via PR close+reopen (issue #2673)",
+                "consecutive cycles past the %ds observation floor — "
+                "mechanically retriggered event delivery via PR close+reopen "
+                "(issue #2673)",
                 self._workflow_id[:8],
                 pr_number,
                 head,
                 cycles,
+                ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR,
             )
             return True
 
         # Below the threshold: this may just be slow CI provisioning right
         # after the push. Record the observation and defer.
-        self._record_zero_check_runs_tracker(
-            tracker, head, cycles, retriggered=False, pr_number=pr_number
-        )
+        self._record_zero_check_runs_tracker(tracker, record, pr_number=pr_number)
+        elapsed_s = int((now - first_seen).total_seconds())
         logger.info(
             "Workflow %s PR #%s: head %s reports zero check-runs "
-            "(observation %d/%d, issue #2673)",
+            "(observation %d cycles, %ds/%ds floor elapsed, issue #2673)",
             self._workflow_id[:8],
             pr_number,
             head,
             cycles,
-            ZERO_CHECK_RUNS_RETRIGGER_CYCLES,
+            elapsed_s,
+            ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR,
         )
         return True
 
-    def _load_zero_check_runs_tracker(self) -> tuple[dict | None, dict]:
-        """Return (latest open pr_zero_check_runs milestone, parsed metadata)."""
+    def _load_zero_check_runs_tracker(self) -> tuple[dict | None, dict, bool]:
+        """Return (latest open pr_zero_check_runs milestone, parsed metadata,
+        load_ok).
+
+        ``load_ok`` is False when the milestone list itself failed: callers
+        must then NOT record (a create would orphan the unread tracker).
+        """
         try:
             milestones = self.repo.list_milestones(
                 self._workflow_id, phase="merge", status="in_progress"
@@ -8173,7 +8385,7 @@ class AutonomousOrchestrator:
                 self._workflow_id[:8],
                 exc,
             )
-            return None, {}
+            return None, {}, False
         for ms in reversed(milestones or []):
             if ms.get("milestone_type") != "pr_zero_check_runs":
                 continue
@@ -8181,22 +8393,25 @@ class AutonomousOrchestrator:
                 meta = json.loads(ms.get("metadata") or "{}")
             except (json.JSONDecodeError, TypeError):
                 meta = {}
-            return ms, meta if isinstance(meta, dict) else {}
-        return None, {}
+            return ms, meta if isinstance(meta, dict) else {}, True
+        return None, {}, True
 
     def _record_zero_check_runs_tracker(
         self,
         tracker: dict | None,
-        head: str,
-        cycles: int,
+        record: dict,
         *,
-        retriggered: bool,
         pr_number: int,
         summary: str = "",
         error_message: str = "",
     ) -> None:
-        """Create/update the pr_zero_check_runs milestone (audit + counter)."""
-        metadata = json.dumps({"head_sha": head, "cycles": cycles, "retriggered": retriggered})
+        """Create/update the pr_zero_check_runs milestone (audit + state).
+
+        ``record`` is the full tracker metadata dict (head_sha, cycles,
+        first_seen_at, retriggered, retriggered_at, reopen_pending,
+        reopen_attempts).
+        """
+        metadata = json.dumps(record)
         dev_round = int((self.workflow or {}).get("dev_round", 1) or 1)
         if tracker is not None:
             updates: dict = {"metadata": metadata}
@@ -8230,10 +8445,28 @@ class AutonomousOrchestrator:
             },
         )
 
+    def _finalize_zero_check_runs_tracker(
+        self, tracker: dict | None, status: str, error_message: str = ""
+    ) -> None:
+        """Terminal close of the tracker on the escalation path (#2673).
+
+        Update-only: with no loaded tracker there is nothing to close (the
+        caller defers instead of recording when the load failed).
+        """
+        if tracker is None:
+            return
+        updates = {
+            "status": status,
+            "result_summary": ("Zero-check-runs episode escalated as transient infrastructure"),
+        }
+        if error_message:
+            updates["error_message"] = error_message
+        self.repo.update_milestone(tracker.get("milestone_id", ""), updates)
+
     def _close_zero_check_runs_tracker(self) -> None:
         """Complete an open tracker when check-runs appear again (#2673)."""
-        tracker, _meta = self._load_zero_check_runs_tracker()
-        if tracker is None:
+        tracker, _meta, load_ok = self._load_zero_check_runs_tracker()
+        if not load_ok or tracker is None:
             return
         self.repo.update_milestone(
             tracker.get("milestone_id", ""),

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1758,6 +1758,12 @@ CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 # the workflow is marked failed for manual intervention.
 TRANSIENT_RETRY_MAX = 6
 
+# Issue #2673: how many consecutive scheduler cycles a check-gated PR's head
+# must report ZERO check-runs before the mechanical retrigger (PR close+reopen)
+# fires. ~2 cycles (each ≥30s apart in practice) avoids racing slow CI
+# provisioning right after a push.
+ZERO_CHECK_RUNS_RETRIGGER_CYCLES = 2
+
 # _TRANSIENT_ORCHESTRATOR_KEYWORDS + _is_transient_git_error moved to
 # constants.py (shared with phases/pr_review.py); re-imported above.
 
@@ -7980,6 +7986,262 @@ class AutonomousOrchestrator:
 
     def resolve_merge_conflicts(self, gh, branch_name, pr_number):
         return self._resolve_merge_conflicts(gh, branch_name, pr_number)
+
+    def zero_check_runs_fallback(self, gh, pr_number, pr_head_sha, base_branch, checks):
+        return self._zero_check_runs_fallback(gh, pr_number, pr_head_sha, base_branch, checks)
+
+    def _zero_check_runs_fallback(
+        self, gh, pr_number: int, pr_head_sha: str, base_branch: str, checks: list
+    ) -> bool:
+        """Issue #2673: bounded mechanical fallback for a zero-check-runs PR.
+
+        A GitHub event-delivery gap leaves a PR's head with ZERO check-runs
+        (no push/synchronize events, so ci.yml never runs): required checks
+        can then never appear, ``mergeStateStatus`` stays BLOCKED, and the
+        merge phase used to retry silently forever with no detection, no
+        fallback and no alert (workflow #2550 / PR #2578 spun 4h+).
+
+        State machine, persisted in a ``pr_zero_check_runs`` milestone (no
+        schema change; ``transient_retry_count`` is unusable because
+        advance() resets it on every clean retry) and keyed on the verified
+        head SHA so a new push starts a fresh observation window:
+
+        - zero-checks cycle 1..N-1: record the observation, defer (retry);
+        - cycle N (``ZERO_CHECK_RUNS_RETRIGGER_CYCLES``): mechanically
+          retrigger event delivery via PR close+reopen (a CI nudge, not a
+          code/PR-content change), audit it (milestone + event), defer one
+          more cycle so the reopened events can provision CI;
+        - any later zero-checks cycle: raise a transient-classified
+          ``GitHubOpsError`` ("zero check-runs") so advance()'s existing
+          Layer-2 machinery makes the stall VISIBLE (error_message + bounded
+          retries, then a diagnosable failure) instead of silent spinning.
+
+        Returns True when the merge cycle should defer to the next scheduler
+        cycle. Returns False when the fallback does not apply (check-runs
+        present — closes out any open tracker; base branch requires no
+        checks; required set unobservable; PR not open; head SHA missing).
+        """
+        head = (pr_head_sha or "").strip()
+        if checks:
+            # Check-runs exist — delivery is healthy. Close out any tracker
+            # an earlier zero-check episode left open so the timeline shows
+            # the episode ended.
+            self._close_zero_check_runs_tracker()
+            return False
+        if not head:
+            return False
+
+        # Zero check-runs is only an incident when the base branch actually
+        # REQUIRES checks — otherwise it is the normal state of a repo with
+        # no CI gating and the merge must proceed untouched. An unobservable
+        # required set degrades to the legacy behaviour (no fallback) rather
+        # than fabricating an incident (#1989 fail-closed spirit).
+        try:
+            protection = gh.get_branch_protection(base_branch)
+            required_contexts = set(
+                ((protection or {}).get("required_status_checks") or {}).get("contexts") or []
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade, never block the merge
+            logger.warning(
+                "Workflow %s: could not resolve required checks for '%s' "
+                "before the zero-check-runs fallback: %s",
+                self._workflow_id[:8],
+                base_branch,
+                exc,
+            )
+            return False
+        if not required_contexts:
+            return False
+
+        tracker, meta = self._load_zero_check_runs_tracker()
+        if tracker is not None and meta.get("head_sha") == head:
+            cycles = int(meta.get("cycles") or 0)
+            retriggered = bool(meta.get("retriggered"))
+        else:
+            # No tracker, or the head moved (new push): fresh window.
+            cycles = 0
+            retriggered = False
+        cycles += 1
+
+        if retriggered:
+            # The close+reopen retrigger already fired (cycle N) and at least
+            # one further cycle has elapsed — GitHub still reports zero
+            # check-runs for this head. Escalate as transient infrastructure
+            # (keyword-matched in _TRANSIENT_ORCHESTRATOR_KEYWORDS) so
+            # advance() retries with backoff and finally fails visibly.
+            err = GitHubOpsError(
+                f"PR #{pr_number} head {head} reports zero check-runs after a "
+                f"close+reopen retrigger — GitHub event delivery gap on this "
+                f"branch; treating as transient infrastructure"
+            )
+            self._record_zero_check_runs_tracker(
+                tracker,
+                head,
+                cycles,
+                retriggered=True,
+                pr_number=pr_number,
+                error_message=str(err),
+            )
+            logger.error(
+                "Workflow %s PR #%s: zero check-runs persisted past the "
+                "mechanical retrigger (head=%s, cycle=%d) — escalating as "
+                "transient infrastructure",
+                self._workflow_id[:8],
+                pr_number,
+                head,
+                cycles,
+            )
+            raise err
+
+        if cycles >= ZERO_CHECK_RUNS_RETRIGGER_CYCLES:
+            # Threshold reached: nudge event delivery via close+reopen. Only
+            # meaningful on an open PR — a closed one falls through to the
+            # legacy merge path (its rejection handles it).
+            try:
+                pr_state = str((gh.get_pr(pr_number) or {}).get("state") or "").lower()
+            except GitHubOpsError:
+                logger.warning(
+                    "Workflow %s PR #%s: could not read PR state before the "
+                    "zero-check-runs retrigger; deferring to next cycle",
+                    self._workflow_id[:8],
+                    pr_number,
+                )
+                return True
+            if pr_state != "open":
+                logger.info(
+                    "Workflow %s PR #%s is %s; skipping zero-check-runs retrigger",
+                    self._workflow_id[:8],
+                    pr_number,
+                    pr_state or "unknown",
+                )
+                return False
+            gh.close_pr(pr_number)
+            gh.reopen_pr(pr_number)
+            self._record_zero_check_runs_tracker(
+                tracker,
+                head,
+                cycles,
+                retriggered=True,
+                pr_number=pr_number,
+                summary=f"Retriggered CI via PR close+reopen (cycle {cycles})",
+            )
+            self._emit(
+                "zero_check_runs_retrigger",
+                {
+                    "pr_number": pr_number,
+                    "head_sha": head,
+                    "cycles": cycles,
+                    "action": "close_reopen",
+                },
+            )
+            logger.warning(
+                "Workflow %s PR #%s: head %s has had zero check-runs for %d "
+                "consecutive cycles — mechanically retriggered event delivery "
+                "via PR close+reopen (issue #2673)",
+                self._workflow_id[:8],
+                pr_number,
+                head,
+                cycles,
+            )
+            return True
+
+        # Below the threshold: this may just be slow CI provisioning right
+        # after the push. Record the observation and defer.
+        self._record_zero_check_runs_tracker(
+            tracker, head, cycles, retriggered=False, pr_number=pr_number
+        )
+        logger.info(
+            "Workflow %s PR #%s: head %s reports zero check-runs "
+            "(observation %d/%d, issue #2673)",
+            self._workflow_id[:8],
+            pr_number,
+            head,
+            cycles,
+            ZERO_CHECK_RUNS_RETRIGGER_CYCLES,
+        )
+        return True
+
+    def _load_zero_check_runs_tracker(self) -> tuple[dict | None, dict]:
+        """Return (latest open pr_zero_check_runs milestone, parsed metadata)."""
+        try:
+            milestones = self.repo.list_milestones(
+                self._workflow_id, phase="merge", status="in_progress"
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade, never block the merge
+            logger.warning(
+                "Workflow %s: could not list milestones for the zero-check-runs " "tracker: %s",
+                self._workflow_id[:8],
+                exc,
+            )
+            return None, {}
+        for ms in reversed(milestones or []):
+            if ms.get("milestone_type") != "pr_zero_check_runs":
+                continue
+            try:
+                meta = json.loads(ms.get("metadata") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+            return ms, meta if isinstance(meta, dict) else {}
+        return None, {}
+
+    def _record_zero_check_runs_tracker(
+        self,
+        tracker: dict | None,
+        head: str,
+        cycles: int,
+        *,
+        retriggered: bool,
+        pr_number: int,
+        summary: str = "",
+        error_message: str = "",
+    ) -> None:
+        """Create/update the pr_zero_check_runs milestone (audit + counter)."""
+        metadata = json.dumps({"head_sha": head, "cycles": cycles, "retriggered": retriggered})
+        dev_round = int((self.workflow or {}).get("dev_round", 1) or 1)
+        if tracker is not None:
+            updates: dict = {"metadata": metadata}
+            if summary:
+                updates["result_summary"] = summary
+            if error_message:
+                updates["error_message"] = error_message
+            self.repo.update_milestone(tracker.get("milestone_id", ""), updates)
+            return
+        kwargs = {
+            "workflow_id": self._workflow_id,
+            "phase": "merge",
+            "milestone_type": "pr_zero_check_runs",
+            "status": "in_progress",
+            "dev_round": dev_round,
+            "github_pr_number": pr_number,
+            "title": f"PR #{pr_number} head reports zero check-runs (issue #2673)",
+            "metadata": metadata,
+        }
+        if summary:
+            kwargs["result_summary"] = summary
+        if error_message:
+            kwargs["error_message"] = error_message
+        ms = self.repo.create_milestone(kwargs)
+        self._emit(
+            "milestone_created",
+            {
+                "milestone_id": (ms or {}).get("milestone_id", ""),
+                "milestone_type": "pr_zero_check_runs",
+                "title": kwargs["title"],
+            },
+        )
+
+    def _close_zero_check_runs_tracker(self) -> None:
+        """Complete an open tracker when check-runs appear again (#2673)."""
+        tracker, _meta = self._load_zero_check_runs_tracker()
+        if tracker is None:
+            return
+        self.repo.update_milestone(
+            tracker.get("milestone_id", ""),
+            {
+                "status": "completed",
+                "result_summary": "Check-runs appeared; zero-check-runs episode ended",
+            },
+        )
 
     # --- PhaseHost pr_review-phase helpers (#2044 Phase B T11) ---
     # Thin public aliases over the orchestrator-private underscore helpers so

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -158,15 +158,16 @@ class PhaseHost(Protocol):
 
     def zero_check_runs_fallback(self, gh, pr_number, pr_head_sha, base_branch, checks) -> bool:
         """Issue #2673: bounded mechanical fallback for a PR head reporting
-        ZERO check-runs (GitHub event-delivery gap). Persists its cycle
-        counter in a ``pr_zero_check_runs`` milestone, retriggers event
-        delivery via PR close+reopen after
-        ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` consecutive zero-check cycles,
-        then escalates a still-zero head as a transient-classified
-        ``GitHubOpsError``. Returns True when it took over the cycle (caller
-        should defer). Stays on the host because the counter/audit state is
-        orchestrator bookkeeping (milestones + events), not a service-owned
-        field.
+        ZERO check-runs (GitHub event-delivery gap). Persists its observation
+        window in a ``pr_zero_check_runs`` milestone (first_seen_at wall-clock
+        floor + cycle counter), retriggers event delivery via PR close+reopen
+        once ``ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR`` elapsed AND
+        ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` cycles were observed (retrying a
+        failed reopen via a bounded ``reopen_pending`` state), then escalates
+        a still-zero head as a transient-classified ``GitHubOpsError``.
+        Returns True when it took over the cycle (caller should defer).
+        Stays on the host because the counter/audit state is orchestrator
+        bookkeeping (milestones + events), not a service-owned field.
         """
 
     # ── PR-review-phase helpers (#2044 Phase B T11) ──────────────────────────

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -156,6 +156,19 @@ class PhaseHost(Protocol):
         git_workspace service directly for what is logically a phase action.
         """
 
+    def zero_check_runs_fallback(self, gh, pr_number, pr_head_sha, base_branch, checks) -> bool:
+        """Issue #2673: bounded mechanical fallback for a PR head reporting
+        ZERO check-runs (GitHub event-delivery gap). Persists its cycle
+        counter in a ``pr_zero_check_runs`` milestone, retriggers event
+        delivery via PR close+reopen after
+        ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` consecutive zero-check cycles,
+        then escalates a still-zero head as a transient-classified
+        ``GitHubOpsError``. Returns True when it took over the cycle (caller
+        should defer). Stays on the host because the counter/audit state is
+        orchestrator bookkeeping (milestones + events), not a service-owned
+        field.
+        """
+
     # ── PR-review-phase helpers (#2044 Phase B T11) ──────────────────────────
     # Same rationale as the merge helpers above: orchestrator-private methods
     # (agent runner wrappers, artifact readers, CI polling, scope validation,

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -269,6 +269,24 @@ def handle(ctx, deps) -> PhaseResult:
                 raise GitHubOpsError(
                     f"Unable to query CI checks before merging PR #{pr_number}: {e}"
                 ) from e
+            # Issue #2673: a PR whose head reports ZERO check-runs on a
+            # check-gated base is the GitHub event-delivery-gap signature —
+            # required checks can never appear, so the merge below can only
+            # be rejected and the phase used to retry silently forever.
+            # ``zero_check_runs_fallback`` owns the gate (only fires when the
+            # base branch actually requires checks), the bounded cycle
+            # counter, the close+reopen retrigger and the final visible
+            # transient escalation. With check-runs present the same call
+            # just closes out any tracker an earlier episode left open.
+            if not checks:
+                if deps.host.zero_check_runs_fallback(
+                    gh, pr_number, pr_head_sha, base_branch, checks
+                ):
+                    return PhaseResult.retry()
+            elif deps.host.zero_check_runs_fallback(
+                gh, pr_number, pr_head_sha, base_branch, checks
+            ):
+                return PhaseResult.retry()
             failed = _ci_repair_targets(checks)
             if failed:
                 deps.host.start_ci_repair_round(wf, pr_number, failed)

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -274,18 +274,12 @@ def handle(ctx, deps) -> PhaseResult:
             # required checks can never appear, so the merge below can only
             # be rejected and the phase used to retry silently forever.
             # ``zero_check_runs_fallback`` owns the gate (only fires when the
-            # base branch actually requires checks), the bounded cycle
-            # counter, the close+reopen retrigger and the final visible
-            # transient escalation. With check-runs present the same call
-            # just closes out any tracker an earlier episode left open.
-            if not checks:
-                if deps.host.zero_check_runs_fallback(
-                    gh, pr_number, pr_head_sha, base_branch, checks
-                ):
-                    return PhaseResult.retry()
-            elif deps.host.zero_check_runs_fallback(
-                gh, pr_number, pr_head_sha, base_branch, checks
-            ):
+            # base branch actually requires checks), the wall-clock floored
+            # observation window, the close+reopen retrigger and the final
+            # visible transient escalation. With check-runs present the same
+            # call just closes out any tracker an earlier episode left open
+            # (returning False) — one unconditional call, no branching.
+            if deps.host.zero_check_runs_fallback(gh, pr_number, pr_head_sha, base_branch, checks):
                 return PhaseResult.retry()
             failed = _ci_repair_targets(checks)
             if failed:

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -56,6 +56,9 @@ def _build_deps(
     host = MagicMock(name="host")
     # perform_git_cleanup returns (status, error) — default to completed.
     host.perform_git_cleanup.return_value = ("completed", "")
+    # zero_check_runs_fallback returns False (did not take over the cycle) by
+    # default; only zero-check-runs tests opt into True (#2673).
+    host.zero_check_runs_fallback.return_value = False
     # validate_pre_merge_change_scope returns "" (no scope error) by default;
     # tests that want the scope-fail branch override this.
     host.validate_pre_merge_change_scope.return_value = ""
@@ -334,3 +337,61 @@ def test_merge_policy_block_with_settled_ci_still_pauses():
 
     assert result.outcome == "pause"
     host.emit_status_change.assert_called_once()
+
+
+# ── zero check-runs fallback (#2673) ──────────────────────────────────────
+
+
+def test_merge_zero_check_runs_with_required_gate_defers_to_fallback():
+    """A PR whose head reports ZERO check-runs on a check-gated base branch is
+    the #2673 signature (GitHub event-delivery gap): required checks can never
+    appear, so attempting the merge can only be rejected. The handler must
+    hand the cycle to the bounded mechanical fallback instead."""
+    deps, host = _build_deps(
+        checks=[],
+        merge_state={"mergeable": True, "mergeable_state": "blocked"},
+    )
+    deps.gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": ["PR Gate"]}
+    }
+    host.zero_check_runs_fallback.return_value = True
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert isinstance(result, PhaseResult)
+    assert result.outcome == "retry"
+    host.zero_check_runs_fallback.assert_called_once_with(deps.gh, 123, "abc123", "main", [])
+    # The merge attempt is deferred to the fallback — merge_pr is not called.
+    deps.gh.merge_pr.assert_not_called()
+
+
+def test_merge_zero_check_runs_ungated_base_merges_directly():
+    """Zero check-runs on a base branch with NO required checks is the normal
+    state (no CI gating). The handler still consults the fallback (the gate —
+    required-contexts — lives inside it), but its False return lets the merge
+    proceed untouched."""
+    deps, host = _build_deps(
+        checks=[],
+        merge_state={"mergeable": True, "mergeable_state": "clean"},
+    )
+    deps.gh.get_branch_protection.return_value = {"required_status_checks": {"contexts": []}}
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    host.zero_check_runs_fallback.assert_called_once_with(deps.gh, 123, "abc123", "main", [])
+    deps.gh.merge_pr.assert_called_once_with(123, strategy="merge")
+
+
+def test_merge_checks_present_closes_out_tracker_and_merges():
+    """With check-runs present the fallback is only a tracker close-out call
+    (returns False); the normal merge flow is untouched."""
+    deps, host = _build_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],
+        merge_state={"mergeable": True, "mergeable_state": "clean"},
+    )
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    host.zero_check_runs_fallback.assert_called_once_with(
+        deps.gh, 123, "abc123", "main", [{"name": "PR Gate", "bucket": "pass"}]
+    )
+    deps.gh.merge_pr.assert_called_once_with(123, strategy="merge")

--- a/tests/autonomous/test_phase_host_contract.py
+++ b/tests/autonomous/test_phase_host_contract.py
@@ -24,6 +24,9 @@ def test_phase_host_protocol_has_narrow_surface():
         "start_ci_repair_round",
         "perform_git_cleanup",
         "resolve_merge_conflicts",
+        # Issue #2673: zero-check-runs fallback (milestone-backed counter +
+        # close+reopen retrigger + transient escalation).
+        "zero_check_runs_fallback",
     ]:
         assert hasattr(PhaseHost, method), f"PhaseHost missing {method}"
     # annotation-only data member lives in __annotations__, not dir()

--- a/tests/autonomous/test_zero_check_runs_fallback.py
+++ b/tests/autonomous/test_zero_check_runs_fallback.py
@@ -1,0 +1,261 @@
+"""Issue #2673: zero-check-runs fallback state machine (merge phase).
+
+A GitHub event-delivery gap leaves a PR's head with ZERO check-runs: no push,
+no pull_request synchronize, no check-run is ever created. Required checks
+then stay pending forever, mergeState stays BLOCKED, and the merge phase used
+to retry silently every scheduler cycle with no detection, no fallback and no
+alert (workflow #2550 / PR #2578 spun 4h+).
+
+These tests pin the orchestrator-side fallback host helper
+(``zero_check_runs_fallback``) that the merge handler calls when the PR's
+checks come back empty:
+
+- cycle accounting persists in a ``pr_zero_check_runs`` milestone (no schema
+  change), keyed on the verified head SHA so a new push resets the window;
+- after ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` consecutive zero-check cycles the
+  helper mechanically retriggers event delivery via PR close+reopen;
+- one cycle after the retrigger, still-zero check-runs escalates to a
+  transient-classified ``GitHubOpsError`` so advance()'s existing transient
+  machinery makes the stall VISIBLE (error_message + bounded retries) instead
+  of silent spinning;
+- a PR on a base branch with NO required checks never enters the fallback
+  (zero check-runs is the normal state there, the merge proceeds directly).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.constants import _TRANSIENT_ORCHESTRATOR_KEYWORDS
+from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+# ── Harness ──────────────────────────────────────────────────────────────────
+
+
+def _make_orchestrator(workflow: dict) -> AutonomousOrchestrator:
+    """Build an orchestrator whose repo/emitter are fully mocked.
+
+    Follows tests/autonomous/test_orchestrator_characterization.py: patch the
+    DB/repo/session constructions at import time so __init__ does no real
+    work, then drive ``o.repo`` as a MagicMock.
+    """
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch("app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"),
+        patch("app.modules.workspace.session_manager.SessionManager"),
+        patch("app.modules.workspace.autonomous.agent_runner.AutonomousAgentRunner"),
+    ):
+        o = AutonomousOrchestrator(workflow.get("workflow_id", "wf-test"))
+    o.repo = MagicMock(name="repo")
+    o.repo.get_workflow.return_value = dict(workflow)
+    o.emitter = MagicMock(name="emitter")
+    return o
+
+
+def _workflow(**overrides) -> dict:
+    wf = {
+        "workflow_id": "wf-test",
+        "status": "merging",
+        "current_phase": "merge",
+        "github_pr_number": 2578,
+        "branch_name": "auto-dev/wf-test",
+        "original_branch_name": "main",
+        "dev_round": 1,
+        "transient_retry_count": 0,
+    }
+    wf.update(overrides)
+    return wf
+
+
+def _tracker_milestone(
+    head_sha: str = "abc123", cycles: int = 1, retriggered: bool = False
+) -> dict:
+    return {
+        "milestone_id": "ms-zero-1",
+        "workflow_id": "wf-test",
+        "phase": "merge",
+        "milestone_type": "pr_zero_check_runs",
+        "status": "in_progress",
+        "metadata": json.dumps(
+            {"head_sha": head_sha, "cycles": cycles, "retriggered": retriggered}
+        ),
+    }
+
+
+def _gh(
+    *,
+    required: list[str] | None = None,
+    pr_state: str = "open",
+) -> MagicMock:
+    gh = MagicMock(name="gh")
+    gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": required if required is not None else ["PR Gate"]}
+    }
+    gh.get_pr.return_value = {"state": pr_state, "number": 2578}
+    return gh
+
+
+# ── Cycle accounting ─────────────────────────────────────────────────────────
+
+
+class TestZeroCheckRunsCycleAccounting:
+    def test_first_zero_check_cycle_records_tracker_and_defers(self):
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = []
+        gh = _gh()
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        gh.reopen_pr.assert_not_called()
+        o.repo.create_milestone.assert_called_once()
+        kwargs = o.repo.create_milestone.call_args[0][0] or o.repo.create_milestone.call_args.kwargs
+        assert kwargs["milestone_type"] == "pr_zero_check_runs"
+        assert kwargs["status"] == "in_progress"
+        meta = json.loads(kwargs["metadata"])
+        assert meta["head_sha"] == "abc123"
+        assert meta["cycles"] == 1
+        assert meta["retriggered"] is False
+
+    def test_new_head_resets_counter_without_retrigger(self):
+        """A new push (new head SHA) must start a fresh observation window —
+        the tracker left by the old head neither skips cycles nor fires a
+        stale close+reopen."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(head_sha="oldsha", cycles=1)]
+        gh = _gh()
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "newsha", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        o.repo.update_milestone.assert_called_once()
+        updates = o.repo.update_milestone.call_args[0][1]
+        meta = json.loads(updates["metadata"])
+        assert meta["head_sha"] == "newsha"
+        assert meta["cycles"] == 1
+        assert meta["retriggered"] is False
+
+    def test_checks_present_closes_tracker_and_returns_false(self):
+        """When check-runs appear (delivery recovered or CI started), the
+        helper closes out any open tracker and lets the merge proceed."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+
+        took_over = o.zero_check_runs_fallback(
+            gh, 2578, "abc123", "main", [{"name": "test (3.12)", "bucket": "pass"}]
+        )
+
+        assert took_over is False
+        gh.get_branch_protection.assert_not_called()
+        gh.close_pr.assert_not_called()
+        o.repo.update_milestone.assert_called_once()
+        assert o.repo.update_milestone.call_args[0][1]["status"] == "completed"
+        o.repo.create_milestone.assert_not_called()
+
+    def test_no_required_checks_never_enters_fallback(self):
+        """Zero check-runs on an unprotected base is the NORMAL state (repos
+        without CI gating); the merge must proceed untouched."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = []
+        gh = _gh(required=[])
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is False
+        o.repo.create_milestone.assert_not_called()
+        gh.close_pr.assert_not_called()
+
+    def test_protection_probe_failure_degrades_to_no_fallback(self):
+        """An undeterminable required set must not fabricate a zero-check
+        incident — degrade to the legacy behaviour (return False)."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = []
+        gh = _gh()
+        gh.get_branch_protection.side_effect = GitHubOpsError("blind probe")
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is False
+        o.repo.create_milestone.assert_not_called()
+
+
+# ── Mechanical retrigger (close + reopen) ────────────────────────────────────
+
+
+class TestZeroCheckRunsRetrigger:
+    def test_threshold_cycle_retriggers_via_close_and_reopen(self):
+        """Second consecutive zero-check cycle: close+reopen the PR through
+        the API (a CI nudge — no code/PR-content change), record it on the
+        tracker + an audit event, and defer one more cycle."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_called_once_with(2578)
+        gh.reopen_pr.assert_called_once_with(2578)
+        o.repo.update_milestone.assert_called()
+        retrigger_updates = [
+            call.args[1]
+            for call in o.repo.update_milestone.call_args_list
+            if json.loads(call.args[1].get("metadata", "{}")).get("retriggered")
+        ]
+        assert retrigger_updates, "tracker must record the retrigger durably"
+        emitted_types = [c.args[1] for c in o.emitter.emit.call_args_list]
+        assert "zero_check_runs_retrigger" in emitted_types
+
+    def test_closed_pr_skips_retrigger(self):
+        """close+reopen only makes sense on an open PR; a closed one falls
+        through to the legacy path."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh(pr_state="closed")
+
+        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is False
+        gh.close_pr.assert_not_called()
+
+
+# ── Escalation to visible transient infrastructure error ─────────────────────
+
+
+class TestZeroCheckRunsEscalation:
+    def test_still_zero_after_retrigger_raises_transient_githubopserror(self):
+        """One cycle after the retrigger, still-zero check-runs must raise a
+        transient-classified GitHubOpsError so advance()'s existing transient
+        machinery (error_message + bounded retries, then visible failure)
+        takes over — never a silent infinite wait."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=2, retriggered=True)]
+        gh = _gh()
+
+        with pytest.raises(GitHubOpsError) as excinfo:
+            o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        err = str(excinfo.value)
+        assert "2578" in err and "abc123" in err
+        # advance() classifies transients by keyword match against the
+        # lowercased message — the escalation must actually classify.
+        lowered = err.lower()
+        assert any(kw in lowered for kw in _TRANSIENT_ORCHESTRATOR_KEYWORDS), err
+
+    def test_retrigger_failure_propagates(self):
+        """If the close/reopen API call itself fails, propagate so advance()
+        handles it like any other GitHubOpsError (visible, retried)."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+        gh.close_pr.side_effect = GitHubOpsError("api refused")
+
+        with pytest.raises(GitHubOpsError):
+            o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])

--- a/tests/autonomous/test_zero_check_runs_fallback.py
+++ b/tests/autonomous/test_zero_check_runs_fallback.py
@@ -10,14 +10,23 @@ These tests pin the orchestrator-side fallback host helper
 (``zero_check_runs_fallback``) that the merge handler calls when the PR's
 checks come back empty:
 
-- cycle accounting persists in a ``pr_zero_check_runs`` milestone (no schema
+- observation state persists in a ``pr_zero_check_runs`` milestone (no schema
   change), keyed on the verified head SHA so a new push resets the window;
-- after ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` consecutive zero-check cycles the
-  helper mechanically retriggers event delivery via PR close+reopen;
-- one cycle after the retrigger, still-zero check-runs escalates to a
-  transient-classified ``GitHubOpsError`` so advance()'s existing transient
-  machinery makes the stall VISIBLE (error_message + bounded retries) instead
-  of silent spinning;
+- the PRIMARY gate is a wall-clock observation floor
+  (``ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR``, 20 minutes): the scheduler hot loop
+  is ``_stop_event.wait(10)`` with no per-phase backoff, so cycles can arrive
+  seconds apart — a few rapid zero-check cycles within the floor must merely
+  defer (slow CI provisioning), never retrigger or escalate;
+- once the floor elapsed AND ``ZERO_CHECK_RUNS_RETRIGGER_CYCLES`` cycles were
+  observed, the helper mechanically retriggers event delivery via PR
+  close+reopen; if the reopen half fails after a successful close, a
+  ``reopen_pending`` tracker state makes the next cycle RETRY the reopen
+  (bounded by ``ZERO_CHECK_RUNS_REOPEN_RETRY_MAX``) instead of the closed-PR
+  guard permanently skipping while the PR stays closed;
+- once the retrigger completed and its own observation floor elapsed with
+  still-zero check-runs, the helper escalates to a transient-classified
+  ``GitHubOpsError`` (closing the tracker) so advance()'s existing transient
+  machinery makes the stall VISIBLE instead of silent spinning;
 - a PR on a base branch with NO required checks never enters the fallback
   (zero check-runs is the normal state there, the merge proceeds directly).
 """
@@ -25,6 +34,7 @@ checks come back empty:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,6 +44,21 @@ from app.modules.workspace.autonomous.github_ops import GitHubOpsError
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
 # ── Harness ──────────────────────────────────────────────────────────────────
+
+# Frozen clock: every test drives the patchable module-level ``_utcnow`` so
+# wall-clock floor arithmetic is deterministic.
+_NOW = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _patch_now(moment: datetime):
+    return patch(
+        "app.modules.workspace.autonomous.orchestrator._utcnow",
+        return_value=moment,
+    )
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat()
 
 
 def _make_orchestrator(workflow: dict) -> AutonomousOrchestrator:
@@ -72,17 +97,33 @@ def _workflow(**overrides) -> dict:
 
 
 def _tracker_milestone(
-    head_sha: str = "abc123", cycles: int = 1, retriggered: bool = False
+    head_sha: str = "abc123",
+    cycles: int = 1,
+    retriggered: bool = False,
+    *,
+    first_seen_at: str | None = None,
+    retriggered_at: str | None = None,
+    reopen_pending: bool = False,
+    reopen_attempts: int = 0,
 ) -> dict:
+    meta: dict = {"head_sha": head_sha, "cycles": cycles, "retriggered": retriggered}
+    # Default: the head was first seen 25 minutes ago — past the 20-minute
+    # floor, so cycle-count/threshold tests exercise their gate directly.
+    meta["first_seen_at"] = (
+        first_seen_at if first_seen_at is not None else _iso(_NOW - timedelta(minutes=25))
+    )
+    if retriggered_at is not None:
+        meta["retriggered_at"] = retriggered_at
+    if reopen_pending:
+        meta["reopen_pending"] = True
+        meta["reopen_attempts"] = reopen_attempts
     return {
         "milestone_id": "ms-zero-1",
         "workflow_id": "wf-test",
         "phase": "merge",
         "milestone_type": "pr_zero_check_runs",
         "status": "in_progress",
-        "metadata": json.dumps(
-            {"head_sha": head_sha, "cycles": cycles, "retriggered": retriggered}
-        ),
+        "metadata": json.dumps(meta),
     }
 
 
@@ -99,6 +140,19 @@ def _gh(
     return gh
 
 
+def _recorded_metadata(o: AutonomousOrchestrator) -> list[dict]:
+    """Every tracker metadata payload written this call (create or update)."""
+    payloads = [
+        json.loads(call.args[1]["metadata"])
+        for call in o.repo.update_milestone.call_args_list
+        if "metadata" in call.args[1]
+    ]
+    for call in o.repo.create_milestone.call_args_list:
+        kwargs = call.args[0] or call.kwargs
+        payloads.append(json.loads(kwargs["metadata"]))
+    return payloads
+
+
 # ── Cycle accounting ─────────────────────────────────────────────────────────
 
 
@@ -108,7 +162,8 @@ class TestZeroCheckRunsCycleAccounting:
         o.repo.list_milestones.return_value = []
         gh = _gh()
 
-        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
 
         assert took_over is True
         gh.close_pr.assert_not_called()
@@ -121,6 +176,9 @@ class TestZeroCheckRunsCycleAccounting:
         assert meta["head_sha"] == "abc123"
         assert meta["cycles"] == 1
         assert meta["retriggered"] is False
+        # The observation window starts NOW — the wall-clock floor is measured
+        # from this persisted timestamp, not from process uptime.
+        assert meta["first_seen_at"] == _iso(_NOW)
 
     def test_new_head_resets_counter_without_retrigger(self):
         """A new push (new head SHA) must start a fresh observation window —
@@ -130,7 +188,8 @@ class TestZeroCheckRunsCycleAccounting:
         o.repo.list_milestones.return_value = [_tracker_milestone(head_sha="oldsha", cycles=1)]
         gh = _gh()
 
-        took_over = o.zero_check_runs_fallback(gh, 2578, "newsha", "main", [])
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "newsha", "main", [])
 
         assert took_over is True
         gh.close_pr.assert_not_called()
@@ -140,6 +199,8 @@ class TestZeroCheckRunsCycleAccounting:
         assert meta["head_sha"] == "newsha"
         assert meta["cycles"] == 1
         assert meta["retriggered"] is False
+        # Fresh window: first_seen_at restarts for the new head.
+        assert meta["first_seen_at"] == _iso(_NOW)
 
     def test_checks_present_closes_tracker_and_returns_false(self):
         """When check-runs appear (delivery recovered or CI started), the
@@ -185,20 +246,158 @@ class TestZeroCheckRunsCycleAccounting:
         assert took_over is False
         o.repo.create_milestone.assert_not_called()
 
+    def test_tracker_load_failure_defers_without_duplicate_tracker(self):
+        """If the tracker milestone cannot be listed (swallowed DB failure),
+        the helper must NOT create a second in_progress tracker (that would
+        orphan the unloaded one). It defers; the next cycle re-reads."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.side_effect = Exception("db down")
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        o.repo.create_milestone.assert_not_called()
+        o.repo.update_milestone.assert_not_called()
+        gh.close_pr.assert_not_called()
+
+
+# ── Wall-clock observation floor ─────────────────────────────────────────────
+
+
+class TestZeroCheckRunsWallClockFloor:
+    def test_rapid_cycles_within_floor_defer_without_retrigger(self):
+        """The scheduler hot loop runs every ~10s, so cycles can pile up
+        minutes after the push. However many cycles elapsed, the retrigger
+        must NOT fire before the 20-minute observation floor — otherwise a
+        slow-CI-provisioning head is terminally failed in ~2-3 minutes
+        (regression vs. the old recoverable spin)."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(
+                cycles=5,
+                first_seen_at=_iso(_NOW - timedelta(minutes=5)),
+            )
+        ]
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        gh.reopen_pr.assert_not_called()
+        # The observation is still recorded (cycle 6) with the ORIGINAL
+        # first_seen_at — the floor window is not restarted by deferrals.
+        metas = _recorded_metadata(o)
+        assert metas, "observation must still be recorded"
+        assert metas[-1]["cycles"] == 6
+        assert metas[-1]["first_seen_at"] == _iso(_NOW - timedelta(minutes=5))
+
+    def test_cycles_past_floor_retrigger(self):
+        """Floor elapsed AND ≥2 cycles observed: the retrigger fires."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_called_once_with(2578)
+        gh.reopen_pr.assert_called_once_with(2578)
+        metas = _recorded_metadata(o)
+        assert any(m.get("retriggered") for m in metas), "retrigger must be durable"
+        assert any(
+            m.get("retriggered_at") == _iso(_NOW) for m in metas
+        ), "retrigger timestamp must be persisted for the escalation floor"
+
+    def test_after_retrigger_within_floor_defers_without_escalation(self):
+        """The retrigger fired but its own 20-minute floor has not elapsed —
+        CI provisioning after the reopened events needs time. No escalation."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(
+                cycles=2,
+                retriggered=True,
+                retriggered_at=_iso(_NOW - timedelta(minutes=5)),
+            )
+        ]
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        gh.reopen_pr.assert_not_called()
+
+    def test_after_retrigger_past_floor_escalates_and_closes_tracker(self):
+        """Still zero check-runs one floor after the retrigger: raise the
+        transient-classified GitHubOpsError AND close the tracker milestone
+        (no orphaned in_progress tracker on the terminal path)."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(
+                cycles=2,
+                retriggered=True,
+                retriggered_at=_iso(_NOW - timedelta(minutes=25)),
+            )
+        ]
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            with pytest.raises(GitHubOpsError) as excinfo:
+                o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        err = str(excinfo.value)
+        assert "2578" in err and "abc123" in err
+        lowered = err.lower()
+        assert any(kw in lowered for kw in _TRANSIENT_ORCHESTRATOR_KEYWORDS), err
+        finalize_calls = [
+            call.args[1]
+            for call in o.repo.update_milestone.call_args_list
+            if call.args[1].get("status") not in (None, "in_progress")
+        ]
+        assert (
+            finalize_calls and finalize_calls[-1]["status"] == "failed"
+        ), "escalation must close the tracker (status failed) with the error recorded"
+
+    def test_tracker_without_first_seen_backfills_floor(self):
+        """A pre-floor tracker metadata (no first_seen_at) must not retrigger
+        immediately: the observation floor restarts from now."""
+        o = _make_orchestrator(_workflow())
+        stale = _tracker_milestone(cycles=5)
+        meta = json.loads(stale["metadata"])
+        meta.pop("first_seen_at", None)
+        stale["metadata"] = json.dumps(meta)
+        o.repo.list_milestones.return_value = [stale]
+        gh = _gh()
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        assert _recorded_metadata(o)[-1]["first_seen_at"] == _iso(_NOW)
+
 
 # ── Mechanical retrigger (close + reopen) ────────────────────────────────────
 
 
 class TestZeroCheckRunsRetrigger:
     def test_threshold_cycle_retriggers_via_close_and_reopen(self):
-        """Second consecutive zero-check cycle: close+reopen the PR through
-        the API (a CI nudge — no code/PR-content change), record it on the
-        tracker + an audit event, and defer one more cycle."""
+        """Floor elapsed + second consecutive zero-check cycle: close+reopen
+        the PR through the API (a CI nudge — no code/PR-content change),
+        record it on the tracker + an audit event, and defer one more
+        cycle."""
         o = _make_orchestrator(_workflow())
         o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
         gh = _gh()
 
-        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
 
         assert took_over is True
         gh.close_pr.assert_called_once_with(2578)
@@ -220,10 +419,117 @@ class TestZeroCheckRunsRetrigger:
         o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
         gh = _gh(pr_state="closed")
 
-        took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
 
         assert took_over is False
         gh.close_pr.assert_not_called()
+
+    def test_retrigger_failure_propagates(self):
+        """If the close API call itself fails, propagate so advance() handles
+        it like any other GitHubOpsError (visible, retried)."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+        gh.close_pr.side_effect = GitHubOpsError("api refused")
+
+        with _patch_now(_NOW):
+            with pytest.raises(GitHubOpsError):
+                o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+
+# ── Partial state: close succeeded, reopen failed ────────────────────────────
+
+
+class TestZeroCheckRunsReopenPending:
+    def test_reopen_failure_after_close_records_reopen_pending(self):
+        """close_pr succeeded but reopen_pr raised: the PR is now CLOSED. The
+        tracker must record ``reopen_pending`` so the NEXT cycle retries the
+        reopen — the closed-PR guard alone would permanently skip the
+        retrigger while the PR stays closed."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
+        gh = _gh()
+        gh.reopen_pr.side_effect = GitHubOpsError("reopen refused")
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        metas = _recorded_metadata(o)
+        assert any(
+            m.get("reopen_pending") and m.get("reopen_attempts") == 1 for m in metas
+        ), "partial state must be recorded durably"
+        # The retrigger is INCOMPLETE — no success event was emitted.
+        emitted_types = [c.args[1] for c in o.emitter.emit.call_args_list]
+        assert "zero_check_runs_retrigger" not in emitted_types
+
+    def test_reopen_pending_closed_pr_retries_reopen_next_cycle(self):
+        """Next cycle sees reopen_pending + PR closed: it attempts the reopen
+        (not a skip). Success completes the retrigger durably."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(cycles=2, retriggered=False, reopen_pending=True, reopen_attempts=1)
+        ]
+        gh = _gh(pr_state="closed")
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()  # close already happened
+        gh.reopen_pr.assert_called_once_with(2578)
+        metas = _recorded_metadata(o)
+        assert any(
+            m.get("retriggered") and m.get("retriggered_at") == _iso(_NOW) for m in metas
+        ), "completed reopen must start the escalation floor"
+        emitted_types = [c.args[1] for c in o.emitter.emit.call_args_list]
+        assert "zero_check_runs_retrigger" in emitted_types
+
+    def test_reopen_pending_open_pr_completes_retrigger(self):
+        """reopen_pending but the PR reads OPEN (someone reopened it manually,
+        or the earlier failure was spurious): treat the retrigger as complete
+        and start the escalation floor — do not close an open PR."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(cycles=2, retriggered=False, reopen_pending=True, reopen_attempts=1)
+        ]
+        gh = _gh(pr_state="open")
+
+        with _patch_now(_NOW):
+            took_over = o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        assert took_over is True
+        gh.close_pr.assert_not_called()
+        gh.reopen_pr.assert_not_called()
+        metas = _recorded_metadata(o)
+        assert any(m.get("retriggered") and not m.get("reopen_pending") for m in metas)
+
+    def test_reopen_retry_exhausted_escalates_visibly(self):
+        """Reopen attempts hit the retry cap and the PR is still closed:
+        escalate as a transient-classified GitHubOpsError (and close the
+        tracker) — never a silent skip with a permanently closed PR."""
+        o = _make_orchestrator(_workflow())
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(cycles=3, retriggered=False, reopen_pending=True, reopen_attempts=2)
+        ]
+        gh = _gh(pr_state="closed")
+
+        with _patch_now(_NOW):
+            with pytest.raises(GitHubOpsError) as excinfo:
+                o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+
+        err = str(excinfo.value)
+        assert "2578" in err and "abc123" in err
+        lowered = err.lower()
+        assert any(kw in lowered for kw in _TRANSIENT_ORCHESTRATOR_KEYWORDS), err
+        gh.reopen_pr.assert_not_called()  # cap reached — no further attempts
+        finalize_calls = [
+            call.args[1]
+            for call in o.repo.update_milestone.call_args_list
+            if call.args[1].get("status") not in (None, "in_progress")
+        ]
+        assert finalize_calls and finalize_calls[-1]["status"] == "failed"
 
 
 # ── Escalation to visible transient infrastructure error ─────────────────────
@@ -231,16 +537,21 @@ class TestZeroCheckRunsRetrigger:
 
 class TestZeroCheckRunsEscalation:
     def test_still_zero_after_retrigger_raises_transient_githubopserror(self):
-        """One cycle after the retrigger, still-zero check-runs must raise a
-        transient-classified GitHubOpsError so advance()'s existing transient
-        machinery (error_message + bounded retries, then visible failure)
-        takes over — never a silent infinite wait."""
+        """Still-zero check-runs one observation floor after the retrigger
+        must raise a transient-classified GitHubOpsError so advance()'s
+        existing transient machinery (error_message + bounded retries, then
+        visible failure) takes over — never a silent infinite wait."""
         o = _make_orchestrator(_workflow())
-        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=2, retriggered=True)]
+        o.repo.list_milestones.return_value = [
+            _tracker_milestone(
+                cycles=2, retriggered=True, retriggered_at=_iso(_NOW - timedelta(minutes=25))
+            )
+        ]
         gh = _gh()
 
-        with pytest.raises(GitHubOpsError) as excinfo:
-            o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
+        with _patch_now(_NOW):
+            with pytest.raises(GitHubOpsError) as excinfo:
+                o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])
 
         err = str(excinfo.value)
         assert "2578" in err and "abc123" in err
@@ -248,14 +559,3 @@ class TestZeroCheckRunsEscalation:
         # lowercased message — the escalation must actually classify.
         lowered = err.lower()
         assert any(kw in lowered for kw in _TRANSIENT_ORCHESTRATOR_KEYWORDS), err
-
-    def test_retrigger_failure_propagates(self):
-        """If the close/reopen API call itself fails, propagate so advance()
-        handles it like any other GitHubOpsError (visible, retried)."""
-        o = _make_orchestrator(_workflow())
-        o.repo.list_milestones.return_value = [_tracker_milestone(cycles=1)]
-        gh = _gh()
-        gh.close_pr.side_effect = GitHubOpsError("api refused")
-
-        with pytest.raises(GitHubOpsError):
-            o.zero_check_runs_fallback(gh, 2578, "abc123", "main", [])

--- a/tests/issues/2428/test_merge_wiring.py
+++ b/tests/issues/2428/test_merge_wiring.py
@@ -51,6 +51,10 @@ def _ctx(workflow: dict) -> WorkflowContext:
 def _deps(*, checks, required=REQUIRED, merge_raises=None):
     host = MagicMock(name="host")
     host.perform_git_cleanup.return_value = ("completed", "")
+    # Issue #2673: the zero-check-runs fallback must not take over the
+    # cycle in these wiring tests (checks are reported non-empty or the
+    # gating is asserted separately).
+    host.zero_check_runs_fallback.return_value = False
     host.validate_pre_merge_change_scope.return_value = ""
     host.sync_failed_pr_with_main.return_value = False
     host.branch_contains_main.return_value = False


### PR DESCRIPTION
## Summary

Workflow #2550 (PR #2578) spun in the merge/wait loop for 4h+ because its branch's push produced **zero GitHub events** (no push, no `pull_request synchronize`; a manual close+reopen also produced zero events while repo-wide delivery was healthy). The PR therefore had **zero check-runs**, required checks stayed pending forever, `mergeStateStatus` stayed BLOCKED, and the merge phase retried silently with no detection, no fallback and no alert.

This adds the approved bounded mechanical fallback in the merge/wait path:

- **Detection**: when the merge-phase advance inspects a PR's checks (`phases/merge.py`, the point where checks/mergeability are already evaluated) and the head reports zero check-runs on a base branch that **actually requires checks** (`get_branch_protection`, classic + ruleset union), the cycle is handed to a new PhaseHost helper `zero_check_runs_fallback` (state machine in `orchestrator.py`).
- **Persistence without a schema change**: the cycle counter lives in a `pr_zero_check_runs` milestone's metadata, keyed on the verified head SHA so a new push resets the window. (`transient_retry_count` is unusable — `advance()` resets it on every clean retry; `ci_repair_context` feeds the CI-repair agent prompt, so overloading it was rejected.)
- **Retrigger**: after `ZERO_CHECK_RUNS_RETRIGGER_CYCLES` (2) consecutive zero-check cycles, mechanically retrigger event delivery via PR close+reopen — new `GitHubOps.close_pr`/`reopen_pr` (`api_only`, service-user identity; a CI nudge, not a code/PR-content change) — audited via milestone + `zero_check_runs_retrigger` event. `_do_wait` itself needed no change: its auto-merge branch immediately advances to merge, where checks are inspected and where the spin lived.
- **Visible escalation**: one cycle after the retrigger, still-zero check-runs raises a transient-classified `GitHubOpsError` (`zero check-runs` keyword added to `_TRANSIENT_ORCHESTRATOR_KEYWORDS`), so `advance()`'s existing Layer-2 machinery makes the stall VISIBLE (error_message + bounded retries up to `TRANSIENT_RETRY_MAX`, then a diagnosable failure) instead of silent wait-spinning.
- **Guard rails**: never fires on a base branch with no required checks (zero check-runs is the normal state there — merge proceeds untouched), degrades to legacy behaviour when the required set is unobservable, skips the retrigger on a non-open PR, and closes out the tracker once check-runs appear.

## Files

- `app/modules/workspace/autonomous/orchestrator.py` — `ZERO_CHECK_RUNS_RETRIGGER_CYCLES`, `_zero_check_runs_fallback` state machine + tracker helpers + PhaseHost alias
- `app/modules/workspace/autonomous/github_ops.py` — `close_pr` / `reopen_pr`
- `app/modules/workspace/autonomous/phases/merge.py` — call site at the pre-merge checks inspection
- `app/modules/workspace/autonomous/phase_host.py` — Protocol entry (with per-method rationale per the accepted-debt rule)
- `app/modules/workspace/autonomous/constants.py` — transient keyword
- Tests: `tests/autonomous/test_zero_check_runs_fallback.py` (state machine, 9 cases), `tests/autonomous/phases/test_merge.py` (handler wiring, 3 cases), contract test + `tests/issues/2428/test_merge_wiring.py` harness default updated

Note on scope: the task constraint listed `orchestrator.py` + `github_ops.py`; the merge-phase advance lives in `phases/merge.py` + `phase_host.py` since #2044 Phase B, so a minimal call-site/Protocol wiring there was unavoidable (same code, extracted). No schema migration. `acceptance_verification.py` and sudoers generators untouched.

## Test evidence

- New tests red first (TDD): `AttributeError: no attribute 'zero_check_runs_fallback'` before implementation.
- `tests/autonomous/test_zero_check_runs_fallback.py` + `tests/autonomous/phases/` + `tests/autonomous/test_phase_host_contract.py` + `tests/issues/2428/`: **52 + 22 passed** after implementation.
- Scoped pre-commit (black/isort/ruff/mypy/bandit/...): all Passed on changed files.
- Local full suite (`-m "not postgres"`): 5074 passed; every failing group reproduces isolated on a clean `origin/main` worktree (api_key_proxy ×2 files, generate_default_rules_sqlite, dingtalk, feishu) or is intermittent sqlite/db contention (daily_stats, autonomous_ci_guardrails — pass isolated on both trees; concurrent pytest runs from other agents were active on this machine). None touches code changed here; CI is the authoritative gate.

Refs #2673 (tracking issue; stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)