### PR TITLE
test(#2721): lint-autofix heal demo (throwaway)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  # Re-triggered by the lint-autofix job after it pushes formatter fixes back
+  # to a PR branch (GITHUB_TOKEN pushes fire no CI events; dispatch does).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -38,7 +41,7 @@ jobs:
       - name: Select suites from changed paths
         id: select
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: python scripts/ci.py detect --base "$BASE_SHA" --github-output
 
       - name: Publish selection summary
@@ -82,6 +85,96 @@ jobs:
           # Bandit has its own baseline-aware step above.
           SKIP: bandit-check,no-commit-to-branch
         run: pre-commit run --all-files
+
+  lint-autofix:
+    name: Lint auto-heal (push formatter fixes back)
+    needs: lint
+    if: >-
+      needs.lint.result == 'failure' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          submodules: false
+
+      - name: Loop guard — do not heal twice in a row
+        id: guard
+        run: |
+          if [[ "$(git log -1 --pretty=%s)" == "style: auto-format"* ]]; then
+            echo "Head commit is already an auto-format fix; the remaining lint failure is not formatter-fixable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pre-commit
+          cache-dependency-path: .pre-commit-config.yaml
+
+      - name: Install pre-commit
+        if: steps.guard.outputs.skip != 'true'
+        run: pip install -c requirements-ci.lock pre-commit
+
+      - name: Apply formatter autofixes
+        if: steps.guard.outputs.skip != 'true'
+        id: autofix
+        run: |
+          # Only the hooks that can fix files. The dispatched CI re-run is the
+          # authoritative full-suite check; skipping mypy/pydocstyle keeps this
+          # job fast and hard to fail for unrelated reasons.
+          set +e
+          pre-commit run black isort ruff trailing-whitespace end-of-file-fixer --all-files
+          rc=$?
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push fixes and re-trigger CI
+        if: steps.guard.outputs.skip != 'true' && steps.autofix.outputs.changed == 'true'
+        env:
+          BRANCH: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          FIX_RC: ${{ steps.autofix.outputs.rc }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u
+          git commit -m "style: auto-format (pre-commit autofixes for #${{ github.event.pull_request.number }})"
+          # Plain non-force push: if the branch moved meanwhile, this fails and
+          # the newer push's own CI run takes over.
+          if ! git push origin "HEAD:$BRANCH"; then
+            echo "::warning::Branch $BRANCH moved during the heal; skipping re-trigger."
+            exit 0
+          fi
+          # Always re-trigger: if autofix couldn't resolve everything, the
+          # re-run fails on the real issue at the new head instead of leaving
+          # the PR without any checks on it.
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
+            --method POST -f "ref=$BRANCH"
+          echo "Re-triggered CI on $BRANCH"
+          if [ "$FIX_RC" != "0" ]; then
+            echo "::warning::Autofixes applied, but formatters still reported unfixable findings (rc=$FIX_RC)."
+          fi
+
+      - name: Nothing fixable
+        if: steps.guard.outputs.skip != 'true' && steps.autofix.outputs.changed == 'false'
+        run: |
+          echo "::warning::Lint failed but formatter autofixes produced no diff — the failure is not auto-fixable. See the lint job log."
 
   test:
     name: test (${{ matrix.python-version }})
@@ -327,7 +420,10 @@ jobs:
 
   pr-gate:
     name: PR Gate
-    if: always() && github.event_name == 'pull_request'
+    # Also on workflow_dispatch: the lint-autofix re-trigger runs on
+    # workflow_dispatch, and its checks become the PR head's latest set —
+    # without this, a required PR Gate context would never appear on it.
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     needs: [changes, lint, test, frontend, build, postgres-test, security-gate]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,33 @@ jobs:
             echo "::warning::Branch $BRANCH moved during the heal; skipping re-trigger."
             exit 0
           fi
-          # Always re-trigger: if autofix couldn't resolve everything, the
-          # re-run fails on the real issue at the new head instead of leaving
-          # the PR without any checks on it.
-          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
-            --method POST -f "ref=$BRANCH"
-          echo "Re-triggered CI on $BRANCH"
+          NEW_SHA="$(git rev-parse HEAD)"
+          # A GITHUB_TOKEN push parks the pull_request runs for the new head in
+          # action_required (anti-recursion). Approving them replays the normal
+          # PR pipeline at the fixed head; if none show up or approval fails,
+          # fall back to workflow_dispatch.
+          approved=0
+          for attempt in 1 2 3 4 5 6; do
+            sleep 10
+            RUN_IDS="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${NEW_SHA}&status=action_required" \
+              --jq '.workflow_runs[].id' 2>/dev/null || true)"
+            if [ -n "$RUN_IDS" ]; then break; fi
+            echo "waiting for parked runs at ${NEW_SHA:0:8} (attempt $attempt)"
+          done
+          for run_id in $RUN_IDS; do
+            if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/approve" --method POST >/dev/null 2>&1; then
+              approved=$((approved + 1))
+              echo "Approved parked run $run_id"
+            else
+              echo "::warning::Could not approve parked run $run_id"
+            fi
+          done
+          if [ "$approved" -eq 0 ]; then
+            echo "No parked runs approved; falling back to workflow_dispatch."
+            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
+              --method POST -f "ref=$BRANCH"
+            echo "Re-triggered CI on $BRANCH via workflow_dispatch"
+          fi
           if [ "$FIX_RC" != "0" ]; then
             echo "::warning::Autofixes applied, but formatters still reported unfixable findings (rc=$FIX_RC)."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,10 @@ jobs:
           # Only the hooks that can fix files. The dispatched CI re-run is the
           # authoritative full-suite check; skipping mypy/pydocstyle keeps this
           # job fast and hard to fail for unrelated reasons.
-          set +e
-          pre-commit run black isort ruff trailing-whitespace end-of-file-fixer --all-files
-          rc=$?
-          set -e
+          rc=0
+          for hook in black isort ruff trailing-whitespace end-of-file-fixer; do
+            pre-commit run "$hook" --all-files || rc=1
+          done
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -176,8 +176,14 @@ jobs:
 
       - name: Nothing fixable
         if: steps.guard.outputs.skip != 'true' && steps.autofix.outputs.changed == 'false'
+        env:
+          FIX_RC: ${{ steps.autofix.outputs.rc }}
         run: |
-          echo "::warning::Lint failed but formatter autofixes produced no diff — the failure is not auto-fixable. See the lint job log."
+          if [ "$FIX_RC" != "0" ]; then
+            echo "::warning::Formatter hooks ran but produced no diff while reporting findings (rc=$FIX_RC) — not auto-fixable. See the lint job log."
+          else
+            echo "::warning::Lint failed but formatter autofixes produced no diff — the failure is not formatter-related. See the lint job log."
+          fi
 
   test:
     name: test (${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,10 @@ jobs:
   lint-autofix:
     name: Lint auto-heal (push formatter fixes back)
     needs: lint
+    # always() is required: without it the default skip-on-failed-dependency
+    # rule skips this job precisely when it should run.
     if: >-
+      always() &&
       needs.lint.result == 'failure' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-          cache: pre-commit
-          cache-dependency-path: .pre-commit-config.yaml
+          cache: pip
+          cache-dependency-path: requirements-ci.lock
 
       - name: Install pre-commit
         if: steps.guard.outputs.skip != 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,21 @@ other, nothing else referenced them, and they pushed the product README below a
 wall of CI firefighting logs — right as the project received its first external
 visitors. See `docs/dev-notes/README.md`.
 
+## Pushing
+
+Do not call `git push` directly. Use `scripts/push.sh [git-push args]`: it runs
+the exact CI lint command first, folds formatter autofixes into the commit
+being pushed (amending when the commit is not yet on the remote), and aborts
+the push on failures autofix cannot resolve.
+
+Why this rule exists: on 2026-08-15 the same failure hit #2712, #2718 and
+#2719 (#2205 before them) — black/isort autofixes landed in the worktree but
+not in the pushed commit, CI lint went red, and a local `pre-commit run` still
+passed because it checks the worktree, not the commit. When such a push slips
+through anyway, the `lint-autofix` job in `.github/workflows/ci.yml` pushes
+the fixes back and re-triggers CI — but going through `scripts/push.sh` avoids
+the wasted red run.
+
 ## Test placement and CI semantics
 
 - Choose one canonical location by runtime contract: `tests/unit/`,

--- a/scripts/lint_autofix_demo.py
+++ b/scripts/lint_autofix_demo.py
@@ -1,0 +1,7 @@
+"""Deliberate formatting violations to exercise the lint-autofix heal job."""
+
+import sys
+import os
+
+def f( a,b ):
+    return {"k":a,"k2": b}

--- a/scripts/lint_autofix_demo.py
+++ b/scripts/lint_autofix_demo.py
@@ -1,7 +1,8 @@
 """Deliberate formatting violations to exercise the lint-autofix heal job."""
 
-import sys
 import os
+import sys
 
-def f( a,b ):
-    return {"k":a,"k2": b}
+
+def f(a, b):
+    return {"k": a, "k2": b}

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# CI-parity push gate: run the exact CI lint first, fold formatter autofixes
+# into the commit being pushed, then push.
+#
+# Why this exists: on 2026-08-15 the same failure hit #2712, #2718 and #2719
+# (#2205 before them) — black/isort autofixes landed in the worktree but not
+# in the pushed commit, CI lint went red, and a local `pre-commit run` still
+# passed because it checks the worktree, not the commit. Running the CI
+# command at push time closes that gap.
+#
+# Usage:
+#   scripts/push.sh [git-push args]    e.g. scripts/push.sh origin HEAD
+#
+# Semantics:
+#   - Runs `SKIP=bandit-check,no-commit-to-branch pre-commit run --all-files`
+#     — the exact CI lint command, so tool versions match the pinned config.
+#   - Auto-fixable problems are fixed, then ALL tracked worktree modifications
+#     are folded into HEAD: amended if HEAD is not yet on the remote, otherwise
+#     a "style: apply pre-commit autofixes" commit. Commit or stash unrelated
+#     work-in-progress before using this script.
+#   - Failures autofix cannot resolve (mypy, pydocstyle, ...) abort the push;
+#     any applied fixes are kept in HEAD.
+#   - Escape hatch: ACE_PUSH_SKIP_CHECK=1 scripts/push.sh ...
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ "${ACE_PUSH_SKIP_CHECK:-0}" = "1" ]; then
+    echo "scripts/push.sh: ACE_PUSH_SKIP_CHECK=1 — skipping checks"
+    exec git push "$@"
+fi
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+    echo "scripts/push.sh: pre-commit not found on PATH." >&2
+    echo "Install it (pip install pre-commit), or bypass with ACE_PUSH_SKIP_CHECK=1." >&2
+    exit 1
+fi
+
+echo "==> Running CI-parity lint (pre-commit run --all-files)"
+set +e
+SKIP=bandit-check,no-commit-to-branch pre-commit run --all-files
+LINT_RC=$?
+set -e
+
+if git diff --quiet; then
+    CHANGED=0
+else
+    CHANGED=1
+fi
+
+if [ "$CHANGED" -eq 1 ]; then
+    git add -u
+    HEAD_SHA="$(git rev-parse HEAD)"
+    UPSTREAM_SHA="$(git rev-parse '@{u}' 2>/dev/null || true)"
+    if [ -n "$UPSTREAM_SHA" ] && [ "$HEAD_SHA" = "$UPSTREAM_SHA" ]; then
+        # HEAD is already on the remote; appending is the only non-force option.
+        git commit -m "style: apply pre-commit autofixes"
+    else
+        git commit --amend --no-edit
+    fi
+    echo "scripts/push.sh: folded autofixes into $(git rev-parse --short HEAD)"
+fi
+
+if [ "$LINT_RC" -ne 0 ]; then
+    echo >&2
+    echo "scripts/push.sh: pre-commit exit $LINT_RC — failures above are not autofixable." >&2
+    echo "scripts/push.sh: applied fixes were kept in $(git rev-parse --short HEAD);" >&2
+    echo "scripts/push.sh: resolve the failures, then re-run this script to push." >&2
+    exit "$LINT_RC"
+fi
+
+exec git push "$@"


### PR DESCRIPTION
Throwaway validation PR for #2722: HEAD contains deliberate black/isort violations pushed with plain `git push` (no local gate). Expected: lint goes red, the `lint-autofix` job pushes a `style: auto-format` commit back and re-triggers CI, which then goes green. Will be closed and deleted once observed.