### PR TITLE
fix(tests): realign 1395 launcher tests with evolved guards (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -145,94 +145,6 @@
       "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "RuntimeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestBuildAgentEnv::test_fallback_on_proxy_failure",
-      "outcome": "failure",
-      "summary": "RuntimeError: LLM proxy setup failed; refusing to launch autonomous agent with inherited credentials (set OPENACE_ALLOW_RAW_KEY_FALLBACK=1 only in development)."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_completed_session_reactivated_to_active",
-      "outcome": "failure",
-      "summary": "AssertionError: assert call('sess-co..._tenant=False) == (('sess-compl...': None}), {})"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_error_session_reactivated_to_active",
-      "outcome": "failure",
-      "summary": "AssertionError: assert call('sess-er..._tenant=False) == (('sess-error...': None}), {})"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestSingleShotUserIdPropagation::test_single_shot_passes_real_user_id_to_env",
-      "outcome": "failure",
-      "summary": "TypeError: TestSingleShotUserIdPropagation.test_single_shot_passes_real_user_id_to_env.<locals>.fake_build_env() got an unexpected keyword argument 'task_id'"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_can_handle_signals_while_waiting_for_agent",
-      "outcome": "failure",
-      "summary": "assert 'trap cleanup_isolated EXIT' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): the open-ace service runs as the `openace…"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline",
-      "outcome": "failure",
-      "summary": "assert 'signature_registry=\"/run/openace-agent-git-signature-${target_uid}\"' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): …"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_api_retry_triggers_activity",
-      "outcome": "failure",
-      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_assistant_still_triggers_activity",
-      "outcome": "failure",
-      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_init_triggers_activity",
-      "outcome": "failure",
-      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_no_subtype_does_not_trigger",
-      "outcome": "failure",
-      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_thinking_tokens_is_not_forwarded",
-      "outcome": "failure",
-      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
-    },
-    {
       "category": "setup_error",
       "exception_type": "AssertionError",
       "issue_number": "144",
@@ -1243,8 +1155,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-15 prune 20 resolved issue-740 mixed entries: all stale fixtures vs evolved guards. (a) hand-rolled users DDL drifted (schema partial indexes on missing columns) — fixtures now schema-first; (b) Database(bare_path) silently fell back to ~/.open-ace/ace.db — fixtures now use sqlite:/// URLs (also stops cross-DB pollution); (c) stop/pause patch targets renamed (_stop/_pause_running_task); (d) create-workflow tests stub the route-level user_repo singleton + count_active_workflows_by_user and add the now-required branch_strategy=worktree; (e) list tests stub count_workflows (JSON-serializable total); (f) run-agent wrapper tests get the 716-style _trusted_repo_boundary autouse fixture (#2271 guard stubs); review follow-ups: batch6 DATABASE_URL patcher now stopped in finally; batch4 user_repo stubbed so the system_account assertion is environment-independent. Negative control: neutering the fixture re-fails the planning representative. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31861753845",
+    "prune_note": "2026-08-15 prune 11 resolved issue-1395 launcher entries: stale expectations vs evolved production. (a) _StubProcess poll() + runner-stub session_manager attrs for the sidebar-session resolution _read_stdout now performs; (b) init test asserts the init activity among calls (session_resolved is a new legitimate event); (c) raw-key fallback is dev-opt-in (OPENACE_ALLOW_RAW_KEY_FALLBACK=1); (d) reactivation assertions gain require_tenant=False; (e) stub lambdas accept **kwargs (task_id); (f) launcher static tests follow the script's evolution (isolation_key registry, on_exit/reclaim EXIT traps, dual signal registrations, explicit post-wait on_exit). Negative control: removing poll() re-fails the init representative. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31863197203",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -458,11 +458,16 @@ def test_isolated_wrapper_can_handle_signals_while_waiting_for_agent():
 
     wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
 
-    assert "trap cleanup_isolated EXIT" in wrapper
-    assert "trap 'exit 129' HUP" in wrapper
-    assert "trap 'exit 130' INT" in wrapper
-    assert "trap 'exit 143' TERM" in wrapper
-    assert '"GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 9>&- &' in wrapper
+    # #2403: the EXIT trap is now `on_exit` (full tree reclaim), with an
+    # earlier-armed 'reclaim_task_tree || true' EXIT trap covering the
+    # pre-child window; HUP/INT/TERM exit-code traps are registered twice
+    # (task setup + child wait).
+    assert "trap on_exit EXIT" in wrapper
+    assert "trap 'reclaim_task_tree || true' EXIT" in wrapper
+    assert wrapper.count("trap 'exit 129' HUP") == 2
+    assert wrapper.count("trap 'exit 130' INT") == 2
+    assert wrapper.count("trap 'exit 143' TERM") == 2
+    assert '"$@" <&0 9>&- &' in wrapper
     assert "agent_child_pid=$!" in wrapper
     assert 'wait "$agent_child_pid"' in wrapper
 
@@ -527,7 +532,9 @@ def test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline():
 
     wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
 
-    signature_registry = 'signature_registry="/run/openace-agent-git-signature-${target_uid}"'
+    # The registry is keyed by the per-attempt isolation key (#2437/#2020:
+    # task-<id> when sharded, uid-<uid> otherwise) — no longer target_uid.
+    signature_registry = 'signature_registry="/run/openace-agent-git-signature-${isolation_key}"'
     recovery = '"$previous_git_acl_snapshot"; then'
     current_baseline = 'git_entry_before="$(git_entry_signature "$project_dir")"'
     current_acl_baseline = 'git_acl_before="$(git_entry_acl_snapshot "$project_dir")"'
@@ -543,7 +550,9 @@ def test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline():
     assert wrapper.index(current_baseline) < wrapper.index(first_acl_grant)
     assert wrapper.index(current_acl_baseline) < wrapper.index(first_acl_grant)
     assert wrapper.index("printf '%s\\n%s\\n%s\\n' \\") < wrapper.index(first_acl_grant)
-    assert wrapper.index("cleanup_isolated\n", wrapper.index('wait "$agent_child_pid"')) < (
+    # Post-wait reclaim: the explicit on_exit call (the EXIT trap is disarmed
+    # on the success path right after it — #2403) precedes final verification.
+    assert wrapper.index("    on_exit\n", wrapper.index('wait "$agent_child_pid"')) < (
         wrapper.index(final_verification)
     )
     assert wrapper.index(final_verification) < wrapper.index(
@@ -911,13 +920,16 @@ class TestBuildAgentEnv:
             "app.modules.workspace.api_key_proxy.get_api_key_proxy_service",
             fake_get_service,
         )
+        # The raw-key fallback is dev-opt-in only (fail closed otherwise):
+        # set the explicit escape hatch this test exercises.
+        monkeypatch.setenv("OPENACE_ALLOW_RAW_KEY_FALLBACK", "1")
         adapter = MagicMock()
         env = agent_runner.AutonomousAgentRunner._build_agent_env(
             adapter, "claude-code", user_id=None, session_id="s", model=""
         )
         # adapter.get_env_vars never called (setup failed before that)
         adapter.get_env_vars.assert_not_called()
-        # env is a plain dict copy of os.environ
+        # env is a scrubbed copy of os.environ (non-LLM credentials removed)
         assert isinstance(env, dict)
 
     # ── Regression (PR #1467 review comment 2) ────────────────────────────
@@ -980,7 +992,7 @@ class TestSingleShotUserIdPropagation:
         runner = self._make_runner()
         captured = {}
 
-        def fake_build_env(adapter, cli_tool, user_id, session_id, model):
+        def fake_build_env(adapter, cli_tool, user_id, session_id, model, **kwargs):
             captured["user_id"] = user_id
             return {"PATH": "/bin"}
 
@@ -993,7 +1005,7 @@ class TestSingleShotUserIdPropagation:
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.agent_runner.AutonomousAgentRunner"
             "._wrap_agent_cmd",
-            staticmethod(lambda cmd, project_path, system_account: (cmd, None)),
+            staticmethod(lambda cmd, project_path, system_account, **kwargs: (cmd, None)),
         )
 
         adapter = MagicMock()
@@ -1191,7 +1203,7 @@ class TestRunAgentTaskSessionReactivation:
         calls = runner.session_manager.update_session_fields.call_args_list
         assert calls[0] == (
             ("sess-completed", {"status": "active", "completed_at": None, "paused_at": None}),
-            {},
+            {"require_tenant": False},
         )
 
     def test_error_session_reactivated_to_active(self, monkeypatch):
@@ -1210,7 +1222,7 @@ class TestRunAgentTaskSessionReactivation:
         calls = runner.session_manager.update_session_fields.call_args_list
         assert calls[0] == (
             ("sess-error", {"status": "active", "completed_at": None, "paused_at": None}),
-            {},
+            {"require_tenant": False},
         )
 
     def test_active_session_no_reactivation_call(self, monkeypatch):

--- a/tests/issues/1395/test_system_event_activity.py
+++ b/tests/issues/1395/test_system_event_activity.py
@@ -24,12 +24,16 @@ class _FakeStream:
 
 
 class _StubProcess:
-    """Minimal stand-in for subprocess.Popen — only stdout/returncode are read."""
+    """Minimal stand-in for subprocess.Popen — stdout/returncode/poll are read."""
 
     returncode = None  # is_running → True (process not exited)
 
     def __init__(self, stdout):
         self.stdout = stdout
+
+    def poll(self):
+        """Popen.poll() for a never-exited stub."""
+        return None
 
 
 def _make_session(lines):
@@ -50,6 +54,10 @@ def _make_runner():
 
     runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
     runner._activity_callback = MagicMock()
+    # Attributes _read_stdout's sidebar-session resolution touches on the real
+    # runner (built by __init__, absent on a bare __new__ instance).
+    runner.session_manager = None
+    runner.remote_session_manager = None
     return runner
 
 
@@ -95,10 +103,14 @@ class TestSystemEventActivityForwarding:
             ]
         )
         runner._read_stdout(session)
-        runner._activity_callback.assert_called_once_with(
-            "sess-1",
-            {"type": "system", "subtype": "init"},
-        )
+        # init pins the CLI session id, which also emits a session_resolved
+        # activity; assert the init event is forwarded (not the sole call).
+        init_calls = [
+            c
+            for c in runner._activity_callback.call_args_list
+            if c.args[1:2] == ({"type": "system", "subtype": "init"},)
+        ]
+        assert len(init_calls) == 1
 
     def test_no_subtype_does_not_trigger(self):
         """A system event without subtype (e.g. bare 'initialized') must


### PR DESCRIPTION
Refs #2457. Baseline shrink-only: 11 issue-1395 entries (branch numbering 175→164; main is at 155 after #2682 — the PR conflict is resolved at merge by pruning the same 11 from main's base).

All 11 entries were stale expectations vs evolved production:

- **_StubProcess poll() + runner-stub attrs**: _read_stdout's sidebar-session resolution touches `process.poll()` and `self.session_manager`/`remote_session_manager` — absent on the bare `__new__` stubs.
- **init activity**: pinning the CLI session id now also emits a `session_resolved` activity; the assertion checks the init event is forwarded exactly once among the calls.
- **Raw-key fallback** is dev-opt-in since the fail-closed hardening — the test sets `OPENACE_ALLOW_RAW_KEY_FALLBACK=1` explicitly.
- **Session reactivation** assertions gain the `require_tenant=False` kwarg (#1789 lineage: relaxed for an existing session row).
- **Stub lambdas** accept **kwargs (`task_id` kwarg added to _build_agent_env/_wrap_agent_cmd).
- **Launcher static tests** follow the script's evolution: signature registry keyed by `${isolation_key}` (#2437/#2020, not `${target_uid}`); EXIT traps are `trap on_exit EXIT` + the earlier `reclaim_task_tree || true` arm (#2403); HUP/INT/TERM registered twice (task setup + child wait); post-wait reclaim is the explicit `on_exit` call.

## Evidence

- Local: all 11 baseline entries pass (52/54 in the dir; 2 skips predate).
- Negative control (throwaway worktree): removing `poll()` re-fails the init representative.
- Full 4-shard lane run 31863197203: `known=164, new=0, resolved=0, changed=0, collection_errors=0, invalid=0, exit_code=0` (diff.json artifact).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>