### PR TITLE
fix: enable manager role to access manage mode (#2575)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@
  *
  * Dual-track routing system:
  * - /work/* - Work mode (WorkLayout with three-column layout) - All users
- * - /manage/* - Manage mode (ManageLayout with sidebar navigation) - Admin only
+ * - /manage/* - Manage mode (ManageLayout with sidebar navigation) - Admin and Manager roles
  * - /login, /logout - Public routes
  *
  * Performance optimizations:
@@ -28,7 +28,7 @@ import { useAuth, useTheme } from '@/hooks';
 import { useAppStore } from '@/store';
 import { t } from '@/i18n';
 import { initializeQueryKeyRegistry } from '@/utils';
-import { isAdmin } from '@/utils/permissions';
+import { canAccessManageMode } from '@/utils/permissions';
 
 // Initialize query key registry on app load
 initializeQueryKeyRegistry();
@@ -390,7 +390,7 @@ const ManageRoutes: React.FC = () => {
 // Main App Content (requires auth)
 const AppContent: React.FC = () => {
   const { user } = useAuth();
-  const userIsAdmin = isAdmin(user);
+  const userCanAccessManage = canAccessManageMode(user);
 
   // Sync app mode with URL on mount
   useEffect(() => {
@@ -413,17 +413,17 @@ const AppContent: React.FC = () => {
         {/* Work Mode Routes - All users */}
         <Route path="/work/*" element={<WorkRoutes />} />
 
-        {/* Manage Mode Routes - Admin only */}
+        {/* Manage Mode Routes - Admin and Manager roles */}
         <Route
           path="/manage/*"
-          element={userIsAdmin ? <ManageRoutes /> : <Navigate to="/work" replace />}
+          element={userCanAccessManage ? <ManageRoutes /> : <Navigate to="/work" replace />}
         />
 
         {/* Legacy Routes - redirect based on user role */}
         <Route
           path="/dashboard"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/dashboard" replace />
             ) : (
               <Navigate to="/work" replace />
@@ -433,7 +433,7 @@ const AppContent: React.FC = () => {
         <Route
           path="/messages"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/messages" replace />
             ) : (
               <Navigate to="/work" replace />
@@ -443,7 +443,7 @@ const AppContent: React.FC = () => {
         <Route
           path="/analysis"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/analysis" replace />
             ) : (
               <Navigate to="/work" replace />
@@ -453,13 +453,17 @@ const AppContent: React.FC = () => {
         <Route
           path="/management"
           element={
-            userIsAdmin ? <Navigate to="/manage/users" replace /> : <Navigate to="/work" replace />
+            userCanAccessManage ? (
+              <Navigate to="/manage/users" replace />
+            ) : (
+              <Navigate to="/work" replace />
+            )
           }
         />
         <Route
           path="/security"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/security" replace />
             ) : (
               <Navigate to="/work" replace />
@@ -473,11 +477,11 @@ const AppContent: React.FC = () => {
         {/* Report - Keep as standalone for now */}
         <Route path="/report" element={<LegacyAppContent />} />
 
-        {/* Default redirect - Admin goes to manage mode, others go to work mode */}
+        {/* Default redirect - Admin/Manager goes to manage mode, others go to work mode */}
         <Route
           path="/"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/dashboard" replace />
             ) : (
               <Navigate to="/work" replace />
@@ -487,7 +491,7 @@ const AppContent: React.FC = () => {
         <Route
           path="*"
           element={
-            userIsAdmin ? (
+            userCanAccessManage ? (
               <Navigate to="/manage/dashboard" replace />
             ) : (
               <Navigate to="/work" replace />

--- a/frontend/src/components/common/ModeSwitcher.tsx
+++ b/frontend/src/components/common/ModeSwitcher.tsx
@@ -1,7 +1,8 @@
 /**
  * ModeSwitcher Component - Switch between Work and Manage modes
  *
- * Note: Only visible for admin users. Non-admin users are restricted to Work mode.
+ * Note: Only visible for admin and manager users.
+ * Non-admin/non-manager users are restricted to Work mode.
  */
 
 import React from 'react';
@@ -12,7 +13,7 @@ import { useAppStore } from '@/store';
 import { useAuth } from '@/hooks';
 import { t } from '@/i18n';
 import type { AppMode } from '@/types';
-import { isAdmin } from '@/utils/permissions';
+import { canAccessManageMode } from '@/utils/permissions';
 
 interface ModeSwitcherProps {
   className?: string;
@@ -23,10 +24,10 @@ export const ModeSwitcher: React.FC<ModeSwitcherProps> = ({ className }) => {
   const language = useLanguage();
   const { user } = useAuth();
 
-  const userIsAdmin = isAdmin(user);
+  const userCanAccessManage = canAccessManageMode(user);
 
-  // Don't render for non-admin users
-  if (!userIsAdmin) {
+  // Don't render for users who can't access manage mode
+  if (!userCanAccessManage) {
     return null;
   }
 

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -10,6 +10,12 @@ import type { User } from '@/types';
 export const ADMIN_ROLES = ['admin', 'platform_admin', 'tenant_admin'] as const;
 
 /**
+ * Roles that can access Manage Mode (admin pages)
+ * Includes admin roles and manager role (who has view/export permissions but not management permissions)
+ */
+export const MANAGE_MODE_ROLES = ['admin', 'platform_admin', 'tenant_admin', 'manager'] as const;
+
+/**
  * Check if a role string represents an admin role
  * @param role - Role string to check
  * @returns true if the role is an admin role
@@ -26,6 +32,17 @@ export function isAdminRole(role: string | null | undefined): boolean {
  */
 export function isAdmin(user: User | null | undefined): boolean {
   return isAdminRole(user?.role);
+}
+
+/**
+ * Check if user can access Manage Mode
+ * Admin roles and manager role can access Manage Mode.
+ * Manager can only access non-admin-only pages (dashboard, analysis, messages, audit, projects).
+ * @param user - Current user
+ * @returns true if user can access Manage Mode
+ */
+export function canAccessManageMode(user: User | null | undefined): boolean {
+  return MANAGE_MODE_ROLES.includes(user?.role as any);
 }
 
 /**


### PR DESCRIPTION
Closes #2575

## 修复内容
- Add `MANAGE_MODE_ROLES` constant and `canAccessManageMode()` function
- Update App.tsx to use `canAccessManageMode()` for route control
- Update ModeSwitcher.tsx to use `canAccessManageMode()`

## 设计说明
Manager role can now access manage mode with tenant isolation.
- Manager 必须关联 `tenant_id`
- Manager 只能访问自己租户的数据
- Backend tenant check logic already correctly handles manager role

## 测试
- ✅ TypeScript 类型检查通过
- ✅ Lint 检查通过（无错误）
- ✅ 856 个前端测试通过

## 修复方案
根据 Issue 评论中的方案 A（需要租户隔离）实现