### PR TITLE
feat(autonomous): lazy dependency preparation for agent worktrees (#2699)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2138,7 +2138,8 @@ def _cleanup_backoff_time(attempts: int) -> str:
 # a permissions bug — it retries around permissions instead of installing.
 _DEPENDENCY_FAILURE_PATTERNS = (
     re.compile(r"node_modules[/\\]\.vite-temp", re.IGNORECASE),
-    re.compile(r"Cannot find module ['\"]?vitest", re.IGNORECASE),
+    re.compile(r"Cannot find (?:module|package) ['\"]?vitest", re.IGNORECASE),
+    re.compile(r"vitest: command not found", re.IGNORECASE),
     re.compile(r"EACCES: permission denied[^\n]*node_modules", re.IGNORECASE),
 )
 
@@ -6511,7 +6512,7 @@ class AutonomousOrchestrator:
         (excluding ``current_milestone_id`` — the just-created in_progress
         milestone for THIS round has an empty summary and must not shadow the
         prior report; same milestone selection as
-        ``_recompute_prior_test_milestone_verdict``) and runs the
+        ``_carry_forward_prior_test_verdict``) and runs the
         :func:`_dependency_failure_directive` signature match over it. Any
         lookup error returns ``""`` — the directive is additive.
         """

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2123,6 +2123,61 @@ def _cleanup_backoff_time(attempts: int) -> str:
     return (datetime.now(timezone.utc) + timedelta(seconds=delay)).strftime("%Y-%m-%d %H:%M:%S")
 
 
+# ── #2699: lazy dependency preparation ──────────────────────────────────────
+# The worktree node_modules shim was reverted (#2694/#2698): it ran via
+# ``sudo -u <owner> bash -c`` which sudoers rejects by design (#2650), so it
+# never worked on multi-user prod, and it hardcoded this repo's frontend/
+# layout. Dependency setup is now the agent's job, in two layers: a proactive
+# prompt rule (check node_modules + lockfile-detected install before running
+# frontend commands) and a failure-signature translation below.
+#
+# The trap these signatures recognize: a clean worktree has no node_modules
+# (gitignored); Node resolution walks up into the project owner's main clone,
+# so vitest LOADS (deps "visible") but vite's cache write into the
+# owner-owned node_modules/.vite-temp is EACCES. To the agent that reads like
+# a permissions bug — it retries around permissions instead of installing.
+_DEPENDENCY_FAILURE_PATTERNS = (
+    re.compile(r"node_modules[/\\]\.vite-temp", re.IGNORECASE),
+    re.compile(r"Cannot find module ['\"]?vitest", re.IGNORECASE),
+    re.compile(r"EACCES: permission denied[^\n]*node_modules", re.IGNORECASE),
+)
+
+_DEPENDENCY_PREP_RULE = (
+    "5. 环境准备：运行任何前端/JS 测试或构建命令前，先检查 worktree 内是否存在 "
+    "node_modules；不存在且仓库有锁文件（package-lock.json / pnpm-lock.yaml / "
+    "yarn.lock / bun.lockb）时，先在对应目录安装依赖（npm ci / "
+    "pnpm install --frozen-lockfile / yarn install --frozen-lockfile / "
+    "bun install）再运行命令；纯后端任务无需处理，不要安装任何前端依赖。\n"
+)
+
+
+def _dependency_failure_directive(prior_output: str | None) -> str:
+    """#2699 backstop: translate a missing-deps failure into an install directive.
+
+    Returns the directive when ``prior_output`` (the prior round's test
+    report) hits one of :data:`_DEPENDENCY_FAILURE_PATTERNS`, else ``""``.
+    Empty/unparsable input returns ``""`` — the directive is additive and must
+    never fabricate a dependency problem the output does not show.
+    """
+    if not prior_output:
+        return ""
+    if not any(p.search(prior_output) for p in _DEPENDENCY_FAILURE_PATTERNS):
+        return ""
+    return (
+        "## 依赖环境修复指令\n"
+        "上一轮输出命中了依赖缺失特征（node_modules 权限被拒或找不到 vitest）。"
+        "worktree 是干净检出，node_modules 不存在，模块解析向上落到了项目主 clone "
+        "的 node_modules——读得到但写不进，这不是权限配置问题，不要用 sudo/chmod "
+        "绕过。本轮必须：\n"
+        "1. 在 worktree 内按仓库锁文件先安装依赖：package-lock.json → `npm ci`；"
+        "pnpm-lock.yaml → `pnpm install --frozen-lockfile`；yarn.lock → "
+        "`yarn install --frozen-lockfile`；bun.lockb → `bun install`"
+        "（monorepo 在对应子目录执行）；\n"
+        "2. 安装完成后重新执行验证矩阵中的测试命令，并在回复中包含原始输出；\n"
+        "3. 若仓库没有锁文件或不是 JS 项目，则失败另有原因，按原流程排查并在报告中说明。\n\n"
+    )
+
+
 def _head_tail_excerpt(text: str, limit: int = 6000) -> str:
     """Truncate ``text`` preserving BOTH ends (#2590).
 
@@ -6449,6 +6504,38 @@ class AutonomousOrchestrator:
             logger.debug("prior verdict carry-forward failed: %s", e)
             return ExecutionVerdict.NOT_RUN, f"carry-forward failed: {e}"
 
+    def _prior_dependency_failure_directive(self, current_milestone_id: str) -> str:
+        """#2699: missing-deps directive from the PRIOR round's test report.
+
+        Reads the latest prior ``tests_run`` milestone's ``result_summary``
+        (excluding ``current_milestone_id`` — the just-created in_progress
+        milestone for THIS round has an empty summary and must not shadow the
+        prior report; same milestone selection as
+        ``_recompute_prior_test_milestone_verdict``) and runs the
+        :func:`_dependency_failure_directive` signature match over it. Any
+        lookup error returns ``""`` — the directive is additive.
+        """
+        if not current_milestone_id:
+            return ""
+        try:
+            milestones = self.repo.list_milestones(self._workflow_id, phase="development")
+        except Exception:
+            return ""
+        prior = [
+            ms
+            for ms in milestones
+            if ms.get("milestone_type") == "tests_run"
+            and (ms.get("milestone_id") or "") != current_milestone_id
+            and ms.get("result_summary")
+        ]
+        if not prior:
+            return ""
+        try:
+            latest = max(prior, key=lambda m: int(m.get("id") or 0))
+        except (ValueError, TypeError):
+            latest = prior[-1]
+        return _dependency_failure_directive(latest.get("result_summary") or "")
+
     def _structured_failure_repair_feedback(
         self, structured_reason: str, evidences: list, test_summary: str
     ) -> str:
@@ -6469,6 +6556,13 @@ class AutonomousOrchestrator:
             "请先根据以下失败信息修复测试或修复被测试暴露的产品代码，"
             "再重新执行验证；不得跳过测试或改写断言来让测试通过。",
         ]
+        # #2699: a missing-deps signature is not a code defect — hand the dev
+        # round the install directive FIRST so it does not "fix" an EACCES by
+        # editing permissions or skipping the frontend suite.
+        directive = _dependency_failure_directive(test_summary or "")
+        if directive:
+            lines.append("")
+            lines.append(directive.rstrip())
         failed_lines = []
         for evidence in evidences or []:
             if getattr(evidence, "verdict", "") != ExecutionVerdict.FAILED.value:
@@ -10887,6 +10981,11 @@ class AutonomousOrchestrator:
                 "2. 不得引用之前回合的结果作为本轮验证证据；\n"
                 "3. 如果确认测试无法执行，在回复末尾单独一行输出 `TEST_STATUS: skipped` 并说明原因。\n\n"
             )
+            # #2699 backstop: when the prior round's report hit the missing-deps
+            # signature (EACCES on node_modules/.vite-temp / Cannot find module
+            # vitest), redirect the retry at installing dependencies in the
+            # worktree instead of chasing permissions.
+            test_prompt += self._prior_dependency_failure_directive(test_ms.get("milestone_id", ""))
         if issue_number:
             test_prompt += (
                 f"## 关联 Issue\n"
@@ -10904,16 +11003,17 @@ class AutonomousOrchestrator:
             "2. 必须优先覆盖上面列出的必测方面；只有在发现跨层影响、契约变化、迁移/依赖/CI 改动等证据时，才扩大到更广范围。\n"
             "3. 除非验证矩阵或仓库文档明确要求，否则不要从裸 `python -m pytest`、`pytest tests/`、全仓库扫描式命令开始。\n"
             "4. 具体命令必须优先从 `.github/workflows/`、`package.json`、`frontend/package.json`、`pytest.ini`、`tests/README.md`、`Makefile`、`tox.ini`、`scripts/` 等仓库事实中映射出来，不要凭空假设。\n"
-            "5. 结果汇总时必须交代：验证方面、执行命令、结果、是否已覆盖方案要求；如果某一项不跑，必须说明理由。\n"
-            "6. 如果仓库中完全没有明确约定，再按框架后备顺序尝试：\n"
+            + _DEPENDENCY_PREP_RULE
+            + "6. 结果汇总时必须交代：验证方面、执行命令、结果、是否已覆盖方案要求；如果某一项不跑，必须说明理由。\n"
+            "7. 如果仓库中完全没有明确约定，再按框架后备顺序尝试：\n"
             "   - Python：`python -m pytest` 或 `python3 -m pytest`\n"
             "   - Python 兜底：`python -m unittest discover -s tests`\n"
             "   - 前端项目：`npm test` 或 `npx vitest run`\n"
-            "7. 如果所有测试框架都不可用，至少执行以下验证：\n"
+            "8. 如果所有测试框架都不可用，至少执行以下验证：\n"
             '   - 用 `python -c "import <模块>"` 验证关键模块能正常导入\n'
             "   - 用 `python -m py_compile <文件>` 验证修改的文件没有语法错误\n"
             "   - 手动验证核心功能逻辑\n"
-            "8. 如果测试确实无法运行，在回复末尾单独一行输出 `TEST_STATUS: skipped`\n\n"
+            "9. 如果测试确实无法运行，在回复末尾单独一行输出 `TEST_STATUS: skipped`\n\n"
             "## ⛔ CRITICAL: 测试结果报告格式（强制要求）\n"
             "测试结果报告必须严格遵循以下标准格式之一：\n"
             '- Python pytest: "X passed, Y failed, Z skipped" 或 "X passed in Y.Zs"\n'

--- a/tests/unit/test_lazy_dependency_prep_2699.py
+++ b/tests/unit/test_lazy_dependency_prep_2699.py
@@ -1,0 +1,121 @@
+"""#2699: lazy dependency preparation for agent worktrees.
+
+The reverted node_modules shim (#2694/#2698) left the cross-user EACCES trap
+in place: a clean worktree has no ``node_modules`` (gitignored), Node
+resolution walks up into the project owner's main clone — deps load (reads
+work) but vite's cache write into the owner-owned ``node_modules/.vite-temp``
+is denied. To the agent that reads like a permissions bug, not missing deps,
+so it retries around permissions instead of installing.
+
+These tests lock the two replacement layers:
+
+1. Proactive rule in the test-phase strategy prompt (check node_modules +
+   lockfile-detected install before running frontend commands).
+2. Failure-signature translation: the prior round's report hitting the
+   missing-deps signature injects an explicit "install deps first" directive
+   into (a) the fresh-retry prompt and (b) the #2590 dev-repair feedback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import (
+    _DEPENDENCY_PREP_RULE,
+    _dependency_failure_directive,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ORCHESTRATOR_PY = PROJECT_ROOT / "app" / "modules" / "workspace" / "autonomous" / "orchestrator.py"
+
+pytestmark = [pytest.mark.issue(2699), pytest.mark.regression]
+
+
+class TestDependencyFailureDirective:
+    def test_matches_vite_temp_eacces(self):
+        out = (
+            "Error: EACCES: permission denied, open "
+            "'/home/qlfan/repo/frontend/node_modules/.vite-temp/config.json'"
+        )
+        directive = _dependency_failure_directive(out)
+        assert directive, "EACCES on node_modules/.vite-temp must trigger the directive"
+        assert "npm ci" in directive
+        assert "pnpm install --frozen-lockfile" in directive
+
+    def test_matches_cannot_find_module_vitest(self):
+        out = "node:internal/modules/cjs/loader: Error: Cannot find module 'vitest'"
+        assert _dependency_failure_directive(out)
+
+    def test_matches_windows_style_path(self):
+        out = r"Error: EACCES: permission denied 'C:\repo\frontend\node_modules\.vite-temp\x'"
+        assert _dependency_failure_directive(out)
+
+    def test_normal_pytest_failure_no_directive(self):
+        out = "FAILED tests/test_app.py::test_login - AssertionError: expected 200"
+        assert _dependency_failure_directive(out) == ""
+
+    def test_empty_output_no_directive(self):
+        assert _dependency_failure_directive("") == ""
+        assert _dependency_failure_directive(None) == ""  # type: ignore[arg-type]
+
+    def test_directive_is_actionable_not_permission_chasing(self):
+        """The directive must redirect the agent away from permission
+        workarounds (sudo/chmod) toward installing deps in the worktree."""
+        directive = _dependency_failure_directive(
+            "EACCES: permission denied, open '/r/frontend/node_modules/.vite-temp/c'"
+        )
+        assert "worktree" in directive
+        assert "重新执行" in directive
+
+
+class TestProactiveRule:
+    def test_rule_covers_all_four_lockfiles(self):
+        for cmd in (
+            "npm ci",
+            "pnpm install --frozen-lockfile",
+            "yarn install --frozen-lockfile",
+            "bun install",
+        ):
+            assert cmd in _DEPENDENCY_PREP_RULE, cmd
+
+    def test_rule_scopes_to_frontend_commands(self):
+        """Pure-backend tasks must stay zero-cost — the rule must tell the
+        agent it only applies before frontend/JS commands."""
+        assert "前端" in _DEPENDENCY_PREP_RULE
+        assert "node_modules" in _DEPENDENCY_PREP_RULE
+
+    @pytest.mark.issue(2699)
+    def test_rule_wired_into_test_prompt(self):
+        """Drift lock: the test-phase strategy prompt must reference the rule
+        constant (mirroring the #2635/#2674 source-grep locks)."""
+        text = ORCHESTRATOR_PY.read_text()
+        assert "_DEPENDENCY_PREP_RULE" in text, (
+            "orchestrator no longer references _DEPENDENCY_PREP_RULE; the "
+            "proactive dependency rule must stay wired into the test-phase "
+            "strategy prompt (Issue #2699)"
+        )
+
+    def test_directive_wired_into_retry_and_repair_paths(self):
+        """Drift lock: the signature translation must be consulted at both
+        delivery sites — the fresh-retry prompt (prior milestone summary) and
+        the #2590 dev-repair feedback."""
+        text = ORCHESTRATOR_PY.read_text()
+        assert text.count("_dependency_failure_directive") >= 3, (
+            "expected _dependency_failure_directive at: definition + retry "
+            "prompt site + dev-repair feedback site (Issue #2699)"
+        )
+
+
+class TestPriorSummaryDirective:
+    def test_orchestrator_helper_reads_prior_tests_run_summary(self):
+        """The retry-path helper must read the PRIOR tests_run milestone's
+        result_summary (excluding the current milestone) — same milestone
+        selection as _recompute_prior_test_milestone_verdict."""
+        text = ORCHESTRATOR_PY.read_text()
+        assert "_prior_dependency_failure_directive" in text
+        # Exclusion of the current milestone is load-bearing: without it the
+        # just-created in_progress tests_run milestone (empty summary) could
+        # shadow the prior round's report.
+        assert "!= current_milestone_id" in text or "!= current_milestone_id" in text

--- a/tests/unit/test_lazy_dependency_prep_2699.py
+++ b/tests/unit/test_lazy_dependency_prep_2699.py
@@ -100,22 +100,157 @@ class TestProactiveRule:
     def test_directive_wired_into_retry_and_repair_paths(self):
         """Drift lock: the signature translation must be consulted at both
         delivery sites — the fresh-retry prompt (prior milestone summary) and
-        the #2590 dev-repair feedback."""
+        the #2590 dev-repair feedback. Pins the exact call shapes: a bare
+        substring count would also match the _prior_ helper's own name."""
         text = ORCHESTRATOR_PY.read_text()
-        assert text.count("_dependency_failure_directive") >= 3, (
-            "expected _dependency_failure_directive at: definition + retry "
-            "prompt site + dev-repair feedback site (Issue #2699)"
-        )
+        # Retry-prompt site (method call; the `def` line spells it without the
+        # `self.` prefix, so this only matches the call).
+        assert "self._prior_dependency_failure_directive(" in text
+        # Dev-repair feedback site (module-level call with the report text).
+        assert '_dependency_failure_directive(test_summary or "")' in text
 
 
 class TestPriorSummaryDirective:
     def test_orchestrator_helper_reads_prior_tests_run_summary(self):
         """The retry-path helper must read the PRIOR tests_run milestone's
         result_summary (excluding the current milestone) — same milestone
-        selection as _recompute_prior_test_milestone_verdict."""
+        selection as _carry_forward_prior_test_verdict."""
         text = ORCHESTRATOR_PY.read_text()
         assert "_prior_dependency_failure_directive" in text
         # Exclusion of the current milestone is load-bearing: without it the
         # just-created in_progress tests_run milestone (empty summary) could
         # shadow the prior round's report.
-        assert "!= current_milestone_id" in text or "!= current_milestone_id" in text
+        assert "!= current_milestone_id" in text
+
+
+class TestRetryPromptDelivery:
+    """Behavioral: drive ``_run_test_phase`` (harness mirrors
+    tests/unit/test_prior_milestone_verdict_carryforward.py) and assert the
+    directive actually lands in the dispatched agent prompt — not merely that
+    the source references it."""
+
+    @staticmethod
+    def _drive(test_retries: int, prior_summary: str):
+        from unittest.mock import MagicMock, patch
+
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        wf = {
+            "workflow_id": "wf-2699",
+            "user_id": 1,
+            "title": "T",
+            "status": "developing",
+            "requirements_text": "r",
+            "project_path": "/tmp/p",
+            "worktree_path": "/tmp/p",
+            "workspace_type": "local",
+            "cli_tool": "claude-code",
+            "branch_name": "auto-dev/x",
+            "branch_strategy": "worktree",
+            "current_phase": "development",
+            "dev_round": 1,
+            "current_round": 1,
+            "github_issue_number": 2699,
+            "test_retries": test_retries,
+            "skip_retries": 0,
+            "dev_retries_on_test_fail": 0,
+            "error_message": "",
+        }
+        result = AgentTaskResult(
+            session_id="sess",
+            response_text="1 passed",
+            visible_response_text="1 passed",
+            success=True,
+        )
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator." "AutonomousWorkflowRepository"
+            ) as repo_cls,
+        ):
+            repo = MagicMock()
+            repo.get_workflow.return_value = wf
+            repo.list_milestones.return_value = [
+                {
+                    "milestone_id": "ms-prior",
+                    "workflow_id": "wf-2699",
+                    "phase": "development",
+                    "milestone_type": "tests_run",
+                    "id": 10,
+                    "result_summary": prior_summary,
+                },
+                {
+                    "milestone_id": "ms-cur",
+                    "workflow_id": "wf-2699",
+                    "phase": "development",
+                    "milestone_type": "tests_run",
+                    "id": 11,
+                    "result_summary": "",
+                },
+            ]
+            repo.create_milestone.return_value = {"milestone_id": "ms-cur"}
+            repo.update_workflow.return_value = wf
+            repo.update_milestone.return_value = {}
+            repo.create_event.return_value = {"id": 1}
+            repo_cls.return_value = repo
+            from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+            orch = AutonomousOrchestrator("wf-2699")
+            orch.repo = repo
+            orch.emitter = MagicMock()
+            orch._gh = MagicMock()
+            orch._gh.has_uncommitted_changes.return_value = False
+        orch._update_workflow = MagicMock()
+        orch._post_github_comment = MagicMock()
+        orch._run_agent = MagicMock(return_value=result)
+        orch._runtime_environment_gate = MagicMock(return_value="")
+        orch._build_test_execution_context = MagicMock(return_value=("", []))
+        orch._project_runtime_contract = MagicMock(return_value="")
+        orch._artifact_visible_text = MagicMock(return_value="1 passed")
+        orch._artifact_text = MagicMock(return_value="1 passed")
+        orch._artifact_tldr = MagicMock(return_value="")
+        orch._shadow_compare_evidence = MagicMock()
+        orch._validate_test_report_format = MagicMock(return_value=(True, ""))
+        structured = (
+            "app.modules.workspace.autonomous.orchestrator."
+            "AutonomousOrchestrator._compute_structured_test_verdict"
+        )
+        passing = "app.modules.workspace.autonomous.orchestrator." "_has_passing_test_tool_result"
+        with (
+            patch(structured, return_value=("passed", [], "scripted")),
+            patch(passing, return_value=True),
+        ):
+            orch._run_test_phase(wf, 1, orch._gh)
+        return orch
+
+    def test_retry_prompt_contains_directive_when_prior_report_hits_signature(self):
+        orch = self._drive(
+            test_retries=1,
+            prior_summary=(
+                "Error: EACCES: permission denied, open "
+                "'/r/frontend/node_modules/.vite-temp/config.json'"
+            ),
+        )
+        prompt = orch._run_agent.call_args.kwargs["prompt"]
+        assert "依赖环境修复指令" in prompt
+        assert "npm ci" in prompt
+
+    def test_retry_prompt_clean_prior_report_no_directive(self):
+        orch = self._drive(
+            test_retries=1,
+            prior_summary="2 passed, 0 failed (pytest)",
+        )
+        prompt = orch._run_agent.call_args.kwargs["prompt"]
+        assert "依赖环境修复指令" not in prompt
+
+    def test_first_round_never_gets_directive_even_with_stale_summary(self):
+        """No retry → no directive, regardless of what an old milestone says —
+        the proactive rule (item 5) is the only first-round guidance."""
+        orch = self._drive(
+            test_retries=0,
+            prior_summary="EACCES: permission denied node_modules/.vite-temp",
+        )
+        prompt = orch._run_agent.call_args.kwargs["prompt"]
+        assert "依赖环境修复指令" not in prompt
+        # The proactive rule IS present on every round.
+        assert "npm ci" in prompt


### PR DESCRIPTION
## 方案（issue #2699，用户确认的零配置通用方向）

回退 shim（#2698）后，跨用户 EACCES 陷阱仍在：干净 worktree 无 node_modules，Node 解析向上落到主 clone——依赖"看得见"（加载成功），vite 写缓存被拒 → 对 agent 像权限 bug，它会绕权限而不是装依赖。

| 层 | 机制 | 成本 |
|---|---|---|
| 主动规则 | 测试策略 prompt 新增第 5 条：跑前端/JS 命令前查 worktree node_modules，缺且仓库有锁文件 → 按锁文件装（npm ci / pnpm install --frozen-lockfile / yarn install --frozen-lockfile / bun install） | 纯后端任务零成本 |
| 失败签名翻译 | 上一轮报告命中签名（EACCES node_modules/.vite-temp、Cannot find module vitest）→ fresh-retry prompt 与 #2590 dev-repair feedback 注入"先装依赖"指令，明确禁止 sudo/chmod 绕过 | 仅失败后多一轮定向纠偏 |

通用性：任何项目形状/包管理器、无用户配置、无新增 sudoers；执行身份天然合规（装进 worktree，ACL 写范围）。

## 实现落点

- `_DEPENDENCY_PREP_RULE` / `_dependency_failure_directive` / `_prior_dependency_failure_directive`（读前一个 `tests_run` milestone 的 `result_summary`，排除当前 in_progress milestone）
- 测试策略清单插入第 5 条（原 5-8 顺延为 6-9）；重试指令块后追加 directive；`_structured_failure_repair_feedback` 头部插入 directive

## 测试（TDD，11 个）

签名匹配（EACCES/找不到 vitest/Windows 路径/正常 pytest 失败不误报/空输入）+ 四锁文件覆盖 + 纯后端零成本语义 + 两处交付点 drift-lock（源码锁，镜像 #2635/#2674 先例）。回归：tests/autonomous + retry/carryforward/verdict 全家 186 passed。

Refs open-ace/open-ace#2699（依赖 #2698 已合）