### PR TITLE
fix: 项目时间字段添加 UTC 时区标识 (#2753)

### DIFF
--- a/app/models/project.py
+++ b/app/models/project.py
@@ -7,6 +7,7 @@ Data models for project management and statistics.
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from app.utils.datetime_utils import ensure_utc_suffix
 from app.utils.helpers import parse_db_datetime
 
 
@@ -34,8 +35,8 @@ class Project:
             "name": self.name,
             "description": self.description,
             "created_by": self.created_by,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
             "is_active": self.is_active,
             "is_shared": self.is_shared,
         }
@@ -92,8 +93,8 @@ class UserProject:
             "user_id": self.user_id,
             "project_id": self.project_id,
             "username": self.username,
-            "first_access_at": (self.first_access_at.isoformat() if self.first_access_at else None),
-            "last_access_at": (self.last_access_at.isoformat() if self.last_access_at else None),
+            "first_access_at": ensure_utc_suffix(self.first_access_at),
+            "last_access_at": ensure_utc_suffix(self.last_access_at),
             "total_sessions": self.total_sessions,
             "total_tokens": self.total_tokens,
             "total_requests": self.total_requests,
@@ -153,8 +154,8 @@ class ProjectStats:
             "total_requests": self.total_requests,
             "total_duration_seconds": self.total_duration_seconds,
             "total_duration_hours": self.get_duration_hours(),
-            "first_access": self.first_access.isoformat() if self.first_access else None,
-            "last_access": self.last_access.isoformat() if self.last_access else None,
+            "first_access": ensure_utc_suffix(self.first_access),
+            "last_access": ensure_utc_suffix(self.last_access),
             "user_stats": [u.to_dict() for u in self.user_stats],
         }
 

--- a/tests/unit/test_models_project.py
+++ b/tests/unit/test_models_project.py
@@ -91,7 +91,7 @@ class TestProject:
         assert d["name"] == "ProjA"
         assert d["description"] is None
         assert d["created_by"] == 1
-        assert d["created_at"] == "2025-03-01T12:00:00"
+        assert d["created_at"] == "2025-03-01T12:00:00Z"
         assert d["updated_at"] is None
         assert d["is_active"] is True
         assert d["is_shared"] is False
@@ -229,7 +229,7 @@ class TestUserProject:
         assert d["id"] == 2
         assert d["user_id"] == 3
         assert d["project_id"] == 7
-        assert d["first_access_at"] == "2025-05-10T08:30:00"
+        assert d["first_access_at"] == "2025-05-10T08:30:00Z"
         assert d["last_access_at"] is None
         assert d["total_sessions"] == 5
         assert d["total_tokens"] == 1000
@@ -326,7 +326,7 @@ class TestProjectStats:
         assert d["project_name"] == "C"
         assert d["total_users"] == 3
         assert d["total_duration_hours"] == 3.0
-        assert d["first_access"] == "2025-03-20T14:00:00"
+        assert d["first_access"] == "2025-03-20T14:00:00Z"
         assert d["last_access"] is None
         assert len(d["user_stats"]) == 1
 


### PR DESCRIPTION
Closes #2753

## 修复内容
在项目相关模型的序列化方法中使用 `ensure_utc_suffix()` 为时间字段添加 UTC 时区标识，修复浏览器将 UTC 时间误为本地时间的问题。

## 修改详情

修改文件：`app/models/project.py`

1. **导入 `ensure_utc_suffix` 函数**
2. **修改 `Project.to_dict()`**: `created_at`, `updated_at` 添加 UTC 标识
3. **修改 `UserProject.to_dict()`**: `first_access_at`, `last_access_at` 添加 UTC 标识
4. **修改 `ProjectStats.to_dict()`**: `first_access`, `last_access` 添加 UTC 标识

## 修复方案
详见 Issue 评论

## 效果
- 修复前：API 返回 `2026-08-17T08:06:59`（无时区标识）
- 修复后：API 返回 `2026-08-17T08:06:59Z`（UTC 标识）
- 浏览器将正确识别为 UTC 时间并转换为本地时间显示