### PR TITLE
fix(#2715): add fresh-session retry for review agent success-but-empty result

### DIFF
--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -589,6 +589,32 @@ def handle(ctx, deps) -> PhaseResult:
 
     review_text = host.artifact_text(review_result)
     if not review_text.strip():
+        # A --resumed session whose last turn already ended can synthesize
+        # an empty "No response requested" terminal result (0 tokens) — a
+        # transient resume no-op, not a genuine failure (the run itself
+        # succeeded). Retry ONCE with a brand-new session (session_line=
+        # "fresh"), which cannot no-op because it isn't resuming. The
+        # review prompt embeds the diff inline, so a fresh session still
+        # has what it needs. Genuine failures / overflows / integrity
+        # violations are handled above and never reach here.
+        retry_result = host.run_agent_with_context_recovery(
+            wf=wf,
+            workflow_id=host.workflow_id,
+            cli_tool=review_tool,
+            model=wf.get("model", ""),
+            project_path=wf.get("worktree_path") or wf.get("project_path", ""),
+            prompt=review_prompt,
+            workspace_type=wf.get("workspace_type", "local"),
+            remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=_zcode_planning_mode(wf),
+            allowed_tools=REVIEW_ALLOWED_TOOLS.get(review_tool, []),
+            session_line="fresh",
+            milestone_id=review_ms.get("milestone_id", ""),
+        )
+        host.accumulate_tokens(retry_result)
+        review_result = retry_result
+        review_text = host.artifact_text(review_result)
+    if not review_text.strip():
         message = "PR review agent returned no result"
         repo.update_milestone(
             review_ms.get("milestone_id", ""),

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -15,7 +15,9 @@ Coverage:
 - changes-requested (not approved, under cap) with fix succeeding →
   PhaseResult.retry (scheduler re-enters pr_review for the next round)
 - CI pending after approved review → start_ci_repair_round + PhaseResult.retry
-- failure path: review agent returns no result → PhaseResult.failed
+- review agent success-but-empty → fresh retry; retry non-empty → continues
+- review agent success-but-empty → fresh retry; retry also empty → PhaseResult.failed
+- review agent genuine failure (success=False) → PhaseResult.failed, no retry
 - failure path: read-only tool unsupported → PhaseResult.failed
 """
 
@@ -278,8 +280,9 @@ def test_ci_pending_after_approved_review_starts_repair_and_retries():
 
 
 def test_review_agent_no_result_returns_failed():
-    """A review agent that succeeds but returns an empty artifact fails closed:
-    PhaseResult.failed with the no-result message."""
+    """When BOTH the initial review run and the fresh retry return empty text,
+    the phase fails closed: PhaseResult.failed with the no-result message.
+    (Both calls share the same always-empty mock return value.)"""
     gh = _gh()
     empty_result = _agent(text="   \n")
     host = _host(
@@ -294,6 +297,56 @@ def test_review_agent_no_result_returns_failed():
     assert result.outcome == "failed"
     assert result.next_status == "failed"
     assert "no result" in result.structured_error.get("message", "")
+
+
+# ── review agent empty-result retry ──────────────────────────────────────
+
+
+def test_review_empty_first_call_retries_fresh_and_succeeds():
+    """When the review agent (session_line='review') returns success but EMPTY
+    artifact text — a transient resume no-op — handle() retries ONCE with a
+    fresh session (session_line='fresh'). If the retry returns non-empty text
+    the phase does NOT fail: it continues normally."""
+    gh = _gh()
+    empty_review = _agent(text="")
+    fresh_review = _agent(text="LGTM: all criteria met.\n")
+    summary_result = _agent(text="Summary: changes look good.")
+    host = _host(
+        review_is_approved=True,
+        run_agent_with_context_recovery=MagicMock(
+            side_effect=[empty_review, fresh_review, summary_result]
+        ),
+    )
+    host.artifact_text.side_effect = lambda r: getattr(r, "response_text", "") or ""
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps)
+
+    assert result.outcome != "failed", result
+    # Second call must be the fresh retry.
+    assert host.run_agent_with_context_recovery.call_count >= 2
+    second_kwargs = host.run_agent_with_context_recovery.call_args_list[1].kwargs
+    assert second_kwargs.get("session_line") == "fresh"
+
+
+def test_review_genuine_failure_does_not_trigger_fresh_retry():
+    """A genuine review-agent failure (success=False) takes the existing failure
+    path — it must NOT trigger the fresh-retry backstop, which is reserved for a
+    SUCCEEDED-but-empty run. run_agent is called exactly once."""
+    gh = _gh()
+    failed_review = _agent(text="", success=False)
+    failed_review.error = "agent crashed"
+    host = _host(
+        run_agent_with_context_recovery=MagicMock(return_value=failed_review),
+    )
+    host.artifact_text.side_effect = lambda r: getattr(r, "response_text", "") or ""
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "failed"
+    # Exactly one review call — no fresh retry.
+    assert host.run_agent_with_context_recovery.call_count == 1
 
 
 # ── summary agent empty-result retry ─────────────────────────────────────

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
+import pytest
+
 from app.modules.workspace.autonomous import phases as phases_pkg
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
@@ -279,6 +281,8 @@ def test_ci_pending_after_approved_review_starts_repair_and_retries():
 # ── failure paths → failed ────────────────────────────────────────────────
 
 
+@pytest.mark.regression
+@pytest.mark.issue(2715)
 def test_review_agent_no_result_returns_failed():
     """When BOTH the initial review run and the fresh retry return empty text,
     the phase fails closed: PhaseResult.failed with the no-result message.
@@ -302,6 +306,8 @@ def test_review_agent_no_result_returns_failed():
 # ── review agent empty-result retry ──────────────────────────────────────
 
 
+@pytest.mark.regression
+@pytest.mark.issue(2715)
 def test_review_empty_first_call_retries_fresh_and_succeeds():
     """When the review agent (session_line='review') returns success but EMPTY
     artifact text — a transient resume no-op — handle() retries ONCE with a
@@ -329,6 +335,8 @@ def test_review_empty_first_call_retries_fresh_and_succeeds():
     assert second_kwargs.get("session_line") == "fresh"
 
 
+@pytest.mark.regression
+@pytest.mark.issue(2715)
 def test_review_genuine_failure_does_not_trigger_fresh_retry():
     """A genuine review-agent failure (success=False) takes the existing failure
     path — it must NOT trigger the fresh-retry backstop, which is reserved for a


### PR DESCRIPTION
## Summary

- When a `--resumed` review session's last turn has already ended, the agent synthesizes an empty "No response requested" result (0 tokens) — a resume no-op, not a genuine failure. The workflow previously terminal-failed with no retry.
- Apply the same empty→fresh retry pattern already used for the summary agent (#2570 / fb680a17) and fix-agent (#2611): when `review_text` is empty but the run succeeded, retry once with `session_line="fresh"`. Only fail if the fresh retry also returns empty.
- Add three new tests covering: (1) fresh retry succeeds → phase continues, (2) both attempts empty → `PhaseResult.failed`, (3) genuine failure (success=False) → no retry, one call.

Closes #2715.

## Root cause

`phases/pr_review.py` L590–604 (before this fix) had no retry on success-but-empty, unlike the summary path (L738–778) and fix-agent path which both gained fresh-retry backstops in prior PRs. The review session for workflow 02dae370 had accumulated 12.3M tokens over 3 days; round 5 resume-noop'd and the workflow terminal-failed.

## Test plan

- [x] Existing `test_review_agent_no_result_returns_failed` still passes (both calls return empty → fails closed)
- [x] New `test_review_empty_first_call_retries_fresh_and_succeeds` — empty first call, non-empty fresh retry → phase does not fail, second call uses `session_line="fresh"`
- [x] New `test_review_genuine_failure_does_not_trigger_fresh_retry` — `success=False` takes existing failure path, only 1 agent call
- [x] Pre-existing summary and fix-agent retry tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)