### PR TITLE
fix(#2706): tiebreak scheduler selection on batch_order after created_at

### DIFF
--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -966,6 +966,13 @@ class AutonomousScheduler:
             key=lambda wf: (
                 1 if wf.get("status") == "waiting" else 0,
                 wf.get("created_at") or "",
+                # Batch siblings share created_at (one INSERT loop), so
+                # batch_order must break the tie or later siblings can be
+                # selected ahead of earlier ones and starve behind conflict
+                # locks (#2706). Non-batch rows (NULL) map to 0; workflow_id
+                # keeps the total order stable regardless.
+                wf.get("batch_order") if wf.get("batch_order") is not None else 0,
+                wf.get("workflow_id") or "",
             )
         )
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -966,12 +966,8 @@ class AutonomousScheduler:
             key=lambda wf: (
                 1 if wf.get("status") == "waiting" else 0,
                 wf.get("created_at") or "",
-                # Batch siblings share created_at (one INSERT loop), so
-                # batch_order must break the tie or later siblings can be
-                # selected ahead of earlier ones and starve behind conflict
-                # locks (#2706). Non-batch rows (NULL) map to 0; workflow_id
-                # keeps the total order stable regardless.
-                wf.get("batch_order") if wf.get("batch_order") is not None else 0,
+                # Tiebreak same-created_at batch siblings on batch_order (#2706); NULL→0; workflow_id keeps total order stable.
+                bo if (bo := wf.get("batch_order")) is not None else 0,
                 wf.get("workflow_id") or "",
             )
         )

--- a/tests/unit/test_scheduler_batch_order_tiebreak.py
+++ b/tests/unit/test_scheduler_batch_order_tiebreak.py
@@ -1,0 +1,96 @@
+"""Regression (#2706): scheduler selection must tiebreak on batch_order.
+
+Batch siblings are inserted in one loop, so they share (or nearly share)
+``created_at``. The selection sort keyed only on ``(waiting, created_at)``,
+leaving same-timestamp siblings ordered by whatever the DB returned — a later
+sibling could repeatedly win the batch's single slot and hold the conflict
+lock while the earlier one starved behind it, surfacing as a batch "stuck for
+hours". ``batch_order`` is persisted at insert time
+(autonomous_repo.py) but was never read back here.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2706)]
+
+CREATED_AT = "2026-08-15 12:00:00"
+
+
+def _wf(workflow_id, batch_id, batch_order, **overrides):
+    base = {
+        "workflow_id": workflow_id,
+        "status": "pending",
+        "created_at": CREATED_AT,
+        "batch_id": batch_id,
+        "batch_order": batch_order,
+        "worktree_path": f"/wt/{workflow_id}",
+        "branch_name": f"auto/{workflow_id}",
+    }
+    base.update(overrides)
+    return base
+
+
+def _run_one_cycle(scheduler, workflows):
+    mock_repo = MagicMock()
+    mock_repo.get_active_workflows.return_value = workflows
+    mock_repo.get_queued_workflows.return_value = []
+    with (
+        patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+        patch.object(
+            scheduler, "_advance_single", side_effect=lambda workflow_id: workflow_id
+        ) as advance,
+    ):
+        scheduler._process_workflows()
+    return [call.args[0] for call in advance.call_args_list]
+
+
+def test_same_created_at_batch_siblings_selected_in_batch_order():
+    """With identical created_at, the batch's earlier sibling (batch_order 0)
+    must win the batch's single slot even when the DB returns rows in reverse
+    order — Python's stable sort otherwise preserves the wrong order."""
+    scheduler = AutonomousScheduler()
+    workflows = [
+        _wf("wf-later", "batch-1", 1),
+        _wf("wf-earlier", "batch-1", 0),
+    ]
+
+    selected = _run_one_cycle(scheduler, workflows)
+
+    assert selected == ["wf-earlier"]
+
+
+def test_batch_order_tiebreak_honors_waiting_priority_first(monkeypatch):
+    """The waiting-last priority is unchanged: a waiting sibling still sorts
+    behind pending work even with a smaller batch_order. Concurrency is capped
+    to 1 so the single slot deterministically goes to the pending sibling
+    (ThreadPool invocation order is otherwise non-deterministic)."""
+    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
+    scheduler = AutonomousScheduler()
+    workflows = [
+        _wf("wf-waiting", "batch-1", 0, status="waiting"),
+        _wf("wf-pending", "batch-1", 1),
+    ]
+
+    selected = _run_one_cycle(scheduler, workflows)
+
+    assert selected == ["wf-pending"]
+
+
+def test_null_batch_order_same_created_at_falls_back_to_workflow_id(monkeypatch):
+    """Non-batch rows (batch_order NULL) with identical created_at must order
+    by workflow_id — a stable total order, and no TypeError from comparing
+    None with int."""
+    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
+    scheduler = AutonomousScheduler()
+    workflows = [
+        _wf("wf-b", "", None),
+        _wf("wf-a", "", None),
+    ]
+
+    selected = _run_one_cycle(scheduler, workflows)
+
+    assert selected == ["wf-a"]

--- a/tests/unit/test_scheduler_batch_order_tiebreak.py
+++ b/tests/unit/test_scheduler_batch_order_tiebreak.py
@@ -1,13 +1,4 @@
-"""Regression (#2706): scheduler selection must tiebreak on batch_order.
-
-Batch siblings are inserted in one loop, so they share (or nearly share)
-``created_at``. The selection sort keyed only on ``(waiting, created_at)``,
-leaving same-timestamp siblings ordered by whatever the DB returned — a later
-sibling could repeatedly win the batch's single slot and hold the conflict
-lock while the earlier one starved behind it, surfacing as a batch "stuck for
-hours". ``batch_order`` is persisted at insert time
-(autonomous_repo.py) but was never read back here.
-"""
+"""Regression (#2706): tiebreak same-created_at batch siblings on batch_order."""
 
 from unittest.mock import MagicMock, patch
 
@@ -48,10 +39,9 @@ def _run_one_cycle(scheduler, workflows):
     return [call.args[0] for call in advance.call_args_list]
 
 
-def test_same_created_at_batch_siblings_selected_in_batch_order():
-    """With identical created_at, the batch's earlier sibling (batch_order 0)
-    must win the batch's single slot even when the DB returns rows in reverse
-    order — Python's stable sort otherwise preserves the wrong order."""
+def test_same_created_at_batch_siblings_selected_in_batch_order(monkeypatch):
+    """Identical created_at + reverse DB order: batch_order 0 must win the batch's single slot."""
+    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [
         _wf("wf-later", "batch-1", 1),
@@ -64,10 +54,7 @@ def test_same_created_at_batch_siblings_selected_in_batch_order():
 
 
 def test_batch_order_tiebreak_honors_waiting_priority_first(monkeypatch):
-    """The waiting-last priority is unchanged: a waiting sibling still sorts
-    behind pending work even with a smaller batch_order. Concurrency is capped
-    to 1 so the single slot deterministically goes to the pending sibling
-    (ThreadPool invocation order is otherwise non-deterministic)."""
+    """Waiting-last priority is unchanged: pending beats waiting regardless of batch_order."""
     monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [
@@ -81,9 +68,7 @@ def test_batch_order_tiebreak_honors_waiting_priority_first(monkeypatch):
 
 
 def test_null_batch_order_same_created_at_falls_back_to_workflow_id(monkeypatch):
-    """Non-batch rows (batch_order NULL) with identical created_at must order
-    by workflow_id — a stable total order, and no TypeError from comparing
-    None with int."""
+    """NULL batch_order + identical created_at orders by workflow_id: stable total order, no None-vs-int TypeError."""
     monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [


### PR DESCRIPTION
## 问题

Fixes #2706

同一批次创建的兄弟工作流 `created_at` 相同（单次 INSERT 循环落库），而调度器选路排序只看 `(status==waiting, created_at)`。同为 waiting=0 且 created_at 相同时，顺序完全取决于 DB 返回顺序——批内靠后的工作流可能反复先于靠前的兄弟抢到批内唯一槽位并持有冲突锁（如同 repo workspace 锁），靠前的兄弟要等数小时才轮到，监控侧表现为批卡死。`batch_order` / `batch_total` 在 `autonomous_repo.py` 正常落库，但 scheduler 从未读取。

## 修复

`app/services/autonomous_scheduler.py` 选路排序 key 从 `(waiting, created_at)` 扩展为 `(waiting, created_at, batch_order, workflow_id)`：

- `batch_order` 作为 `created_at` 之后的 tiebreak，批内按配置顺序推进；
- 非批次行 `batch_order` 为 NULL，映射为 0（避免 None 与 int 比较抛 TypeError）；
- `workflow_id` 兜底，保证全序稳定（含 NULL batch_order 的行之间）。

## 测试

新增 `tests/unit/test_scheduler_batch_order_tiebreak.py`（`pytest.mark.regression` + `pytest.mark.issue(2706)`，按 TEST_LAYERS 约定放规范层 unit，未新增 tests/issues 目录）：

1. `test_same_created_at_batch_siblings_selected_in_batch_order` — 同 created_at、DB 逆序返回时，batch_order 0 的兄弟必须先获得批内槽位；
2. `test_batch_order_tiebreak_honors_waiting_priority_first` — waiting 靠后的既有优先级不受影响；
3. `test_null_batch_order_same_created_at_falls_back_to_workflow_id` — NULL batch_order + 相同 created_at 时按 workflow_id 稳定排序，且无 TypeError。

验证：

- 还原修复后测试 1、3 失败，应用修复后 3 个全部通过（回归测试有效）；
- 既有套件无回归：`tests/issues/716/test_scheduler.py` + `tests/unit/test_scheduler_acceptance_conflict_key.py`（23 passed）、`tests/issues/2431/` + `tests/issues/716/test_autonomous_repo.py`（106 passed）；
- ruff / black / isort 全部通过。