### PR TITLE
fix: 管理端无法查看远程机器上的活动会话状态 (#2580)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -2982,6 +2982,101 @@ class RemoteAgentManager:
                 logger.error(f"Failed to get machine assignments: {e}")
                 return []
 
+    def get_machine_sessions(
+        self,
+        machine_id: str,
+        status: str = "all",
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Get list of active/paused sessions on a machine.
+
+        Issue #2580: Admin dashboard feature for viewing remote machine sessions.
+
+        Args:
+            machine_id: The machine UUID to query.
+            status: Filter by status - "active", "paused", or "all" (default).
+            limit: Maximum number of sessions to return (default 50, max 200).
+
+        Returns:
+            List of session dicts with: session_id, user_id, username, status,
+            project_path, model, tool_name, created_at, updated_at
+        """
+        # Clamp limit to max 200
+        limit = min(max(1, limit), 200)
+
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+
+            try:
+                # Build status filter
+                if status == "active":
+                    status_clause = "AND s.status = 'active'"
+                elif status == "paused":
+                    status_clause = "AND s.status = 'paused'"
+                else:
+                    # "all" shows active + paused only (not completed/stopped/error)
+                    status_clause = "AND s.status IN ('active', 'paused')"
+
+                cursor.execute(
+                    f"""
+                    SELECT
+                        s.session_id,
+                        s.user_id,
+                        u.username,
+                        s.status,
+                        s.project_path,
+                        s.model,
+                        s.tool_name,
+                        s.created_at,
+                        s.updated_at
+                    FROM agent_sessions s
+                    LEFT JOIN users u ON s.user_id = u.id
+                    WHERE s.remote_machine_id = {_param()}
+                    AND s.workspace_type = 'remote'
+                    {status_clause}
+                    ORDER BY s.updated_at DESC
+                    LIMIT {_param()}
+                """,
+                    (machine_id, limit),
+                )
+
+                rows = cursor.fetchall()
+                result = []
+                for row in rows:
+                    if isinstance(row, dict):
+                        result.append(
+                            {
+                                "session_id": row["session_id"],
+                                "user_id": row["user_id"],
+                                "username": row["username"],
+                                "status": row["status"],
+                                "project_path": row["project_path"],
+                                "model": row["model"],
+                                "tool_name": row["tool_name"],
+                                "created_at": row["created_at"],
+                                "updated_at": row["updated_at"],
+                            }
+                        )
+                    else:
+                        # Tuple format
+                        result.append(
+                            {
+                                "session_id": row[0],
+                                "user_id": row[1],
+                                "username": row[2],
+                                "status": row[3],
+                                "project_path": row[4],
+                                "model": row[5],
+                                "tool_name": row[6],
+                                "created_at": row[7],
+                                "updated_at": row[8],
+                            }
+                        )
+                return result
+            except Exception as e:
+                logger.error(f"Failed to get machine sessions: {e}")
+                return []
+
     def _batch_get_token_status(self, cursor, machine_ids: list[str]) -> dict[str, str]:
         """Batch-query token status for multiple machines.
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1395,6 +1395,40 @@ def get_machine_users(machine_id):
     )
 
 
+@remote_bp.route("/machines/<machine_id>/sessions", methods=["GET"])
+@machine_admin_required
+def get_machine_sessions(machine_id):
+    """
+    Get list of active sessions on a machine. System admin or machine admin.
+
+    Issue #2580: Admin dashboard feature for viewing remote machine sessions.
+    """
+    # Validate tenant access
+    machine, error = _check_machine_tenant_access(machine_id)
+    if error:
+        return error
+
+    # Parse query parameters
+    status = request.args.get("status", "all")
+    if status not in ("active", "paused", "all"):
+        status = "all"
+
+    try:
+        limit = int(request.args.get("limit", 50))
+    except (TypeError, ValueError):
+        limit = 50
+
+    agent_mgr = get_remote_agent_manager()
+    sessions = agent_mgr.get_machine_sessions(machine_id, status=status, limit=limit)
+
+    return jsonify(
+        {
+            "success": True,
+            "sessions": sessions,
+        }
+    )
+
+
 # ==================== Session Management (User) ====================
 
 

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -38,6 +38,18 @@ export interface MachineAssignment {
   granted_at: string;
 }
 
+export interface MachineSession {
+  session_id: string;
+  user_id: number | null;
+  username: string | null;
+  status: string;
+  project_path: string | null;
+  model: string | null;
+  tool_name: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 export interface ApiKey {
   id: number;
   provider: string;
@@ -291,6 +303,16 @@ export const remoteApi = {
 
   getMachineUsers(machineId: string): Promise<{ success: boolean; users: MachineAssignment[] }> {
     return apiClient.get(`/api/remote/machines/${machineId}/users`);
+  },
+
+  getMachineSessions(
+    machineId: string,
+    params?: { status?: string; limit?: number }
+  ): Promise<{ success: boolean; sessions: MachineSession[] }> {
+    const query: Record<string, string> = {};
+    if (params?.status) query.status = params.status;
+    if (params?.limit !== undefined) query.limit = String(params.limit);
+    return apiClient.get(`/api/remote/machines/${machineId}/sessions`, query);
   },
 
   assignUser(

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -1102,7 +1102,9 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
       )}
 
       {/* Active Sessions - Issue #2580 */}
-      {canManageUsers && <MachineSessionsSection machineId={machine.machine_id} language={language} />}
+      {canManageUsers && (
+        <MachineSessionsSection machineId={machine.machine_id} language={language} />
+      )}
     </Modal>
   );
 };

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -13,6 +13,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   useMachines,
   useMachineUsers,
+  useMachineSessions,
   useGenerateToken,
   useDeregisterMachine,
   useRotateMachineToken,
@@ -1099,6 +1100,86 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
           )}
         </div>
       )}
+
+      {/* Active Sessions - Issue #2580 */}
+      {canManageUsers && <MachineSessionsSection machineId={machine.machine_id} language={language} />}
     </Modal>
+  );
+};
+
+// ==================== Machine Sessions Section ====================
+
+interface MachineSessionsSectionProps {
+  machineId: string;
+  language: Language;
+}
+
+const MachineSessionsSection: React.FC<MachineSessionsSectionProps> = ({
+  machineId,
+  language,
+}) => {
+  const { data, isLoading, refetch } = useMachineSessions(machineId);
+  const sessions = data?.sessions ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="mt-4">
+        <h6 className="mb-2">{t('activeSessions', language) || 'Active Sessions'}</h6>
+        <Loading size="md" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="d-flex justify-content-between align-items-center mb-2">
+        <h6 className="mb-0">{t('activeSessions', language) || 'Active Sessions'}</h6>
+        <Button variant="outline-secondary" size="sm" onClick={() => refetch()}>
+          <i className="bi bi-arrow-clockwise me-1" />
+          {t('refresh', language)}
+        </Button>
+      </div>
+
+      {sessions.length === 0 ? (
+        <p className="text-muted">
+          {t('noActiveSessions', language) || 'No active sessions on this machine'}
+        </p>
+      ) : (
+        <div className="table-responsive">
+          <table className="table table-sm table-hover">
+            <thead>
+              <tr>
+                <th>{t('sessionId', language) || 'Session ID'}</th>
+                <th>{t('user', language) || 'User'}</th>
+                <th>{t('status', language)}</th>
+                <th>{t('projectPath', language) || 'Project'}</th>
+                <th>{t('model', language) || 'Model'}</th>
+                <th>{t('lastActivity', language) || 'Last Activity'}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((session) => (
+                <tr key={session.session_id}>
+                  <td className="font-monospace">{session.session_id.substring(0, 8)}...</td>
+                  <td>{session.username ?? '-'}</td>
+                  <td>
+                    <Badge variant={session.status === 'active' ? 'success' : 'warning'}>
+                      {session.status}
+                    </Badge>
+                  </td>
+                  <td className="text-truncate" style={{ maxWidth: '150px' }}>
+                    {session.project_path ?? '-'}
+                  </td>
+                  <td>{session.model ?? '-'}</td>
+                  <td>
+                    {session.updated_at ? new Date(session.updated_at).toLocaleString() : '-'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
   );
 };

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -1102,12 +1102,7 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
       )}
 
       {/* Active Sessions - Issue #2580 */}
-      {canManageUsers && (
-        <MachineSessionsSection
-          machineId={machine.machine_id}
-          language={language}
-        />
-      )}
+      {canManageUsers && <MachineSessionsSection machineId={machine.machine_id} language={language} />}
     </Modal>
   );
 };
@@ -1119,10 +1114,7 @@ interface MachineSessionsSectionProps {
   language: Language;
 }
 
-const MachineSessionsSection: React.FC<MachineSessionsSectionProps> = ({
-  machineId,
-  language,
-}) => {
+const MachineSessionsSection: React.FC<MachineSessionsSectionProps> = ({ machineId, language }) => {
   const { data, isLoading, refetch } = useMachineSessions(machineId);
   const sessions = data?.sessions ?? [];
 

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -1102,7 +1102,12 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
       )}
 
       {/* Active Sessions - Issue #2580 */}
-      {canManageUsers && <MachineSessionsSection machineId={machine.machine_id} language={language} />}
+      {canManageUsers && (
+        <MachineSessionsSection
+          machineId={machine.machine_id}
+          language={language}
+        />
+      )}
     </Modal>
   );
 };

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -74,6 +74,7 @@ export { useGlobalFetch } from './useFetch';
 export {
   useMachines,
   useMachineUsers,
+  useMachineSessions,
   useGenerateToken,
   useDeregisterMachine,
   useRotateMachineToken,

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -29,8 +29,8 @@ export function useMachineSessions(
   options?: { status?: string; limit?: number }
 ) {
   return useQuery({
-    queryKey: ["remote", "machines", machineId, "sessions", options],
-    queryFn: () => remoteApi.getMachineSessions(machineId ?? "", options),
+    queryKey: ['remote', 'machines', machineId, 'sessions', options],
+    queryFn: () => remoteApi.getMachineSessions(machineId ?? '', options),
     enabled: !!machineId,
     refetchInterval: 30000, // 30s refresh to match heartbeat frequency
   });

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -24,6 +24,18 @@ export function useMachineUsers(machineId: string | null) {
   });
 }
 
+export function useMachineSessions(
+  machineId: string | null,
+  options?: { status?: string; limit?: number }
+) {
+  return useQuery({
+    queryKey: ["remote", "machines", machineId, "sessions", options],
+    queryFn: () => remoteApi.getMachineSessions(machineId ?? "", options),
+    enabled: !!machineId,
+    refetchInterval: 30000, // 30s refresh to match heartbeat frequency
+  });
+}
+
 export function useGenerateToken() {
   const queryClient = useQueryClient();
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -735,6 +735,8 @@ export const translations: Record<Language, Translations> = {
 
     // Sessions
     activeSessions: 'Active Sessions',
+    noActiveSessions: 'No active sessions on this machine',
+    lastActivity: 'Last Activity',
     noSessionsFound: 'No sessions found with current filters',
     noAgentSessions:
       'No agent sessions found. Sessions are created when using AI tools in Workspace.',
@@ -2714,6 +2716,8 @@ export const translations: Record<Language, Translations> = {
 
     // Sessions
     activeSessions: '活跃会话',
+    noActiveSessions: '该机器上暂无活动会话',
+    lastActivity: '最近活动',
     noSessionsFound: '未找到符合条件的会话',
     noAgentSessions: '暂无 Agent 会话。在 Workspace 中使用 AI 工具时会自动创建会话。',
     allStatus: '所有状态',


### PR DESCRIPTION
## 修复内容

Closes #2580

### 问题
管理员无法从管理端查看远程机器上的活动会话信息。

### 修复方案
1. **后端新增 API**: `GET /api/remote/machines/<machine_id>/sessions`
   - 返回该机器上的活动会话列表
   - 包含：session_id, user_id, username, status, project_path, model, created_at, updated_at
   - 支持 status 过滤（active/paused/all）
   - 支持 limit 参数（默认 50，最大 200）
   - 权限控制：复用 `@machine_admin_required` 装饰器

2. **前端变更**：
   - RemoteMachineManagement 组件添加"活动会话"区域
   - 新增 useMachineSessions hook
   - 添加相关 i18n 翻译

### 文件变更
- `app/routes/remote.py`: 新增 `get_machine_sessions` 路由
- `app/modules/workspace/remote_agent_manager.py`: 新增 `get_machine_sessions` 方法
- `frontend/src/api/remote.ts`: 新增 `MachineSession` 类型和 `getMachineSessions` API
- `frontend/src/hooks/useRemote.ts`: 新增 `useMachineSessions` hook
- `frontend/src/components/features/management/RemoteMachineManagement.tsx`: 添加活动会话区域
- `frontend/src/i18n/index.ts`: 添加翻译

### 测试计划
- [ ] 手动测试：管理员查看远程机器详情时显示活动会话
- [ ] 手动测试：会话列表正确显示用户、状态、时间等信息
- [ ] 手动测试：空会话时显示"暂无活动会话"
- [ ] 手动测试：刷新按钮正常工作