### PR TITLE
fix(#2705): align Work-page token display with quota enforcement via user_daily_stats

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1389,23 +1389,49 @@ class UsageRepository:
         start_date: str,
         end_date: str,
     ) -> tuple[int, int]:
-        """Query session_messages for tokens/requests in a date window.
+        """Get session token/request usage for a date window.
 
-        Changed from agent_sessions.created_at to session_messages.timestamp
-        to correctly count messages for long-running sessions like webui:N.
-        See Issue #1974 for details.
+        Uses user_daily_stats (fast path, same source as quota enforcement) so
+        the Work-page display matches what enforcement sees. Falls back to
+        agent_sessions.total_tokens when user_daily_stats has no data for the
+        period (e.g. the aggregator hasn't run yet for today's sessions).
+
+        Never reads daily_messages (#1125: analysis fact tables must not
+        participate in Workspace runtime display).
+
+        Fixes #2705: the previous session_messages SUM under-counted by ~10%
+        because cache and other non-message token costs are not recorded in
+        individual message rows.
         """
+        # Fast path: user_daily_stats — identical to quota_manager enforcement.
+        try:
+            row = self.db.fetch_one(
+                """
+                SELECT
+                    COALESCE(SUM(tokens), 0) as tokens,
+                    COALESCE(SUM(requests), 0) as requests
+                FROM user_daily_stats
+                WHERE user_id = ? AND date >= ? AND date <= ?
+                """,
+                (user_id, start_date, end_date),
+            )
+            if row and (int(row["tokens"]) > 0 or int(row["requests"]) > 0):
+                return int(row["tokens"]), int(row["requests"])
+        except Exception:
+            pass
+
+        # Fallback: agent_sessions.total_tokens with created_at date attribution.
+        # Matches quota_manager._get_usage_in_range() legacy path.
         session_row = self.db.fetch_one(
             """
             SELECT
-                COALESCE(SUM(sm.tokens_used), 0) as tokens,
-                COUNT(CASE WHEN sm.role = 'assistant' THEN 1 END) as requests
-            FROM session_messages sm
-            JOIN agent_sessions a ON sm.session_id = a.session_id
-            WHERE a.user_id = ?
-              AND a.workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(sm.timestamp AS DATE) >= ? AND CAST(sm.timestamp AS DATE) <= ?
-        """,
+                COALESCE(SUM(total_tokens), 0) as tokens,
+                COUNT(*) as requests
+            FROM agent_sessions
+            WHERE user_id = ?
+              AND workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+            """,
             (user_id, start_date, end_date),
         )
         session_tokens = int(session_row["tokens"]) if session_row else 0

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1402,6 +1402,14 @@ class UsageRepository:
         Fixes #2705: the previous session_messages SUM under-counted by ~10%
         because cache and other non-message token costs are not recorded in
         individual message rows.
+
+        Known trade-off (#1974): both paths attribute session tokens to the
+        session's created_at date, not to individual message timestamps. A
+        session spanning midnight will have all its tokens counted on the
+        creation day in the daily view. This matches enforcement (which has
+        always used created_at attribution) and is the correct behaviour for
+        quota display; per-message timestamp attribution for the trend chart
+        is a separate follow-up concern.
         """
         # Fast path: user_daily_stats — identical to quota_manager enforcement.
         try:

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -10,8 +10,9 @@ user_daily_stats has no data for the period. This closes the ~10% gap where
 the previous session_messages SUM missed cache and other non-message token costs.
 """
 
-import pytest
 from unittest.mock import MagicMock, call
+
+import pytest
 
 from app.repositories.usage_repo import UsageRepository
 
@@ -111,7 +112,7 @@ class TestGetSessionOnlyUsage:
         db = MagicMock()
         db.fetch_one.side_effect = [
             {"tokens": 0, "requests": 0},  # user_daily_stats: empty
-            None,                           # agent_sessions: no rows
+            None,  # agent_sessions: no rows
         ]
         repo = _make_repo(db)
 

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -1,14 +1,17 @@
-"""Tests for UsageRepository.get_session_only_usage (#1269 P1).
+"""Tests for UsageRepository.get_session_only_usage (#1269 P1, #2705).
 
-Pins that the Work-page quota display reads session_messages (filtered by timestamp)
-and never daily_messages, per the #1125 data-contract rule that analysis fact
-tables must not participate in Workspace runtime display.
+Pins that the Work-page quota display reads user_daily_stats (same source as
+quota enforcement) and never daily_messages, per the #1125 data-contract rule
+that analysis fact tables must not participate in Workspace runtime display.
 
-Updated for Issue #1974: Query now filters by session_messages.timestamp instead
-of agent_sessions.created_at to correctly count messages for long-running sessions.
+Updated for Issue #2705: Query now reads user_daily_stats first (matching
+quota enforcement) and falls back to agent_sessions.total_tokens when
+user_daily_stats has no data for the period. This closes the ~10% gap where
+the previous session_messages SUM missed cache and other non-message token costs.
 """
 
-from unittest.mock import MagicMock
+import pytest
+from unittest.mock import MagicMock, call
 
 from app.repositories.usage_repo import UsageRepository
 
@@ -20,34 +23,96 @@ def _make_repo(db):
 
 
 class TestGetSessionOnlyUsage:
-    def test_queries_session_messages_by_timestamp(self):
-        """The query must read session_messages and filter by message timestamp."""
+    def test_reads_user_daily_stats_first(self):
+        """Fast path: user_daily_stats is queried first and its values returned
+        when the table has data, without falling back to agent_sessions."""
         db = MagicMock()
-        db.fetch_one.return_value = {"tokens": 12345, "requests": 7}
+        db.fetch_one.return_value = {"tokens": 4_063_745_521, "requests": 500}
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-08-01", end_date="2026-08-16"
+        )
+
+        sql = db.fetch_one.call_args[0][0]
+        assert "FROM user_daily_stats" in sql
+        assert "daily_messages" not in sql
+        assert result["tokens"] == 4_063_745_521
+        assert result["requests"] == 500
+        # local_* legs are zeroed since daily_messages is excluded.
+        assert result["local_tokens"] == 0
+        assert result["local_requests"] == 0
+        # Only one DB call — no fallback needed.
+        assert db.fetch_one.call_count == 1
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_fast_path_scoped_to_user_and_date_range(self):
+        """user_daily_stats query must bind user_id and the date window."""
+        db = MagicMock()
+        db.fetch_one.return_value = {"tokens": 100, "requests": 1}
+        repo = _make_repo(db)
+
+        repo.get_session_only_usage(user_id=42, start_date="2026-06-01", end_date="2026-06-25")
+
+        params = db.fetch_one.call_args[0][1]
+        assert params == (42, "2026-06-01", "2026-06-25")
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_falls_back_to_agent_sessions_when_daily_stats_empty(self):
+        """When user_daily_stats returns zero tokens and zero requests (e.g. the
+        aggregator hasn't run yet for today), _session_usage falls back to
+        agent_sessions.total_tokens — the enforcement legacy path."""
+        db = MagicMock()
+        # First call (user_daily_stats): tokens=0, requests=0 → trigger fallback.
+        # Second call (agent_sessions): authoritative total_tokens.
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},
+            {"tokens": 9_999_999, "requests": 77},
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-08-16", end_date="2026-08-16"
+        )
+
+        assert result["tokens"] == 9_999_999
+        assert result["requests"] == 77
+        assert db.fetch_one.call_count == 2
+        # Second call must query agent_sessions (not session_messages, not daily_messages).
+        fallback_sql = db.fetch_one.call_args_list[1][0][0]
+        assert "FROM agent_sessions" in fallback_sql
+        assert "total_tokens" in fallback_sql
+        assert "session_messages" not in fallback_sql
+        assert "daily_messages" not in fallback_sql
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2705)
+    def test_daily_stats_table_missing_falls_back_to_agent_sessions(self):
+        """If user_daily_stats raises (table doesn't exist on an older schema),
+        _session_usage falls back gracefully to agent_sessions."""
+        db = MagicMock()
+        db.fetch_one.side_effect = [
+            Exception("no such table: user_daily_stats"),
+            {"tokens": 12345, "requests": 7},
+        ]
         repo = _make_repo(db)
 
         result = repo.get_session_only_usage(
             user_id=1, start_date="2026-06-25", end_date="2026-06-25"
         )
 
-        sql = db.fetch_one.call_args[0][0]
-        # Query now starts from session_messages and joins agent_sessions
-        assert "FROM session_messages" in sql
-        assert "JOIN agent_sessions" in sql
-        assert "daily_messages" not in sql
-        # Must filter by message timestamp, not session created_at
-        assert "CAST(sm.timestamp AS DATE)" in sql
-        # Must cover all workspace types (local autonomous/terminal/remote).
-        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
         assert result["tokens"] == 12345
         assert result["requests"] == 7
-        # local_* legs are zeroed since daily_messages is excluded.
-        assert result["local_tokens"] == 0
-        assert result["local_requests"] == 0
 
-    def test_zero_when_no_sessions(self):
+    def test_zero_when_no_data_anywhere(self):
+        """When both user_daily_stats and agent_sessions return no data, result is zeros."""
         db = MagicMock()
-        db.fetch_one.return_value = None
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},  # user_daily_stats: empty
+            None,                           # agent_sessions: no rows
+        ]
         repo = _make_repo(db)
 
         result = repo.get_session_only_usage(
@@ -58,13 +123,18 @@ class TestGetSessionOnlyUsage:
         assert result["requests"] == 0
         assert result["local_tokens"] == 0
 
-    def test_scoped_to_user_and_date_range(self):
-        """The query must bind user_id and the date window."""
+    def test_never_reads_daily_messages(self):
+        """Neither the fast path nor the fallback may read daily_messages (#1125)."""
         db = MagicMock()
-        db.fetch_one.return_value = {"tokens": 0, "requests": 0}
+        # Trigger both paths: daily_stats empty → fallback fires.
+        db.fetch_one.side_effect = [
+            {"tokens": 0, "requests": 0},
+            {"tokens": 1, "requests": 1},
+        ]
         repo = _make_repo(db)
 
-        repo.get_session_only_usage(user_id=42, start_date="2026-06-01", end_date="2026-06-25")
+        repo.get_session_only_usage(user_id=1, start_date="2026-06-01", end_date="2026-06-30")
 
-        params = db.fetch_one.call_args[0][1]
-        assert params == (42, "2026-06-01", "2026-06-25")
+        for c in db.fetch_one.call_args_list:
+            sql = c[0][0]
+            assert "daily_messages" not in sql, f"Forbidden table in SQL: {sql}"


### PR DESCRIPTION
## Summary

- **Root cause**: `_session_usage()` summed `session_messages.tokens_used` (individual message rows), which misses cache and other non-message token costs. Quota enforcement uses `user_daily_stats` (aggregated from `agent_sessions.total_tokens`), producing a ~10% gap: UI showed 3.62B (90.6%) while enforcement had already blocked at 4.06B (101.6%).
- **Fix**: Rewrite `_session_usage()` to mirror the enforcement data path — fast path reads `user_daily_stats`, fallback reads `agent_sessions.total_tokens` when daily stats are empty (e.g. aggregator hasn't run for today). `daily_messages` is never accessed (#1125 constraint preserved).
- **#1974 trade-off documented**: Both paths use `created_at` date attribution (same as enforcement), so a session spanning midnight has all tokens on the creation day. This matches enforcement and is intentional; per-message timestamp attribution for the trend chart is a separate follow-up concern. Documented in docstring.
- **Tests**: Replace old `session_messages`-asserting tests with ones that pin the new `user_daily_stats` fast path, `agent_sessions` fallback (zero daily stats), exception-fallback (schema lag), zero-everywhere, and the no-`daily_messages` invariant. black/isort clean.

Closes #2705. Supersedes #2719 (rebased clean on main, #2718 already merged).

## Data alignment

| Path | Source | Aug 1–16 tokens |
|---|---|---|
| Enforcement (before & after) | `user_daily_stats` → `agent_sessions.total_tokens` | 4,063,745,521 (101.6%) |
| UI (before) | `session_messages.tokens_used` SUM | 3,623,471,565 (90.6%) |
| UI (after) | `user_daily_stats` → `agent_sessions.total_tokens` | 4,063,745,521 (101.6%) ✓ |

## Test plan

- [x] `test_reads_user_daily_stats_first` — fast path returns `user_daily_stats` values, single DB call
- [x] `test_fast_path_scoped_to_user_and_date_range` — params bound correctly
- [x] `test_falls_back_to_agent_sessions_when_daily_stats_empty` — zero daily stats → fallback fires, uses `total_tokens`
- [x] `test_daily_stats_table_missing_falls_back_to_agent_sessions` — exception → fallback
- [x] `test_zero_when_no_data_anywhere` — both paths empty → zeros
- [x] `test_never_reads_daily_messages` — `daily_messages` absent from all SQL (#1125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)