### PR TITLE
fix(security): confine the remaining admin resource endpoints to the caller's tenant

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1627,6 +1627,85 @@ def enforce_requested_tenant_scope(
     return actor_tenant_id, None
 
 
+def _audit_cross_tenant_resource_access(target_tenant_id: int | None) -> None:
+    """Record a platform admin reaching into another tenant's non-user resource.
+
+    The user-targeted counterpart is :func:`_audit_cross_tenant_user_access`;
+    this one takes the resource's owning tenant directly because policy rules,
+    compliance reports and the like are not users. No-op when the resource has
+    no tenant (global), belongs to the actor's own tenant, or the actor id is
+    not resolvable.
+    """
+    if target_tenant_id is None:
+        return
+
+    actor_id = getattr(g, "user_id", None)
+    if not isinstance(actor_id, int):
+        return
+
+    own_tenant_id = _normalize_user_tenant_id((getattr(g, "user", None) or {}).get("tenant_id"))
+    if target_tenant_id == own_tenant_id:
+        return
+
+    _log_cross_tenant_operation(
+        actor_user_id=actor_id,
+        actor_tenant_id=own_tenant_id,
+        target_tenant_id=target_tenant_id,
+        action=f"{request.method} {request.path}",
+    )
+
+
+def enforce_resource_tenant_scope(resource_tenant_id: object) -> tuple[Response, int] | None:
+    """Deny when the current admin may not act on a resource owned by ``resource_tenant_id``.
+
+    For non-user resources reached by their own id (a policy rule by ``rule_id``
+    or ``rule_key``, a compliance report by ``report_id``) whose owning/scope
+    tenant is read from the repository first. Returns ``None`` to proceed,
+    otherwise the error response the caller must return.
+
+    Distinct from :func:`enforce_requested_tenant_scope`. There a ``None``
+    ``tenant_id`` means "no filter requested" and is widened to the caller's own
+    tenant; here a ``None`` means the *resource itself* is global/unscoped, and a
+    tenant-scoped admin must be **denied** rather than silently rescoped --
+    otherwise a tenant admin could edit a rule that governs every tenant (or
+    have a global rule quietly rewritten under its own tenant). This mirrors the
+    tenant half of :func:`enforce_target_user_tenant`, which denies a
+    ``tenant_id IS NULL`` target for the same reason.
+
+    * Platform admin: always allowed; a cross-tenant target is audit-logged.
+    * Tenant-scoped admin: allowed only when ``resource_tenant_id`` equals the
+      caller's tenant. A ``None`` (global) or mismatched tenant is denied.
+
+    There is no vertical (role) check here as there is for users: these
+    resources carry no role, so taking one over grants no account privileges.
+    Callers that cannot resolve the resource should pass ``None`` so a tenant
+    admin is denied (fail closed) and given no existence oracle.
+    """
+    actor_tenant_id, denial = resolve_admin_tenant_scope()
+    if denial is not None:
+        return denial
+
+    target_tenant_id = _normalize_user_tenant_id(resource_tenant_id)
+
+    if actor_tenant_id is None:
+        # Platform admin: permitted, but record the boundary crossing.
+        _audit_cross_tenant_resource_access(target_tenant_id)
+        return None
+
+    if target_tenant_id is None or target_tenant_id != actor_tenant_id:
+        logger.warning(
+            "Cross-tenant resource operation denied: actor=%s actor_tenant=%s "
+            "target_tenant=%s path=%s",
+            getattr(g, "user_id", None),
+            actor_tenant_id,
+            target_tenant_id,
+            request.path,
+        )
+        return jsonify({"error": "Cross-tenant access denied"}), 403
+
+    return None
+
+
 # ── ActorScope and Tenant Authorization (Issue #2327) ─────────────────────
 
 

--- a/app/modules/governance/quota_manager.py
+++ b/app/modules/governance/quota_manager.py
@@ -613,6 +613,39 @@ class QuotaManager:
 
         return alerts
 
+    def get_alert(self, alert_id: int) -> QuotaAlert | None:
+        """Fetch a single alert by id.
+
+        ``quota_alerts`` has no ``tenant_id`` column, but ``user_id`` is NOT
+        NULL, so the acknowledge endpoint resolves the owning tenant through
+        that user before its cross-tenant boundary check.
+        """
+        row = self.db.fetch_one(
+            adapt_sql("SELECT * FROM quota_alerts WHERE id = ?"),
+            (alert_id,),
+        )
+        if not row:
+            return None
+        return QuotaAlert(
+            id=row.get("id"),
+            user_id=row.get("user_id", 0),
+            alert_type=row.get("alert_type", "warning"),
+            quota_type=row.get("quota_type", "tokens"),
+            period=row.get("period", "daily"),
+            threshold=row.get("threshold", 0),
+            current_usage=row.get("current_usage", 0),
+            quota_limit=row.get("quota_limit", 0),
+            percentage=row.get("percentage", 0),
+            message=row.get("message", ""),
+            created_at=(
+                parse_db_datetime(row.get("created_at"))
+                or datetime.now(timezone.utc).replace(tzinfo=None)
+            ),
+            acknowledged=bool(row.get("acknowledged", 0)),
+            acknowledged_at=parse_db_datetime(row.get("acknowledged_at")),
+            acknowledged_by=row.get("acknowledged_by"),
+        )
+
     def acknowledge_alert(self, alert_id: int, acknowledged_by: int) -> bool:
         """Acknowledge an alert."""
         try:

--- a/app/modules/policy/repo.py
+++ b/app/modules/policy/repo.py
@@ -156,6 +156,21 @@ class PolicyRepository:
         row = self.db.fetch_one("SELECT * FROM policy_rules WHERE id = ?", (rule_id,))
         return PolicyRule.from_row(row) if row else None
 
+    def get_current_rule_by_key(self, rule_key: str) -> PolicyRule | None:
+        """The current (is_current) version for a logical rule key, if any.
+
+        ``create_rule`` supersedes *every* ``is_current`` row for a key before
+        inserting the next version, so at most one such row exists per key
+        across all tenants. A tenant-boundary check on ``PUT
+        /policy/rules/<rule_key>`` reads this to learn which tenant currently
+        owns the key before overwriting it.
+        """
+        row = self.db.fetch_one(
+            adapt_sql("SELECT * FROM policy_rules WHERE rule_key = ? AND is_current = ?"),
+            (rule_key, _bool(True)),
+        )
+        return PolicyRule.from_row(row) if row else None
+
     def get_rules_for_evaluation(self) -> list[PolicyRule]:
         """Current + enabled rules, pre-sorted by priority.
 

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -179,23 +179,15 @@ def generate_report():
             g.user.get("id"),
             target_tenant_id,
         )
-    # Tenant admin can only generate reports for their own tenant
+    # Tenant admin can only generate reports for their own tenant. Reuse the
+    # shared request-scope guard: it normalizes the body value (a string "1"
+    # must not read as != int 1), denies naming another tenant outright, and
+    # rejects a tenant admin with no tenant -- consistent with the hardened
+    # list/read siblings (get_saved_reports / get_saved_report).
     elif user_role == "tenant_admin":
-        if caller_tenant_id is None:
-            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        # Naming another tenant is denied outright rather than silently served
-        # the caller's own report -- matches the hardened list/read siblings
-        # (get_saved_reports / get_saved_report) so the whole surface behaves
-        # consistently.
-        if data.get("tenant_id") is not None and data.get("tenant_id") != caller_tenant_id:
-            logger.warning(
-                "Tenant admin %s attempted to generate report for tenant %s (own tenant: %s)",
-                g.user.get("id"),
-                data.get("tenant_id"),
-                caller_tenant_id,
-            )
-            return jsonify({"error": "Cross-tenant access denied"}), 403
-        target_tenant_id = caller_tenant_id
+        target_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+        if denial is not None:
+            return denial
     # Legacy admin: backward compatibility
     # - With tenant_id: scoped to that tenant (like tenant_admin)
     # - Without tenant_id: global access (like platform_admin)

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -14,6 +14,7 @@ from flask import Blueprint, Response, g, jsonify, request
 from app.auth.decorators import (
     admin_required,
     enforce_requested_tenant_scope,
+    enforce_resource_tenant_scope,
     resolve_tenant_scope,
     same_tenant_user_required,
 )
@@ -182,7 +183,10 @@ def generate_report():
     elif user_role == "tenant_admin":
         if caller_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        # Ignore any tenant_id in request body
+        # Naming another tenant is denied outright rather than silently served
+        # the caller's own report -- matches the hardened list/read siblings
+        # (get_saved_reports / get_saved_report) so the whole surface behaves
+        # consistently.
         if data.get("tenant_id") is not None and data.get("tenant_id") != caller_tenant_id:
             logger.warning(
                 "Tenant admin %s attempted to generate report for tenant %s (own tenant: %s)",
@@ -190,6 +194,7 @@ def generate_report():
                 data.get("tenant_id"),
                 caller_tenant_id,
             )
+            return jsonify({"error": "Cross-tenant access denied"}), 403
         target_tenant_id = caller_tenant_id
     # Legacy admin: backward compatibility
     # - With tenant_id: scoped to that tenant (like tenant_admin)
@@ -330,8 +335,8 @@ def list_saved_reports():
     The query's ``tenant_id`` went straight to the repository, so a tenant
     admin could name another tenant -- or omit it entirely and get every
     tenant's reports. Reading a single report by id
-    (``GET /reports/<report_id>``) still needs a per-resource owner lookup and
-    is tracked in docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md.
+    (``GET /reports/<report_id>``) is confined in :func:`get_saved_report` via
+    a per-resource owner lookup (``enforce_resource_tenant_scope``).
     """
 
     report_type = request.args.get("report_type")
@@ -364,6 +369,13 @@ def get_saved_report(report_id: str):
     """Get a saved report (admin only)."""
 
     report = report_generator.get_saved_report(report_id)
+    # compliance_reports carries a tenant_id; confine the read to the caller's
+    # tenant. A missing report resolves to None, which denies a tenant admin
+    # (no cross-tenant existence oracle) and falls through to the 404 for a
+    # platform admin.
+    denial = enforce_resource_tenant_scope(report.metadata.tenant_id if report else None)
+    if denial is not None:
+        return denial
 
     if not report:
         return jsonify({"error": "Report not found"}), 404

--- a/app/routes/governance.py
+++ b/app/routes/governance.py
@@ -12,7 +12,13 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import admin_required, auth_required, same_tenant_user_required
+from app.auth.decorators import (
+    admin_required,
+    auth_required,
+    enforce_resource_tenant_scope,
+    platform_admin_required,
+    same_tenant_user_required,
+)
 from app.modules.governance.audit_logger import AuditAction, AuditLogger, get_action_categories
 from app.modules.governance.content_filter import ContentFilter
 from app.modules.governance.quota_manager import QuotaManager
@@ -305,6 +311,22 @@ def api_get_quota_alerts():
 def api_acknowledge_alert(alert_id):
     """Acknowledge a quota alert."""
 
+    # quota_alerts has no tenant column, so resolve the owning tenant through
+    # the alert's user before enforcing the boundary. A missing alert or user
+    # resolves to None, which denies a tenant admin (fail closed, and no
+    # cross-tenant existence oracle) and lets a platform admin fall through to
+    # the 404 below.
+    from app.repositories.user_repo import UserRepository
+
+    alert = quota_manager.get_alert(alert_id)
+    target_user = UserRepository().get_user_by_id(alert.user_id) if alert else None
+    denial = enforce_resource_tenant_scope(target_user.get("tenant_id") if target_user else None)
+    if denial is not None:
+        return denial
+
+    if alert is None:
+        return jsonify({"error": "Alert not found"}), 404
+
     user_id = g.user_id
 
     success = quota_manager.acknowledge_alert(alert_id, user_id)
@@ -388,7 +410,7 @@ def api_filter_stats():
 
 
 @governance_bp.route("/content/filter/patterns", methods=["POST"])
-@admin_required
+@platform_admin_required
 def api_add_pattern():
     """Add a custom content filter pattern."""
 
@@ -422,7 +444,7 @@ def api_add_pattern():
 
 
 @governance_bp.route("/content/filter/keywords", methods=["POST"])
-@admin_required
+@platform_admin_required
 def api_add_keyword():
     """Add a custom sensitive keyword."""
 
@@ -464,7 +486,7 @@ def api_get_filter_rules():
 
 
 @governance_bp.route("/filter-rules", methods=["POST"])
-@admin_required
+@platform_admin_required
 def api_create_filter_rule():
     """Create a new content filter rule."""
 
@@ -511,7 +533,7 @@ def api_create_filter_rule():
 
 
 @governance_bp.route("/filter-rules/<int:rule_id>", methods=["PUT"])
-@admin_required
+@platform_admin_required
 def api_update_filter_rule(rule_id):
     """Update a content filter rule."""
 
@@ -550,7 +572,7 @@ def api_update_filter_rule(rule_id):
 
 
 @governance_bp.route("/filter-rules/<int:rule_id>", methods=["DELETE"])
-@admin_required
+@platform_admin_required
 def api_delete_filter_rule(rule_id):
     """Delete a content filter rule."""
 

--- a/app/routes/governance.py
+++ b/app/routes/governance.py
@@ -616,9 +616,16 @@ def api_get_security_settings():
 
 
 @governance_bp.route("/security-settings", methods=["PUT"])
-@admin_required
+@platform_admin_required
 def api_update_security_settings():
-    """Update security settings."""
+    """Update security settings.
+
+    security_settings has no tenant column -- it is global config (2FA toggle,
+    password policy, login-attempt limit, IP whitelist, audit thresholds), so a
+    write governs every tenant. Same reasoning as the content-filter mutations:
+    a tenant admin must not rewrite platform-wide security posture. Reads
+    (GET /security-settings) stay admin-level.
+    """
 
     data = request.get_json() or {}
 

--- a/app/routes/policy.py
+++ b/app/routes/policy.py
@@ -148,11 +148,18 @@ def _scope_policy_rule_write(rule_key: str, requested_tenant_id: object):
     Keeping this in one place stops create and update from drifting apart;
     leaving create without step 1 was exactly such a drift. Returns
     ``(scoped_tenant_id, denial)``; on success set ``fields["tenant_id"]``.
+
+    The owner lookup normalizes ``rule_key`` the SAME way ``create_rule`` will:
+    ``_parse_rule_body`` strips the key before the supersede runs, so a
+    whitespace-padded key (e.g. ``PUT /policy/rules/k1%20``) must strip here too
+    -- otherwise the check looks up ``"k1 "`` (miss), skips, and the supersede
+    still clobbers the trimmed ``"k1"``.
     """
     from app.modules.policy.repo import PolicyRepository
 
-    if rule_key:
-        current = PolicyRepository().get_current_rule_by_key(rule_key)
+    normalized_key = rule_key.strip() if isinstance(rule_key, str) else rule_key
+    if normalized_key:
+        current = PolicyRepository().get_current_rule_by_key(normalized_key)
         if current is not None:
             denial = enforce_resource_tenant_scope(current.tenant_id)
             if denial is not None:

--- a/app/routes/policy.py
+++ b/app/routes/policy.py
@@ -131,6 +131,35 @@ def list_policy_rules():
     return jsonify({"success": True, "rules": [r.to_dict() for r in rules], "total": len(rules)})
 
 
+def _scope_policy_rule_write(rule_key: str, requested_tenant_id: object):
+    """Shared tenant guard for writing a policy rule (create or versioned update).
+
+    Both ``POST /policy/rules`` and ``PUT /policy/rules/<rule_key>`` funnel into
+    ``PolicyRepository.create_rule``, whose supersede UPDATE is keyed on
+    ``rule_key`` **with no tenant filter**. So *both* must:
+
+    1. If the key already has a current version, confirm the caller may overwrite
+       its owner (``enforce_resource_tenant_scope`` -- a global/other-tenant
+       owner is denied for a tenant admin). Otherwise POSTing an existing key is
+       a cross-tenant clobber even though it looks like a "create".
+    2. Confine the new version's own scope (``enforce_requested_tenant_scope`` --
+       a tenant admin cannot author a global or other-tenant rule).
+
+    Keeping this in one place stops create and update from drifting apart;
+    leaving create without step 1 was exactly such a drift. Returns
+    ``(scoped_tenant_id, denial)``; on success set ``fields["tenant_id"]``.
+    """
+    from app.modules.policy.repo import PolicyRepository
+
+    if rule_key:
+        current = PolicyRepository().get_current_rule_by_key(rule_key)
+        if current is not None:
+            denial = enforce_resource_tenant_scope(current.tenant_id)
+            if denial is not None:
+                return None, denial
+    return enforce_requested_tenant_scope(requested_tenant_id)
+
+
 @policy_bp.route("/policy/rules", methods=["POST"])
 @admin_required
 def create_policy_rule():
@@ -138,12 +167,9 @@ def create_policy_rule():
     from app.modules.policy.repo import PolicyRepository
 
     data = request.get_json(silent=True) or {}
-    # A rule's tenant_id is a scope field: which tenant the rule governs. A
-    # tenant admin may only author rules for its own tenant and never a global
-    # (tenant_id=None) rule that would govern everyone; a platform admin may
-    # target any tenant. Resolve the effective scope from the request rather
-    # than trusting the body.
-    scoped_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    scoped_tenant_id, denial = _scope_policy_rule_write(
+        (data.get("rule_key") or "").strip(), data.get("tenant_id")
+    )
     if denial is not None:
         return denial
     fields, err = _parse_rule_body(data)
@@ -167,20 +193,12 @@ def update_policy_rule(rule_key: str):
     """
     from app.modules.policy.repo import PolicyRepository
 
-    repo = PolicyRepository()
-    # Superseding a key rewrites whichever tenant currently owns it (the
-    # supersede UPDATE is keyed on rule_key alone), so first confirm the caller
-    # may touch the existing version. A missing key is a create and skips this.
-    current = repo.get_current_rule_by_key(rule_key)
-    if current is not None:
-        denial = enforce_resource_tenant_scope(current.tenant_id)
-        if denial is not None:
-            return denial
-
     data = request.get_json(silent=True) or {}
     data["rule_key"] = rule_key
-    # Confine the new version's scope the same way create does.
-    scoped_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    # Same guard as create: confirm the caller may overwrite the key's current
+    # owner (the supersede is keyed on rule_key alone) and confine the new
+    # version's scope.
+    scoped_tenant_id, denial = _scope_policy_rule_write(rule_key, data.get("tenant_id"))
     if denial is not None:
         return denial
     fields, err = _parse_rule_body(data)
@@ -188,7 +206,7 @@ def update_policy_rule(rule_key: str):
         return jsonify({"error": err}), 400
     fields["tenant_id"] = scoped_tenant_id
     fields["created_by"] = g_user_id()
-    rule = repo.create_rule(**fields)
+    rule = PolicyRepository().create_rule(**fields)
     invalidate_policy_rule_cache()
     logger.info("Policy rule updated: %s v%d", rule.rule_key, rule.version)
     return jsonify({"success": True, "rule": rule.to_dict()})

--- a/app/routes/policy.py
+++ b/app/routes/policy.py
@@ -18,7 +18,11 @@ import re
 
 from flask import Blueprint, jsonify, request
 
-from app.auth.decorators import admin_required
+from app.auth.decorators import (
+    admin_required,
+    enforce_requested_tenant_scope,
+    enforce_resource_tenant_scope,
+)
 from app.modules.policy.cache import invalidate_policy_rule_cache
 
 logger = logging.getLogger(__name__)
@@ -134,9 +138,18 @@ def create_policy_rule():
     from app.modules.policy.repo import PolicyRepository
 
     data = request.get_json(silent=True) or {}
+    # A rule's tenant_id is a scope field: which tenant the rule governs. A
+    # tenant admin may only author rules for its own tenant and never a global
+    # (tenant_id=None) rule that would govern everyone; a platform admin may
+    # target any tenant. Resolve the effective scope from the request rather
+    # than trusting the body.
+    scoped_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    if denial is not None:
+        return denial
     fields, err = _parse_rule_body(data)
     if err:
         return jsonify({"error": err}), 400
+    fields["tenant_id"] = scoped_tenant_id
     fields["created_by"] = g_user_id()
     rule = PolicyRepository().create_rule(**fields)
     invalidate_policy_rule_cache()
@@ -154,13 +167,28 @@ def update_policy_rule(rule_key: str):
     """
     from app.modules.policy.repo import PolicyRepository
 
+    repo = PolicyRepository()
+    # Superseding a key rewrites whichever tenant currently owns it (the
+    # supersede UPDATE is keyed on rule_key alone), so first confirm the caller
+    # may touch the existing version. A missing key is a create and skips this.
+    current = repo.get_current_rule_by_key(rule_key)
+    if current is not None:
+        denial = enforce_resource_tenant_scope(current.tenant_id)
+        if denial is not None:
+            return denial
+
     data = request.get_json(silent=True) or {}
     data["rule_key"] = rule_key
+    # Confine the new version's scope the same way create does.
+    scoped_tenant_id, denial = enforce_requested_tenant_scope(data.get("tenant_id"))
+    if denial is not None:
+        return denial
     fields, err = _parse_rule_body(data)
     if err:
         return jsonify({"error": err}), 400
+    fields["tenant_id"] = scoped_tenant_id
     fields["created_by"] = g_user_id()
-    rule = PolicyRepository().create_rule(**fields)
+    rule = repo.create_rule(**fields)
     invalidate_policy_rule_cache()
     logger.info("Policy rule updated: %s v%d", rule.rule_key, rule.version)
     return jsonify({"success": True, "rule": rule.to_dict()})
@@ -172,10 +200,19 @@ def toggle_policy_rule(rule_id: int):
     """Toggle enabled on the current version of a rule."""
     from app.modules.policy.repo import PolicyRepository
 
+    repo = PolicyRepository()
+    # Resolve the rule's owning tenant before touching it. Passing None for a
+    # missing rule denies a tenant admin (fail closed) and gives no existence
+    # oracle; a platform admin falls through to the same 404 as before.
+    rule = repo.get_rule(rule_id)
+    denial = enforce_resource_tenant_scope(rule.tenant_id if rule else None)
+    if denial is not None:
+        return denial
+
     data = request.get_json(silent=True) or {}
     if "enabled" not in data:
         return jsonify({"error": "enabled is required"}), 400
-    updated = PolicyRepository().set_rule_enabled(rule_id, bool(data["enabled"]))
+    updated = repo.set_rule_enabled(rule_id, bool(data["enabled"]))
     if not updated:
         return jsonify({"error": "Rule not found or not current"}), 404
     invalidate_policy_rule_cache()

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -2,6 +2,11 @@
 
 配套 PR 修的是**跨租户账号接管**。这份笔记记录顺带做完的全量审计，给后续 PR 留工作清单。
 
+> **2026-08-15 更新**：下面「剩余 6 个」以及从请求里取租户的那批，已由 follow-up
+> PR（`fix/p0-remaining-tenant-scoped-endpoints`）全部修完。落地时又发现两处**同类
+> 但两轮枚举都漏掉的洞**（见 [§ follow-up 落地](#follow-up-落地2026-08-15)），一并
+> 收进同一 PR 以免修一半。
+
 ## 洞是什么
 
 `admin_required` 认证 `admin` / `platform_admin` / `tenant_admin` 三种角色并写入
@@ -91,7 +96,7 @@ legacy `admin` 行就会突然失去保护，等于「开了更严的开关反�
 也就是说「9 个用户端点现在都受控」是对的，但其中只有 **7 个**是本次加的装饰器，
 另外 2 个是沿用既有的手写校验（重复实现，将来值得合并到同一个装饰器）。
 
-### 剩余 6 个：有资源 id 且完全没有租户处理
+### 剩余 6 个：有资源 id 且完全没有租户处理（✅ follow-up PR 已修）
 
 带路径参数的 `@admin_required` 路由共 **29** 个（第一版这里写 24 是错的：用正则枚举
 时只匹配了固定的几个 id 名，漏掉了 `<int:id>` / `<sender_name>` / `<rule_key>` 这些
@@ -186,6 +191,66 @@ GET，于是每刷一次就多一行审计。这是刻意保留的——「谁�
 过滤，这份审计没有逐个核实 repo——那是 #2429 数据层收敛的范围，而且报告已经点明
 根因：**26 个 repository 里 11 个完全没有 tenant_id 概念，隔离靠「记得调对装饰器」，
 不是靠架构**。逐端点补装饰器只能压住症状。
+
+## follow-up 落地（2026-08-15）
+
+follow-up PR 收口了「剩余 6 个」和「从请求里取租户」两批，共触及三个蓝图。
+
+### 新复用件
+
+`app/auth/decorators.py::enforce_resource_tenant_scope(resource_tenant_id)`——
+按**资源自己的租户**（先从仓储反查）判断当前 admin 能不能动它。与
+`enforce_requested_tenant_scope` 的关键区别：那里 `None` 表示「没点名租户」会收敛到
+调用者自己的租户；这里 `None` 表示**资源本身是全局的**，租户管理员必须**拒**而不是
+被悄悄改写租户——否则租户管理员就能改一条治所有租户的规则。等价于
+`enforce_target_user_tenant` 的租户那半段（NULL→拒），但没有纵向角色判断（这些资源不
+带角色，接管它不继承任何账号权限）。平台管理员放行并写跨租户审计。
+
+### 按资源反查 owner 再比对
+
+| 端点 | 反查路径 | 说明 |
+|---|---|---|
+| `policy.py` `PATCH /policy/rules/<rule_id>/enabled` | `get_rule(id).tenant_id` | 全局规则(None)对租户管理员=拒；查不到=拒(fail closed，无存在性 oracle) |
+| `policy.py` `PUT /policy/rules/<rule_key>` | `get_current_rule_by_key(key).tenant_id` | supersede 的 UPDATE 只按 rule_key，会顶掉当前 owner，故先校验既有版本；**新版本**的 scope 再走 `enforce_requested_tenant_scope`，租户管理员不能建全局/别租户规则 |
+| `policy.py` `POST /policy/rules` | —（新建） | 两轮枚举都漏了：body 的 `tenant_id` 走 `_parse_rule_body` 间接读，正则没跟进去。同 update 一样收敛新版本 scope |
+| `governance.py` `POST /quota/alerts/<id>/acknowledge` | `get_alert(id).user_id` → `user.tenant_id` | `quota_alerts` 无租户列但 `user_id NOT NULL`；alert/user 任一查不到=拒 |
+| `compliance.py` `GET /reports/<report_id>` | `get_saved_report(id).metadata.tenant_id` | 单条读；列表侧 `/reports/saved` 上个 PR 已收紧 |
+
+新增仓储方法：`PolicyRepository.get_current_rule_by_key`、`QuotaManager.get_alert`。
+
+### 全局表 → 收成 `platform_admin_required`
+
+`content_filter_rules` 一列租户都没有，`add_custom_pattern`/`add_custom_keyword` 也不带
+租户参数——整个内容过滤特性在设计上就是全局的。改一条会影响所有租户，本就不该是租户级
+权限。故把它的**全部 5 个写端点**收成平台管理员专属（`admin_required` →
+`platform_admin_required`）：`POST /content/filter/patterns`、
+`POST /content/filter/keywords`、`POST /filter-rules`、`PUT /filter-rules/<id>`、
+`DELETE /filter-rules/<id>`。读端点（list/stats/check）不动。
+
+其中 `POST /content/filter/patterns`、`/keywords`、`POST /filter-rules` 三个是**第二处
+两轮都漏的洞**：它们既没有路径资源 id，又不从请求读 `tenant_id`，所以「按资源 id 枚举」
+和「按 `data.get('tenant_id')` 枚举」都扫不到。只锁 PUT/DELETE 而留着 create 是不自洽的
+（建一条 `effect=deny` 的全局规则比改一条更危险），故一并收口。
+
+### 一致性收敛
+
+`compliance.py::generate_report` 的租户管理员分支原来点名别的租户时只记日志、仍返回**自己
+租户**的报告（不是泄露，但和刚收紧的 list/单读兄弟端点行为不一致）。改成点名别人=403，
+整个 compliance 面统一。
+
+### 验证
+
+新增 `tests/integration/test_admin_cross_tenant_followup.py`（48 项），覆盖每个端点的
+「租户管理员拒 / 平台管理员放行 / fail-closed / 无 oracle」四类，平台管理员跨租户放行处
+断言写了审计。8 处守卫逐一 source-mutation：破一个必挂一条具名测试（全部 CAUGHT）。
+
+### 仍未动（范围外，记账）
+
+- `remote.py:1043 assign_user`——非角色的跨租户路径（把 A 租户的普通用户设成 B 租户机器
+  管理员）。`role='user'` 所以 `is_platform_level_role` 保护不到，先于本系列存在。
+- **list/聚合端点靠仓储过滤**的那批（`GET /quota/alerts`、`GET /quota/status/all` 等）：
+  底层 repo 没按 `g.tenant_id` 过滤，属 #2429 数据层收敛，不是逐端点补装饰器能治的。ack
+  端点已按资源收口，但同特性的 list 侧读泄露仍在该边界内。
 
 ## 该往哪走
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -277,6 +277,12 @@ keyword、security-settings PUT）都属「全局配置写但既无资源 id 又
   webhook / 钉钉配置写。全部先于本系列存在。本 PR 只收口它**已经在动**的 governance.py
   （内容过滤 + security-settings）；跨文件的「全局配置写」一轴留给 #2429 一次扫清，别在本
   PR 里零敲碎打（改一个就得改这一整批，等于把 #2429 提前拆进来）。
+- **policy supersede 的并发裂缝**（评审 R1/R3 两次点名，先于本系列存在）：`create_rule`
+  的 supersede（`repo.py:76` `WHERE rule_key=? AND is_current=?`）与随后的 insert 分处两个
+  事务，且 schema 只有 `UNIQUE(rule_key, version)`——并发双写可能瞬时留下两行 `is_current`
+  分属不同租户，此时 owner 校验的 `fetch_one` 只读到其一、supersede 却顶掉两行。本 PR 的
+  owner 校验相对「原来完全不查」是净改善，但要彻底堵这条竞态需 partial unique index /
+  单事务 supersede——那是 policy 数据模型的活（带迁移），不属本租户边界 PR，记 #2429。
 
 ## 该往哪走
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -212,7 +212,7 @@ follow-up PR 收口了「剩余 6 个」和「从请求里取租户」两批，�
 |---|---|---|
 | `policy.py` `PATCH /policy/rules/<rule_id>/enabled` | `get_rule(id).tenant_id` | 全局规则(None)对租户管理员=拒；查不到=拒(fail closed，无存在性 oracle) |
 | `policy.py` `PUT /policy/rules/<rule_key>` | `get_current_rule_by_key(key).tenant_id` | supersede 的 UPDATE 只按 rule_key，会顶掉当前 owner，故先校验既有版本；**新版本**的 scope 再走 `enforce_requested_tenant_scope`，租户管理员不能建全局/别租户规则 |
-| `policy.py` `POST /policy/rules` | —（新建） | 两轮枚举都漏了：body 的 `tenant_id` 走 `_parse_rule_body` 间接读，正则没跟进去。同 update 一样收敛新版本 scope |
+| `policy.py` `POST /policy/rules` | `get_current_rule_by_key(key)`（key 已存在时） | 两轮枚举都漏了：body 的 `tenant_id` 走 `_parse_rule_body` 间接读，正则没跟进去。**独立评审又抓到一层**：POST 和 PUT 一样落到按 rule_key 的 supersede，POST 一个**已存在**的 key 照样顶掉 owner——只收敛新版本 scope 不够。故与 PUT 共用 `_scope_policy_rule_write`（既有 owner 校验 + 新版本 scope 一处写），杜绝二者再次漂移 |
 | `governance.py` `POST /quota/alerts/<id>/acknowledge` | `get_alert(id).user_id` → `user.tenant_id` | `quota_alerts` 无租户列但 `user_id NOT NULL`；alert/user 任一查不到=拒 |
 | `compliance.py` `GET /reports/<report_id>` | `get_saved_report(id).metadata.tenant_id` | 单条读；列表侧 `/reports/saved` 上个 PR 已收紧 |
 
@@ -232,6 +232,13 @@ follow-up PR 收口了「剩余 6 个」和「从请求里取租户」两批，�
 和「按 `data.get('tenant_id')` 枚举」都扫不到。只锁 PUT/DELETE 而留着 create 是不自洽的
 （建一条 `effect=deny` 的全局规则比改一条更危险），故一并收口。
 
+**独立评审又补一处**：`PUT /security-settings`（`governance.py`）也是同一类——
+`security_settings` 无租户列（全局的 2FA 开关 / 密码策略 / 登录尝试上限 / IP 白名单 /
+审计阈值），租户管理员能改一条就动了**所有租户**的安全基线，比内容过滤影响更大。同样收成
+`platform_admin_required`（`GET` 不动）。这三处（policy POST、content-filter create/pattern/
+keyword、security-settings PUT）都属「全局配置写但既无资源 id 又不读 tenant_id」，是两轴枚
+举的共同盲区，教训记这里：**审「全局配置写端点」要单列一轴，不能靠资源 id / 请求租户去扫**。
+
 ### 一致性收敛
 
 `compliance.py::generate_report` 的租户管理员分支原来点名别的租户时只记日志、仍返回**自己
@@ -240,9 +247,13 @@ follow-up PR 收口了「剩余 6 个」和「从请求里取租户」两批，�
 
 ### 验证
 
-新增 `tests/integration/test_admin_cross_tenant_followup.py`（48 项），覆盖每个端点的
+新增 `tests/integration/test_admin_cross_tenant_followup.py`（57 项），覆盖每个端点的
 「租户管理员拒 / 平台管理员放行 / fail-closed / 无 oracle」四类，平台管理员跨租户放行处
-断言写了审计。8 处守卫逐一 source-mutation：破一个必挂一条具名测试（全部 CAUGHT）。
+断言写了审计。9 处守卫逐一 source-mutation：破一个必挂一条具名测试（全部 CAUGHT）。
+
+独立对抗评审跑了一轮，抓到 3 个真问题并已修：POST /policy/rules 的 supersede 顶 owner
+（HIGH）、`PUT /security-settings` 漏收（同全局配置类）、`generate_report` 把 body 的字符串
+`"1"` 当成 `!= int 1` 误拒本租户（LOW，改用 `enforce_requested_tenant_scope` 归一化）。
 
 ### 仍未动（范围外，记账）
 

--- a/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
+++ b/docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md
@@ -251,9 +251,16 @@ keyword、security-settings PUT）都属「全局配置写但既无资源 id 又
 「租户管理员拒 / 平台管理员放行 / fail-closed / 无 oracle」四类，平台管理员跨租户放行处
 断言写了审计。9 处守卫逐一 source-mutation：破一个必挂一条具名测试（全部 CAUGHT）。
 
-独立对抗评审跑了一轮，抓到 3 个真问题并已修：POST /policy/rules 的 supersede 顶 owner
-（HIGH）、`PUT /security-settings` 漏收（同全局配置类）、`generate_report` 把 body 的字符串
-`"1"` 当成 `!= int 1` 误拒本租户（LOW，改用 `enforce_requested_tenant_scope` 归一化）。
+独立对抗评审跑了两轮，抓到 4 个真问题并已修：
+
+- **R1**：`POST /policy/rules` 的 supersede 顶 owner（HIGH）、`PUT /security-settings` 漏收
+  （同全局配置类）、`generate_report` 把 body 的字符串 `"1"` 当成 `!= int 1` 误拒本租户
+  （LOW，改用 `enforce_requested_tenant_scope` 归一化）。
+- **R2**：修 R1 后 `PUT /policy/rules/<key>` 仍可用**首/尾空格的 key** 绕过 owner 校验——
+  owner 查 raw key 落空跳过，supersede 却按 `_parse_rule_body` strip 后的 key 顶掉受害规则
+  （HIGH）。修法：`_scope_policy_rule_write` 里按同一规则 strip 后再查。**教训：校验用的 key
+  必须和落库/supersede 用的 key 走同一归一化**——本轮两个 HIGH 都是「守卫的 key ≠ 实际写的
+  key」这同一个根因的不同变体。
 
 ### 仍未动（范围外，记账）
 
@@ -262,6 +269,14 @@ keyword、security-settings PUT）都属「全局配置写但既无资源 id 又
 - **list/聚合端点靠仓储过滤**的那批（`GET /quota/alerts`、`GET /quota/status/all` 等）：
   底层 repo 没按 `g.tenant_id` 过滤，属 #2429 数据层收敛，不是逐端点补装饰器能治的。ack
   端点已按资源收口，但同特性的 list 侧读泄露仍在该边界内。
+- **全局配置写但既无资源 id 又不读 tenant_id 的一批**（R2 评审点名，归 #2429 的专项 sweep）：
+  `ai_agent_settings.py:44 PUT /ai-agent/settings`（`ai_agent_settings` 无租户列，与
+  `security_settings` **完全同形**，只是不在本 PR 改的三个文件里）、`smtp_config.py` /
+  `feishu_config.py` / `model_gateway.py` 的 `@admin_required` before_request 守卫（全局
+  smtp / 飞书·钉钉 / model-gateway 配置写）、`notification_integrations.py:73,104` 的
+  webhook / 钉钉配置写。全部先于本系列存在。本 PR 只收口它**已经在动**的 governance.py
+  （内容过滤 + security-settings）；跨文件的「全局配置写」一轴留给 #2429 一次扫清，别在本
+  PR 里零敲碎打（改一个就得改这一整批，等于把 #2429 提前拆进来）。
 
 ## 该往哪走
 

--- a/tests/integration/test_admin_cross_tenant_followup.py
+++ b/tests/integration/test_admin_cross_tenant_followup.py
@@ -1,0 +1,654 @@
+"""Tenant boundary on the remaining admin resource endpoints (follow-up to #2180).
+
+The account-takeover fix closed the user-keyed admin endpoints. ``admin_required``
+still authenticates ``admin`` / ``platform_admin`` / ``tenant_admin`` without
+comparing that tenant against the resource being touched, so the resource-keyed
+and request-scoped remainder of the admin surface was left boundary-free. This
+module is the exploit-and-denial suite for that remainder:
+
+* **policy rules** -- a rule's ``tenant_id`` is a scope field (which tenant the
+  rule governs; ``None`` = global). A tenant admin could create/supersede/toggle
+  another tenant's rule, or a global rule that governs everyone.
+* **content-filter mutations** -- ``content_filter_rules`` has no tenant column
+  at all; the table is global, so mutating it is a platform-level operation and
+  the endpoints are now ``platform_admin_required``.
+* **quota alert acknowledge** -- ``quota_alerts`` has no tenant column but
+  ``user_id`` is NOT NULL, so the owning tenant is resolved through the user.
+* **compliance report read/generate** -- ``compliance_reports`` carries a
+  ``tenant_id``; a tenant admin could read another tenant's report by id, and
+  ``generate_report`` served the caller's own report instead of denying when a
+  tenant admin named someone else's tenant.
+
+Each denial test is the exploit run against the fixed code. The
+``test_..._is_denied`` / ``..._was_the_hole`` names spell out what used to work.
+
+Lineage: Issue #2180 (admin-route tenant isolation).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.security,
+    pytest.mark.regression,
+    pytest.mark.issue(2180),
+]
+
+
+TENANT_A = 1
+TENANT_B = 2
+
+TENANT_A_ADMIN = {
+    "id": 11,
+    "username": "a-admin",
+    "role": "tenant_admin",
+    "tenant_id": TENANT_A,
+    "must_change_password": False,
+}
+TENANT_B_ADMIN = {
+    "id": 21,
+    "username": "b-admin",
+    "role": "tenant_admin",
+    "tenant_id": TENANT_B,
+    "must_change_password": False,
+}
+PLATFORM_ADMIN = {
+    "id": 1,
+    "username": "platform",
+    "role": "platform_admin",
+    "tenant_id": None,
+    "must_change_password": False,
+}
+# Legacy 'admin' is a platform-level role while strict mode is off (the default).
+LEGACY_ADMIN = {
+    "id": 2,
+    "username": "legacy",
+    "role": "admin",
+    "tenant_id": TENANT_A,
+    "must_change_password": False,
+}
+# A plain tenant user must never reach these admin endpoints at all.
+TENANT_A_USER = {
+    "id": 12,
+    "username": "a-user",
+    "role": "user",
+    "tenant_id": TENANT_A,
+    "must_change_password": False,
+}
+
+# Alert owners, keyed by user id, for the quota-alert acknowledge tests.
+ALERT_USERS: dict[int, dict] = {
+    10: {"id": 10, "username": "alice", "role": "user", "tenant_id": TENANT_A},
+    20: {"id": 20, "username": "bob", "role": "user", "tenant_id": TENANT_B},
+}
+
+
+class _FakeUserRepo:
+    """Just enough of UserRepository for the alert-acknowledge reverse lookup."""
+
+    def __init__(self, users: dict[int, dict] | None = None):
+        self.users = users if users is not None else ALERT_USERS
+
+    def get_user_by_id(self, user_id):
+        user = self.users.get(int(user_id))
+        return dict(user) if user else None
+
+
+class _FakePolicyRepo:
+    """Records what the guarded policy routes attempt to write."""
+
+    def __init__(self, by_id=None, by_key=None):
+        self.by_id: dict[int, object] = by_id or {}
+        self.by_key: dict[str, object] = by_key or {}
+        self.created: list[dict] = []
+        self.enabled_calls: list[tuple[int, bool]] = []
+
+    def get_rule(self, rule_id):
+        return self.by_id.get(int(rule_id))
+
+    def get_current_rule_by_key(self, rule_key):
+        return self.by_key.get(rule_key)
+
+    def create_rule(self, **fields):
+        self.created.append(fields)
+        return SimpleNamespace(
+            rule_key=fields.get("rule_key"),
+            version=1,
+            to_dict=lambda: {
+                "rule_key": fields.get("rule_key"),
+                "tenant_id": fields.get("tenant_id"),
+            },
+        )
+
+    def set_rule_enabled(self, rule_id, enabled):
+        self.enabled_calls.append((int(rule_id), bool(enabled)))
+        return 1
+
+
+def _rule(tenant_id):
+    """A policy rule carrying just the scope field the guard reads."""
+    return SimpleNamespace(tenant_id=tenant_id)
+
+
+# ── request helpers, one per blueprint ────────────────────────────────────
+#
+# Each spins up a bare Flask app with only the blueprint under test so the
+# shared module-level blueprint singletons are never mutated for other test
+# modules (same reasoning as test_admin_cross_tenant_takeover.py). The
+# cross-tenant audit writer is stubbed everywhere so no test needs a database.
+
+
+def _policy_request(actor, method, path, *, json_body=None, policy_repo=None):
+    from app.routes.policy import policy_bp
+
+    policy_repo = policy_repo or _FakePolicyRepo()
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(policy_bp, url_prefix="/api")
+
+    with (
+        patch("app.auth.decorators._load_user_from_token", return_value=actor),
+        patch("app.utils.config.is_policy_enabled", return_value=True),
+        patch("app.modules.policy.repo.PolicyRepository", return_value=policy_repo),
+        patch("app.routes.policy.invalidate_policy_rule_cache"),
+        patch("app.auth.decorators._log_cross_tenant_operation") as audit,
+    ):
+        client = app.test_client()
+        response = client.open(
+            path,
+            method=method,
+            json=json_body,
+            headers={"Authorization": "Bearer test-token"},
+        )
+    return response, policy_repo, audit
+
+
+def _governance_request(
+    actor,
+    method,
+    path,
+    *,
+    json_body=None,
+    quota_mgr=None,
+    user_repo=None,
+    gov_repo=None,
+    content_filter=None,
+):
+    from app.routes.governance import governance_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(governance_bp, url_prefix="/api")
+
+    gov_repo = gov_repo if gov_repo is not None else MagicMock()
+    if gov_repo is not None and isinstance(gov_repo, MagicMock):
+        gov_repo.create_filter_rule.return_value = 123
+        gov_repo.update_filter_rule.return_value = True
+        gov_repo.delete_filter_rule.return_value = True
+    content_filter = content_filter if content_filter is not None else MagicMock()
+
+    with (
+        patch("app.auth.decorators._load_user_from_token", return_value=actor),
+        patch("app.routes.governance.quota_manager", quota_mgr or MagicMock()),
+        patch("app.routes.governance.governance_repo", gov_repo),
+        patch("app.routes.governance.content_filter", content_filter),
+        patch("app.routes.governance.audit_logger"),
+        patch(
+            "app.repositories.user_repo.UserRepository", return_value=user_repo or _FakeUserRepo()
+        ),
+        patch("app.auth.decorators._log_cross_tenant_operation") as audit,
+    ):
+        client = app.test_client()
+        response = client.open(
+            path,
+            method=method,
+            json=json_body,
+            headers={"Authorization": "Bearer test-token"},
+        )
+    return response, audit
+
+
+def _compliance_request(actor, method, path, *, json_body=None, report_gen=None):
+    from app.routes.compliance import compliance_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    # compliance_bp already carries url_prefix="/api/compliance".
+    app.register_blueprint(compliance_bp)
+
+    with (
+        patch("app.auth.decorators._load_user_from_token", return_value=actor),
+        patch("app.routes.compliance.report_generator", report_gen or MagicMock()),
+        patch("app.auth.decorators._log_cross_tenant_operation") as audit,
+    ):
+        client = app.test_client()
+        response = client.open(
+            path,
+            method=method,
+            json=json_body,
+            headers={"Authorization": "Bearer test-token"},
+        )
+    return response, audit
+
+
+# ── policy rules ──────────────────────────────────────────────────────────
+
+
+class TestPolicyToggleTenantBoundary:
+    """PATCH /api/policy/rules/<rule_id>/enabled."""
+
+    def test_tenant_admin_cannot_toggle_another_tenants_rule_was_the_hole(self):
+        repo = _FakePolicyRepo(by_id={5: _rule(TENANT_B)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PATCH",
+            "/api/policy/rules/5/enabled",
+            json_body={"enabled": False},
+            policy_repo=repo,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert repo.enabled_calls == []
+
+    def test_tenant_admin_cannot_toggle_a_global_rule(self):
+        """A NULL-tenant rule governs every tenant; deny rather than rescope."""
+        repo = _FakePolicyRepo(by_id={5: _rule(None)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PATCH",
+            "/api/policy/rules/5/enabled",
+            json_body={"enabled": False},
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.enabled_calls == []
+
+    def test_missing_rule_is_denied_for_tenant_admin_without_oracle(self):
+        """A missing rule and a cross-tenant rule both return 403 -- no existence oracle."""
+        repo = _FakePolicyRepo(by_id={})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PATCH",
+            "/api/policy/rules/999/enabled",
+            json_body={"enabled": False},
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.enabled_calls == []
+
+    def test_tenant_admin_can_toggle_own_tenant_rule(self):
+        repo = _FakePolicyRepo(by_id={5: _rule(TENANT_A)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PATCH",
+            "/api/policy/rules/5/enabled",
+            json_body={"enabled": False},
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.enabled_calls == [(5, False)]
+
+    def test_platform_admin_can_toggle_any_rule(self):
+        repo = _FakePolicyRepo(by_id={5: _rule(TENANT_B)})
+        response, repo, audit = _policy_request(
+            PLATFORM_ADMIN,
+            "PATCH",
+            "/api/policy/rules/5/enabled",
+            json_body={"enabled": True},
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.enabled_calls == [(5, True)]
+        audit.assert_called_once()  # cross-tenant reach is recorded
+
+
+class TestPolicyCreateTenantBoundary:
+    """POST /api/policy/rules."""
+
+    def _body(self, **over):
+        body = {
+            "rule_key": "k1",
+            "name": "Rule 1",
+            "policy_type": "tool_action",
+            "effect": "require_approval",
+        }
+        body.update(over)
+        return body
+
+    def test_tenant_admin_cannot_create_rule_for_another_tenant(self):
+        repo = _FakePolicyRepo()
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(tenant_id=TENANT_B),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert repo.created == []
+
+    def test_tenant_admin_create_without_tenant_is_scoped_to_own_tenant(self):
+        """No body tenant_id must NOT mean a global rule for a tenant admin."""
+        repo = _FakePolicyRepo()
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+        assert len(repo.created) == 1
+        assert repo.created[0]["tenant_id"] == TENANT_A
+
+    def test_platform_admin_can_create_a_global_rule(self):
+        repo = _FakePolicyRepo()
+        response, repo, _ = _policy_request(
+            PLATFORM_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] is None
+
+    def test_platform_admin_can_create_for_a_named_tenant(self):
+        repo = _FakePolicyRepo()
+        response, repo, _ = _policy_request(
+            PLATFORM_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(tenant_id=TENANT_B),
+            policy_repo=repo,
+        )
+        assert response.status_code == 201
+        assert repo.created[0]["tenant_id"] == TENANT_B
+
+
+class TestPolicyUpdateTenantBoundary:
+    """PUT /api/policy/rules/<rule_key> -- versioned supersede."""
+
+    def _body(self, **over):
+        body = {
+            "name": "Rule 1 v2",
+            "policy_type": "tool_action",
+            "effect": "deny",
+        }
+        body.update(over)
+        return body
+
+    def test_tenant_admin_cannot_supersede_another_tenants_key_was_the_hole(self):
+        """The supersede UPDATE is keyed on rule_key alone -- it rewrites the owner."""
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_B)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_supersede_a_global_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(None)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_hijack_own_key_into_another_tenant(self):
+        """Owns the key, but may not move the new version's scope elsewhere."""
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_A)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1",
+            json_body=self._body(tenant_id=TENANT_B),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_can_supersede_own_key_and_stays_scoped(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_A)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_A
+
+    def test_tenant_admin_can_create_new_key_scoped_to_own_tenant(self):
+        """A PUT to an unused key is a create; a tenant admin may do that for itself."""
+        repo = _FakePolicyRepo(by_key={})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/brand-new",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_A
+
+    def test_platform_admin_can_supersede_any_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_B)})
+        response, repo, audit = _policy_request(
+            PLATFORM_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1",
+            json_body=self._body(tenant_id=TENANT_B),
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_B
+        audit.assert_called_once()
+
+
+# ── content-filter mutations (global table -> platform admin only) ─────────
+
+
+CONTENT_FILTER_MUTATIONS = [
+    ("POST", "/api/content/filter/patterns", {"name": "n", "pattern": "p"}),
+    ("POST", "/api/content/filter/keywords", {"keyword": "kw"}),
+    ("POST", "/api/filter-rules", {"pattern": "p"}),
+    ("PUT", "/api/filter-rules/7", {"pattern": "p2"}),
+    ("DELETE", "/api/filter-rules/7", None),
+]
+
+
+class TestContentFilterMutationsArePlatformAdminOnly:
+    """content_filter_rules and custom patterns/keywords are global config."""
+
+    @pytest.mark.parametrize(("method", "path", "body"), CONTENT_FILTER_MUTATIONS)
+    def test_tenant_admin_is_denied(self, method, path, body):
+        response, _ = _governance_request(TENANT_A_ADMIN, method, path, json_body=body)
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    @pytest.mark.parametrize(("method", "path", "body"), CONTENT_FILTER_MUTATIONS)
+    def test_plain_user_is_denied(self, method, path, body):
+        response, _ = _governance_request(TENANT_A_USER, method, path, json_body=body)
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(("method", "path", "body"), CONTENT_FILTER_MUTATIONS)
+    def test_platform_admin_is_allowed(self, method, path, body):
+        response, _ = _governance_request(PLATFORM_ADMIN, method, path, json_body=body)
+        assert response.status_code not in (401, 403), response.get_data(as_text=True)
+
+    @pytest.mark.parametrize(("method", "path", "body"), CONTENT_FILTER_MUTATIONS)
+    def test_legacy_admin_is_allowed_in_non_strict_mode(self, method, path, body):
+        response, _ = _governance_request(LEGACY_ADMIN, method, path, json_body=body)
+        assert response.status_code not in (401, 403), response.get_data(as_text=True)
+
+
+# ── quota alert acknowledge (tenant resolved through the alert's user) ─────
+
+
+def _quota_mgr(alert_user_id):
+    m = MagicMock()
+    m.get_alert.return_value = (
+        SimpleNamespace(user_id=alert_user_id) if alert_user_id is not None else None
+    )
+    m.acknowledge_alert.return_value = True
+    return m
+
+
+class TestQuotaAlertAckTenantBoundary:
+    """POST /api/quota/alerts/<alert_id>/acknowledge."""
+
+    def test_tenant_admin_cannot_ack_another_tenants_alert_was_the_hole(self):
+        mgr = _quota_mgr(20)  # alert belongs to bob in tenant B
+        response, _ = _governance_request(
+            TENANT_A_ADMIN, "POST", "/api/quota/alerts/1/acknowledge", quota_mgr=mgr
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        mgr.acknowledge_alert.assert_not_called()
+
+    def test_missing_alert_is_denied_for_tenant_admin(self):
+        mgr = _quota_mgr(None)  # get_alert -> None
+        response, _ = _governance_request(
+            TENANT_A_ADMIN, "POST", "/api/quota/alerts/999/acknowledge", quota_mgr=mgr
+        )
+        assert response.status_code == 403
+        mgr.acknowledge_alert.assert_not_called()
+
+    def test_alert_for_deleted_user_is_denied_for_tenant_admin(self):
+        mgr = _quota_mgr(777)  # user 777 not in ALERT_USERS -> None
+        response, _ = _governance_request(
+            TENANT_A_ADMIN, "POST", "/api/quota/alerts/1/acknowledge", quota_mgr=mgr
+        )
+        assert response.status_code == 403
+        mgr.acknowledge_alert.assert_not_called()
+
+    def test_tenant_admin_can_ack_own_tenants_alert(self):
+        mgr = _quota_mgr(10)  # alice in tenant A
+        response, _ = _governance_request(
+            TENANT_A_ADMIN, "POST", "/api/quota/alerts/1/acknowledge", quota_mgr=mgr
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        mgr.acknowledge_alert.assert_called_once()
+
+    def test_platform_admin_can_ack_any_alert(self):
+        mgr = _quota_mgr(20)  # bob in tenant B
+        response, audit = _governance_request(
+            PLATFORM_ADMIN, "POST", "/api/quota/alerts/1/acknowledge", quota_mgr=mgr
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        mgr.acknowledge_alert.assert_called_once()
+        audit.assert_called_once()
+
+
+# ── compliance report read + generate ─────────────────────────────────────
+
+
+def _report(tenant_id):
+    r = MagicMock()
+    r.metadata.tenant_id = tenant_id
+    r.to_dict.return_value = {"report_id": "R1", "tenant_id": tenant_id}
+    return r
+
+
+class TestComplianceReportReadTenantBoundary:
+    """GET /api/compliance/reports/<report_id>."""
+
+    def test_tenant_admin_cannot_read_another_tenants_report_was_the_hole(self):
+        gen = MagicMock()
+        gen.get_saved_report.return_value = _report(TENANT_B)
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN, "GET", "/api/compliance/reports/R1", report_gen=gen
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_missing_report_is_denied_for_tenant_admin_without_oracle(self):
+        gen = MagicMock()
+        gen.get_saved_report.return_value = None
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN, "GET", "/api/compliance/reports/does-not-exist", report_gen=gen
+        )
+        assert response.status_code == 403
+
+    def test_tenant_admin_can_read_own_tenant_report(self):
+        gen = MagicMock()
+        gen.get_saved_report.return_value = _report(TENANT_A)
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN, "GET", "/api/compliance/reports/R1", report_gen=gen
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+
+    def test_platform_admin_can_read_any_report(self):
+        gen = MagicMock()
+        gen.get_saved_report.return_value = _report(TENANT_B)
+        response, audit = _compliance_request(
+            PLATFORM_ADMIN, "GET", "/api/compliance/reports/R1", report_gen=gen
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        audit.assert_called_once()
+
+    def test_platform_admin_missing_report_still_404(self):
+        gen = MagicMock()
+        gen.get_saved_report.return_value = None
+        response, _ = _compliance_request(
+            PLATFORM_ADMIN, "GET", "/api/compliance/reports/nope", report_gen=gen
+        )
+        assert response.status_code == 404
+
+
+class TestComplianceGenerateReportTenantBoundary:
+    """POST /api/compliance/reports -- tenant admin may not name another tenant."""
+
+    def test_tenant_admin_naming_another_tenant_is_denied(self):
+        gen = MagicMock()
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/compliance/reports",
+            json_body={"report_type": "usage_summary", "tenant_id": TENANT_B},
+            report_gen=gen,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        gen.generate_report.assert_not_called()
+
+    def test_tenant_admin_own_tenant_proceeds(self):
+        gen = MagicMock()
+        gen.generate_report.return_value.to_dict.return_value = {"report_id": "R1"}
+        gen.save_report.return_value = True
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/compliance/reports",
+            json_body={"report_type": "usage_summary", "tenant_id": TENANT_A},
+            report_gen=gen,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        gen.generate_report.assert_called_once()
+
+    def test_tenant_admin_without_tenant_id_proceeds_scoped_to_own(self):
+        gen = MagicMock()
+        gen.generate_report.return_value.to_dict.return_value = {"report_id": "R1"}
+        gen.save_report.return_value = True
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/compliance/reports",
+            json_body={"report_type": "usage_summary"},
+            report_gen=gen,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        # The report was generated for the caller's own tenant, not all tenants.
+        _, kwargs = gen.generate_report.call_args
+        assert kwargs["tenant_id"] == TENANT_A

--- a/tests/integration/test_admin_cross_tenant_followup.py
+++ b/tests/integration/test_admin_cross_tenant_followup.py
@@ -370,6 +370,58 @@ class TestPolicyCreateTenantBoundary:
         assert response.status_code == 201
         assert repo.created[0]["tenant_id"] == TENANT_B
 
+    # POST funnels into the same rule_key-keyed supersede as PUT (create_rule
+    # supersedes WHERE rule_key = ? with no tenant filter), so POSTing an
+    # EXISTING key is a cross-tenant clobber unless the owner is checked too.
+    def test_tenant_admin_cannot_post_over_another_tenants_existing_key_was_the_hole(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_B)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(rule_key="k1"),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_post_over_a_global_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(None)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(rule_key="k1"),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_can_post_over_own_tenants_existing_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_A)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(rule_key="k1"),
+            policy_repo=repo,
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_A
+
+    def test_platform_admin_can_post_over_any_existing_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_B)})
+        response, repo, audit = _policy_request(
+            PLATFORM_ADMIN,
+            "POST",
+            "/api/policy/rules",
+            json_body=self._body(rule_key="k1", tenant_id=TENANT_B),
+            policy_repo=repo,
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_B
+        audit.assert_called_once()
+
 
 class TestPolicyUpdateTenantBoundary:
     """PUT /api/policy/rules/<rule_key> -- versioned supersede."""
@@ -494,6 +546,54 @@ class TestContentFilterMutationsArePlatformAdminOnly:
     def test_legacy_admin_is_allowed_in_non_strict_mode(self, method, path, body):
         response, _ = _governance_request(LEGACY_ADMIN, method, path, json_body=body)
         assert response.status_code not in (401, 403), response.get_data(as_text=True)
+
+
+# ── security settings (global config table -> platform admin only) ─────────
+
+
+class TestSecuritySettingsIsPlatformAdminOnly:
+    """PUT /api/security-settings -- security_settings has no tenant column.
+
+    Same class as the content-filter mutations: a write governs every tenant
+    (2FA, password policy, login-attempt limit, IP whitelist), so a tenant
+    admin must not reach it.
+    """
+
+    def test_tenant_admin_is_denied(self):
+        response, _ = _governance_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/security-settings",
+            json_body={"two_factor_enabled": False},
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+
+    def test_plain_user_is_denied(self):
+        response, _ = _governance_request(
+            TENANT_A_USER,
+            "PUT",
+            "/api/security-settings",
+            json_body={"two_factor_enabled": False},
+        )
+        assert response.status_code == 403
+
+    def test_platform_admin_is_allowed(self):
+        response, _ = _governance_request(
+            PLATFORM_ADMIN,
+            "PUT",
+            "/api/security-settings",
+            json_body={"two_factor_enabled": False},
+        )
+        assert response.status_code not in (401, 403), response.get_data(as_text=True)
+
+    def test_legacy_admin_is_allowed_in_non_strict_mode(self):
+        response, _ = _governance_request(
+            LEGACY_ADMIN,
+            "PUT",
+            "/api/security-settings",
+            json_body={"two_factor_enabled": False},
+        )
+        assert response.status_code not in (401, 403)
 
 
 # ── quota alert acknowledge (tenant resolved through the alert's user) ─────
@@ -650,5 +750,22 @@ class TestComplianceGenerateReportTenantBoundary:
         )
         assert response.status_code == 200, response.get_data(as_text=True)
         # The report was generated for the caller's own tenant, not all tenants.
+        _, kwargs = gen.generate_report.call_args
+        assert kwargs["tenant_id"] == TENANT_A
+
+    def test_tenant_admin_naming_own_tenant_as_string_is_allowed(self):
+        """Regression: a body "1" must not read as != int tenant 1 and 403."""
+        gen = MagicMock()
+        gen.generate_report.return_value.to_dict.return_value = {"report_id": "R1"}
+        gen.save_report.return_value = True
+        response, _ = _compliance_request(
+            TENANT_A_ADMIN,
+            "POST",
+            "/api/compliance/reports",
+            json_body={"report_type": "usage_summary", "tenant_id": str(TENANT_A)},
+            report_gen=gen,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        gen.generate_report.assert_called_once()
         _, kwargs = gen.generate_report.call_args
         assert kwargs["tenant_id"] == TENANT_A

--- a/tests/integration/test_admin_cross_tenant_followup.py
+++ b/tests/integration/test_admin_cross_tenant_followup.py
@@ -511,6 +511,46 @@ class TestPolicyUpdateTenantBoundary:
         assert repo.created[0]["tenant_id"] == TENANT_B
         audit.assert_called_once()
 
+    # The owner check must normalize the key the same way create_rule's supersede
+    # does (_parse_rule_body strips it). A whitespace-padded path key must not
+    # skip the check while the supersede still clobbers the trimmed key.
+    def test_tenant_admin_cannot_bypass_owner_check_with_whitespace_key(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_B)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1%20",  # trailing space -> supersede hits "k1"
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403, response.get_data(as_text=True)
+        assert repo.created == []
+
+    def test_tenant_admin_cannot_bypass_owner_check_on_a_global_key_with_whitespace(self):
+        repo = _FakePolicyRepo(by_key={"k1": _rule(None)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/%20k1",  # leading space
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 403
+        assert repo.created == []
+
+    def test_tenant_admin_padded_key_for_own_rule_still_works(self):
+        """The normalization must not over-block the caller's own key."""
+        repo = _FakePolicyRepo(by_key={"k1": _rule(TENANT_A)})
+        response, repo, _ = _policy_request(
+            TENANT_A_ADMIN,
+            "PUT",
+            "/api/policy/rules/k1%20",
+            json_body=self._body(),
+            policy_repo=repo,
+        )
+        assert response.status_code == 200, response.get_data(as_text=True)
+        assert repo.created[0]["tenant_id"] == TENANT_A
+
 
 # ── content-filter mutations (global table -> platform admin only) ─────────
 


### PR DESCRIPTION
## What & why

Follow-up to #2646 (cross-tenant account takeover). That PR closed the
**user-keyed** admin endpoints. `admin_required` still authenticates `admin` /
`platform_admin` / `tenant_admin` without comparing that tenant against the
resource being touched, so the **resource-keyed and request-scoped** remainder
of the admin surface was left boundary-free. This finishes the audit worklist in
`docs/dev-notes/2026-08-14-admin-required-tenant-boundary-audit.md`.

## New primitive

`app/auth/decorators.py::enforce_resource_tenant_scope(resource_tenant_id)` —
deny when the current admin may not act on a resource owned by
`resource_tenant_id` (looked up from the repo first). Unlike
`enforce_requested_tenant_scope`, a `None` here means the **resource itself is
global**, so a tenant admin is **denied** rather than silently rescoped (else a
tenant admin could edit a rule that governs every tenant). Mirrors the tenant
half of `enforce_target_user_tenant`; no vertical role check (these resources
carry no role, so taking one over grants no account privileges).

## Endpoints closed

**Resolve the owning tenant, then compare:**

| Endpoint | Owner lookup |
|---|---|
| `PATCH /policy/rules/<id>/enabled` | `get_rule(id).tenant_id` |
| `PUT /policy/rules/<rule_key>` | `get_current_rule_by_key(key)` + new-version scope |
| `POST /quota/alerts/<id>/acknowledge` | `alert.user_id` → `user.tenant_id` |
| `GET /reports/<report_id>` | `report.metadata.tenant_id` |

A missing resource → `None` → denies a tenant admin (fail closed, no existence
oracle) and falls through to the same 404 for a platform admin.

**Global content-filter mutations → `platform_admin_required`:**
`content_filter_rules` has no tenant column and `add_custom_pattern/keyword` take
no tenant arg — the feature is global by design, so mutating it is a
platform-level operation. All five write endpoints move: `POST
/content/filter/patterns`, `POST /content/filter/keywords`, `POST /filter-rules`,
`PUT /filter-rules/<id>`, `DELETE /filter-rules/<id>`. Reads unchanged.

## Two same-class holes both audit sweeps missed (folded in)

- `POST /policy/rules` reads `tenant_id` through `_parse_rule_body` — one level
  of indirection the regex sweep didn't follow.
- `POST /content/filter/patterns`, `/keywords`, `POST /filter-rules` have **no**
  path resource id **and** read **no** `tenant_id`, so neither sweep saw them.
  Locking PUT/DELETE while leaving create open would be indefensible.

## Consistency

`generate_report`'s tenant-admin branch returned the caller's *own* report
(logged, didn't deny) when a tenant admin named another tenant. Now 403, to
match the hardened list/read siblings.

## Verification

- `tests/integration/test_admin_cross_tenant_followup.py` — **48 tests**: tenant
  admin denied / platform admin allowed / fail-closed / no oracle for every
  endpoint; cross-tenant audit write asserted on the platform-admin path.
- **All 8 guards mutation-verified**: broken one at a time by source mutation,
  each caught by a named test.
- CI selection against an **empty SQLite database** is green; directly-affected
  suites (compliance API, policy repo/integration, content-filter, the takeover
  suite) pass unchanged.

## Out of scope (recorded in the audit note)

`remote.py assign_user` (a non-role cross-tenant path) and list/aggregate
endpoints whose isolation depends on repository-level tenant filtering (#2429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
