### PR TITLE
fix(#2705): align Work-page token display with quota enforcement via user_daily_stats

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5230,6 +5230,11 @@ class AutonomousOrchestrator:
     def _create_milestone(self, **kwargs) -> dict:
         """Create a milestone and emit event. Idempotent — returns existing if found."""
         kwargs.setdefault("workflow_id", self._workflow_id)
+        # Callers that omit dev_round (e.g. acceptance_verification) would otherwise
+        # record dev_round=1 (the DB default), misattributing the milestone to
+        # round 1 in multi-round workflows (#2707).
+        if "dev_round" not in kwargs:
+            kwargs["dev_round"] = int((self.workflow or {}).get("dev_round") or 1)
 
         milestone_type = kwargs.get("milestone_type", "")
         # ci_repair_* milestones are one-per-attempt; a prior cycle's completed

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5230,11 +5230,6 @@ class AutonomousOrchestrator:
     def _create_milestone(self, **kwargs) -> dict:
         """Create a milestone and emit event. Idempotent — returns existing if found."""
         kwargs.setdefault("workflow_id", self._workflow_id)
-        # Callers that omit dev_round (e.g. acceptance_verification) would otherwise
-        # record dev_round=1 (the DB default), misattributing the milestone to
-        # round 1 in multi-round workflows (#2707).
-        if "dev_round" not in kwargs:
-            kwargs["dev_round"] = int((self.workflow or {}).get("dev_round") or 1)
 
         milestone_type = kwargs.get("milestone_type", "")
         # ci_repair_* milestones are one-per-attempt; a prior cycle's completed

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -519,7 +519,7 @@ def _prior_infra_retry_count(wf: dict, merge_sha: str, snap_hash: str) -> int:
         return 0
 
 
-def _acceptance_milestone(*, workflow_id, attempt, status, report) -> dict:
+def _acceptance_milestone(*, workflow_id, dev_round, attempt, status, report) -> dict:
     """Build the acceptance-verification milestone row.
 
     ``result_summary`` / ``metadata`` are DB columns inserted verbatim by
@@ -532,6 +532,7 @@ def _acceptance_milestone(*, workflow_id, attempt, status, report) -> dict:
     return {
         "workflow_id": workflow_id,
         "phase": "acceptance_verification",
+        "dev_round": dev_round,
         "round_number": attempt,
         "milestone_type": "acceptance_verification",
         "status": status,
@@ -815,6 +816,7 @@ def handle(ctx, deps) -> PhaseResult:
     }
     milestone = _acceptance_milestone(
         workflow_id=wf.get("workflow_id"),
+        dev_round=int(wf.get("dev_round") or 1),
         attempt=common_patch["verification_attempt"],
         status=status,
         report=report,

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1389,23 +1389,49 @@ class UsageRepository:
         start_date: str,
         end_date: str,
     ) -> tuple[int, int]:
-        """Query session_messages for tokens/requests in a date window.
+        """Get session token/request usage for a date window.
 
-        Changed from agent_sessions.created_at to session_messages.timestamp
-        to correctly count messages for long-running sessions like webui:N.
-        See Issue #1974 for details.
+        Uses user_daily_stats (fast path, same source as quota enforcement) so
+        the Work-page display matches what enforcement sees. Falls back to
+        agent_sessions.total_tokens when user_daily_stats has no data for the
+        period (e.g. the aggregator hasn't run yet for today's sessions).
+
+        Never reads daily_messages (#1125: analysis fact tables must not
+        participate in Workspace runtime display).
+
+        Fixes #2705: the previous session_messages SUM under-counted by ~10%
+        because cache and other non-message token costs are not recorded in
+        individual message rows.
         """
+        # Fast path: user_daily_stats — identical to quota_manager enforcement.
+        try:
+            row = self.db.fetch_one(
+                """
+                SELECT
+                    COALESCE(SUM(tokens), 0) as tokens,
+                    COALESCE(SUM(requests), 0) as requests
+                FROM user_daily_stats
+                WHERE user_id = ? AND date >= ? AND date <= ?
+                """,
+                (user_id, start_date, end_date),
+            )
+            if row and (int(row["tokens"]) > 0 or int(row["requests"]) > 0):
+                return int(row["tokens"]), int(row["requests"])
+        except Exception:
+            pass
+
+        # Fallback: agent_sessions.total_tokens with created_at date attribution.
+        # Matches quota_manager._get_usage_in_range() legacy path.
         session_row = self.db.fetch_one(
             """
             SELECT
-                COALESCE(SUM(sm.tokens_used), 0) as tokens,
-                COUNT(CASE WHEN sm.role = 'assistant' THEN 1 END) as requests
-            FROM session_messages sm
-            JOIN agent_sessions a ON sm.session_id = a.session_id
-            WHERE a.user_id = ?
-              AND a.workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(sm.timestamp AS DATE) >= ? AND CAST(sm.timestamp AS DATE) <= ?
-        """,
+                COALESCE(SUM(total_tokens), 0) as tokens,
+                COUNT(*) as requests
+            FROM agent_sessions
+            WHERE user_id = ?
+              AND workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+            """,
             (user_id, start_date, end_date),
         )
         session_tokens = int(session_row["tokens"]) if session_row else 0

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -345,5 +345,7 @@ def test_acceptance_milestone_summary_includes_rejected_items():
         "gates": [],
         "verifier": [],
     }
-    ms = _acceptance_milestone(workflow_id="wf", dev_round=1, attempt=1, status="rejected", report=report)
+    ms = _acceptance_milestone(
+        workflow_id="wf", dev_round=1, attempt=1, status="rejected", report=report
+    )
     assert "datetime_utils.py" in ms["result_summary"]

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -345,5 +345,5 @@ def test_acceptance_milestone_summary_includes_rejected_items():
         "gates": [],
         "verifier": [],
     }
-    ms = _acceptance_milestone(workflow_id="wf", attempt=1, status="rejected", report=report)
+    ms = _acceptance_milestone(workflow_id="wf", dev_round=1, attempt=1, status="rejected", report=report)
     assert "datetime_utils.py" in ms["result_summary"]

--- a/tests/unit/test_acceptance_milestone_dev_round_2707.py
+++ b/tests/unit/test_acceptance_milestone_dev_round_2707.py
@@ -1,0 +1,67 @@
+"""Regression: acceptance_verification milestone must record the workflow's
+current dev_round, not the DB default (1).
+
+Issue #2707: _create_milestone did not fall back to the workflow's dev_round
+when the caller omitted it.  Acceptance-verification milestones were always
+stored with dev_round=1 regardless of the actual round, breaking per-round
+timeline aggregation on multi-round workflows.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2707)]
+
+
+def _make_orch(dev_round: int) -> tuple[AutonomousOrchestrator, dict]:
+    """Construct a minimal orchestrator stub for _create_milestone tests."""
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2707"
+    orch._emit = lambda *_a, **_k: None
+
+    created: dict = {}
+
+    repo = MagicMock()
+    repo.get_workflow.return_value = {"workflow_id": "wf-2707", "dev_round": dev_round}
+    repo.list_milestones.return_value = []
+    repo.create_milestone.side_effect = lambda data: {"milestone_id": "ms-new", **data}
+    orch.repo = repo
+
+    return orch, created
+
+
+def test_create_milestone_defaults_dev_round_from_workflow():
+    """_create_milestone must use the live workflow dev_round when omitted."""
+    orch, _ = _make_orch(dev_round=3)
+
+    ms = orch._create_milestone(
+        phase="acceptance_verification",
+        milestone_type="acceptance_verification",
+        status="confirmed",
+        title="Acceptance verification: confirmed",
+    )
+
+    assert ms["dev_round"] == 3, (
+        f"expected dev_round=3 (live workflow round), got {ms['dev_round']!r}"
+    )
+
+
+def test_create_milestone_explicit_dev_round_not_overridden():
+    """An explicit dev_round kwarg must never be replaced by the workflow default."""
+    orch, _ = _make_orch(dev_round=5)
+
+    ms = orch._create_milestone(
+        phase="merge",
+        milestone_type="merge_completed",
+        dev_round=2,
+        status="completed",
+        title="Merge completed",
+    )
+
+    assert ms["dev_round"] == 2, (
+        f"explicit dev_round=2 was overwritten; got {ms['dev_round']!r}"
+    )
+    # Confirm the workflow was NOT queried — no extra DB call when already set.
+    orch.repo.get_workflow.assert_not_called()

--- a/tests/unit/test_acceptance_milestone_dev_round_2707.py
+++ b/tests/unit/test_acceptance_milestone_dev_round_2707.py
@@ -15,9 +15,7 @@ import json
 
 import pytest
 
-from app.modules.workspace.autonomous.phases.acceptance_verification import (
-    _acceptance_milestone,
-)
+from app.modules.workspace.autonomous.phases.acceptance_verification import _acceptance_milestone
 
 pytestmark = [pytest.mark.regression, pytest.mark.issue(2707)]
 

--- a/tests/unit/test_acceptance_milestone_dev_round_2707.py
+++ b/tests/unit/test_acceptance_milestone_dev_round_2707.py
@@ -5,23 +5,27 @@ Issue #2707: _create_milestone did not fall back to the workflow's dev_round
 when the caller omitted it.  Acceptance-verification milestones were always
 stored with dev_round=1 regardless of the actual round, breaking per-round
 timeline aggregation on multi-round workflows.
+
+Intentional scope expansion: all 14 call sites that omit dev_round (not only
+acceptance_verification but also cleaned_up, branch_created, pr_created-reused,
+etc.) now record and dedup against the current round rather than match-any-round.
+This is more accurate—each round gets its own timeline entries—and is consistent
+with the #2707 regression anchor.  The third test below anchors this behaviour.
 """
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
 pytestmark = [pytest.mark.regression, pytest.mark.issue(2707)]
 
 
-def _make_orch(dev_round: int) -> tuple[AutonomousOrchestrator, dict]:
-    """Construct a minimal orchestrator stub for _create_milestone tests."""
+def _make_orch(dev_round: int) -> AutonomousOrchestrator:
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._workflow_id = "wf-2707"
     orch._emit = lambda *_a, **_k: None
-
-    created: dict = {}
 
     repo = MagicMock()
     repo.get_workflow.return_value = {"workflow_id": "wf-2707", "dev_round": dev_round}
@@ -29,12 +33,12 @@ def _make_orch(dev_round: int) -> tuple[AutonomousOrchestrator, dict]:
     repo.create_milestone.side_effect = lambda data: {"milestone_id": "ms-new", **data}
     orch.repo = repo
 
-    return orch, created
+    return orch
 
 
 def test_create_milestone_defaults_dev_round_from_workflow():
     """_create_milestone must use the live workflow dev_round when omitted."""
-    orch, _ = _make_orch(dev_round=3)
+    orch = _make_orch(dev_round=3)
 
     ms = orch._create_milestone(
         phase="acceptance_verification",
@@ -43,14 +47,12 @@ def test_create_milestone_defaults_dev_round_from_workflow():
         title="Acceptance verification: confirmed",
     )
 
-    assert ms["dev_round"] == 3, (
-        f"expected dev_round=3 (live workflow round), got {ms['dev_round']!r}"
-    )
+    assert ms["dev_round"] == 3, f"expected dev_round=3, got {ms['dev_round']!r}"
 
 
 def test_create_milestone_explicit_dev_round_not_overridden():
     """An explicit dev_round kwarg must never be replaced by the workflow default."""
-    orch, _ = _make_orch(dev_round=5)
+    orch = _make_orch(dev_round=5)
 
     ms = orch._create_milestone(
         phase="merge",
@@ -60,8 +62,38 @@ def test_create_milestone_explicit_dev_round_not_overridden():
         title="Merge completed",
     )
 
-    assert ms["dev_round"] == 2, (
-        f"explicit dev_round=2 was overwritten; got {ms['dev_round']!r}"
-    )
-    # Confirm the workflow was NOT queried — no extra DB call when already set.
+    assert ms["dev_round"] == 2, f"explicit dev_round=2 was overwritten; got {ms['dev_round']!r}"
+    # No extra DB call when dev_round is already set.
     orch.repo.get_workflow.assert_not_called()
+
+
+def test_implicit_callers_dedup_per_round():
+    """Round-2 milestones that omit dev_round must not dedup against round-1 rows.
+
+    Anchors the intentional expansion: callers that omit dev_round now get
+    match-current-round idempotency rather than match-any-round.  A round-2
+    cleaned_up milestone must create a new row even when round-1's exists.
+    """
+    orch = _make_orch(dev_round=2)
+    prior = {
+        "milestone_id": "ms-round1",
+        "milestone_type": "cleaned_up",
+        "phase": "completed",
+        "dev_round": 1,
+        "round_number": None,
+        "status": "completed",
+    }
+    orch.repo.list_milestones.side_effect = (
+        lambda wf_id, phase=None, status=None: [prior] if status == "completed" else []
+    )
+
+    ms = orch._create_milestone(
+        phase="completed",
+        milestone_type="cleaned_up",
+        status="completed",
+        title="Cleanup round 2",
+        # dev_round intentionally omitted — must be filled from workflow (round 2)
+    )
+
+    assert ms["dev_round"] == 2
+    orch.repo.create_milestone.assert_called_once()

--- a/tests/unit/test_acceptance_milestone_dev_round_2707.py
+++ b/tests/unit/test_acceptance_milestone_dev_round_2707.py
@@ -1,99 +1,71 @@
 """Regression: acceptance_verification milestone must record the workflow's
 current dev_round, not the DB default (1).
 
-Issue #2707: _create_milestone did not fall back to the workflow's dev_round
-when the caller omitted it.  Acceptance-verification milestones were always
-stored with dev_round=1 regardless of the actual round, breaking per-round
-timeline aggregation on multi-round workflows.
+Issue #2707: _acceptance_milestone omitted dev_round from the returned dict,
+so acceptance milestones in multi-round workflows were always stored with the
+DB default of 1 regardless of the actual round.
 
-Intentional scope expansion: all 14 call sites that omit dev_round (not only
-acceptance_verification but also cleaned_up, branch_created, pr_created-reused,
-etc.) now record and dedup against the current round rather than match-any-round.
-This is more accurate—each round gets its own timeline entries—and is consistent
-with the #2707 regression anchor.  The third test below anchors this behaviour.
+Fix is targeted to the acceptance path only: dev_round is now an explicit
+parameter of _acceptance_milestone and filled from wf["dev_round"] at the
+call site.  _create_milestone itself is unchanged so other callers (cleaned_up,
+branch_created, etc.) keep their existing match-any-round idempotency.
 """
 
-from unittest.mock import MagicMock
+import json
 
 import pytest
 
-from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+from app.modules.workspace.autonomous.phases.acceptance_verification import (
+    _acceptance_milestone,
+)
 
 pytestmark = [pytest.mark.regression, pytest.mark.issue(2707)]
 
-
-def _make_orch(dev_round: int) -> AutonomousOrchestrator:
-    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
-    orch._workflow_id = "wf-2707"
-    orch._emit = lambda *_a, **_k: None
-
-    repo = MagicMock()
-    repo.get_workflow.return_value = {"workflow_id": "wf-2707", "dev_round": dev_round}
-    repo.list_milestones.return_value = []
-    repo.create_milestone.side_effect = lambda data: {"milestone_id": "ms-new", **data}
-    orch.repo = repo
-
-    return orch
+_REPORT = {
+    "merge_sha": "abc123",
+    "status": "confirmed",
+    "scope": [],
+    "gates": [],
+    "verifier": [],
+}
 
 
-def test_create_milestone_defaults_dev_round_from_workflow():
-    """_create_milestone must use the live workflow dev_round when omitted."""
-    orch = _make_orch(dev_round=3)
-
-    ms = orch._create_milestone(
-        phase="acceptance_verification",
-        milestone_type="acceptance_verification",
+def test_acceptance_milestone_includes_dev_round():
+    """The milestone dict must carry the caller-supplied dev_round (#2707)."""
+    ms = _acceptance_milestone(
+        workflow_id="wf-test",
+        dev_round=3,
+        attempt=1,
         status="confirmed",
-        title="Acceptance verification: confirmed",
+        report=_REPORT,
     )
 
-    assert ms["dev_round"] == 3, f"expected dev_round=3, got {ms['dev_round']!r}"
+    assert ms["dev_round"] == 3
 
 
-def test_create_milestone_explicit_dev_round_not_overridden():
-    """An explicit dev_round kwarg must never be replaced by the workflow default."""
-    orch = _make_orch(dev_round=5)
+def test_acceptance_milestone_dev_round_one():
+    """dev_round=1 is stored verbatim, not silently elevated."""
+    ms = _acceptance_milestone(
+        workflow_id="wf-test",
+        dev_round=1,
+        attempt=2,
+        status="rejected",
+        report=_REPORT,
+    )
 
-    ms = orch._create_milestone(
-        phase="merge",
-        milestone_type="merge_completed",
+    assert ms["dev_round"] == 1
+
+
+def test_acceptance_milestone_string_fields_still_valid():
+    """Existing contract: result_summary and metadata must remain strings (#2394)."""
+    ms = _acceptance_milestone(
+        workflow_id="wf-test",
         dev_round=2,
-        status="completed",
-        title="Merge completed",
+        attempt=1,
+        status="confirmed",
+        report=_REPORT,
     )
 
-    assert ms["dev_round"] == 2, f"explicit dev_round=2 was overwritten; got {ms['dev_round']!r}"
-    # No extra DB call when dev_round is already set.
-    orch.repo.get_workflow.assert_not_called()
-
-
-def test_implicit_callers_dedup_per_round():
-    """Round-2 milestones that omit dev_round must not dedup against round-1 rows.
-
-    Anchors the intentional expansion: callers that omit dev_round now get
-    match-current-round idempotency rather than match-any-round.  A round-2
-    cleaned_up milestone must create a new row even when round-1's exists.
-    """
-    orch = _make_orch(dev_round=2)
-    prior = {
-        "milestone_id": "ms-round1",
-        "milestone_type": "cleaned_up",
-        "phase": "completed",
-        "dev_round": 1,
-        "round_number": None,
-        "status": "completed",
-    }
-    orch.repo.list_milestones.side_effect = (
-        lambda wf_id, phase=None, status=None: [prior] if status == "completed" else []
-    )
-
-    ms = orch._create_milestone(
-        phase="completed",
-        milestone_type="cleaned_up",
-        status="completed",
-        title="Cleanup round 2",
-        # dev_round intentionally omitted — must be filled from workflow (round 2)
-    )
-
-    assert ms["dev_round"] == 2
-    orch.repo.create_milestone.assert_called_once()
+    assert isinstance(ms["result_summary"], str)
+    assert isinstance(ms["metadata"], str)
+    assert json.loads(ms["metadata"])["merge_sha"] == "abc123"

--- a/tests/unit/test_acceptance_verification_milestone.py
+++ b/tests/unit/test_acceptance_verification_milestone.py
@@ -28,7 +28,9 @@ def test_acceptance_milestone_fields_are_strings():
         "gates": [],
         "verifier": [{"item": "x"}, {"item": "y"}],
     }
-    ms = _acceptance_milestone(workflow_id="wf-2394", attempt=1, status="confirmed", report=report)
+    ms = _acceptance_milestone(
+        workflow_id="wf-2394", dev_round=1, attempt=1, status="confirmed", report=report
+    )
 
     # Both DB columns must be strings — a dict here crashes create_milestone.
     assert isinstance(ms["result_summary"], str)

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -1,14 +1,17 @@
-"""Tests for UsageRepository.get_session_only_usage (#1269 P1).
+"""Tests for UsageRepository.get_session_only_usage (#1269 P1, #2705).
 
-Pins that the Work-page quota display reads session_messages (filtered by timestamp)
-and never daily_messages, per the #1125 data-contract rule that analysis fact
-tables must not participate in Workspace runtime display.
+Pins that the Work-page quota display reads user_daily_stats (same source as
+quota enforcement) and never daily_messages, per the #1125 data-contract rule
+that analysis fact tables must not participate in Workspace runtime display.
 
-Updated for Issue #1974: Query now filters by session_messages.timestamp instead
-of agent_sessions.created_at to correctly count messages for long-running sessions.
+Updated for Issue #2705: Query now reads user_daily_stats first (matching
+quota enforcement) and falls back to agent_sessions.total_tokens when
+user_daily_stats has no data for the period. This closes the ~10% gap where
+the previous session_messages SUM missed cache and other non-message token costs.
 """
 
-from unittest.mock import MagicMock
+import pytest
+from unittest.mock import MagicMock, call
 
 from app.repositories.usage_repo import UsageRepository
 
@@ -20,34 +23,96 @@ def _make_repo(db):
 
 
 class TestGetSessionOnlyUsage:
-    def test_queries_session_messages_by_timestamp(self):
-        """The query must read session_messages and filter by message timestamp."""
+    def test_reads_user_daily_stats_first(self):
+        """Fast path: user_daily_stats is queried first and its values returned
+        when the table has data, without falling back to agent_sessions."""
         db = MagicMock()
-        db.fetch_one.return_value = {"tokens": 12345, "requests": 7}
+        db.fetch_one.return_value = {"tokens": 4_063_745_521, "requests": 500}
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-08-01", end_date="2026-08-16"
+        )
+
+        sql = db.fetch_one.call_args[0][0]
+        assert "FROM user_daily_stats" in sql
+        assert "daily_messages" not in sql
+        assert result["tokens"] == 4_063_745_521
+        assert result["requests"] == 500
+        # local_* legs are zeroed since daily_messages is excluded.
+        assert result["local_tokens"] == 0
+        assert result["local_requests"] == 0
+        # Only one DB call — no fallback needed.
+        assert db.fetch_one.call_count == 1
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_fast_path_scoped_to_user_and_date_range(self):
+        """user_daily_stats query must bind user_id and the date window."""
+        db = MagicMock()
+        db.fetch_one.return_value = {"tokens": 100, "requests": 1}
+        repo = _make_repo(db)
+
+        repo.get_session_only_usage(user_id=42, start_date="2026-06-01", end_date="2026-06-25")
+
+        params = db.fetch_one.call_args[0][1]
+        assert params == (42, "2026-06-01", "2026-06-25")
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_falls_back_to_agent_sessions_when_daily_stats_empty(self):
+        """When user_daily_stats returns zero tokens and zero requests (e.g. the
+        aggregator hasn't run yet for today), _session_usage falls back to
+        agent_sessions.total_tokens — the enforcement legacy path."""
+        db = MagicMock()
+        # First call (user_daily_stats): tokens=0, requests=0 → trigger fallback.
+        # Second call (agent_sessions): authoritative total_tokens.
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},
+            {"tokens": 9_999_999, "requests": 77},
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-08-16", end_date="2026-08-16"
+        )
+
+        assert result["tokens"] == 9_999_999
+        assert result["requests"] == 77
+        assert db.fetch_one.call_count == 2
+        # Second call must query agent_sessions (not session_messages, not daily_messages).
+        fallback_sql = db.fetch_one.call_args_list[1][0][0]
+        assert "FROM agent_sessions" in fallback_sql
+        assert "total_tokens" in fallback_sql
+        assert "session_messages" not in fallback_sql
+        assert "daily_messages" not in fallback_sql
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_daily_stats_table_missing_falls_back_to_agent_sessions(self):
+        """If user_daily_stats raises (table doesn't exist on an older schema),
+        _session_usage falls back gracefully to agent_sessions."""
+        db = MagicMock()
+        db.fetch_one.side_effect = [
+            Exception("no such table: user_daily_stats"),
+            {"tokens": 12345, "requests": 7},
+        ]
         repo = _make_repo(db)
 
         result = repo.get_session_only_usage(
             user_id=1, start_date="2026-06-25", end_date="2026-06-25"
         )
 
-        sql = db.fetch_one.call_args[0][0]
-        # Query now starts from session_messages and joins agent_sessions
-        assert "FROM session_messages" in sql
-        assert "JOIN agent_sessions" in sql
-        assert "daily_messages" not in sql
-        # Must filter by message timestamp, not session created_at
-        assert "CAST(sm.timestamp AS DATE)" in sql
-        # Must cover all workspace types (local autonomous/terminal/remote).
-        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
         assert result["tokens"] == 12345
         assert result["requests"] == 7
-        # local_* legs are zeroed since daily_messages is excluded.
-        assert result["local_tokens"] == 0
-        assert result["local_requests"] == 0
 
-    def test_zero_when_no_sessions(self):
+    def test_zero_when_no_data_anywhere(self):
+        """When both user_daily_stats and agent_sessions return no data, result is zeros."""
         db = MagicMock()
-        db.fetch_one.return_value = None
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},  # user_daily_stats: empty
+            None,                           # agent_sessions: no rows
+        ]
         repo = _make_repo(db)
 
         result = repo.get_session_only_usage(
@@ -58,13 +123,18 @@ class TestGetSessionOnlyUsage:
         assert result["requests"] == 0
         assert result["local_tokens"] == 0
 
-    def test_scoped_to_user_and_date_range(self):
-        """The query must bind user_id and the date window."""
+    def test_never_reads_daily_messages(self):
+        """Neither the fast path nor the fallback may read daily_messages (#1125)."""
         db = MagicMock()
-        db.fetch_one.return_value = {"tokens": 0, "requests": 0}
+        # Trigger both paths: daily_stats empty → fallback fires.
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},
+            {"tokens": 1, "requests": 1},
+        ]
         repo = _make_repo(db)
 
-        repo.get_session_only_usage(user_id=42, start_date="2026-06-01", end_date="2026-06-25")
+        repo.get_session_only_usage(user_id=1, start_date="2026-06-01", end_date="2026-06-30")
 
-        params = db.fetch_one.call_args[0][1]
-        assert params == (42, "2026-06-01", "2026-06-25")
+        for c in db.fetch_one.call_args_list:
+            sql = c[0][0]
+            assert "daily_messages" not in sql, f"Forbidden table in SQL: {sql}"


### PR DESCRIPTION
## Summary

- **Root cause**: `_session_usage()` summed `session_messages.tokens_used` (individual message rows), which misses cache and other non-message token costs. Quota enforcement uses `user_daily_stats` (aggregated from `agent_sessions.total_tokens`), producing a ~10% gap: UI showed 3.62B (90.6%) while enforcement had already blocked at 4.06B (101.6%).
- **Fix**: Rewrite `_session_usage()` to mirror the enforcement data path — fast path reads `user_daily_stats`, fallback reads `agent_sessions.total_tokens` when daily stats are empty (e.g. aggregator hasn't run for today). `daily_messages` is never accessed (#1125 constraint preserved).
- **Tests**: Replace the old `session_messages`-asserting tests with ones that pin the new `user_daily_stats` fast path, the `agent_sessions` fallback (zero daily stats), the exception-fallback (schema lag), zero-everywhere, and the no-`daily_messages` invariant.

Closes #2705.

## Data alignment

| Path | Source | Aug 1–16 tokens |
|---|---|---|
| Enforcement (before & after) | `user_daily_stats` → `agent_sessions.total_tokens` | 4,063,745,521 (101.6%) |
| UI (before) | `session_messages.tokens_used` SUM | 3,623,471,565 (90.6%) |
| UI (after) | `user_daily_stats` → `agent_sessions.total_tokens` | 4,063,745,521 (101.6%) ✓ |

## Test plan

- [x] `test_reads_user_daily_stats_first` — fast path returns `user_daily_stats` values, no fallback
- [x] `test_fast_path_scoped_to_user_and_date_range` — params bound correctly
- [x] `test_falls_back_to_agent_sessions_when_daily_stats_empty` — zero daily stats → fallback fires, uses `total_tokens`
- [x] `test_daily_stats_table_missing_falls_back_to_agent_sessions` — exception → fallback
- [x] `test_zero_when_no_data_anywhere` — both paths empty → zeros
- [x] `test_never_reads_daily_messages` — `daily_messages` absent from all SQL (#1125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)