### PR TITLE
fix(tests): realign 733 orchestrator tests with evolved guards (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -979,102 +979,6 @@
     {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_allows_different_commits",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 2 == 0"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commit_failure_falls_back_to_fail",
-      "outcome": "failure",
-      "summary": "AssertionError: Expected 'git_commit' to have been called once. Called 0 times."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commits_uncommitted_changes",
-      "outcome": "failure",
-      "summary": "AssertionError: Expected 'git_add_all' to have been called once. Called 0 times."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_detects_no_code_changes",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 'no code changes' in 'cannot establish a trusted git context before agent execution'"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_agent_fails",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 'timeout' in 'cannot establish a trusted git context before agent execution'"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_commit_unavailable",
-      "outcome": "failure",
-      "summary": "AssertionError: assert 2 == 0"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_includes_last_review",
-      "outcome": "failure",
-      "summary": "AssertionError: assert False"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_without_review",
-      "outcome": "failure",
-      "summary": "AssertionError: assert False"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_default_permission_mode_is_auto_edit",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: users"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_development_passes_permission_mode",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: users"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_initial_plan_prompt_forbids_full_code",
-      "outcome": "failure",
-      "summary": "assert 0 >= 1"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "733",
-      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_refined_plan_prompt_forbids_full_code",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: users"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestBackwardCompatibility::test_do_development_still_works",
       "outcome": "failure",
@@ -1499,8 +1403,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-15 prune 24 resolved issue-716 orchestrator-tail entries: all were stale test fixtures/assertions vs evolved production preconditions (plan reviewed 2 rounds to CLEAN). (a) phases/*.handle verify PR heads/branch relations/cumulative scope via real git probes — bare MagicMock _run_git routed every guard to its deferral branch; fixed with a shared _fake_git_run side_effect (cat-file ok, show-ref rc=1, merge-base --is-ancestor rc=1, merge-base SHA, rev-parse distinct SHAs); (b) stale assertions: merge terminal pair now acceptance_verification/verification_pending (#2335), PR bodies use Implements (never Closes); (c) preparation: #1573 derived full branch name + #1552 rev-parse-resolved immutable base; (d) delete_branch #2043 structured result; (e) TestStopSession fixture deadlock reordered to preserve the #2078 cancel window. Negative control: removing the helper re-fails merge+pr_review. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31818445454",
+    "prune_note": "2026-08-15 prune 12 resolved issue-733 entries: stale fixtures vs evolved guards. (a) autouse _trusted_repo_boundary fixture (716 pattern) for the #2271 repo-integrity family + module-level UserRepository owner lookup; (b) dev flow rebinds self._gh via _get_gh after the fixture's class patch expires — commit-verification tests keep GitHubOps patched through _do_development; (c) 'no code changes' semantics narrowed to the resume shape (branch changes vs base, no new commit) — tests seed that shape; (d) milestone diff stats must be JSON-safe; scope probes via _fake_git_run; (e) final-plan 'not yet addressed' warning intentionally dropped in 97466e1c. Negative control: removing the fixture's snapshot stub re-fails the dev representative. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31859516985",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/733/test_orchestrator_733.py
+++ b/tests/issues/733/test_orchestrator_733.py
@@ -16,6 +16,25 @@ import pytest
 from app.modules.workspace.autonomous.models import AgentTaskResult
 
 
+def _fake_git_run(*args, **kwargs):
+    """Fake GitHubOps._run_git for the scope-verification probes (as in 716)."""
+
+    def _rc(rc=0, out=""):
+        return MagicMock(returncode=rc, stdout=out, stderr="")
+
+    cmd = list(args[0]) if args else []
+    if cmd[:2] == ["merge-base", "--is-ancestor"]:
+        return _rc(1)
+    if cmd[:1] == ["merge-base"]:
+        return _rc(0, "base0f1e2d3c4b5a6978901234f5e6d7\n")
+    if cmd[:1] == ["rev-parse"]:
+        target = cmd[1] if len(cmd) > 1 else ""
+        if target.endswith("^2"):
+            return _rc(1)
+        return _rc(0, f"{abs(hash(target)) % (10**12):040x}\n")
+    return _rc(0)
+
+
 def _make_workflow(**overrides):
     """Create a minimal workflow dict for testing."""
     base = {
@@ -114,6 +133,63 @@ def _make_orchestrator(wf_data):
         orch._gh = mock_gh
 
     return orch, mock_repo
+
+
+@pytest.fixture(autouse=True)
+def _trusted_repo_boundary(monkeypatch):
+    """Trusted repo/git/user boundary for synthetic /tmp paths.
+
+    Production local runs fail closed (#2271 repo-integrity guard,
+    trusted-git-context registration, owner lookup) when they cannot
+    touch a real repository; these tests use synthetic paths. Dedicated
+    guardrail tests exercise the fail-closed behavior itself. (Same
+    pattern as tests/issues/716 and 740.)
+    """
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+    from app.repositories.user_repo import UserRepository
+
+    def snapshot(orchestrator, wf, workspace_type, system_account):
+        if workspace_type != "local":
+            return None
+        context = orchestrator._resolve_effective_repo_context(wf)
+        repo_path = context.get("repo_path", "/tmp/test-project")
+        return {
+            "context": context,
+            "effective": {
+                "repo_path": repo_path,
+                "top_level": repo_path,
+                "git_dir": f"{repo_path}/.git",
+                "git_identity": "1:1",
+                "common_dir": f"{repo_path}/.git",
+                "common_identity": "1:1",
+                "origin": "git@github.com:open-ace/open-ace.git",
+            },
+        }
+
+    monkeypatch.setattr(AutonomousOrchestrator, "_snapshot_repo_context", snapshot)
+    monkeypatch.setattr(
+        AutonomousOrchestrator,
+        "_validate_repo_context_after_run",
+        lambda self, before_state, system_account: "",
+    )
+    monkeypatch.setattr(
+        GitHubOps,
+        "register_trusted_git_context",
+        classmethod(lambda cls, *args, **kwargs: None),
+    )
+    monkeypatch.setattr(GitHubOps, "bind_trusted_git_context", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(
+        UserRepository,
+        "get_user_by_id",
+        lambda self, user_id: {
+            "id": user_id,
+            "username": "owner",
+            "system_account": None,
+            "role": "platform_admin",
+            "tenant_id": None,
+        },
+    )
 
 
 class TestAutonomousContext:
@@ -243,19 +319,38 @@ class TestDevelopmentCommitVerification:
         orch._gh.get_current_commit.return_value = "abc123"
         # No uncommitted changes either
         orch._gh.has_uncommitted_changes.return_value = False
-        # No existing branch changes vs base — truly no code changes
+        # Branch carries pre-existing changes vs base (resume scenario), but the
+        # agent produced no NEW commit this session: production now fails with
+        # "no code changes" only in this shape (a bare empty branch proceeds —
+        # nothing to verify against).
         orch._gh.get_diff_stats.return_value = {
-            "additions": 0,
-            "deletions": 0,
-            "files": 0,
-            "commits": 0,
+            "additions": 3,
+            "deletions": 1,
+            "files": 2,
+            "commits": 2,
         }
+        # The divergence log holds no agent-authored commits, so the resume
+        # acceptance path does not apply.
+        orch._gh._run_git.return_value = MagicMock(
+            returncode=0, stdout="abc123 other work\n", stderr=""
+        )
+        # The post-dev branch check re-reads the current branch; keep it on the
+        # workflow's branch so the round isn't failed as a branch escape.
+        orch._gh.get_current_branch.return_value = "auto-dev/test"
 
         mock_repo.list_milestones.return_value = [
             {"milestone_type": "plan_created", "plan_content": "Build feature X"},
         ]
 
-        orch._do_development(wf)
+        # Keep GitHubOps patched for the whole call: _make_orchestrator's
+        # `with patch(...)` expires before _do_development runs, and the dev
+        # flow rebinds self._gh via _get_gh() — which would otherwise build a
+        # REAL GitHubOps against the synthetic /tmp path.
+        with patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            return_value=orch._gh,
+        ):
+            orch._do_development(wf)
 
         failed_updates = self._get_failed_updates(mock_repo)
         assert len(failed_updates) >= 1
@@ -298,12 +393,27 @@ class TestDevelopmentCommitVerification:
         # Same commit before and after agent runs, then changes after auto-commit
         orch._gh.get_current_commit.side_effect = ["abc123", "abc123", "def456"]
         orch._gh.has_uncommitted_changes.return_value = True
+        orch._gh.get_current_branch.return_value = "auto-dev/test"
+        # Post-commit diff stats are recorded on the milestone (must be JSON-safe)
+        orch._gh.get_commit_diff_stats.return_value = {
+            "additions": 5,
+            "deletions": 1,
+            "files": 2,
+            "commits": 1,
+        }
+        # Scope verification probes (merge-base/rev-parse) need real-looking git.
+        orch._gh._run_git.side_effect = _fake_git_run
 
         mock_repo.list_milestones.return_value = [
             {"milestone_type": "plan_created", "plan_content": "Build feature X"},
         ]
 
-        orch._do_development(wf)
+        # Keep GitHubOps patched for the whole call (see test_detects_no_code_changes).
+        with patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            return_value=orch._gh,
+        ):
+            orch._do_development(wf)
 
         # Should have auto-committed with no_verify=True
         orch._gh.git_add_all.assert_called_once()
@@ -328,19 +438,30 @@ class TestDevelopmentCommitVerification:
         orch._gh.get_current_commit.return_value = "abc123"
         orch._gh.has_uncommitted_changes.return_value = True
         orch._gh.git_commit.side_effect = Exception("pre-commit hook rejected")
-        # No existing branch changes vs base
+        orch._gh.get_current_branch.return_value = "auto-dev/test"
+        # Branch carries pre-existing changes vs base (the only shape where a
+        # no-new-commit round fails with "no code changes" under current
+        # semantics), with no agent-authored commits in the divergence log.
         orch._gh.get_diff_stats.return_value = {
-            "additions": 0,
-            "deletions": 0,
-            "files": 0,
-            "commits": 0,
+            "additions": 3,
+            "deletions": 1,
+            "files": 2,
+            "commits": 2,
         }
+        orch._gh._run_git.return_value = MagicMock(
+            returncode=0, stdout="abc123 other work\n", stderr=""
+        )
 
         mock_repo.list_milestones.return_value = [
             {"milestone_type": "plan_created", "plan_content": "Build feature X"},
         ]
 
-        orch._do_development(wf)
+        # Keep GitHubOps patched for the whole call (see test_detects_no_code_changes).
+        with patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            return_value=orch._gh,
+        ):
+            orch._do_development(wf)
 
         # Should have attempted auto-commit
         orch._gh.git_commit.assert_called_once()
@@ -523,11 +644,13 @@ class TestFinalPlanAnnotation:
             orch._commit_phase_result(result)
 
         # add_issue_comment is called 3 times: plan, review, final
-        # Check the last call (Final Plan)
+        # Check the last call (Final Plan). Since 97466e1c the "feedback not
+        # yet addressed" warning is gone — the last review's feedback drives a
+        # final refine instead, so the final plan simply carries the refined
+        # content.
         comment = self._get_last_comment(orch._gh)
         assert "Final Implementation Plan" in comment
-        assert "not yet addressed" in comment
-        assert "Still need to handle timeout edge case" in comment
+        assert "Final refined plan content" in comment
 
     def test_final_plan_without_review(self):
         """When no review content exists, Final Plan is posted without annotation."""


### PR DESCRIPTION
Refs #2457. Baseline 187 → 175 (−12), shrink-only. All 12 issue-733 entries were stale fixtures vs evolved production preconditions:

- **Autouse `_trusted_repo_boundary` fixture (716 pattern)**: the #2271 repo-integrity family (snapshot + post-run validation + trusted-git-context registration) and the module-level UserRepository owner lookup all fail-closed on the synthetic /tmp paths these tests use.
- **`_get_gh` rebinding after the class patch expires**: the dev flow rebinds `self._gh` via `_get_gh()` after `_make_orchestrator`'s `with patch(...)` block exits — the three commit-verification tests now keep GitHubOps patched for the whole `_do_development` call and pin `get_current_branch`, so the verification probes hit the configured mock instead of a real GitHubOps on a synthetic path.
- **"No code changes" semantics narrowed**: production only fails a no-new-commit round when the branch carries pre-existing changes vs base (resume shape); the two affected tests seed that shape (branch diff commits>0 + a divergence log without agent-authored commits).
- **JSON-safe milestone diff stats** (dict, not MagicMock) and scope probes (merge-base/rev-parse) via the 716 `_fake_git_run` side_effect.
- **Final-plan annotation**: the "feedback not yet addressed" warning was intentionally dropped in 97466e1c (feedback now drives a final refine) — the test asserts the refined content instead.

## Evidence

- Local: 15/15 in the file; all 12 baseline entries PASS.
- Negative control (throwaway worktree): removing the fixture's snapshot stub re-fails the dev representative.
- Full 4-shard lane run 31859765045: `known=175, new=0, resolved=0, changed=0, collection_errors=0, invalid=0, exit_code=0` (diff.json artifact).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
