### PR TITLE
fix(#2711): stop sync short-circuit from spawning unbounded review rounds

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5822,6 +5822,12 @@ class AutonomousOrchestrator:
         ):
             # The push starts a new synthetic-merge CI run. Do not consume a
             # bounded AI repair attempt for stale-tree synchronization.
+            # Signal the pr_review handler to skip a full review next cycle and
+            # only re-poll CI (#2711); without this the handler re-enters as a
+            # new review round, bypassing all #2443 convergence guards.
+            self._update_workflow(
+                {"error_message": "CI repair deferred: waiting for CI after main sync"}
+            )
             return
 
         # After the non-AI main synchronization above, check the attempt limit

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -417,13 +417,13 @@ def handle(ctx, deps) -> PhaseResult:
     if not pr_number:
         pr_number = host.get_workflow_field("github_pr_number")
 
-    # After _start_ci_repair_round synced the branch with main, skip the full
-    # review cycle and only re-check CI (#2711). Without this guard the handler
-    # re-enters as a new review round, bypassing all #2443 convergence guards
-    # and incrementing current_round past max_pr_review_rounds.
-    if (wf.get("error_message") or "").startswith(
-        "CI repair deferred: waiting for CI after main sync"
-    ):
+    # Any "CI repair deferred:" sentinel (sync-wait, transient API error,
+    # no-change) means _start_ci_repair_round already handled this cycle.
+    # Skip the full review and only re-check CI (#2711): without this guard the
+    # handler re-enters as a new review round, bypassing all #2443 convergence
+    # guards.  The whole prefix family is matched so a transient/no-change
+    # deferral mid-repair also skips the phantom review round.
+    if (wf.get("error_message") or "").startswith("CI repair deferred:"):
         fresh_failures: list = []
         if pr_number:
             try:

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -417,6 +417,30 @@ def handle(ctx, deps) -> PhaseResult:
     if not pr_number:
         pr_number = host.get_workflow_field("github_pr_number")
 
+    # After _start_ci_repair_round synced the branch with main, skip the full
+    # review cycle and only re-check CI (#2711). Without this guard the handler
+    # re-enters as a new review round, bypassing all #2443 convergence guards
+    # and incrementing current_round past max_pr_review_rounds.
+    if (wf.get("error_message") or "").startswith(
+        "CI repair deferred: waiting for CI after main sync"
+    ):
+        fresh_failures: list = []
+        if pr_number:
+            try:
+                fresh_checks = host.poll_ci_status(gh, pr_number)
+                fresh_failures = [c for c in fresh_checks if c.get("bucket") == "fail"]
+            except Exception:
+                pass
+        if not fresh_failures:
+            host.emit_phase_change({"phase": "report"})
+            return PhaseResult.completed(
+                next_phase="report",
+                next_status="reporting",
+                workflow_patch={"error_message": ""},
+            )
+        host.start_ci_repair_round(wf, pr_number, fresh_failures)
+        return PhaseResult.retry(workflow_patch={})
+
     # Code review
     review_ms = host.create_milestone_idempotent(
         phase="pr_review",
@@ -770,6 +794,16 @@ def handle(ctx, deps) -> PhaseResult:
                 is_pr=True,
                 context="review-summary",
             )
+
+        # Re-poll CI immediately before the go/no-go decision. The entry
+        # snapshot (captured before review/fix) may predate a fix push made
+        # this cycle, causing a spurious ci_failed_before_report (#2711).
+        if pr_number:
+            try:
+                fresh_checks = host.poll_ci_status(gh, pr_number)
+                ci_failures = [c for c in fresh_checks if c.get("bucket") == "fail"]
+            except Exception:
+                pass  # keep entry snapshot; next cycle sees fresh state
 
         # Check CI status before proceeding to report phase (Issue #1662). If
         # CI failed, enter CI repair loop instead of reporting.

--- a/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
+++ b/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
@@ -260,3 +260,47 @@ def test_ci_repoll_before_decision_still_triggers_repair_on_persistent_failure()
 
     assert result.outcome == "retry"
     host.start_ci_repair_round.assert_called_once()
+
+
+# ── Widened guard: transient / no-change overwrite also skips review ─────
+
+
+def test_transient_deferred_sentinel_skips_full_review_advances_to_report_when_ci_green():
+    """start_ci_repair_round overwrites error_message with
+    'CI repair deferred: transient API error ...' on 503/429.  The widened
+    guard ('CI repair deferred:' prefix family) must catch this so a transient
+    deferral mid-repair does not spawn a phantom review round (#2711 review
+    comment — important)."""
+    gh = _gh()
+    host = _host(poll_ci_status=MagicMock(return_value=_PASS_CHECKS))
+    deps = _deps(host, gh)
+
+    transient_sentinel = "CI repair deferred: transient API error - 503 upstream"
+    result = pr_review_phase.handle(
+        _ctx(_workflow(error_message=transient_sentinel, current_round=3)), deps
+    )
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "report"
+    host.run_agent_with_context_recovery.assert_not_called()
+
+
+def test_no_change_deferred_sentinel_skips_full_review_triggers_repair_when_ci_failing():
+    """start_ci_repair_round overwrites error_message with
+    'CI repair deferred: agent produced no code changes' on an empty-commit
+    round.  The widened guard must also catch this so no phantom review round
+    fires; the handler delegates to start_ci_repair_round for re-entry
+    (#2711 review comment — important)."""
+    gh = _gh()
+    host = _host(poll_ci_status=MagicMock(return_value=[_FAIL_CHECK]))
+    deps = _deps(host, gh)
+
+    no_change_sentinel = "CI repair deferred: agent produced no code changes"
+    result = pr_review_phase.handle(
+        _ctx(_workflow(error_message=no_change_sentinel, current_round=3)), deps
+    )
+
+    assert result.outcome == "retry"
+    host.start_ci_repair_round.assert_called_once()
+    host.run_agent_with_context_recovery.assert_not_called()
+    assert "current_round" not in result.workflow_patch

--- a/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
+++ b/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
@@ -1,0 +1,262 @@
+"""Regression (#2711): pr_review CI-repair sync loop and stale CI snapshot.
+
+Two structural bugs that both caused unbounded pr_review rounds:
+
+1. _start_ci_repair_round synced the branch with main then returned bare,
+   leaving no state change. The next scheduler cycle re-entered pr_review as a
+   full new review round, bypassing all #2443 convergence guards. Fix: write a
+   sentinel to error_message so the handler recognises the "just synced" state.
+
+2. ci_failures captured at handler entry was never refreshed before the final
+   CI go/no-go decision. A fix push made during the same cycle started a new CI
+   run, but the entry snapshot still showed failures → spurious
+   ci_failed_before_report milestone. Fix: re-poll immediately before the check.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
+from app.modules.workspace.autonomous.phases import pr_review as pr_review_phase
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2711)]
+
+_SYNC_SENTINEL = "CI repair deferred: waiting for CI after main sync"
+_FAIL_CHECK = {"name": "ci", "bucket": "fail", "state": "failure"}
+_PASS_CHECKS: list = []
+
+
+# ── helpers (mirrors test_pr_review.py helpers) ───────────────────────────
+
+
+def _ctx(workflow: dict) -> WorkflowContext:
+    return WorkflowContext(
+        workflow=workflow,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings={},
+        cancellation=threading.Event(),
+    )
+
+
+def _run_git(args, check=True):
+    if args[:1] == ["rev-parse"]:
+        return MagicMock(stdout=f"{args[1]}-sha\n", returncode=0)
+    if args[:2] == ["merge-base", "--is-ancestor"]:
+        return MagicMock(stdout="", returncode=1)
+    return MagicMock(stdout="", returncode=0)
+
+
+def _gh(branch: str = "feature-x") -> MagicMock:
+    gh = MagicMock(name="gh")
+    gh._run_git.side_effect = _run_git
+    gh.get_current_branch.return_value = branch
+    gh.get_diff_stats.return_value = {"commits": 1, "additions": 2, "deletions": 0, "files": 1}
+    gh.git_push.return_value = None
+    return gh
+
+
+def _agent(text: str = "approved") -> AgentTaskResult:
+    return AgentTaskResult(
+        session_id="sess-1",
+        response_text=text,
+        total_tokens=10,
+        total_input_tokens=5,
+        total_output_tokens=5,
+        success=True,
+        error=None,
+    )
+
+
+def _host(**overrides) -> MagicMock:
+    host = MagicMock(name="host")
+    host.workflow_id = "wf-test"
+    host.must_run_full_review_rounds.return_value = False
+    host.validate_autonomous_change_scope.return_value = ""
+    host.get_workflow_field.return_value = None
+    host.refresh_workflow_snapshot.return_value = {}
+    host.create_milestone_idempotent.return_value = {"milestone_id": "ms-x"}
+    host.get_pr_review_diff.return_value = "DIFF"
+    host.smart_truncate_diff.side_effect = lambda t: t
+    host.clean_agent_text.side_effect = lambda t: t or ""
+    host.poll_ci_status.return_value = _PASS_CHECKS
+    host.run_agent_with_context_recovery.return_value = _agent()
+    host.accumulate_tokens.return_value = None
+    host.abort_on_repo_integrity_violation.return_value = False
+    host.is_context_overflow.return_value = False
+    host.artifact_text.side_effect = lambda r: getattr(r, "response_text", "") or ""
+    host.artifact_tldr.return_value = "tldr"
+    host.review_is_approved.return_value = True
+    host.post_github_comment.return_value = None
+    host.apply_pr_review_fix.return_value = True
+    host.cancel_milestone_for_shutdown.return_value = None
+    host.start_ci_repair_round.return_value = None
+    for k, v in overrides.items():
+        if callable(v) or isinstance(v, MagicMock):
+            setattr(host, k, v)
+        else:
+            setattr(host, k, MagicMock(return_value=v))
+    return host
+
+
+def _deps(host: MagicMock, gh: MagicMock) -> MagicMock:
+    deps = MagicMock(name="deps")
+    deps.host = host
+    deps.gh = gh
+    deps.repo = MagicMock(name="repo")
+    deps.repo.list_milestones.return_value = []
+    deps.repo.get_milestone.return_value = {}
+    return deps
+
+
+def _workflow(**overrides) -> dict:
+    wf = {
+        "workflow_id": "wf-test",
+        "current_phase": "pr_review",
+        "status": "pr_review",
+        "current_round": 0,
+        "max_pr_review_rounds": 5,
+        "dev_round": 1,
+        "branch_name": "feature-x",
+        "github_pr_number": 1234,
+        "github_issue_number": 42,
+        "cli_tool": "claude-code",
+        "content_language": "en",
+    }
+    wf.update(overrides)
+    return wf
+
+
+# ── Bug 1a: _start_ci_repair_round sets sentinel on sync ─────────────────
+
+
+def test_start_ci_repair_round_sets_sync_sentinel_on_branch_behind_main():
+    """After a non-AI main sync push, _start_ci_repair_round must write the sync
+    sentinel to error_message so the next pr_review cycle can detect it and skip
+    a full review round (#2711).  Without the fix, _update_workflow was never
+    called and ci_repair_attempts stayed 0 forever."""
+    orc = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orc._update_workflow = MagicMock()
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-abc"
+    orc._get_gh = MagicMock(return_value=gh)
+    orc._get_preferred_worktree_path = MagicMock(return_value="/wt/x")
+    orc._sync_failed_pr_with_main = MagicMock(return_value=True)
+
+    wf = {"workflow_id": "wf-1", "branch_name": "feat/x", "ci_repair_attempts": 0}
+    failed = [{"name": "ci", "bucket": "fail"}]
+    orc._start_ci_repair_round(wf, 99, failed)
+
+    orc._update_workflow.assert_called_once()
+    patch_arg = orc._update_workflow.call_args[0][0]
+    assert patch_arg.get("error_message", "").startswith(
+        "CI repair deferred: waiting for CI after main sync"
+    ), f"Expected sync sentinel, got: {patch_arg}"
+
+
+# ── Bug 1b: pr_review early exit on sync sentinel ────────────────────────
+
+
+def test_sync_sentinel_skips_full_review_advances_to_report_when_ci_green():
+    """When the sync sentinel is present in error_message and CI is now green,
+    the handler must advance to report WITHOUT running any review/fix/summary
+    agent call (#2711 bug 1b).  Before the fix, a full review round ran instead,
+    incrementing current_round past max_pr_review_rounds."""
+    gh = _gh()
+    host = _host(poll_ci_status=MagicMock(return_value=_PASS_CHECKS))
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(
+        _ctx(_workflow(error_message=_SYNC_SENTINEL)), deps
+    )
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "report"
+    assert result.next_status == "reporting"
+    assert result.workflow_patch.get("error_message") == ""
+    # No review, fix, or summary agent ran.
+    host.run_agent_with_context_recovery.assert_not_called()
+    host.apply_pr_review_fix.assert_not_called()
+    # phase_change{report} emitted.
+    host.emit_phase_change.assert_called_with({"phase": "report"})
+
+
+def test_sync_sentinel_skips_full_review_triggers_ai_repair_when_ci_still_failing():
+    """When the sync sentinel is present and CI is still red, the handler must
+    delegate to start_ci_repair_round and return retry WITHOUT running any review
+    round (#2711 bug 1b).  current_round must not be incremented."""
+    gh = _gh()
+    host = _host(poll_ci_status=MagicMock(return_value=[_FAIL_CHECK]))
+    deps = _deps(host, gh)
+
+    wf = _workflow(error_message=_SYNC_SENTINEL, current_round=3)
+    result = pr_review_phase.handle(_ctx(wf), deps)
+
+    assert result.outcome == "retry"
+    # AI repair triggered.
+    host.start_ci_repair_round.assert_called_once()
+    # No review/fix/summary agent ran.
+    host.run_agent_with_context_recovery.assert_not_called()
+    # current_round must not be set in workflow_patch (no new review round).
+    assert "current_round" not in result.workflow_patch
+
+
+# ── Bug 2: CI re-polled before final decision ─────────────────────────────
+
+
+def test_ci_repoll_before_decision_clears_stale_failures_on_green():
+    """The entry CI snapshot is taken before any fix push; if a fix this cycle
+    cleared the failures the old snapshot still shows red.  The handler must
+    re-poll immediately before the go/no-go decision so a fix-resolved CI leads
+    to report rather than a spurious ci_failed_before_report (#2711 bug 2)."""
+    gh = _gh()
+    # poll_ci_status: first call (entry) returns failures, second call
+    # (re-poll before decision) returns green.
+    host = _host(
+        review_is_approved=True,
+        poll_ci_status=MagicMock(
+            side_effect=[
+                [_FAIL_CHECK],  # entry snapshot
+                _PASS_CHECKS,   # re-poll before decision
+            ]
+        ),
+    )
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(
+        _ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps
+    )
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "report"
+    # CI repair must NOT have been triggered.
+    host.start_ci_repair_round.assert_not_called()
+
+
+def test_ci_repoll_before_decision_still_triggers_repair_on_persistent_failure():
+    """When the re-poll also returns CI failures, the handler still enters the
+    repair loop — the re-poll must not suppress a genuine CI failure."""
+    gh = _gh()
+    host = _host(
+        review_is_approved=True,
+        poll_ci_status=MagicMock(
+            side_effect=[
+                [_FAIL_CHECK],  # entry snapshot
+                [_FAIL_CHECK],  # re-poll before decision
+            ]
+        ),
+    )
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(
+        _ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps
+    )
+
+    assert result.outcome == "retry"
+    host.start_ci_repair_round.assert_called_once()

--- a/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
+++ b/tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py
@@ -172,9 +172,7 @@ def test_sync_sentinel_skips_full_review_advances_to_report_when_ci_green():
     host = _host(poll_ci_status=MagicMock(return_value=_PASS_CHECKS))
     deps = _deps(host, gh)
 
-    result = pr_review_phase.handle(
-        _ctx(_workflow(error_message=_SYNC_SENTINEL)), deps
-    )
+    result = pr_review_phase.handle(_ctx(_workflow(error_message=_SYNC_SENTINEL)), deps)
 
     assert result.outcome == "completed"
     assert result.next_phase == "report"
@@ -223,15 +221,13 @@ def test_ci_repoll_before_decision_clears_stale_failures_on_green():
         poll_ci_status=MagicMock(
             side_effect=[
                 [_FAIL_CHECK],  # entry snapshot
-                _PASS_CHECKS,   # re-poll before decision
+                _PASS_CHECKS,  # re-poll before decision
             ]
         ),
     )
     deps = _deps(host, gh)
 
-    result = pr_review_phase.handle(
-        _ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps
-    )
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps)
 
     assert result.outcome == "completed"
     assert result.next_phase == "report"
@@ -254,9 +250,7 @@ def test_ci_repoll_before_decision_still_triggers_repair_on_persistent_failure()
     )
     deps = _deps(host, gh)
 
-    result = pr_review_phase.handle(
-        _ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps
-    )
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps)
 
     assert result.outcome == "retry"
     host.start_ci_repair_round.assert_called_once()

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -2167,7 +2167,11 @@ def test_failed_pr_sync_happens_before_ai_attempt_limit():
 
     orch._sync_failed_pr_with_main.assert_called_once_with(gh, "auto-dev/test", 42, "pr-head")
     orch._create_milestone.assert_not_called()
-    orch._update_workflow.assert_not_called()
+    # Sync writes the sentinel so the next pr_review cycle skips a full review
+    # round and only re-polls CI (#2711).
+    orch._update_workflow.assert_called_once_with(
+        {"error_message": "CI repair deferred: waiting for CI after main sync"}
+    )
 
 
 def test_nonstandard_report_with_real_test_evidence_does_not_retry():


### PR DESCRIPTION
Fixes #2711

## 问题

两个结构性 bug 导致 `pr_review` 在 CI 失败 + 分支落后 main 的组合下无限循环，`ci_repair_attempts` 恒为 0，#2443 所有护栏不触发：

**Bug 1**：`_start_ci_repair_round` 同步完分支后裸 `return`，不写任何 workflow 状态。调度器下一轮重入 `pr_review` handler，按 `current_round+1` 启动完整 review → fix → summary → CI check 循环，绕过 `max_pr_review_rounds` 上限（实证：配置 3 轮，实跑到 round 6）。

**Bug 2**：`ci_failures` 快照在 handler 入口采集一次后不刷新。本轮 fix push 触发的新 CI run 对入口快照不可见，L776 判定必然滞后一轮，产生虚假的 `ci_failed_before_report` milestone 并触发不必要的 CI repair。

## 修复

**改动 A — `orchestrator.py`**（7 行）：同步后写入哨兵 `error_message`，沿用 transient/no-change 已有 sentinel 模式。

**改动 B — `pr_review.py` 入口**（26 行）：检测到同步哨兵时，跳过完整 review/fix/summary，只重查 CI：
- CI 绿 → 直接推进到 report（清空哨兵）
- CI 红 → 委托 `start_ci_repair_round`（AI 修复或再次同步），return retry，**不递增 `current_round`**

**改动 C — `pr_review.py` 决策前**（8 行）：在 `if ci_failures:` 之前重新 `poll_ci_status`，消除滞后判定。

## 收敛保证

- 同步等待周期仅做「poll CI」，不消耗 review 轮次；一旦进入 AI 修复路径，`ci_repair_attempts` 正常递增，MAX_CI_REPAIR_ATTEMPTS / 指纹不变 give-up / no-change 预算全部生效
- `max_pr_review_rounds` 不再被绕过

## 测试

新增 `tests/autonomous/phases/test_pr_review_ci_repair_sync_2711.py`（`pytest.mark.regression` + `pytest.mark.issue(2711)`，autonomous 层）：

| 测试 | 验证点 |
|------|--------|
| `test_start_ci_repair_round_sets_sync_sentinel_on_branch_behind_main` | 改动 A：sync 后 `_update_workflow` 被调用且写入哨兵 |
| `test_sync_sentinel_skips_full_review_advances_to_report_when_ci_green` | 改动 B：哨兵存在 + CI 绿 → `completed(report)`，零 agent 调用 |
| `test_sync_sentinel_skips_full_review_triggers_ai_repair_when_ci_still_failing` | 改动 B：哨兵存在 + CI 红 → `retry`，零 agent 调用，`current_round` 不递增 |
| `test_ci_repoll_before_decision_clears_stale_failures_on_green` | 改动 C：entry 红但 re-poll 绿 → `completed(report)`，CI repair 不触发 |
| `test_ci_repoll_before_decision_still_triggers_repair_on_persistent_failure` | 改动 C：re-poll 仍红 → repair 正常触发（regression 无泄漏） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)