### PR TITLE
fix: #2680 follow-ups (AUTH_TOKEN scrub, executor topology scrub, pytest-process guard)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -808,10 +808,15 @@ def create_app(config=None):
     scheduler_mode = os.environ.get("SCHEDULER_MODE", "web")
     # TESTING guard (class-2, 2026-08-15): a test process must never start
     # real schedulers — they operate on the real DB (orphan-kill advancing
-    # workflows, ghost-pausing rows). Tests that need a scheduler call
-    # init_autonomous_scheduler() directly.
-    if scheduler_mode == "scheduler" and app.config.get("TESTING"):
-        logger.info("Background services skipped (TESTING mode)")
+    # workflows, ghost-pausing rows). PYTEST_VERSION covers post-hoc
+    # config["TESTING"] assignments and bare create_app() calls under pytest.
+    # Tests that need a scheduler call init_autonomous_scheduler() directly.
+    # Note: PYTEST_VERSION propagates to test-spawned server subprocesses; a
+    # future test that wants a live scheduler child must unset it.
+    if scheduler_mode == "scheduler" and (
+        app.config.get("TESTING") or "PYTEST_VERSION" in os.environ
+    ):
+        logger.info("Background services skipped (test process)")
     elif scheduler_mode == "scheduler":
         start_background_services()
         logger.info("Background services started (SCHEDULER_MODE=scheduler)")

--- a/docs/superpowers/plans/2026-08-15-2680-followups.md
+++ b/docs/superpowers/plans/2026-08-15-2680-followups.md
@@ -112,14 +112,21 @@ def test_pytest_process_skips_background_services_even_without_testing():
         env.pop("SCHEDULER_MODE", None)  # topology must not reach CLI subprocesses (#2680)
 ```
 
-`app/__init__.py` 守卫条件改为：
+`app/__init__.py` 守卫条件改为（含审查要求的注释）：
 
 ```python
     if scheduler_mode == "scheduler" and (
         app.config.get("TESTING") or "PYTEST_VERSION" in os.environ
     ):
+        # Note: PYTEST_VERSION propagates to test-spawned server subprocesses;
+        # a future test that wants a live scheduler child must unset it.
         logger.info("Background services skipped (test process)")
 ```
+
+**同步修既有对照测试**（审查必改项：它本身跑在 pytest 下，守卫扩展后会误红）——
+`test_scheduler_mode_still_starts_services_when_not_testing` 开头加
+`monkeypatch.delenv("PYTEST_VERSION", raising=False)`（签名加 `monkeypatch`）。
+必须**删除键**，置空字符串无效（守卫是 `in os.environ` 成员判断）。
 
 - [ ] **Step 5: 绿** + 三个测试文件全量回归。
 - [ ] **Step 6: Commit** `fix: executor topology scrub + pytest-process scheduler guard (#2680 follow-up)`

--- a/docs/superpowers/plans/2026-08-15-2680-followups.md
+++ b/docs/superpowers/plans/2026-08-15-2680-followups.md
@@ -1,0 +1,131 @@
+# #2680 跟进项实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 关闭 #2680 三个跟进项：ANTHROPIC_AUTH_TOKEN 剥离、executor 拓扑剔除、pytest 进程守卫。
+
+**Architecture:** 三处小改 + 单测锁定。spec：`docs/superpowers/specs/2026-08-15-2680-followups-design.md`
+
+---
+
+### Task 1: ANTHROPIC_AUTH_TOKEN 剥离（constants.py）
+
+**Files:**
+- Test: `tests/unit/test_autonomous_ci_guardrails.py`（扩展）
+- Modify: `remote-agent/constants.py:17-31`（`LLM_PROVIDER_ENV_KEYS`）
+
+- [ ] **Step 1: 失败测试**——在 `test_agent_env_scrubs_scheduler_mode` 后新增：
+
+```python
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_agent_env_scrubs_anthropic_auth_token(monkeypatch, tmp_path):
+    """#2680 跟进：ANTHROPIC_AUTH_TOKEN（Claude Code 实际认证变量）必须剥离。"""
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-raw-token-leak-probe")
+
+    adapter = MagicMock()
+    adapter.get_env_vars.return_value = {}
+    env = agent_runner.AutonomousAgentRunner._build_agent_env(
+        adapter, "claude-code", None, "session", "", [sys.executable],
+    )
+
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+```
+
+- [ ] **Step 2: 红**——`python3 -m pytest tests/unit/test_autonomous_ci_guardrails.py::test_agent_env_scrubs_anthropic_auth_token -v`，预期 FAIL（键存在）。
+- [ ] **Step 3: 实现**——`remote-agent/constants.py` `LLM_PROVIDER_ENV_KEYS` 集合中 `"ANTHROPIC_TOKEN",` 后加一行 `"ANTHROPIC_AUTH_TOKEN",`。
+- [ ] **Step 4: 绿** + 既有 90 用例回归。
+- [ ] **Step 5: Commit** `fix: scrub ANTHROPIC_AUTH_TOKEN from agent env (#2680 follow-up)`
+
+### Task 2: executor 拓扑剔除 + pytest 进程守卫
+
+**Files:**
+- Test: `tests/unit/test_remote_executor_env.py`（新建）、`tests/unit/test_app_testing_scheduler_guard.py`（扩展）
+- Modify: `remote-agent/executor.py:968`（`env = dict(os.environ)` 后）、`app/__init__.py:808`（守卫条件）
+
+- [ ] **Step 1: 失败测试 ①**——新建 `tests/unit/test_remote_executor_env.py`：
+
+```python
+"""remote executor _build_env 的拓扑剔除（#2680 跟进）。"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent"))
+
+from executor import ProcessExecutor  # noqa: E402
+
+
+def _make_executor():
+    return ProcessExecutor(
+        server_url="http://localhost:5000",
+        output_callback=None,
+        permission_callback=None,
+        usage_callback=None,
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_executor_env_scrubs_scheduler_mode(monkeypatch):
+    monkeypatch.setenv("SCHEDULER_MODE", "scheduler")
+    env = _make_executor()._build_env("claude-code", "proxy-token")
+    assert "SCHEDULER_MODE" not in env
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_executor_env_scrubs_anthropic_auth_token(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-raw-leak-probe")
+    env = _make_executor()._build_env("claude-code", "proxy-token")
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+```
+
+- [ ] **Step 2: 失败测试 ②**——`tests/unit/test_app_testing_scheduler_guard.py` 追加：
+
+```python
+def test_pytest_process_skips_background_services_even_without_testing():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler", "PYTEST_VERSION": "9.0.3"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({})
+
+    mock_sbs.assert_not_called()
+```
+
+- [ ] **Step 3: 红**——两个文件分别跑，预期新增用例 FAIL。
+- [ ] **Step 4: 实现**——executor `_build_env` 的 `env = dict(os.environ)` 后加：
+
+```python
+        env.pop("SCHEDULER_MODE", None)  # topology must not reach CLI subprocesses (#2680)
+```
+
+`app/__init__.py` 守卫条件改为：
+
+```python
+    if scheduler_mode == "scheduler" and (
+        app.config.get("TESTING") or "PYTEST_VERSION" in os.environ
+    ):
+        logger.info("Background services skipped (test process)")
+```
+
+- [ ] **Step 5: 绿** + 三个测试文件全量回归。
+- [ ] **Step 6: Commit** `fix: executor topology scrub + pytest-process scheduler guard (#2680 follow-up)`
+
+### Task 3: PR + 合并 + 部署
+
+- [ ] `#2680 跟进项` 评论说明 DATABASE_URL 不剔除的理由（测试库隔离需独立设计）
+- [ ] push、PR（`Fixes` 不用——#2680 已被 #2681 关闭，正文引用即可）、独立审查、CI 全绿、merge --delete-branch
+- [ ] 本机 server 重启部署 + 状态监控确认三个工作流不受影响

--- a/docs/superpowers/specs/2026-08-15-2680-followups-design.md
+++ b/docs/superpowers/specs/2026-08-15-2680-followups-design.md
@@ -1,0 +1,67 @@
+# Design: #2680 跟进项（AUTH_TOKEN 剥离 / executor 拓扑剔除 / pytest 进程守卫）
+
+日期：2026-08-15 · 类别：class-2 后续 · 状态：批准（用户授权免问推进）
+
+## 背景
+
+#2680 主修（PR #2681）后遗留三个跟进项，本 spec 一并处理：
+
+1. **`ANTHROPIC_AUTH_TOKEN` 剥离缺口**：`remote-agent/constants.py`
+   `LLM_PROVIDER_ENV_KEYS` 含 `ANTHROPIC_API_KEY/BASE_URL/TOKEN` 但缺
+   `ANTHROPIC_AUTH_TOKEN`（Claude Code CLI 实际使用的认证变量名）。实测
+   本机 dev 场景该变量原样进入 agent env，违反 #2019"agent 只携带 proxy
+   token"的意图。本地（agent_runner）与远程（executor）共用此清单。
+2. **remote executor 拓扑泄漏**：`remote-agent/executor.py::_build_env`
+   `dict(os.environ)` 未剔除 `SCHEDULER_MODE`——与 agent_runner 同款
+   问题（#2681 只修了本地路径）。远程侧当前实际风险低（远端 daemon 非
+   open-ace server 启动），按纵深防御补齐 parity。
+3. **TESTING 后置绕过**：`create_app()` 之后才设 `app.config["TESTING"]`
+   的用法（10+ 测试文件，如 test_remote_session_state_check.py:199）在
+   工厂时刻守卫之后，若 pytest 进程 env 带 `SCHEDULER_MODE=scheduler`
+   仍会起真 scheduler。逐个改测试是大范围机械清扫；改为在守卫上补
+   **pytest 进程检测**：`"PYTEST_VERSION" in os.environ`（pytest 启动即
+   注入，实测存在于测试进程 env；pytest 之外永不存在）。关闭整类"测试
+   进程起真 scheduler"，不管 TESTING 何时设置。
+
+## 改动
+
+1. `remote-agent/constants.py`：`LLM_PROVIDER_ENV_KEYS` 增加
+   `"ANTHROPIC_AUTH_TOKEN"`（归入 LLM provider 键 → dev 逃生门
+   `OPENACE_ALLOW_RAW_KEY_FALLBACK=1` 可保留，与既有语义一致）。
+2. `remote-agent/executor.py::_build_env`：`env = dict(os.environ)` 后
+   `env.pop("SCHEDULER_MODE", None)`（注释同 agent_runner）。
+3. `app/__init__.py` 守卫扩展：
+   ```python
+   if scheduler_mode == "scheduler" and (
+       app.config.get("TESTING") or "PYTEST_VERSION" in os.environ
+   ):
+   ```
+   日志文案改为 `Background services skipped (test process)`。
+
+## 明确不做
+
+- **不剔除 `DATABASE_URL`**：agent（开发 open-ace 仓库自身）跑的测试套件
+  需要"某个"数据库；盲剔除只会让它静默回落到 config.json 指向的库（本机
+  同一个 PG），既不能隔离又改变语义。测试库隔离需要独立设计（如 per-task
+  scratch DB），超出本跟进范围——在 #2680 留言说明。
+- 不迁移 10+ 测试文件的 TESTING 后置写法（守卫扩展已覆盖其实际风险）。
+- 不动 `scheduler_worker.py`（显式 SCHEDULER_MODE=scheduler 的专用进程，
+  pytest 不可能运行它）。
+
+## 隔离约束核对
+
+`remote-agent/executor.py` 属远程会话共享面（[[autonomous-isolation-scope-constraint]]）：
+本次为 **additive**（env 剔除一个 CLI 工具不消费的 open-ace 拓扑变量），
+不改变普通远程会话语义。`constants.py` 增加剥离键与 #2019 既有方向一致。
+
+## 测试（TDD）
+
+1. 失败测试 ①：`_build_agent_env` 在 env 带 `ANTHROPIC_AUTH_TOKEN` 时产物
+   无该键（现测试文件加用例）。
+2. 失败测试 ②：executor `_build_env` 产物无 `SCHEDULER_MODE`（executor
+   可导入性待验证；若重依赖则以 constants 清单单测 + agent_runner 路径
+   覆盖，executor 侧最小 mock 单测）。
+3. 失败测试 ③：`patch.dict(os.environ, {"SCHEDULER_MODE": "scheduler",
+   "PYTEST_VERSION": "x"})` + `create_app()`（不带 TESTING）→ 不启动
+   background services。
+4. 对照：非 pytest、非 TESTING 正路径仍启动（已有对照测试沿用）。

--- a/remote-agent/constants.py
+++ b/remote-agent/constants.py
@@ -22,6 +22,7 @@ LLM_PROVIDER_ENV_KEYS = frozenset(
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_TOKEN",
+        "ANTHROPIC_AUTH_TOKEN",
         "GEMINI_API_KEY",
         "GEMINI_BASE_URL",
         "BAILIAN_CODING_PLAN_API_KEY",

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -966,6 +966,7 @@ class ProcessExecutor:
             Dict of environment variable name -> value.
         """
         env = dict(os.environ)
+        env.pop("SCHEDULER_MODE", None)  # topology must not reach CLI subprocesses (#2680)
 
         # Build the proxy URL that the CLI should use as its API base
         proxy_url = f"{self.server_url}/api/remote/llm-proxy"

--- a/tests/unit/test_app_testing_scheduler_guard.py
+++ b/tests/unit/test_app_testing_scheduler_guard.py
@@ -25,7 +25,10 @@ def test_testing_mode_skips_background_services():
     mock_sbs.assert_not_called()
 
 
-def test_scheduler_mode_still_starts_services_when_not_testing():
+def test_scheduler_mode_still_starts_services_when_not_testing(monkeypatch):
+    # 必须删除键（置空无效——守卫是 in os.environ 成员判断）：本测试跑在
+    # pytest 下，PYTEST_VERSION 存在会触发测试进程守卫。
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
     with (
         patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler"}),
         patch("app.start_background_services") as mock_sbs,
@@ -33,3 +36,13 @@ def test_scheduler_mode_still_starts_services_when_not_testing():
         create_app({"TESTING": False})
 
     mock_sbs.assert_called_once()
+
+
+def test_pytest_process_skips_background_services_even_without_testing():
+    with (
+        patch.dict("os.environ", {"SCHEDULER_MODE": "scheduler", "PYTEST_VERSION": "9.0.3"}),
+        patch("app.start_background_services") as mock_sbs,
+    ):
+        create_app({})
+
+    mock_sbs.assert_not_called()

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -356,6 +356,35 @@ def test_agent_env_scrubs_scheduler_mode(monkeypatch, tmp_path):
     assert "SCHEDULER_MODE" not in env
 
 
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_agent_env_scrubs_anthropic_auth_token(monkeypatch, tmp_path):
+    """#2680 跟进：ANTHROPIC_AUTH_TOKEN（Claude Code 实际认证变量）必须剥离。"""
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-raw-token-leak-probe")
+
+    adapter = MagicMock()
+    adapter.get_env_vars.return_value = {}
+    env = agent_runner.AutonomousAgentRunner._build_agent_env(
+        adapter,
+        "claude-code",
+        None,
+        "session",
+        "",
+        [sys.executable],
+    )
+
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
 def test_agent_guard_bin_falls_back_to_source_when_install_is_incomplete(monkeypatch, tmp_path):
     from pathlib import Path
 

--- a/tests/unit/test_remote_executor_env.py
+++ b/tests/unit/test_remote_executor_env.py
@@ -1,0 +1,38 @@
+"""remote executor _build_env 的敏感/拓扑 env 剥离（#2680 跟进）。"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).resolve().parent.parent.parent
+_remote_agent_str = str(_project_root / "remote-agent")
+if _remote_agent_str not in sys.path:
+    sys.path.insert(0, _remote_agent_str)
+
+from executor import ProcessExecutor  # noqa: E402
+
+
+def _make_executor():
+    return ProcessExecutor(
+        server_url="http://localhost:5000",
+        output_callback=None,
+        permission_callback=None,
+        usage_callback=None,
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_executor_env_scrubs_scheduler_mode(monkeypatch):
+    monkeypatch.setenv("SCHEDULER_MODE", "scheduler")
+    env = _make_executor()._build_env("claude-code", "proxy-token")
+    assert "SCHEDULER_MODE" not in env
+
+
+@pytest.mark.regression
+@pytest.mark.issue(2680)
+def test_executor_env_scrubs_anthropic_auth_token(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-raw-leak-probe")
+    env = _make_executor()._build_env("claude-code", "proxy-token")
+    assert "ANTHROPIC_AUTH_TOKEN" not in env


### PR DESCRIPTION
#2680 跟进项修复（主修为已合并的 #2681，本 PR 不关闭 issue——issue 已随 #2681 关闭，此处仅为可追溯性引用）。

## 三项修复

| 项 | 位置 | 内容 |
|---|---|---|
| ① ANTHROPIC_AUTH_TOKEN 剥离缺口 | `remote-agent/constants.py` | 加入 `LLM_PROVIDER_ENV_KEYS`（Claude Code 实际认证变量；本地 agent_runner 与远程 executor 共用清单，一处修复两路生效）。逃生门 `OPENACE_ALLOW_RAW_KEY_FALLBACK=1` 语义保持（LLM 键可保留）。审查确认：剥离先于 proxy 注入，不会误删注入的 `ANTHROPIC_API_KEY=proxy-token` |
| ② remote executor 拓扑泄漏 | `remote-agent/executor.py::_build_env` | `env.pop("SCHEDULER_MODE")`（与 #2681 的 agent_runner 修复对齐 parity；additive，不改变普通远程会话语义） |
| ③ TESTING 后置绕过守卫 | `app/__init__.py` | 守卫扩展 `"PYTEST_VERSION" in os.environ`——pytest 进程内无论 TESTING 何时设置、create_app 怎么调用都不起真 scheduler（顺带中和 tests/issues/2277/conftest.py 的进程级 SCHEDULER_MODE 泄漏） |

## 明确不做（见 #2680 评论）

- DATABASE_URL 不盲剔除（测试库隔离需独立设计）
- 不迁移 10+ 测试文件的 TESTING 后置写法（③已覆盖其实际风险）

## 测试

- 新增 3 个红→绿用例（全标 `regression`+`issue(2680)`）：agent env 无 AUTH_TOKEN、executor env 无 SCHEDULER_MODE/AUTH_TOKEN、pytest 进程守卫
- 对照测试同步修正（`delenv PYTEST_VERSION`——键删除而非置空，守卫是成员判断）
- 回归：scheduler_guard / autonomous_ci_guardrails / 新两文件共 **116 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
