### PR TITLE
feat: acceptance resume UX — feedback-received banner + verifier failed-items prefill

### DIFF
--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -353,6 +353,32 @@ def _failed_items(report: dict) -> list[tuple[str, dict]]:
     return out
 
 
+def feedback_prefill_from_report(report: dict) -> str:
+    """Pre-fill text for the resume-with-feedback modal (#2491 UX).
+
+    Mirrors the "Rejected / missing" bullet section of the issue comment so
+    the user can submit the verifier's failed-items list as feedback verbatim
+    or lightly edit it, instead of copy-pasting from GitHub. Shares
+    ``_failed_items`` with ``_format_report_comment`` so the two never drift.
+    Returns ``""`` when nothing failed.
+    """
+    status = (report.get("status") or "").lower()
+    failed = _failed_items(report)
+    if not failed:
+        return ""
+    label = "Rejected / missing" if status == "rejected" else "Could not verify"
+    lines = [f"{label}:"]
+    for kind, entry in failed:
+        detail = entry.get("rationale") or ""
+        if not detail:
+            ev = entry.get("evidence") or []
+            if ev and isinstance(ev[0], dict):
+                detail = ev[0].get("note", "")
+        tail = f" — {detail}" if detail else ""
+        lines.append(f"- [{kind}] `{entry.get('item')}` ({entry.get('verdict')}){tail}")
+    return "\n".join(lines)
+
+
 def _acceptance_summary(status: str, report: dict) -> str:
     """Human-readable one-line summary for the milestone card.
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -591,7 +591,38 @@ def _workflow_response(workflow: dict | None) -> dict | None:
     # only provides a sensible default for downstream consumers.
     if normalized.get("content_language") not in ALLOWED_CONTENT_LANGUAGES:
         normalized["content_language"] = DEFAULT_CONTENT_LANGUAGE
+    normalized["acceptance_feedback_prefill"] = _acceptance_feedback_prefill(normalized)
     return normalized
+
+
+def _acceptance_feedback_prefill(workflow: dict) -> str:
+    """Pre-fill text for the resume-with-feedback modal on acceptance pauses.
+
+    Only paused acceptance rows (rejected/indeterminate) carry a prefill — the
+    parse is gated on that so list endpoints never pay for it. Derived via
+    ``feedback_prefill_from_report`` so the issue comment and the prefill
+    share one formatter.
+    """
+    if workflow.get("status") != "paused" or workflow.get("current_phase") != (
+        "acceptance_verification"
+    ):
+        return ""
+    if (workflow.get("verification_status") or "") not in ("rejected", "indeterminate"):
+        return ""
+    raw = workflow.get("verification_report")
+    if not raw:
+        return ""
+    try:
+        report = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    except (TypeError, ValueError):
+        return ""
+    if not isinstance(report, dict):
+        return ""
+    from app.modules.workspace.autonomous.phases.acceptance_verification import (
+        feedback_prefill_from_report,
+    )
+
+    return feedback_prefill_from_report(report)
 
 
 def _parse_int_arg(name: str, default: int) -> int:
@@ -1725,6 +1756,10 @@ def resume_with_feedback(workflow_id):
             "current_phase": "wait",
             "status": "waiting",
             "verification_merge_sha": "",
+            # The resume IS the review outcome — the header banner renders
+            # error_message verbatim, so a stale "awaiting review" here keeps
+            # telling the user the workflow needs them after they just acted.
+            "error_message": "",
         },
     )
 

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -84,6 +84,12 @@ export interface AutonomousWorkflow {
   parent_workflow_id: string | null;
   fork_milestone_id: string | null;
   user_feedback: string;
+  /**
+   * Verifier failed-items prefill (#2491 UX) for the resume-with-feedback
+   * modal — server-derived from the stored verification report on rejected/
+   * indeterminate acceptance pauses. Empty string otherwise.
+   */
+  acceptance_feedback_prefill?: string;
   original_branch_name: string;
   /**
    * JSON snapshot (#2020 Phase B) of the resource/isolation policy actually in

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -419,6 +419,13 @@
   border-left-color: var(--color-danger);
 }
 
+/* Feedback received — the workflow re-enters development on its own (#2491). */
+.timeline-state-banner--feedback {
+  background: color-mix(in srgb, var(--color-success) 10%, var(--bg-primary) 90%);
+  border-color: color-mix(in srgb, var(--color-success) 26%, var(--border-color) 74%);
+  border-left-color: var(--color-success);
+}
+
 .timeline-state-banner--info {
   background: color-mix(in srgb, var(--color-primary) 8%, var(--bg-primary) 92%);
   border-color: color-mix(in srgb, var(--color-primary) 22%, var(--border-color) 78%);

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -204,6 +204,75 @@ describe('WorkflowTimeline paused-state banner (#2634)', () => {
   });
 });
 
+describe('WorkflowTimeline feedback-pending restart state (#2491 UX)', () => {
+  beforeEach(() => {
+    mockResumeWithFeedbackMutate.mockReset();
+    mockAcceptanceOverrideMutate.mockReset();
+  });
+
+  it('shows the feedback-received banner and hides Complete Development for waiting+feedback rows', () => {
+    const { container } = renderTimeline(
+      pausedWorkflow({
+        status: 'waiting',
+        current_phase: 'wait',
+        user_feedback: 'wire CI lanes before re-verify',
+        error_message: '',
+      })
+    );
+
+    const banner = stateBanner(container);
+    expect(banner.className).toContain('timeline-state-banner--feedback');
+    expect(
+      within(banner).getByText('Feedback received — a new development round will start shortly')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /complete development/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps Complete Development for waiting rows WITHOUT feedback', () => {
+    renderTimeline(
+      pausedWorkflow({
+        status: 'waiting',
+        current_phase: 'wait',
+        user_feedback: '',
+        error_message: '',
+      })
+    );
+
+    expect(screen.getByRole('button', { name: /complete development/i })).toBeInTheDocument();
+  });
+
+  it('development-phase rows with leftover user_feedback do not show the feedback banner', () => {
+    const { container } = renderTimeline(
+      pausedWorkflow({
+        status: 'developing',
+        current_phase: 'development',
+        user_feedback: 'wire CI lanes',
+        error_message: '',
+      })
+    );
+
+    expect(container.querySelector('.timeline-state-banner--feedback')).toBeNull();
+  });
+
+  it('pre-fills the feedback modal with the verifier failed-items prefill', () => {
+    const prefill =
+      'Rejected / missing:\n- [verifier] `wire CI lanes` (rejected) — no producer job in workflows';
+    renderTimeline(
+      pausedWorkflow({ verification_status: 'rejected', acceptance_feedback_prefill: prefill })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /new development round/i }));
+
+    const dialog = screen.getByRole('dialog');
+    const textarea = within(dialog).getByRole('textbox');
+    expect(textarea).toHaveValue(prefill);
+    const submit = within(dialog).getByRole('button', { name: /resume with feedback/i });
+    expect(submit).not.toBeDisabled();
+  });
+});
+
 describe('formatAcceptanceReport (#2658)', () => {
   it('renders markdown structure: status heading, meta list, sections, nested evidence', () => {
     const report = {

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -225,9 +225,7 @@ describe('WorkflowTimeline feedback-pending restart state (#2491 UX)', () => {
     expect(
       within(banner).getByText('Feedback received — a new development round will start shortly')
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /complete development/i })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /complete development/i })).not.toBeInTheDocument();
   });
 
   it('keeps Complete Development for waiting rows WITHOUT feedback', () => {

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -541,6 +541,13 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   const isActive = ACTIVE_WORKFLOW_STATUSES.includes(workflow.status);
   const isPaused = workflow.status === 'paused';
   const isWaiting = workflow.current_phase === 'wait';
+  // #2491 UX: the resume-with-feedback already landed — the workflow is queued
+  // to re-enter development on its own. Gated on phase === 'wait' because
+  // user_feedback stays on the row after _do_wait consumes it.
+  const isFeedbackPendingRestart =
+    workflow.status === 'waiting' &&
+    workflow.current_phase === 'wait' &&
+    !!workflow.user_feedback?.trim();
   const allowMilestoneActions =
     isActive || isPaused || isWaiting || workflow.status === 'planning_timeout';
 
@@ -1183,29 +1190,35 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   // action) and quota pauses from generic paused/failed banners.
   const pauseReason = getPauseReasonCategory(workflow);
   const isAcceptanceAwaitingPause = pauseReason === 'acceptance_awaiting';
-  const stateBannerTone = isAcceptanceAwaitingPause
-    ? 'acceptance'
+  const stateBannerTone = isFeedbackPendingRestart
+    ? 'feedback'
+    : isAcceptanceAwaitingPause
+      ? 'acceptance'
+      : workflow.error_message
+        ? 'error'
+        : workflow.status === 'planning_timeout' ||
+            workflow.status === 'paused' ||
+            workflow.status === 'waiting'
+          ? 'warning'
+          : 'info';
+  const stateBannerTitle = isFeedbackPendingRestart
+    ? t('autoBannerFeedbackPending', language)
+    : isAcceptanceAwaitingPause
+      ? t('autoBannerAcceptanceAwaiting', language)
+      : pauseReason === 'quota'
+        ? t('autoBannerQuotaPaused', language)
+        : workflowStatusLabel;
+  const stateBannerMessage = isFeedbackPendingRestart
+    ? workflow.user_feedback
     : workflow.error_message
-      ? 'error'
-      : workflow.status === 'planning_timeout' ||
-          workflow.status === 'paused' ||
-          workflow.status === 'waiting'
-        ? 'warning'
-        : 'info';
-  const stateBannerTitle = isAcceptanceAwaitingPause
-    ? t('autoBannerAcceptanceAwaiting', language)
-    : pauseReason === 'quota'
-      ? t('autoBannerQuotaPaused', language)
-      : workflowStatusLabel;
-  const stateBannerMessage = workflow.error_message
-    ? workflow.error_message
-    : workflow.status === 'planning_timeout'
-      ? t('autoBannerPlanningTimeout', language)
-      : workflow.status === 'paused'
-        ? t('autoBannerPaused', language)
-        : workflow.status === 'waiting'
-          ? t('autoBannerWaiting', language)
-          : '';
+      ? workflow.error_message
+      : workflow.status === 'planning_timeout'
+        ? t('autoBannerPlanningTimeout', language)
+        : workflow.status === 'paused'
+          ? t('autoBannerPaused', language)
+          : workflow.status === 'waiting'
+            ? t('autoBannerWaiting', language)
+            : '';
   const showStateBanner = Boolean(
     workflow.error_message ||
     workflow.status === 'planning_timeout' ||
@@ -2278,7 +2291,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 </Button>
               </>
             )}
-            {!showStateBanner && isWaiting && (
+            {!showStateBanner && isWaiting && !isFeedbackPendingRestart && (
               <Button
                 size="sm"
                 variant="success"
@@ -2425,7 +2438,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               )}
             </div>
             <div className="timeline-state-banner__actions">
-              {isWaiting && (
+              {isWaiting && !isFeedbackPendingRestart && (
                 <Button
                   size="sm"
                   variant="success"
@@ -2440,7 +2453,13 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 <Button
                   size="sm"
                   variant="warning"
-                  onClick={() => setShowResumeFeedbackModal(true)}
+                  onClick={() => {
+                    // #2491 UX: pre-fill with the verifier's failed-items list
+                    // (server-derived from the verification report) so the user
+                    // can submit it verbatim or lightly edit it.
+                    setResumeFeedback(workflow.acceptance_feedback_prefill || '');
+                    setShowResumeFeedbackModal(true);
+                  }}
                   disabled={resumeFeedbackMutation.isPending}
                   title={t('autoResumeWithFeedbackHelp', language)}
                 >

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -2457,7 +2457,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     // #2491 UX: pre-fill with the verifier's failed-items list
                     // (server-derived from the verification report) so the user
                     // can submit it verbatim or lightly edit it.
-                    setResumeFeedback(workflow.acceptance_feedback_prefill || '');
+                    setResumeFeedback(workflow.acceptance_feedback_prefill ?? '');
                     setShowResumeFeedbackModal(true);
                   }}
                   disabled={resumeFeedbackMutation.isPending}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1899,6 +1899,8 @@ export const translations: Record<Language, Translations> = {
     autoBannerPaused: 'This workflow is paused. Resume it to continue the remaining steps.',
     // #2634: paused-state distinction + resume-with-feedback entry
     autoBannerAcceptanceAwaiting: 'Awaiting human acceptance review',
+    // #2491 UX: feedback already submitted — the workflow restarts on its own
+    autoBannerFeedbackPending: 'Feedback received — a new development round will start shortly',
     autoBannerQuotaPaused: 'Quota paused',
     autoPauseReasonAcceptance: 'Awaiting acceptance review',
     autoPauseReasonQuota: 'Quota paused',
@@ -3836,6 +3838,7 @@ export const translations: Record<Language, Translations> = {
     autoBannerPaused: '当前工作流已暂停，恢复后会继续执行剩余步骤。',
     // #2634: 暂停状态区分 + 带反馈重启入口
     autoBannerAcceptanceAwaiting: '验收等待人工处理',
+    autoBannerFeedbackPending: '已收到反馈，即将自动开始新一轮开发',
     autoBannerQuotaPaused: '配额暂停',
     autoPauseReasonAcceptance: '等待验收处理',
     autoPauseReasonQuota: '配额暂停',
@@ -5545,6 +5548,7 @@ export const translations: Record<Language, Translations> = {
     autoBannerPaused: 'このワークフローは一時停止中です。再開すると残りのステップを続行します。',
     // #2634: 一時停止状態の区別 + フィードバック付き再開入口
     autoBannerAcceptanceAwaiting: '承認確認が人間の処理を待っています',
+    autoBannerFeedbackPending: 'フィードバックを受信しました。まもなく次の開発ラウンドを自動開始します',
     autoBannerQuotaPaused: 'クォータ一時停止',
     autoPauseReasonAcceptance: '承認確認待ち',
     autoPauseReasonQuota: 'クォータ一時停止',
@@ -7376,6 +7380,7 @@ export const translations: Record<Language, Translations> = {
     autoBannerPaused: '이 워크플로는 일시정지 상태입니다. 재개하면 남은 단계를 계속 진행합니다.',
     // #2634: 일시정지 상태 구분 + 피드백 재시작 진입점
     autoBannerAcceptanceAwaiting: '수락 확인이 사람의 처리를 기다리는 중',
+    autoBannerFeedbackPending: '피드백이 접수되었습니다. 곧 새 개발 라운드가 자동으로 시작됩니다',
     autoBannerQuotaPaused: '쿼터 일시정지',
     autoPauseReasonAcceptance: '수락 검토 대기',
     autoPauseReasonQuota: '쿼터 일시정지',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5548,7 +5548,8 @@ export const translations: Record<Language, Translations> = {
     autoBannerPaused: 'このワークフローは一時停止中です。再開すると残りのステップを続行します。',
     // #2634: 一時停止状態の区別 + フィードバック付き再開入口
     autoBannerAcceptanceAwaiting: '承認確認が人間の処理を待っています',
-    autoBannerFeedbackPending: 'フィードバックを受信しました。まもなく次の開発ラウンドを自動開始します',
+    autoBannerFeedbackPending:
+      'フィードバックを受信しました。まもなく次の開発ラウンドを自動開始します',
     autoBannerQuotaPaused: 'クォータ一時停止',
     autoPauseReasonAcceptance: '承認確認待ち',
     autoPauseReasonQuota: 'クォータ一時停止',

--- a/tests/e2e/work/e2e_paused_acceptance_ui_playwright.py
+++ b/tests/e2e/work/e2e_paused_acceptance_ui_playwright.py
@@ -23,6 +23,12 @@ repository, mirroring tests/e2e/e2e_acceptance_override_playwright.py):
   4. Rejected workflow timeline (#2658): the "View acceptance report" button
      opens the generic content viewer with the per-item verdicts and evidence
      refs parsed from the acceptance milestone's metadata JSON.
+  5. Rejected pause (#2491 UX): the resume-with-feedback modal opens
+     PRE-FILLED with the verifier failed-items list (server-derived from the
+     stored verification report; confirmed gates excluded).
+  6. Waiting + user_feedback (#2491 UX): the timeline shows the
+     "Feedback received" restart banner and hides the manual
+     "Complete Development" exit.
 
 Seeding: five workflow rows are inserted via AutonomousWorkflowRepository —
 an acceptance-paused (rejected) workflow paused >3 days ago, a quota-paused
@@ -54,6 +60,11 @@ from playwright.sync_api import expect, sync_playwright
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+# Login identity: CI uses the scripts/init_db.py defaults (admin/admin123);
+# a local dev DB may have rotated the admin password, so allow an override
+# (e.g. a dedicated e2e platform-admin user) without touching CI behavior.
+E2E_USERNAME = os.environ.get("E2E_USERNAME", "admin")
+E2E_PASSWORD = os.environ.get("E2E_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-paused-acceptance-ui")
 
 
@@ -91,7 +102,7 @@ def clear_forced_password_change() -> None:
 
     app = create_app()
     with app.app_context():
-        user = UserRepository().get_user_by_username("admin")
+        user = UserRepository().get_user_by_username(E2E_USERNAME)
         if user:
             UserRepository().set_must_change_password(int(user["id"]), False)
 
@@ -117,7 +128,7 @@ def seed_workflow(
 
     app = create_app()
     repo = AutonomousWorkflowRepository()
-    user = UserRepository().get_user_by_username("admin") or {"id": 1}
+    user = UserRepository().get_user_by_username(E2E_USERNAME) or {"id": 1}
     workflow_id = f"e2e-pause-{uuid.uuid4().hex[:12]}"
     with app.app_context():
         repo.create_workflow(
@@ -213,8 +224,8 @@ def cleanup_previous_runs() -> None:
 def login(page) -> None:
     page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
     page.wait_for_selector("#username", state="visible", timeout=15000)
-    page.fill("#username", "admin")
-    page.fill("#password", "admin123")
+    page.fill("#username", E2E_USERNAME)
+    page.fill("#password", E2E_PASSWORD)
     page.click("button[type='submit']")
     page.wait_for_url(lambda url: "/login" not in url, timeout=120000)
 
@@ -402,6 +413,88 @@ def main() -> None:
             expect(viewer.get_by_text("tests/test_login.py:12")).to_be_visible()
             shot(page, "06-report-viewer")
             print("[PASS] acceptance report viewer renders per-item verdicts + evidence")
+
+            # ── 5. Rejected pause: feedback modal prefill (#2491 UX) ──────
+            prefill_id = seed_workflow(
+                title="E2E prefill-acceptance UI #2491",
+                paused_days_ago=0,
+            )
+            import json as _json_dump
+
+            os.environ.setdefault("SCHEDULER_MODE", "web")
+            from app import create_app as _create_app
+
+            _report = {
+                "merge_sha": "abc123def456",
+                "status": "rejected",
+                "verified_by": "glm-5/e2e",
+                "scope": [],
+                "gates": [{"item": "call-chain", "verdict": "confirmed", "evidence": []}],
+                "verifier": [
+                    {
+                        "item": "修复登录失败",
+                        "verdict": "rejected",
+                        "evidence": [],
+                        "rationale": "合并后用例依旧失败",
+                    }
+                ],
+            }
+            _app = _create_app()
+            with _app.app_context():
+                AutonomousWorkflowRepository().update_workflow(
+                    prefill_id,
+                    {"verification_report": _json_dump.dumps(_report, ensure_ascii=False)},
+                )
+            page.goto(
+                f"{BASE_URL}/work/autonomous?workflow={prefill_id}",
+                wait_until="domcontentloaded",
+            )
+            pause(2)
+            page.wait_for_selector(".timeline-state-banner", timeout=30000)
+            page.locator(".timeline-state-banner").get_by_text(
+                "Resume with Feedback", exact=True
+            ).click()
+            pause(0.5)
+            prefill_modal = page.get_by_role("dialog")
+            expect(prefill_modal).to_be_visible()
+            prefill_textarea = prefill_modal.locator("textarea")
+            # Server-derived prefill mirrors the issue comment's failed-items
+            # section: confirmed gates must not leak in.
+            expect(prefill_textarea).to_have_value(
+                "Rejected / missing:\n- [verifier] `修复登录失败` (rejected) — 合并后用例依旧失败"
+            )
+            expect(prefill_modal.get_by_text("Resume with Feedback", exact=True)).to_be_enabled()
+            shot(page, "07-feedback-prefill")
+            print("[PASS] feedback modal pre-fills the verifier failed-items list")
+            prefill_modal.get_by_text("Cancel", exact=True).click()
+            expect(page.get_by_role("dialog")).not_to_be_visible(timeout=10000)
+
+            # ── 6. Waiting+feedback: restart banner, no manual exit ───────
+            waiting_id = seed_workflow(
+                title="E2E feedback-pending UI #2491",
+                status="waiting",
+                current_phase="wait",
+                verification_status="rejected",
+                error_message="",
+                paused_days_ago=0,
+            )
+            with _app.app_context():
+                AutonomousWorkflowRepository().update_workflow(
+                    waiting_id, {"user_feedback": "E2E: wire the missing CI lane"}
+                )
+            page.goto(
+                f"{BASE_URL}/work/autonomous?workflow={waiting_id}",
+                wait_until="domcontentloaded",
+            )
+            pause(2)
+            page.wait_for_selector(".timeline-state-banner--feedback", timeout=30000)
+            expect(
+                page.get_by_text("Feedback received — a new development round will start shortly")
+            ).to_be_visible()
+            # No manual "Complete Development" exit while a restart is queued.
+            expect(page.get_by_text("Complete Development", exact=True)).not_to_be_visible()
+            shot(page, "08-feedback-pending-banner")
+            print("[PASS] waiting+feedback shows restart banner and hides Complete Development")
         finally:
             browser.close()
 

--- a/tests/unit/test_acceptance_override_2658.py
+++ b/tests/unit/test_acceptance_override_2658.py
@@ -229,3 +229,79 @@ class TestResumeWithFeedbackClearsVerificationCache:
         assert updates["current_phase"] == "wait"
         assert updates["status"] == "waiting"
         assert updates["user_feedback"] == "please also handle the edge case"
+
+    def test_resume_clears_stale_error_message(self, app_client):
+        """#2491 UX: the header banner renders ``error_message`` verbatim, so
+        the stale "rejected; awaiting review" text survived the resume and the
+        page kept telling the user the workflow awaited review. Resuming with
+        feedback IS the review outcome — the route must clear it."""
+        client, repo, _ = app_client
+        with ExitStack() as stack:
+            stack.enter_context(_mock_auth(user_id=7, role="user", username="owner"))
+            resp = self._post_feedback(client)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        updates = repo.update_workflow.call_args.args[1]
+        assert updates["error_message"] == ""
+
+
+_REPORT_REJECTED = (
+    '{"status": "rejected", "merge_sha": "abc123",'
+    ' "scope": [], "gates": ['
+    '{"item": "call-chain", "verdict": "confirmed", "evidence": []}'
+    "],"
+    ' "verifier": ['
+    '{"item": "wire CI lanes", "verdict": "rejected", "evidence": [],'
+    ' "rationale": "no producer job in workflows"},'
+    '{"item": "summary artifact", "verdict": "indeterminate",'
+    ' "evidence": [{"note": "single stdlib implementation"}]}'
+    "]}"
+)
+
+
+class TestAcceptanceFeedbackPrefill:
+    """The resume-with-feedback modal pre-fills the verifier's failed-items
+    list so the user can submit it as feedback verbatim or lightly edit it.
+    Derived server-side from the stored ``verification_report`` so the issue
+    comment and the prefill share one formatter."""
+
+    def _get_workflow(self, client, **overrides):
+        client_app = client.application
+        with client_app.test_request_context():
+            from app.routes.autonomous import _workflow_response
+
+            return _workflow_response(_workflow_row(**overrides))
+
+    def test_rejected_pause_gets_prefill_with_failed_items(self, app_client):
+        client, _, _ = app_client
+        resp = self._get_workflow(client, verification_report=_REPORT_REJECTED)
+        prefill = resp["acceptance_feedback_prefill"]
+        assert "- [verifier] `wire CI lanes` (rejected) — no producer job in workflows" in prefill
+        # rationale missing → falls back to the first evidence note
+        assert "`summary artifact` (indeterminate)" in prefill
+        assert "single stdlib implementation" in prefill
+        # confirmed gates must not leak into the prefill
+        assert "call-chain" not in prefill
+
+    def test_prefill_survives_malformed_report(self, app_client):
+        client, _, _ = app_client
+        resp = self._get_workflow(client, verification_report="{not json")
+        assert resp.get("acceptance_feedback_prefill", "") == ""
+
+    def test_non_rejected_pause_has_no_prefill(self, app_client):
+        client, _, _ = app_client
+        resp = self._get_workflow(
+            client,
+            verification_status="confirmed",
+            verification_report='{"status": "confirmed", "verifier": []}',
+        )
+        assert resp.get("acceptance_feedback_prefill", "") == ""
+
+    def test_waiting_row_has_no_prefill(self, app_client):
+        client, _, _ = app_client
+        resp = self._get_workflow(
+            client,
+            status="waiting",
+            current_phase="wait",
+            verification_report=_REPORT_REJECTED,
+        )
+        assert resp.get("acceptance_feedback_prefill", "") == ""


### PR DESCRIPTION
## What

Follow-up UX for the acceptance-rejection resume loop (#2491 scenario, on top of #2658):

1. **Resume-with-feedback now clears `error_message`** — the header banner renders it verbatim, so the stale `Acceptance verification rejected; awaiting review` kept telling the user the workflow needed them *after* they had already acted.
2. **Feedback-pending restart banner** — a `waiting` row at phase `wait` with `user_feedback` set renders a dedicated green `Feedback received` banner (new `--feedback` tone, i18n en/zh/ja/ko) and hides the manual **Complete Development** exit in both render paths — the restart is already queued via `_do_wait`, a manual exit would race it.
3. **Verifier failed-items prefill** — the resume-with-feedback modal opens pre-filled with the verifier's failed-items list (the same `Rejected / missing:` bullets posted to the GitHub issue), server-derived in `_workflow_response` from the stored `verification_report` via a shared formatter so the comment and the prefill never drift. Confirmed gates are excluded; malformed reports degrade to empty.

## Tests

- Backend unit (`tests/unit/test_acceptance_override_2658.py`): error_message cleared on resume; prefill derivation (rejected → bullets, malformed JSON → empty, confirmed/waiting → empty) — 15 passed.
- Frontend vitest (`WorkflowTimeline.test.tsx`): feedback banner + hidden Complete Development for waiting+feedback; no banner for dev-phase rows with leftover feedback; modal prefill — full suite 851 passed.
- E2E (`e2e_paused_acceptance_ui_playwright.py`): +2 scenarios (modal prefill against a seeded verification_report; waiting+feedback banner with no manual exit), all 8 assertions pass headless against a live server.

Refs #2491 (stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)