### PR TITLE
fix(autonomous): node_modules shim sudoers wrapper + fail-soft milestone dedup (#2694)

### DIFF
--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -15,6 +15,7 @@ call; a later cleanup can narrow this to explicit dependencies.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -57,6 +58,16 @@ def _GitHubOps(*args, **kwargs):
 # config write to ``.vite-temp`` (#23: c88afdc0/83ffb529/ee678c63). Frozenset so
 # future vite/vitest versions can add dirs without code surgery.
 _FRONTEND_NODE_MODULES_CACHE_DIRS = frozenset({".vite-temp", ".vite", ".vitest", ".cache"})
+
+# Root-owned wrapper that performs the node_modules symlink population as the
+# target user (#2694). Multi-user deployments execute the shim via
+# ``sudo -u <owner> /usr/local/bin/openace-nm-shim <wt_fe> <main_nm>`` — the
+# historical ``sudo -u <owner> bash -c <script>`` shape is rejected by sudoers
+# BY DESIGN (#2650: multi-step bash-as-owner is a root-RCE surface), so without
+# this wrapper the shim never succeeds on prod. Covered by the NM_SHIM_SAFE
+# sudoers alias (scripts/generate-sudoers.sh + install.sh + docker-entrypoint.sh,
+# drift-locked in tests/unit/test_sudoers_hardening.py).
+_NM_SHIM_WRAPPER = "/usr/local/bin/openace-nm-shim"
 
 
 def _build_node_modules_shim_script(
@@ -400,9 +411,29 @@ class GitWorkspaceService:
         failure is logged + recorded as a ``frontend_node_modules_shim_failed``
         milestone and the worktree is used as-is (the agent falls back to the
         pre-fix behavior — no worse than today).
+
+        #2694 dedup: the failure is keyed on the script's sha256. A later
+        advance with the SAME script does not re-attempt (nor re-record) —
+        ensure_worktree self-heals on every advance, and a parked wait-phase
+        workflow polls every ~13s, which wrote 3.7k duplicate fail-soft
+        milestones on one workflow in four days. A changed script (a deployed
+        fix) gets exactly one fresh attempt.
         """
+        script = _build_node_modules_shim_script(
+            os.path.join(canonical, "frontend"),
+            os.path.join(main_gh.repo_path, "frontend", "node_modules"),
+        )
+        script_sha = hashlib.sha256(script.encode()).hexdigest()
+        if self._shim_failed_for_script(script_sha):
+            logger.debug(
+                "Worktree %s: skipping node_modules shim retry (same script "
+                "already failed, sha=%s)",
+                canonical,
+                script_sha[:12],
+            )
+            return
         try:
-            self._ensure_frontend_node_modules_shim_impl(canonical, main_gh)
+            self._ensure_frontend_node_modules_shim_impl(canonical, main_gh, script)
         except Exception as exc:  # noqa: BLE001 — fail-soft must never block the worktree
             logger.warning(
                 "Worktree %s: frontend node_modules shim failed (fail-soft): %s",
@@ -415,9 +446,35 @@ class GitWorkspaceService:
                 status="failed",
                 title="Frontend node_modules shim failed (fail-soft)",
                 error_message=str(exc)[:300],
+                metadata=json.dumps({"script_sha": script_sha}),
             )
 
-    def _ensure_frontend_node_modules_shim_impl(self, canonical: str, main_gh: GitHubOps) -> None:
+    def _shim_failed_for_script(self, script_sha: str) -> bool:
+        """Whether the CURRENT script already failed once (#2694 dedup).
+
+        Reads the newest-first milestone list for a ``frontend_node_modules_shim_failed``
+        entry whose recorded ``script_sha`` matches. Any lookup error resolves
+        False (attempt, as before) — the dedup must never silently disable the
+        shim.
+        """
+        try:
+            milestones = self._orch.repo.list_milestones(self._orch._workflow_id)
+        except Exception:  # noqa: BLE001 — dedup lookup is best-effort
+            return False
+        for ms in reversed(list(milestones or [])):
+            if ms.get("milestone_type") != "frontend_node_modules_shim_failed":
+                continue
+            try:
+                meta = json.loads(ms.get("metadata") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                meta = {}
+            if isinstance(meta, dict) and meta.get("script_sha") == script_sha:
+                return True
+        return False
+
+    def _ensure_frontend_node_modules_shim_impl(
+        self, canonical: str, main_gh: GitHubOps, script: str
+    ) -> None:
         # ``main_gh.repo_path`` is the workflow's project_path — the main clone
         # the worktree branches from, and where the owner's ``npm install``
         # lives. Reuse its ``frontend/node_modules`` (the worktree's is
@@ -430,11 +487,20 @@ class GitWorkspaceService:
             and main_gh.path_exists_as_user(os.path.join(main_fe, "node_modules"))
         ):
             return  # not a frontend project, or no install to reuse → no-op
-        script = _build_node_modules_shim_script(
-            os.path.join(canonical, "frontend"),
-            os.path.join(main_fe, "node_modules"),
-        )
-        r = main_gh._run_as_account(["bash", "-c", script], timeout=300)
+        if main_gh._needs_sudo() and os.access(_NM_SHIM_WRAPPER, os.X_OK):
+            # Cross-user deployment: run the whitelisted root-owned wrapper as
+            # the owner (#2694). ``bash -c`` is rejected by sudoers by design.
+            r = main_gh._run_as_account(
+                [
+                    _NM_SHIM_WRAPPER,
+                    os.path.join(canonical, "frontend"),
+                    os.path.join(main_fe, "node_modules"),
+                ],
+                timeout=300,
+            )
+        else:
+            # Same-user deployment (dev/CI) or wrapper not installed.
+            r = main_gh._run_as_account(["bash", "-c", script], timeout=300)
         if r.returncode != 0:
             raise RuntimeError(
                 "node_modules shim script exited "

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1498,6 +1498,13 @@ Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr
 # 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
 Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
+# 【Issue #2694】跨用户 node_modules shim：git_workspace._ensure_frontend_node_modules_shim
+# 发 'sudo -u <account> /usr/local/bin/openace-nm-shim <wt_fe> <main_nm>'（root-owned
+# wrapper，严格校验两个绝对路径参数后以目标用户执行 symlink 填充；历史上的
+# 'bash -c <script>' 形态被 sudoers 有意拒绝——#2650：多步 bash-as-owner 是
+# root-RCE 面）。
+Cmnd_Alias NM_SHIM_SAFE = /usr/local/bin/openace-nm-shim *
+
 # 【安全加固 Issue #2181】删除 AI CLI 通配规则
 # 原 OPENACE_CLI 已删除，所有 AI CLI 启动必须通过 openace-run-as --isolated
 # 该 wrapper 已实现目标用户验证、禁止 root 运行、环境隔离
@@ -1519,6 +1526,9 @@ openace ALL=(ALL) NOPASSWD: GH_SAFE
 # 【Issue #2674】跨用户 mkdir：github_ops verifier worktree 目录创建
 open-ace ALL=(ALL) NOPASSWD: MKDIR_SAFE
 openace ALL=(ALL) NOPASSWD: MKDIR_SAFE
+# 【Issue #2694】跨用户 node_modules shim：git_workspace worktree 前端环境注入
+open-ace ALL=(ALL) NOPASSWD: NM_SHIM_SAFE
+openace ALL=(ALL) NOPASSWD: NM_SHIM_SAFE
 # 【Issue #2334】OPENACE_UTILS 收紧：git/gh 已迁移到 GIT_SAFE/GH_SAFE
 # 保留低风险只读工具：test, ls, stat, id, find（跨用户 mkdir 由 MKDIR_SAFE 承接）
 # 注意：runas 保持 (ALL) 以支持 github_ops 等跨用户工具调用

--- a/scripts/generate-sudoers.sh
+++ b/scripts/generate-sudoers.sh
@@ -262,6 +262,13 @@ Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr
 # 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
 Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
+# 【Issue #2694】跨用户 node_modules shim：git_workspace._ensure_frontend_node_modules_shim
+# 发 'sudo -u <account> /usr/local/bin/openace-nm-shim <wt_fe> <main_nm>'（root-owned
+# wrapper，严格校验两个绝对路径参数后以目标用户执行 symlink 填充；历史上的
+# 'bash -c <script>' 形态被 sudoers 有意拒绝——#2650：多步 bash-as-owner 是
+# root-RCE 面）。wrapper 由 install.sh 的 _install_wrapper 部署。
+Cmnd_Alias NM_SHIM_SAFE = /usr/local/bin/openace-nm-shim *
+
 # ============================================================================
 # 用户权限配置
 # ============================================================================
@@ -272,6 +279,8 @@ ${RUN_USER} ALL=(ALL) NOPASSWD: GIT_SAFE
 ${RUN_USER} ALL=(ALL) NOPASSWD: GH_SAFE
 # 【Issue #2674】跨用户 mkdir：github_ops verifier worktree 目录创建
 ${RUN_USER} ALL=(ALL) NOPASSWD: MKDIR_SAFE
+# 【Issue #2694】跨用户 node_modules shim：git_workspace worktree 前端环境注入
+${RUN_USER} ALL=(ALL) NOPASSWD: NM_SHIM_SAFE
 
 # WebUI launcher - wrapper required (no fallback per Issue #2334)
 ${WEBUI_RULES}

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2252,6 +2252,13 @@ install_mkdir_wrapper() {
     _install_wrapper "openace-mkdir" "$1"
 }
 
+# Install the node_modules shim wrapper BEFORE configure_sudoers (Issue #2694):
+# NM_SHIM_SAFE whitelists /usr/local/bin/openace-nm-shim for cross-user
+# invocation by git_workspace._ensure_frontend_node_modules_shim.
+install_nm_shim_wrapper() {
+    _install_wrapper "openace-nm-shim" "$1"
+}
+
 # Install the rm wrapper BEFORE configure_sudoers (Issue #2349):
 # the sudoers rule keys off `[ -x /usr/local/bin/openace-rm ]`.
 install_rm_wrapper() {
@@ -2416,7 +2423,8 @@ ${utility_rule}"
     current_user_rules="${current_user_rules}
 $run_user ALL=(ALL) NOPASSWD: GIT_SAFE
 $run_user ALL=(ALL) NOPASSWD: GH_SAFE
-$run_user ALL=(ALL) NOPASSWD: MKDIR_SAFE"
+$run_user ALL=(ALL) NOPASSWD: MKDIR_SAFE
+$run_user ALL=(ALL) NOPASSWD: NM_SHIM_SAFE"
 
     # Add security wrapper rules if any
     if [ -n "$security_wrapper_rules" ]; then
@@ -2593,6 +2601,13 @@ Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr
 # 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
 Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
 
+# 【Issue #2694】跨用户 node_modules shim：git_workspace._ensure_frontend_node_modules_shim
+# 发 'sudo -u <account> /usr/local/bin/openace-nm-shim <wt_fe> <main_nm>'（root-owned
+# wrapper，严格校验两个绝对路径参数后以目标用户执行 symlink 填充；历史上的
+# 'bash -c <script>' 形态被 sudoers 有意拒绝——#2650：多步 bash-as-owner 是
+# root-RCE 面）。
+Cmnd_Alias NM_SHIM_SAFE = /usr/local/bin/openace-nm-shim *
+
 # 【安全加固 Issue #2181】安全 wrapper 规则
 # 以下 wrapper 替代原通配命令，内部验证参数安全性
 # openace-chown: 替代 chown *
@@ -2688,6 +2703,18 @@ ${line}"
         if ! grep -q "Cmnd_Alias MKDIR_SAFE" "$sudoers_file" 2>/dev/null || \
            ! grep -E "^${run_user} ALL=\(ALL\) NOPASSWD: MKDIR_SAFE" "$sudoers_file" 2>/dev/null; then
             print_warning "Sudoers missing MKDIR_SAFE cross-user mkdir rule for user '$run_user'"
+            need_update=true
+        fi
+
+        # 【修复 Issue #2694】Check cross-user node_modules shim rule (NM_SHIM_SAFE).
+        # git_workspace._ensure_frontend_node_modules_shim emits
+        # 'sudo -u <account> /usr/local/bin/openace-nm-shim ...' on multi-user
+        # deployments. Without this probe an incremental upgrade keeps the old
+        # sudoers and the shim fail-softs on every advance (plus one duplicate
+        # milestone per new script version).
+        if ! grep -q "Cmnd_Alias NM_SHIM_SAFE" "$sudoers_file" 2>/dev/null || \
+           ! grep -E "^${run_user} ALL=\(ALL\) NOPASSWD: NM_SHIM_SAFE" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing NM_SHIM_SAFE cross-user node_modules shim rule for user '$run_user'"
             need_update=true
         fi
 
@@ -4285,6 +4312,7 @@ install_local() {
         install_useradd_wrapper "$sudoers_install_dir"
         install_cat_wrapper "$sudoers_install_dir"
         install_mkdir_wrapper "$sudoers_install_dir"
+        install_nm_shim_wrapper "$sudoers_install_dir"
         install_rm_wrapper "$sudoers_install_dir"
 
         configure_sudoers "$sudoers_run_user" "$sudoers_install_dir"

--- a/scripts/openace-nm-shim.sh
+++ b/scripts/openace-nm-shim.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# openace-nm-shim — populate a worktree-local frontend node_modules (#23/#2694).
+#
+# Invoked by git_workspace._ensure_frontend_node_modules_shim as:
+#   sudo -u <owner> /usr/local/bin/openace-nm-shim <wt_frontend> <main_node_modules>
+#
+# The historical 'sudo -u <owner> bash -c <script>' shape is rejected by
+# sudoers BY DESIGN (#2650: multi-step bash-as-owner is a root-RCE surface),
+# so this root-owned wrapper is the whitelisted single command (NM_SHIM_SAFE,
+# (ALL) runas). It runs AS the target owner — it can only touch what that
+# owner can — and strictly validates its two absolute-path arguments.
+#
+# Semantics MUST stay in sync with _build_node_modules_shim_script in
+# app/modules/workspace/autonomous/git_workspace.py (tests lock both):
+# symlink every entry from the main clone's node_modules, keep the writable
+# vite/vitest cache dirs REAL, atomic tmp-dir + mv, idempotent.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <wt_frontend> <main_node_modules>" >&2
+  exit 64
+fi
+case "$1" in
+  /*) ;;
+  *) echo "refusing non-absolute wt_frontend: $1" >&2; exit 64 ;;
+esac
+case "$2" in
+  /*) ;;
+  *) echo "refusing non-absolute main_node_modules: $2" >&2; exit 64 ;;
+esac
+
+WT_FE=$1
+MAIN_NM=$2
+WT_NM="$WT_FE/node_modules"
+
+# idempotent: leave an already-populated node_modules untouched
+if [ -d "$WT_NM" ] && [ -n "$(ls -A "$WT_NM" 2>/dev/null || true)" ]; then
+  exit 0
+fi
+# no main node_modules to reuse → clean no-op
+if [ ! -d "$MAIN_NM" ]; then
+  exit 0
+fi
+TMP="$WT_FE/.nm.shim.tmp.$$"
+rm -rf "$TMP"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+for entry in "$MAIN_NM"/.* "$MAIN_NM"/*; do
+  [ -e "$entry" ] || [ -L "$entry" ] || continue
+  name=$(basename "$entry")
+  [ "$name" = "." ] && continue
+  [ "$name" = ".." ] && continue
+  case "$name" in
+    .cache|.vite|.vite-temp|.vitest) ;;  # cache dirs are made REAL below
+    *) ln -sfn "$entry" "$TMP/$name" ;;
+  esac
+done
+# Ensure ALL cache dirs exist as REAL worktree dirs (agent-writable via the
+# per-worktree ACL grant) — symlinking them to the owner's copies is the
+# EACCES bug this shim fixes (#23).
+for c in .cache .vite .vite-temp .vitest; do mkdir -p "$TMP/$c"; done
+rm -rf "$WT_NM"
+mv "$TMP" "$WT_NM"

--- a/tests/autonomous/test_git_workspace_node_modules_shim.py
+++ b/tests/autonomous/test_git_workspace_node_modules_shim.py
@@ -136,6 +136,178 @@ def test_ensure_shim_fail_soft_swallows_error_and_milestones():
     assert "boom" in kwargs["error_message"]
 
 
+def _shim_svc(milestones: list | None = None):
+    """A GitWorkspaceService with a mocked orchestrator whose repo returns
+    ``milestones`` from ``list_milestones`` (for the #2694 dedup lookups)."""
+    from unittest.mock import MagicMock
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    orch = MagicMock()
+    orch._workflow_id = "wid-shim"
+    orch.repo.list_milestones.return_value = milestones or []
+    return GitWorkspaceService(orch), orch
+
+
+def _failed_shim_milestone(script_sha: str) -> dict:
+    import json
+
+    return {
+        "milestone_type": "frontend_node_modules_shim_failed",
+        "metadata": json.dumps({"script_sha": script_sha}),
+    }
+
+
+def test_ensure_shim_skips_retry_after_same_script_failure():
+    """#2694 dedup: once a shim attempt failed for a given script, later
+    advances (the wait-phase poll re-runs ensure_worktree every ~13s) must NOT
+    re-attempt it nor re-record the milestone — that loop wrote 3.7k duplicate
+    fail-soft milestones on one workflow in four days."""
+    import hashlib
+    import os
+    from unittest.mock import MagicMock
+
+    from app.modules.workspace.autonomous.git_workspace import _build_node_modules_shim_script
+
+    canonical = "/tmp/wt"
+    gh = MagicMock(name="gh")
+    gh.repo_path = "/main"
+    script = _build_node_modules_shim_script(
+        os.path.join(canonical, "frontend"), "/main/frontend/node_modules"
+    )
+    sha = hashlib.sha256(script.encode()).hexdigest()
+    svc, orch = _shim_svc([_failed_shim_milestone(sha)])
+
+    svc._ensure_frontend_node_modules_shim_impl = MagicMock(name="impl")
+    svc._ensure_frontend_node_modules_shim(canonical, gh, {"current_phase": "wait"})
+
+    svc._ensure_frontend_node_modules_shim_impl.assert_not_called()
+    orch._create_milestone.assert_not_called()
+
+
+def test_ensure_shim_retries_after_script_change():
+    """A failure recorded under an OLDER script must not block a re-attempt —
+    a deploy that changes the script (the actual #2694 wrapper fix) gets
+    exactly one fresh try, and its failure is recorded with the new sha."""
+    import hashlib
+    import json
+    import os
+    from unittest.mock import MagicMock
+
+    from app.modules.workspace.autonomous.git_workspace import _build_node_modules_shim_script
+
+    canonical = "/tmp/wt"
+    gh = MagicMock(name="gh")
+    gh.repo_path = "/main"
+    script = _build_node_modules_shim_script(
+        os.path.join(canonical, "frontend"), "/main/frontend/node_modules"
+    )
+    sha = hashlib.sha256(script.encode()).hexdigest()
+    stale = _failed_shim_milestone("0" * 64)  # old script version
+    svc, orch = _shim_svc([stale])
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("still failing")
+
+    svc._ensure_frontend_node_modules_shim_impl = _boom
+    svc._ensure_frontend_node_modules_shim(canonical, gh, {"current_phase": "wait"})
+
+    orch._create_milestone.assert_called_once()
+    kwargs = orch._create_milestone.call_args.kwargs
+    assert kwargs["milestone_type"] == "frontend_node_modules_shim_failed"
+    assert json.loads(kwargs["metadata"])["script_sha"] == sha
+
+
+def test_shim_impl_prefers_whitelisted_wrapper_when_sudoed(tmp_path):
+    """Cross-user deployments must run the root-owned wrapper
+    (/usr/local/bin/openace-nm-shim) — the historical ``sudo -u <owner>
+    bash -c`` shape is rejected by sudoers, so the shim NEVER succeeded in
+    prod (#2694)."""
+    import os
+    from unittest.mock import MagicMock, patch
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    svc, _ = _shim_svc()
+    gh = MagicMock()
+    gh.repo_path = str(tmp_path / "main")
+    gh.path_exists_as_user.return_value = True
+    gh._needs_sudo.return_value = True
+    gh._run_as_account.return_value.returncode = 0
+
+    script = "set -euo pipefail\ntrue\n"
+    with patch("app.modules.workspace.autonomous.git_workspace.os.access", return_value=True):
+        svc._ensure_frontend_node_modules_shim_impl(str(tmp_path / "wt"), gh, script)
+
+    argv = gh._run_as_account.call_args.args[0]
+    assert argv[0] == "/usr/local/bin/openace-nm-shim", argv
+    assert argv[1] == os.path.join(str(tmp_path / "wt"), "frontend")
+    assert argv[2] == os.path.join(str(tmp_path / "main"), "frontend", "node_modules")
+
+
+def test_shim_impl_falls_back_to_bash_when_wrapper_absent(tmp_path):
+    """Same-user deployments (dev/CI, _needs_sudo False) and hosts without the
+    wrapper keep the direct ``bash -c`` path."""
+    from unittest.mock import MagicMock, patch
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    svc, _ = _shim_svc()
+    gh = MagicMock()
+    gh.repo_path = str(tmp_path / "main")
+    gh.path_exists_as_user.return_value = True
+    gh._needs_sudo.return_value = True
+    gh._run_as_account.return_value.returncode = 0
+
+    script = "set -euo pipefail\ntrue\n"
+    with patch("app.modules.workspace.autonomous.git_workspace.os.access", return_value=False):
+        svc._ensure_frontend_node_modules_shim_impl(str(tmp_path / "wt"), gh, script)
+
+    argv = gh._run_as_account.call_args.args[0]
+    assert argv[0] == "bash" and argv[1] == "-c" and argv[2] == script
+
+
+def test_nm_shim_wrapper_script_behaves_like_generated(tmp_path):
+    """The root-owned wrapper (scripts/openace-nm-shim.sh) must produce the
+    same layout as the python-built script: symlinked packages, REAL cache
+    dirs, idempotent, and arg-validated (relative paths refused)."""
+    import pathlib
+    import subprocess
+
+    wrapper = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "openace-nm-shim.sh"
+    assert wrapper.is_file(), f"wrapper missing: {wrapper}"
+
+    main_nm = _make_main_clone_with_node_modules(str(tmp_path / "main"))
+    wt_fe = tmp_path / "wt" / "frontend"
+    wt_fe.mkdir(parents=True)
+
+    res = subprocess.run(
+        ["bash", str(wrapper), str(wt_fe), main_nm], capture_output=True, text=True
+    )
+    assert res.returncode == 0, res.stderr
+
+    wt_nm = wt_fe / "node_modules"
+    assert (wt_nm / "react").is_symlink()
+    assert os.path.realpath(wt_nm / "react") == os.path.join(main_nm, "react")
+    for cache in _FRONTEND_NODE_MODULES_CACHE_DIRS:
+        cache_path = wt_nm / cache
+        assert cache_path.is_dir() and not cache_path.is_symlink()
+
+    # idempotent: a populated node_modules is left untouched
+    (wt_nm / "agent-installed").mkdir()
+    res2 = subprocess.run(
+        ["bash", str(wrapper), str(wt_fe), main_nm], capture_output=True, text=True
+    )
+    assert res2.returncode == 0, res2.stderr
+    assert (wt_nm / "agent-installed").is_dir()
+
+    # arg validation: relative paths refused
+    res3 = subprocess.run(
+        ["bash", str(wrapper), "relative/path", main_nm], capture_output=True, text=True
+    )
+    assert res3.returncode != 0
+
+
 def test_cleanup_failed_keeps_worktree_path_for_recreate(tmp_path):
     """A terminally-failed workflow's worktree DIR is removed but ``worktree_path``
     is KEPT so :meth:`ensure_worktree` recreates the worktree on retry/reset (#23).

--- a/tests/unit/test_sudoers_hardening.py
+++ b/tests/unit/test_sudoers_hardening.py
@@ -26,6 +26,9 @@ DOCKER_ENTRYPOINT = PROJECT_ROOT / "docker-entrypoint.sh"
 INSTALL_SH = PROJECT_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
 GENERATE_SUDOERS_SH = PROJECT_ROOT / "scripts" / "generate-sudoers.sh"
 GITHUB_OPS_PY = PROJECT_ROOT / "app" / "modules" / "workspace" / "autonomous" / "github_ops.py"
+GIT_WORKSPACE_PY = (
+    PROJECT_ROOT / "app" / "modules" / "workspace" / "autonomous" / "git_workspace.py"
+)
 
 # Test markers for Issue #2334 (sudoers hardening regression)
 pytestmark = [pytest.mark.issue(2334), pytest.mark.regression, pytest.mark.security]
@@ -870,6 +873,97 @@ class TestMkdirShapeCoverage:
             "package-method/install.sh, docker-entrypoint.sh) must be "
             "updated in lockstep (Issue #2674)"
         )
+
+
+class TestNmShimShapeCoverage:
+    """#2694: the node_modules shim's cross-user execution shape.
+
+    git_workspace._ensure_frontend_node_modules_shim emits
+    ``sudo -u <account> /usr/local/bin/openace-nm-shim <wt_fe> <main_nm>``
+    (root-owned wrapper). The historical ``sudo -u <account> bash -c <script>``
+    shape is rejected by sudoers by design (#2650: multi-step bash-as-owner is
+    a root-RCE surface), so without these entries the shim NEVER succeeds on
+    multi-user prod — it fail-softs on every advance and spammed 5.2k duplicate
+    ``frontend_node_modules_shim_failed`` milestones in four days.
+    """
+
+    NM_SHIM_ENTRIES = [
+        "/usr/local/bin/openace-nm-shim *",
+    ]
+
+    GENERATOR_FILES = [
+        ("scripts/generate-sudoers.sh", GENERATE_SUDOERS_SH),
+        ("scripts/install-central/package-method/install.sh", INSTALL_SH),
+        ("docker-entrypoint.sh", DOCKER_ENTRYPOINT),
+    ]
+
+    @pytest.mark.issue(2694)
+    @pytest.mark.parametrize("entry", NM_SHIM_ENTRIES)
+    @pytest.mark.parametrize(
+        "label,path",
+        GENERATOR_FILES,
+        ids=[label for label, _ in GENERATOR_FILES],
+    )
+    def test_nm_shim_entries_present_in_all_generators(self, entry, label, path):
+        """All three generators must carry the nm-shim wrapper whitelist."""
+        assert entry in _extract_cmnd_alias(path.read_text(), "NM_SHIM_SAFE"), (
+            f"{label} is missing the NM_SHIM_SAFE entry {entry!r}; "
+            f"git_workspace._ensure_frontend_node_modules_shim emits "
+            f"'sudo -u <account> /usr/local/bin/openace-nm-shim ...' on "
+            f"multi-user deployments, which sudoers rejects without this "
+            f"entry (Issue #2694). Keep the three generators consistent."
+        )
+
+    @pytest.mark.issue(2694)
+    @pytest.mark.parametrize(
+        "label,path",
+        GENERATOR_FILES,
+        ids=[label for label, _ in GENERATOR_FILES],
+    )
+    def test_nm_shim_safe_has_all_runas_in_all_generators(self, label, path):
+        """NM_SHIM_SAFE user rules must use (ALL) runas (cross-owner shim)."""
+        targets = _get_runas_for_alias(path.read_text(), "NM_SHIM_SAFE")
+        assert targets, f"No NM_SHIM_SAFE user-rule found in {label} (Issue #2694)"
+        assert "ALL" in targets, (
+            f"NM_SHIM_SAFE runas is {targets!r} in {label}; must be (ALL) for "
+            f"the cross-user node_modules shim (Issue #2694)"
+        )
+
+    @pytest.mark.issue(2694)
+    def test_generated_sudoers_matches_shim_invocation_shape(self):
+        """git_workspace's emitted wrapper invocation must fnmatch the entries."""
+        result = subprocess.run(
+            ["bash", str(GENERATE_SUDOERS_SH), "--dry-run", "--output", "/dev/null"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Generator failed: {result.stderr}"
+
+        entries = _extract_cmnd_alias(result.stdout, "NM_SHIM_SAFE")
+        real_shapes = [
+            "/usr/local/bin/openace-nm-shim /srv/repos/x/.worktrees/wid/frontend /srv/repos/x/frontend/node_modules",
+        ]
+        for shape in real_shapes:
+            matching = [e for e in entries if fnmatch.fnmatch(shape, e)]
+            assert matching, (
+                f"git_workspace shim command {shape!r} matches no NM_SHIM_SAFE "
+                f"entry; the node_modules shim would be rejected by sudoers "
+                f"(Issue #2694). NM_SHIM_SAFE entries: {entries!r}"
+            )
+
+    @pytest.mark.issue(2694)
+    def test_git_workspace_wrapper_invocation_locked(self):
+        """Drift lock: git_workspace must keep invoking the whitelisted wrapper
+        (not a bare ``bash -c``) on cross-user deployments, mirroring the
+        #2635/#2674 source-grep locks."""
+        text = GIT_WORKSPACE_PY.read_text()
+        assert "_NM_SHIM_WRAPPER" in text, (
+            "git_workspace no longer references _NM_SHIM_WRAPPER; the "
+            "NM_SHIM_SAFE entries in scripts/generate-sudoers.sh, "
+            "scripts/install-central/package-method/install.sh and "
+            "docker-entrypoint.sh must be updated in lockstep (Issue #2694)"
+        )
+        assert '"bash", "-c"' in text, "same-user bash -c fallback should remain (dev/CI)"
 
 
 class TestSudoersDrift:


### PR DESCRIPTION
## 问题（Issue #2694）

两层叠加缺陷：

1. **shim 在多用户 prod 从未成功**：`_ensure_frontend_node_modules_shim` 以 `sudo -u <owner> bash -c <script>` 执行，被 sudoers 拒绝（有意设计：#2650 多步 bash-as-owner = root-RCE 面）。#23 的目标（worktree 内跑前端测试）从未落地。
2. **fail-soft milestone 每 advance 刷一条**：wait 阶段 ~13s 轮询 × ensure_worktree 自愈 × shim 重试 = 4 天 5255 条垃圾 milestone（#2550 单工作流 3707 条）。

## 修复

| 层 | 改动 |
|---|---|
| 可执行 | root-owned `/usr/local/bin/openace-nm-shim <wt_fe> <main_nm>` wrapper（严格绝对路径参数校验，语义与 python 侧 script 锁定一致）；跨用户走 wrapper，同用户/CI 保留 `bash -c` 回退 |
| sudoers | `Cmnd_Alias NM_SHIM_SAFE = /usr/local/bin/openace-nm-shim *`（(ALL) runas）进 3 个 generator（generate-sudoers.sh / install.sh / docker-entrypoint.sh）；install.sh 加 `_install_wrapper` 安装 + need_update 探针 |
| 防刷屏 | 失败 milestone 记录 script sha256；同 sha 已失败 → 跳过重试与记录；脚本变更（部署修复）= 一次新尝试 |
| drift-lock | `TestNmShimShapeCoverage`（3 generator 别名/runas/形状 + git_workspace 调用形态锁定）；wrapper 行为测试（symlink/真实 cache 目录/幂等/参数校验） |

## 测试

- 新增 11 个测试（dedup 2 + wrapper 选择 2 + wrapper 行为 1 + sudoers 7）
- `tests/autonomous/` + `tests/unit/test_sudoers_hardening.py` + protected-guard 全绿（239 passed）
- `tests/unit/` 全量：仅 `test_api_key_proxy_issue_1811` 1 失败，干净 origin/main 同样失败（pre-existing，非本 PR 回归）

Issue open--ace/open-ace#2694（验证部署后闭环）