### PR TITLE
fix: version-gate gh --allow-escape-sequences in CI log fetches (#2708)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -208,6 +208,22 @@ def _extract_failure_lines(lines: list[str], max_lines: int = 80) -> list[str]:
     return result[-max_lines:] if len(result) > max_lines else result
 
 
+def _unknown_flag_hint(stderr: str) -> str:
+    """Warning suffix naming the gh-version symptom behind 'unknown flag'.
+
+    An ``unknown flag`` exit is a gh-version problem, not a missing log.
+    Without this hint every check reads as "no logs", CI-repair exhausts
+    on deployments running gh < 2.97, and the real cause only shows up in
+    a truncated stderr fragment (Issue #2708 / #2482).
+    """
+    if "unknown flag" in (stderr or "").lower():
+        return (
+            " — likely gh < 2.97 (no --allow-escape-sequences support); "
+            "upgrade gh, otherwise every CI log fetch keeps reading as no logs"
+        )
+    return ""
+
+
 class GitHubOpsError(Exception):
     """Error raised when a GitHub operation fails."""
 
@@ -246,6 +262,10 @@ class GitHubOps:
     # original gitdir directly, preventing confused-deputy pushes.
     _trusted_git_contexts: dict[str, dict[str, str]] = {}
 
+    # gh learned --allow-escape-sequences in 2.97; older gh exits
+    # ``unknown flag`` for it, killing both CI-log fetch paths (Issue #2708).
+    _ESCAPE_FLAG_MIN_GH_VERSION = (2, 97)
+
     def __init__(self, repo_path: str, system_account: str | None = None):
         """
         Args:
@@ -277,6 +297,12 @@ class GitHubOps:
         # Tracks whether _resolve_owner_repo has been attempted, so None can
         # distinguish "tried and failed" from "not yet tried".
         self._owner_repo_resolved: bool = False
+        # Cached gh-version probe for --allow-escape-sequences (added in gh
+        # 2.97). None = not probed yet. Issue #2708: passing the flag to an
+        # older gh makes BOTH log-fetch paths exit ``unknown flag``, so every
+        # failure excerpt comes back empty and CI-repair exhausts with
+        # "0/N failed checks have logs".
+        self._escape_flag_supported: bool | None = None
 
     @classmethod
     def register_trusted_git_context(
@@ -2114,6 +2140,34 @@ class GitHubOps:
             excerpt = excerpt[-max_chars:].lstrip()
         return excerpt
 
+    def _supports_escape_sequences_flag(self) -> bool:
+        """Whether the resolved gh accepts --allow-escape-sequences (>= 2.97).
+
+        Probed once per instance via ``gh --version`` (no repo context, no
+        network) and cached. Fails OPEN — an unprobeable/unparseable gh keeps
+        passing the flag, because dropping it on a modern gh re-breaks log
+        fetches with the ANSI-refusal error the flag exists to lift; the
+        ``unknown flag`` symptom is then named explicitly in the fetch
+        warnings via _unknown_flag_hint (Issue #2708).
+        """
+        if self._escape_flag_supported is None:
+            self._escape_flag_supported = self._probe_escape_sequences_flag()
+        return self._escape_flag_supported
+
+    def _probe_escape_sequences_flag(self) -> bool:
+        try:
+            result = self._run_gh(["--version"], check=False, repo_scoped=False)
+        except GitHubOpsError:
+            return True  # fail open, see _supports_escape_sequences_flag
+        m = re.search(r"version\s+(\d+)\.(\d+)", result.stdout or "")
+        if not m:
+            return True  # fail open, see _supports_escape_sequences_flag
+        return (int(m.group(1)), int(m.group(2))) >= self._ESCAPE_FLAG_MIN_GH_VERSION
+
+    def _escape_sequences_flag(self) -> list[str]:
+        """["--allow-escape-sequences"] on gh >= 2.97, [] on older gh."""
+        return ["--allow-escape-sequences"] if self._supports_escape_sequences_flag() else []
+
     def _fetch_log_excerpt_via_run_list(
         self, check: dict, max_lines: int, max_chars: int, *, filter_lines: bool = True
     ) -> str:
@@ -2174,15 +2228,17 @@ class GitHubOps:
             return ""
 
         view_result = self._run_gh(
-            ["run", "view", run_id, "--log-failed", "--allow-escape-sequences"],
+            ["run", "view", run_id, "--log-failed", *self._escape_sequences_flag()],
             check=False,
         )
         if view_result.returncode != 0:
+            stderr_text = (view_result.stderr or view_result.stdout or "").strip()
             logger.warning(
-                "gh run view --log-failed failed for check '%s' (run=%s): %s",
+                "gh run view --log-failed failed for check '%s' (run=%s): %s%s",
                 name,
                 run_id,
-                (view_result.stderr or view_result.stdout or "").strip()[:200],
+                stderr_text[:200],
+                _unknown_flag_hint(stderr_text),
             )
             return ""
         return self._clean_log_to_excerpt(
@@ -2243,7 +2299,9 @@ class GitHubOps:
                 # passed; without it the job-log REST endpoint always fails and
                 # CI repair can never read failure logs. The sequences are
                 # stripped afterward by _clean_log_to_excerpt / _strip_ansi.
-                api_args.append("--allow-escape-sequences")
+                # Version-gated: gh < 2.97 has no such flag and exits
+                # ``unknown flag`` (Issue #2708).
+                api_args += self._escape_sequences_flag()
                 api_result = self._run_gh(api_args, check=False, repo_scoped=False)
                 if api_result.returncode == 0 and (api_result.stdout or "").strip():
                     return self._clean_log_to_excerpt(
@@ -2252,13 +2310,15 @@ class GitHubOps:
                         max_chars,
                         filter_lines=filter_lines,
                     )
+                api_stderr = (api_result.stderr or api_result.stdout or "").strip()
                 logger.warning(
                     "REST job-log fetch failed for check '%s' (run=%s job=%s), "
-                    "falling back to gh run view: %s",
+                    "falling back to gh run view: %s%s",
                     check.get("name") or "unknown",
                     run_id,
                     job_id,
-                    (api_result.stderr or api_result.stdout or "").strip()[:200],
+                    api_stderr[:200],
+                    _unknown_flag_hint(api_stderr),
                 )
 
             result = self._run_gh(
@@ -2269,17 +2329,19 @@ class GitHubOps:
                     "--job",
                     job_id,
                     "--log-failed",
-                    "--allow-escape-sequences",
+                    *self._escape_sequences_flag(),
                 ],
                 check=False,
             )
             if result.returncode != 0:
+                stderr_text = (result.stderr or result.stdout or "").strip()
                 logger.warning(
-                    "Failed to fetch failed log excerpt for check '%s' (run=%s job=%s): %s",
+                    "Failed to fetch failed log excerpt for check '%s' (run=%s job=%s): %s%s",
                     check.get("name") or "unknown",
                     run_id,
                     job_id,
-                    (result.stderr or result.stdout or "").strip()[:200],
+                    stderr_text[:200],
+                    _unknown_flag_hint(stderr_text),
                 )
                 return ""
             return self._clean_log_to_excerpt(

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -216,7 +216,7 @@ def _unknown_flag_hint(stderr: str) -> str:
     on deployments running gh < 2.97, and the real cause only shows up in
     a truncated stderr fragment (Issue #2708 / #2482).
     """
-    if "unknown flag" in (stderr or "").lower():
+    if "unknown flag" in stderr.lower():
         return (
             " — likely gh < 2.97 (no --allow-escape-sequences support); "
             "upgrade gh, otherwise every CI log fetch keeps reading as no logs"
@@ -2159,6 +2159,11 @@ class GitHubOps:
             result = self._run_gh(["--version"], check=False, repo_scoped=False)
         except GitHubOpsError:
             return True  # fail open, see _supports_escape_sequences_flag
+        # major.minor only: patch is deliberately ignored — the threshold
+        # (_ESCAPE_FLAG_MIN_GH_VERSION) is minor-level, so a patch bump
+        # (e.g. 2.97.1 vs 2.97.0) must never gate the flag. If a future
+        # threshold needs patch granularity, widen BOTH this regex and the
+        # comparison, not just one.
         m = re.search(r"version\s+(\d+)\.(\d+)", result.stdout or "")
         if not m:
             return True  # fail open, see _supports_escape_sequences_flag

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -73,6 +73,9 @@ def test_actions_job_log_prefers_rest_api_without_run_cache():
     gh._repo_host = "github.com"
     gh._owner_repo = "open-ace/open-ace"
     gh._owner_repo_resolved = True
+    # Pin the gh-version probe: this test asserts the modern-gh arg list
+    # (flag present, Issue #2708), so don't let the probe hit fake_run.
+    gh._escape_flag_supported = True
     calls = []
 
     def fake_run(args, check=True, repo_scoped=True):
@@ -108,6 +111,8 @@ def test_actions_job_log_uses_ghes_hostname_without_run_cache():
     gh._repo_host = "gh.example.com"
     gh._owner_repo = "team/project"
     gh._owner_repo_resolved = True
+    # Pin the gh-version probe: modern-gh arg list (flag present, Issue #2708).
+    gh._escape_flag_supported = True
     calls = []
 
     def fake_run(args, check=True, repo_scoped=True):

--- a/tests/unit/test_gh_escape_sequences_flag_version_gating.py
+++ b/tests/unit/test_gh_escape_sequences_flag_version_gating.py
@@ -1,0 +1,214 @@
+"""Version gating for gh's --allow-escape-sequences (Issue #2708).
+
+gh only learned ``--allow-escape-sequences`` in 2.97. On older deployments
+both CI-log fetch paths (``gh api .../jobs/<id>/logs`` and ``gh run view
+--log-failed``) exit ``unknown flag``, every failure excerpt comes back
+empty, and CI-repair exhausts with "0/N failed checks have logs" (see
+#2482). GitHubOps must probe the gh version once, omit the flag below
+2.97, and say so explicitly when a fetch dies on an unknown flag instead
+of swallowing it as "no logs".
+"""
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2708)]
+
+
+def _gh_with_repo() -> GitHubOps:
+    """A GitHubOps whose owner/repo is pre-resolved, like the existing
+    log-fetch tests in test_autonomous_ci_guardrails.py."""
+    gh = GitHubOps("/tmp/repo")
+    gh._repo_slug = "open-ace/open-ace"
+    gh._repo_host = "github.com"
+    gh._owner_repo = "open-ace/open-ace"
+    gh._owner_repo_resolved = True
+    return gh
+
+
+def _result(returncode=0, stdout="", stderr=""):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_version_probe_parses_gh_version_and_caches():
+    gh = GitHubOps("/tmp/repo")
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append((list(args), check, repo_scoped))
+        return _result(stdout="gh version 2.92.0 (2026-05-14)\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        assert gh._supports_escape_sequences_flag() is False
+        assert gh._supports_escape_sequences_flag() is False  # cached, no re-probe
+
+    assert calls == [(["--version"], False, False)]
+
+
+@pytest.mark.parametrize("version", ["2.97.0", "2.97.1", "2.98.0", "3.4.1"])
+def test_version_probe_accepts_modern_gh(version):
+    gh = GitHubOps("/tmp/repo")
+    with patch.object(
+        gh, "_run_gh", return_value=_result(stdout=f"gh version {version} (2026-07-31)\n")
+    ):
+        assert gh._supports_escape_sequences_flag() is True
+
+
+@pytest.mark.parametrize(
+    "probe_result",
+    [
+        GitHubOpsError("gh CLI not found. Please install and authenticate gh."),
+        _result(returncode=127, stdout="", stderr="command not found"),
+        _result(returncode=0, stdout="something completely unlike a version banner", stderr=""),
+    ],
+)
+def test_version_probe_fails_open(probe_result):
+    """Unprobeable gh keeps today's behavior (flag present): dropping the
+    flag on a modern gh would re-break log fetches with ANSI-refusal
+    (#2516-era), which is worse than the old-gh symptom this gate fixes."""
+    gh = GitHubOps("/tmp/repo")
+    if isinstance(probe_result, Exception):
+        patcher = patch.object(gh, "_run_gh", side_effect=probe_result)
+    else:
+        patcher = patch.object(gh, "_run_gh", return_value=probe_result)
+    with patcher:
+        assert gh._supports_escape_sequences_flag() is True
+
+
+def test_old_gh_omits_flag_on_rest_path():
+    gh = _gh_with_repo()
+    gh._escape_flag_supported = False  # probe result for gh 2.92
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append((list(args), repo_scoped))
+        return _result(stdout="pytest failed\n1 failed\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "test",
+                "link": "https://github.com/open-ace/open-ace/actions/runs/123/job/456",
+            }
+        )
+
+    assert "1 failed" in excerpt
+    assert calls == [(["api", "repos/open-ace/open-ace/actions/jobs/456/logs"], False)]
+
+
+def test_old_gh_omits_flag_on_run_view_fallback():
+    gh = _gh_with_repo()
+    gh._escape_flag_supported = False
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append((list(args), repo_scoped))
+        if args[0] == "api":
+            return _result(returncode=1, stderr="HTTP 404: Not Found")
+        return _result(stdout="LINT: failure\nblack...FAILED\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                "link": "https://github.com/open-ace/open-ace/actions/runs/123/job/456",
+            }
+        )
+
+    assert "FAILED" in excerpt
+    assert calls[1] == (["run", "view", "123", "--job", "456", "--log-failed"], True)
+
+
+def test_old_gh_omits_flag_on_run_list_fallback():
+    gh = GitHubOps("/tmp/repo")
+    gh._escape_flag_supported = False
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append(list(args))
+        if args[0] == "run" and args[1] == "list":
+            return _result(stdout=json.dumps([{"databaseId": 777, "name": "lint"}]))
+        return _result(stdout="LINT: failure\nblack...FAILED\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                # REST check-run html_url: not a parseable Actions job URL,
+                # so this exercises _fetch_log_excerpt_via_run_list.
+                "link": "https://github.com/open-ace/open-ace/runs/999",
+                "head_sha": "a" * 40,
+            }
+        )
+
+    assert "FAILED" in excerpt
+    assert calls[-1] == ["run", "view", "777", "--log-failed"]
+
+
+def test_modern_gh_keeps_flag_on_rest_and_run_view_paths():
+    gh = _gh_with_repo()
+    gh._escape_flag_supported = True  # probe result for gh >= 2.97
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append(list(args))
+        if args[0] == "api":
+            # Old-gh-style unknown flag must not happen here; simulate the
+            # REST endpoint refusing so the run-view fallback is exercised.
+            return _result(returncode=1, stderr="HTTP 404: Not Found")
+        return _result(stdout="LINT: failure\nblack...FAILED\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                "link": "https://github.com/open-ace/open-ace/actions/runs/123/job/456",
+            }
+        )
+
+    assert "FAILED" in excerpt
+    assert calls[0] == [
+        "api",
+        "repos/open-ace/open-ace/actions/jobs/456/logs",
+        "--allow-escape-sequences",
+    ]
+    assert calls[1] == [
+        "run",
+        "view",
+        "123",
+        "--job",
+        "456",
+        "--log-failed",
+        "--allow-escape-sequences",
+    ]
+
+
+def test_unknown_flag_failure_warns_with_version_hint(caplog):
+    """When a fetch dies on 'unknown flag' (the fail-open corner: probe could
+    not tell the version), the warning must name the gh-version symptom
+    instead of letting it read as an ordinary 'no logs' (#2708, #2482)."""
+    gh = _gh_with_repo()
+    gh._escape_flag_supported = True
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        return _result(returncode=1, stderr="unknown flag: --allow-escape-sequences")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        with caplog.at_level(logging.WARNING):
+            excerpt = gh.get_check_failure_excerpt(
+                {
+                    "name": "lint",
+                    "link": "https://github.com/open-ace/open-ace/actions/runs/123/job/456",
+                }
+            )
+
+    assert excerpt == ""
+    assert any(
+        "unknown flag" in record.message and "likely gh < 2.97" in record.message
+        for record in caplog.records
+    )

--- a/tests/unit/test_gh_escape_sequences_flag_version_gating.py
+++ b/tests/unit/test_gh_escape_sequences_flag_version_gating.py
@@ -150,6 +150,32 @@ def test_old_gh_omits_flag_on_run_list_fallback():
     assert calls[-1] == ["run", "view", "777", "--log-failed"]
 
 
+def test_modern_gh_keeps_flag_on_run_list_fallback():
+    """Completes the 3-path x 2-version matrix: the run-list fallback keeps
+    the flag on gh >= 2.97 (guards the ANSI-refusal fix, Issue #2708)."""
+    gh = GitHubOps("/tmp/repo")
+    gh._escape_flag_supported = True
+    calls = []
+
+    def fake_run(args, check=True, repo_scoped=True, api_only=False):
+        calls.append(list(args))
+        if args[0] == "run" and args[1] == "list":
+            return _result(stdout=json.dumps([{"databaseId": 777, "name": "lint"}]))
+        return _result(stdout="LINT: failure\nblack...FAILED\n")
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                "link": "https://github.com/open-ace/open-ace/runs/999",
+                "head_sha": "a" * 40,
+            }
+        )
+
+    assert "FAILED" in excerpt
+    assert calls[-1] == ["run", "view", "777", "--log-failed", "--allow-escape-sequences"]
+
+
 def test_modern_gh_keeps_flag_on_rest_and_run_view_paths():
     gh = _gh_with_repo()
     gh._escape_flag_supported = True  # probe result for gh >= 2.97


### PR DESCRIPTION
## 问题（#2708）

`github_ops.py` 三处硬编码 `--allow-escape-sequences`（gh ≥ 2.97 才有该 flag）。低版本 gh 部署上取 CI 日志的两条路径（`gh api .../jobs/<id>/logs` 与 `gh run view --log-failed`）同时报 `unknown flag`，所有失败摘录吞成空串，CI-repair 诊断循环永远输出 `0/1 failed checks have logs`，最终被误判耗尽、工作流 failed（直接受害者 #2482）——日志一直在，只是取不出来。

## 修复

- **版本探测 + 降级**：每个 `GitHubOps` 实例首次用到该 flag 时经 `gh --version` 探测一次（无 repo 上下文、无网络）并缓存；< 2.97 时三处调用点都不带该 flag（老 gh 的 REST 端点本来就不做转义序列拦截，裸调用即可取到日志）。
- **fail-open**：探测失败/输出不可解析时保留 flag——若反过来 fail-closed，会在现代 gh 上重新引入该 flag 本来要解决的 ANSI-refusal 拒绝问题，比老 gh 的 unknown flag 症状更糟。
- **显式症状**：三处日志取失败警告在 stderr 含 `unknown flag` 时追加 "likely gh < 2.97" 提示，不再让版本问题伪装成「没有日志」。

## 测试

- 新增 `tests/unit/test_gh_escape_sequences_flag_version_gating.py`（regression + issue(2708)）13 例：探测解析/缓存、现代版本接受、fail-open、三条路径老 gh 省略 flag、现代 gh 保留 flag（钉住 ANSI-refusal 修复不回归）、unknown-flag 显式警告（caplog）。
- `test_autonomous_ci_guardrails.py` 两条既有测试 pin `_escape_flag_supported = True`（mocked `_run_gh` 会把探测调用记进精确断言）。
- 相关面 140 passed；全量 `tests/unit -m "not postgres"`：4408 passed，仅 4 个 `test_test_layout_policy` 失败——引用的是本机 gitignored 遗留目录（`tests/1826`、`tests/security` 等），不在 git 内，CI 新检出不可见，与本 PR 无关。
- 本机 gh 2.97.0 真实探测冒烟：`_supports_escape_sequences_flag() → True`。

Fixes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)