### PR TITLE
fix(tests): realign 165 remote-session e2e with lane + auth evolution (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -153,78 +153,6 @@
       "summary": "failed on setup with \"AssertionError\""
     },
     {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a1_token_detail",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a2_system_message_storage",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a3_request_count_no_double_count",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a4_abort_request",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a5_allow_permanent",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a6_quota_exceeded_detection",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b1_reconnect_history",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b2_abort_ui",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "165",
-      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b3_permission_permanent_ui",
-      "outcome": "failure",
-      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
-    },
-    {
       "category": "setup_error",
       "exception_type": "",
       "issue_number": "166",
@@ -1067,8 +995,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-15 prune 11 resolved issue-584 remote-directory entries: stale expectations. (a) the remote blueprint's before_request resolves the user via session_access._set_user_from_token whose _load_user_from_token was imported BY VALUE — the fixture now patches that binding (remote_mod itself never imports it), with a tearDown capturing originals BEFORE patching and restoring auth_dec + session_access loaders and remote_agent_manager._agent_manager (no cross-test leak); (b) agent create-directory semantics drifted: existing dir = idempotent success, missing parent walks to the nearest ancestor, False send_command no longer 500s (outcome from browse result; enqueue-failure with no reply yields 504-by-timeout in production). Negative control: dropping the session_access patch re-fails with 401. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31861753845",
+    "prune_note": "2026-08-15 prune 9 resolved issue-165 remote-session e2e entries: stale setup/auth. (a) main()-only runner setup never executed under pytest collection — module-scoped autouse fixture now does lane setup (must_change_password clear, admin login, machine register+assign user_id 1); (b) HA-pool gate requires an api_key_store row advertising the model — fixture seeds qwen3-coder-plus via /api/api-keys; (c) /agent/message needs the agent Bearer token from registration; usage_report needs report_id (legacy window expired 2026-08-04). Negative control: removing the key-seed call re-fails all 9 with the original 400. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31878610663",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/165/test_remote_session_ux.py
+++ b/tests/issues/165/test_remote_session_ux.py
@@ -16,9 +16,10 @@ Open ACE - Issue #165: 远程会话管理与体验完善 E2E Test
   B3: 永久权限允许 UI — 权限面板
   B6: 错误消息国际化 — 中英文错误展示
 
-Run:
-  HEADLESS=true  python tests/165/test_remote_session_ux.py
-  HEADLESS=false python tests/165/test_remote_session_ux.py
+Run (via the lane runner, which starts the isolated server):
+  python scripts/run_extended_tests.py --category issues --issue-numbers 165
+  # direct script mode (requires a server at BASE_URL with admin/admin123):
+  HEADLESS=true  python tests/issues/165/test_remote_session_ux.py
 """
 
 import json
@@ -33,6 +34,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 import contextlib
 
+import pytest
 import requests
 from playwright.sync_api import sync_playwright
 
@@ -40,12 +42,14 @@ from playwright.sync_api import sync_playwright
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
-TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")
+# The lane seeds only admin/admin123; test_user never existed there.
+TEST_USER = os.environ.get("TEST_REAL_USER", "admin")
 TEST_PASS = "admin123"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-165")
 
 # ── 全局状态 ──
 machine_id = None
+agent_bearer = None
 session_id = None
 auth_token = None
 admin_token = None
@@ -97,8 +101,39 @@ def api_admin_login():
     return api_login_as("admin", "admin123")
 
 
+def api_seed_model_key(atoken):
+    """Seed an API key whose cli_settings advertise qwen3-coder-plus.
+
+    create_remote_session's HA-pool gate rejects a model that no active
+    api_key_store row advertises (remote_session_manager "Requested model %s
+    is not supported by remote HA pool") — the lane DB starts with zero keys.
+    """
+    r = requests.post(
+        f"{BASE_URL}/api/api-keys",
+        json={
+            "provider": "openai",
+            "key_name": "e2e-165-model-key",
+            "api_key": "sk-e2e-165-placeholder-key-000000000000",
+            "tenant_id": 1,
+            "scope": "shared",
+            "cli_tools": json.dumps(["qwen-code"]),
+            "cli_settings": json.dumps(
+                {
+                    "qwen-code": {
+                        "modelProviders": {
+                            "openai": [{"id": "qwen3-coder-plus", "name": "qwen3-coder-plus"}]
+                        }
+                    }
+                }
+            ),
+        },
+        cookies={"session_token": atoken},
+    )
+    assert r.status_code == 200, f"Seed api key failed: {r.status_code} {r.text[:200]}"
+
+
 def api_register_machine(atoken):
-    global machine_id
+    global machine_id, agent_bearer
     r = requests.post(
         f"{BASE_URL}/api/remote/machines/register",
         json={"tenant_id": 1},
@@ -122,6 +157,10 @@ def api_register_machine(atoken):
         },
     )
     assert r.status_code == 200
+    # The registration issues a Bearer token; every /agent/message call other
+    # than "register" must present it (Bearer enforcement, agent_tokens table).
+    agent_bearer = r.json()["machine"].get("agent_token")
+    assert agent_bearer, "No agent_token in register response"
 
     r = requests.post(
         f"{BASE_URL}/api/remote/agent/message",
@@ -133,9 +172,12 @@ def api_register_machine(atoken):
     )
     assert r.status_code == 200
 
+    # Assign to the admin (user_id 1 in the lane seed). The create-session
+    # caller is platform_admin and bypasses the assignment check, but keep the
+    # row consistent with the actual test user (the old 89 was a phantom).
     r = requests.post(
         f"{BASE_URL}/api/remote/machines/{machine_id}/assign",
-        json={"user_id": 89, "permission": "admin"},
+        json={"user_id": 1, "permission": "admin"},
         cookies={"session_token": atoken},
     )
     assert r.status_code == 200
@@ -179,6 +221,7 @@ def api_agent_output(data_str, stream="stdout", is_complete=False, sid=None):
             "stream": stream,
             "is_complete": is_complete,
         },
+        headers={"Authorization": f"Bearer {agent_bearer}"},
     )
     return r.status_code == 200
 
@@ -192,21 +235,26 @@ def api_agent_permission_request(control_request_dict, sid=None):
             "session_id": sid or session_id,
             "control_request": control_request_dict,
         },
+        headers={"Authorization": f"Bearer {agent_bearer}"},
     )
     return r.status_code == 200
 
 
 def api_send_usage(sid=None, tokens=None, requests_count=1):
     tokens = tokens or {"input": 1000, "output": 500}
+    # report_id is mandatory since the legacy migration window expired
+    # (2026-08-04): report_id-less payloads are rejected with 400.
     r = requests.post(
         f"{BASE_URL}/api/remote/agent/message",
         json={
             "type": "usage_report",
             "machine_id": machine_id,
             "session_id": sid or session_id,
+            "report_id": f"e2e-165-{uuid.uuid4()}",
             "tokens": tokens,
             "requests": requests_count,
         },
+        headers={"Authorization": f"Bearer {agent_bearer}"},
     )
     return r.status_code == 200
 
@@ -260,6 +308,7 @@ def api_get_pending_commands():
             "status": "busy",
             "active_sessions": 1,
         },
+        headers={"Authorization": f"Bearer {agent_bearer}"},
     )
     assert r.status_code == 200
     return r.json().get("pending_commands", [])
@@ -344,6 +393,50 @@ def _open_chatpage(page, webui_url, webui_token, **extra_params):
         params.append(f"&{k}={v}")
     chat_url = f"{webui_url}/projects{''.join(params)}"
     page.goto(chat_url, wait_until="domcontentloaded", timeout=30000)
+
+
+# ══════════════════════════════════════════════════════
+#  pytest 收集路径下的 setup（main() runner 之外）
+# ══════════════════════════════════════════════════════
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _lane_setup():
+    """Replicate main()'s setup under pytest collection.
+
+    Login (the lane seeds only admin/admin123 — test_user never existed),
+    clear the seeded must_change_password flag, register the test machine,
+    and start the shared browser the UI tests drive.
+    """
+    global admin_token, auth_token, machine_id, _browser, _context, _page
+    import sqlite3
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if os.path.exists(db_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(users)")}
+            if "must_change_password" in cols:
+                conn.execute("UPDATE users SET must_change_password=0 WHERE username='admin'")
+                conn.commit()
+        finally:
+            conn.close()
+
+    admin_token = api_admin_login()
+    auth_token = api_admin_login()
+    api_seed_model_key(admin_token)
+    api_register_machine(admin_token)
+
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        _browser = p.chromium.launch(headless=HEADLESS)
+        _context = _browser.new_context(viewport={"width": 1440, "height": 900}, locale="zh-CN")
+        _page = _context.new_page()
+        _page.set_default_timeout(30000)
+        _browser_login(_page)
+        yield
+        _browser.close()
 
 
 # ══════════════════════════════════════════════════════
@@ -1017,6 +1110,7 @@ def run_tests():
     # 登录 + 注册机器
     admin_token = api_admin_login()
     auth_token = api_login_as()
+    api_seed_model_key(admin_token)
     api_register_machine(admin_token)
     print(f"  ✓ Machine registered: {machine_id[:8]}...")
 


### PR DESCRIPTION
Refs #2457. Baseline shrink-only: 9 issue-165 entries (133 → 124 on current main).

All 9 entries were stale setup/auth assumptions vs today's production/lane:

- **main()-only setup never ran under pytest collection** (auth_token=None → 401 on every request, the recorded baseline signature). A module-scoped autouse `_lane_setup` fixture now replicates the runner setup: clear must_change_password on the seeded admin, login, seed the HA-pool model key, register + assign the machine, start the shared Playwright browser.
- **Lane seeds only admin/admin123** — TEST_USER default was test_user (never existed) and the machine assign targeted phantom user id 89; now user_id 1.
- **HA-pool model gate**: create_remote_session rejects a model no active api_key_store row advertises ("Requested model ... not supported by remote HA pool") — the fixture seeds a key via /api/api-keys whose cli_settings.modelProviders list qwen3-coder-plus.
- **Agent Bearer enforcement**: /agent/message (non-register types) requires the agent_token issued at registration; usage_report additionally requires report_id (legacy migration window expired 2026-08-04). Helpers now present both.

## Evidence

- Local lane (run_extended_tests --isolated-home, same entrypoint as CI): **10 passed**.
- Negative control (throwaway worktree, key-seed call removed): re-fails all 9 with the original 400 "Failed to create remote session" — the seeding is load-bearing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>