### PR TITLE
fix: keep PR review verdict lines in artifact gate and parser

### DIFF
--- a/app/modules/workspace/autonomous/artifact_text.py
+++ b/app/modules/workspace/autonomous/artifact_text.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import re
 
+from app.modules.workspace.autonomous.constants import (
+    REVIEW_RESULT_LINE_FULLMATCH_RE,
+    REVIEW_RESULT_LINE_SEARCH_RE,
+)
+
 # Shared artifact-cleaning helpers used by both the autonomous runner and the
 # orchestrator. Workflow timelines / comments should show publishable output,
 # not the agent's process chatter or leaked tool payloads.
@@ -78,6 +83,20 @@ _PROCESS_LINE_RE = re.compile(
     r"(?im)^\s*(The user wants me to|user wants me to|Let me\b|I need to:).*$"
 )
 _REPEATED_HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$")
+_HEADING_LINE_RE = re.compile(r"^#{1,6}\s", re.MULTILINE)
+_TLDR_BONUS_RE = re.compile(r"TL;DR\*{0,2}\s*:")
+
+
+def _earliest_match(text: str, *patterns: re.Pattern[str]) -> re.Match | None:
+    """First match across patterns (earliest position wins).
+
+    Used for slice-to-structured-start decisions: a contract verdict line that
+    precedes the first markdown heading is itself the structured start, so a
+    short-circuit ``or`` between patterns would slice past it and drop the
+    verdict (workflow 02dae370 failed exactly that way).
+    """
+    matches = [m for m in (p.search(text) for p in patterns) if m]
+    return min(matches, key=lambda m: m.start()) if matches else None
 
 
 def clean_agent_text(text: str) -> str:
@@ -85,7 +104,7 @@ def clean_agent_text(text: str) -> str:
     if not text:
         return text
 
-    match = re.search(r"^#{1,6}\s", text, re.MULTILINE)
+    match = _earliest_match(text, _HEADING_LINE_RE, REVIEW_RESULT_LINE_SEARCH_RE)
     if match:
         text = text[match.start() :]
 
@@ -136,7 +155,7 @@ def _slice_from_structured_start(text: str) -> str:
     if not any(marker in head for marker in _PROCESS_MARKERS):
         return text
 
-    match = _STRUCTURED_LINE_RE.search(text)
+    match = _earliest_match(text, _STRUCTURED_LINE_RE, REVIEW_RESULT_LINE_SEARCH_RE)
     if match and match.start() > 0:
         return text[match.start() :]
     return text
@@ -147,6 +166,10 @@ def _is_process_paragraph(paragraph: str) -> bool:
     if not stripped:
         return False
     if _STRUCTURED_LINE_RE.match(stripped):
+        return False
+    if REVIEW_RESULT_LINE_FULLMATCH_RE.match(stripped):
+        # A machine-contract verdict line is never process chatter — even when
+        # its findings quote chatter ("agent kept saying let me …").
         return False
 
     normalized = re.sub(r"\s+", " ", stripped).lower()
@@ -240,16 +263,19 @@ def score_artifact_text(text: str) -> int:
     if not text:
         return -1
     score = len(text.strip())
-    has_structure = bool(_STRUCTURED_LINE_RE.search(text))
+    has_contract = bool(REVIEW_RESULT_LINE_SEARCH_RE.search(text))
+    has_structure = bool(_STRUCTURED_LINE_RE.search(text)) or has_contract
     if has_structure:
         score += 120
-    if "TL;DR:" in text:
+    if _TLDR_BONUS_RE.search(text):
         score += 40
     if not has_structure:
         paragraph_count = len([p for p in re.split(r"\n\s*\n", text) if p.strip()])
         score -= 80 * max(paragraph_count - 1, 0)
     head = re.sub(r"\s+", " ", text[:240]).lower()
-    score -= 200 * sum(marker in head for marker in _PROCESS_MARKERS)
+    # A text carrying a valid contract verdict line is signal, not chatter:
+    # process markers in its head are quoted findings, not preamble.
+    score -= 0 if has_contract else 200 * sum(marker in head for marker in _PROCESS_MARKERS)
     return score
 
 

--- a/app/modules/workspace/autonomous/constants.py
+++ b/app/modules/workspace/autonomous/constants.py
@@ -212,6 +212,19 @@ _REVIEW_APPROVAL_PHRASES = {
     "ko": "코드 리뷰 통과",
 }
 
+# Machine-readable PR-review verdict contract (the review prompt in
+# phases/pr_review.py asks for a single-line JSON as the last non-summary line
+# before the TL;DR). These patterns are shared by the orchestrator's parser
+# and the artifact-text scorer/cleaners — keep them in sync with the prompt.
+# Exact-line form (fullmatch on one stripped line; group 1 = the JSON blob).
+REVIEW_RESULT_LINE_FULLMATCH_RE = re.compile(r"^REVIEW_RESULT\s*:\s*(\{.*\})$")
+# Multi-line text form (search across a whole artifact).
+REVIEW_RESULT_LINE_SEARCH_RE = re.compile(r"(?m)^REVIEW_RESULT\s*:\s*\{.*\}\s*$")
+# Summary line that may follow the verdict line — bold markers tolerated.
+REVIEW_TLDR_LINE_RE = re.compile(r"^\*{0,2}TL;DR\*{0,2}\s*:", re.IGNORECASE)
+# Decorative separators carry no verdict information. Match a STRIPPED line.
+REVIEW_SEPARATOR_LINE_RE = re.compile(r"^(?:-{3,}|\*{3,}|_{3,})$")
+
 
 def _review_approval_phrase(content_language: str | None) -> str:
     """Approval marker for PR review in the given content language."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -63,6 +63,9 @@ from app.modules.workspace.autonomous.constants import (  # noqa: F401
     PROTECTED_CI_REPAIR_TEST_FILES,
     READ_ONLY_REVIEW_UNSUPPORTED_TOOLS,
     REVIEW_ALLOWED_TOOLS,
+    REVIEW_RESULT_LINE_FULLMATCH_RE,
+    REVIEW_SEPARATOR_LINE_RE,
+    REVIEW_TLDR_LINE_RE,
     VERIFICATION_ALLOWED_TOOLS,
     _extract_pr_number_from_error,
     _is_transient_git_error,
@@ -1873,8 +1876,9 @@ _TLDR_RE = re.compile(r"TL;DR:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
 
 # _REVIEW_APPROVAL_PHRASES + _review_approval_phrase moved to constants.py
 # (shared with phases/pr_review.py); re-imported above.
-
-_REVIEW_RESULT_LINE_RE = re.compile(r"^REVIEW_RESULT\s*:\s*(\{.*\})$")
+#
+# _REVIEW_RESULT_LINE_RE also lives in constants.py now
+# (REVIEW_RESULT_LINE_FULLMATCH_RE), shared with the artifact-text scorer.
 
 
 def _parse_review_result(review_text: str) -> dict | None:
@@ -1890,14 +1894,25 @@ def _parse_review_result(review_text: str) -> dict | None:
     if not nonempty:
         return None
 
+    # Decorative separator lines (--- / *** / ___) carry no verdict
+    # information; the contract line must be the last non-summary line among
+    # CONTENT lines. Filter them once, in the original index space, so the
+    # candidate selection and the REVIEW_RESULT scan below stay comparable.
+    content_indexes = [
+        index for index in nonempty if not REVIEW_SEPARATOR_LINE_RE.match(lines[index].strip())
+    ]
+    if not content_indexes:
+        return None
+
     # The result must be the final non-summary line.  A single TL;DR line may
-    # follow because build_language_instruction() asks every phase for it.
-    last_index = nonempty[-1]
+    # follow because build_language_instruction() asks every phase for it; the
+    # summary may be bolded (**TL;DR**:) and separated by a decorative line.
+    last_index = content_indexes[-1]
     candidate_index = last_index
-    if re.match(r"^TL;DR\s*:", lines[last_index].strip(), re.IGNORECASE):
-        if len(nonempty) < 2:
+    if REVIEW_TLDR_LINE_RE.match(lines[last_index].strip()):
+        if len(content_indexes) < 2:
             return None
-        candidate_index = nonempty[-2]
+        candidate_index = content_indexes[-2]
 
     result_line_indexes = [
         index
@@ -1927,7 +1942,7 @@ def _parse_review_result(review_text: str) -> dict | None:
     if in_fence:
         return None
 
-    match = _REVIEW_RESULT_LINE_RE.fullmatch(lines[candidate_index].strip())
+    match = REVIEW_RESULT_LINE_FULLMATCH_RE.fullmatch(lines[candidate_index].strip())
     if not match:
         return None
     try:

--- a/docs/superpowers/plans/2026-08-17-pr-review-verdict-artifact-gate.md
+++ b/docs/superpowers/plans/2026-08-17-pr-review-verdict-artifact-gate.md
@@ -1,0 +1,123 @@
+# Plan: PR review verdict 不得被 artifact 评分门/解析器判空
+
+- 日期：2026-08-17（v3，两轮独立审查：v1 抓 1 BLOCKING（解析器漏改），v2 复审
+  zero-blocking 附 2 必改 + 1 建议，均已采纳）
+- 背景：monitor-autonomous-workflows class-2，workflow `02dae370`（issue #2550 / PR #2578）
+  于 2026-08-16 13:15 UTC failed，error="PR review agent returned no result"
+- 状态：审查通过，进入实现
+
+## 1. 根因（主证据验证 + 本地复现 + 两轮独立审查复核）
+
+agent 严格按 review prompt 契约（`phases/pr_review.py` ~L510：机器可读单行
+`REVIEW_RESULT: {"verdict":...,"blocking_findings":[...]}` 必须是 TL;DR 前最后一个
+非摘要行）输出最小合规 verdict，但链路上有**两道闸门**都会把这种最小形态判死：
+
+**闸门 1（提取层）**：`pr_review.py` `host.artifact_text` →
+`pick_best_artifact_text`（artifact_text.py L256）只接受 score > −1 的候选；最小
+合规回复（无 markdown 标题、3 段落）得分 102+0+0−160 = **−58** → 返回 `""` →
+pr_review.py ~L592 判 "no result" → PhaseResult.failed（本次 failed 直接原因）。
+
+**闸门 2（解析层）**：`orchestrator._parse_review_result`（~L1885）对同一文本
+返回 None、`_review_is_approved` False，两个独立缺陷：
+- 摘要行识别 `^TL;DR\s*:` 不认粗体 `**TL;DR**:` → 候选行错位；
+- 契约行与 TL;DR 之间的独立 `---` 分隔行成为"最后一个非摘要行" → 索引不匹配。
+
+只修闸门 1 的后果：APPROVE 被读成未通过 → 对已批准 PR 反复修复轮（静默走错方向）。
+
+实测矩阵（main 78ae2f8c，独立审查者复跑一致）：
+
+| 输入 | `_parse_review_result` | 期望 |
+|---|---|---|
+| 契约行+`---`+`**TL;DR**:`（本案原文） | None | APPROVE |
+| 契约行+`---`+`TL;DR:` | None | APPROVE |
+| 契约行+`**TL;DR**:`（无分隔） | None | APPROVE |
+| `All good.`+契约行（对照） | 正常解析 | APPROVE ✓ |
+| `pick_best_artifact_text(本案原文)` | `""` | 非空 |
+
+边界（实测）：F2 = findings 文本含 ≥2 过程词时 `_is_process_paragraph` 丢契约段；
+F1 = 过程性开头 + 后文标题时切片层（`_slice_from_structured_start` **和**
+`clean_agent_text` 的标题切片）删掉其前的契约行（后者为实现时自查发现的第三处
+同型切片，v2 审查未点名，由端到端 F1 测试锁定）。
+
+- `_review_is_approved`（orchestrator.py:6923）纯粹以 `_parse_review_result` verdict
+  为准——两道闸门都修好全链路才通。
+- JSONL 主证据：`/run/openace-agent-tasks/be3dbf69-*.claude-preserve/projects/
+  -home-qlfan-openace-pr----worktrees-02dae370-*/f149678b-*.jsonl` 最后一条 assistant。
+- origin/main（8d1e4aeb）pr_review.py 已有空文本时 fresh-session 重试 band-aid
+  （归因"resume no-op"）；与本修复正交共存。
+
+## 2. 方案（选定 A，弃 B/C）
+
+**A. 契约行在清洗/评分/解析三层都被视为一等结构化内容**。弃 B（phase 层再叠
+fallback）与 C（唯一候选不判空，废噪声门）。
+
+已知限制（接受，如实记录）：`_extract_tldr`/`_TLDR_RE` 对粗体 TL;DR 提取仍不
+命中（外观问题，milestone tldr 优先 structured_tags）；评分放宽后，行首
+`REVIEW_RESULT: {…}` 回显的候选从拒收变为可发布（实践中仅 review phase 产出）。
+
+## 3. 改动清单
+
+1. `constants.py`（叶子模块）新增共享契约模式（注释与 pr_review prompt 契约三方
+   同步维护）：
+   - `REVIEW_RESULT_LINE_FULLMATCH_RE`（orchestrator `_REVIEW_RESULT_LINE_RE`
+     原样搬入，orchestrator 改导入，行为不变；全库仅 orchestrator 两处内部引用）
+   - `REVIEW_RESULT_LINE_SEARCH_RE`（`(?m)` search 版，评分/结构判定用）
+   - `REVIEW_TLDR_LINE_RE`（粗体容忍 `^\*{0,2}TL;DR\*{0,2}\s*:`，IGNORECASE）
+   - `REVIEW_SEPARATOR_LINE_RE`（`^(?:-{3,}|\*{3,}|_{3,})$`；**按 strip 后的行
+     匹配**，容忍尾随空白）
+2. `artifact_text.py`（闸门 1 + F1/F2）：
+   - 新增 `_first_structured_start(text)`：结构行与契约行**取最早命中位置**
+     （禁用短路 or——v2 审查实测短路实现修不了 F1）；`_slice_from_structured_start`
+     与 `clean_agent_text` 的标题切片都改用它（F1，覆盖三处切片中的两处）
+   - `score_artifact_text`：`has_structure` 追加契约行 search 命中；TL;DR 加分改
+     `re.search(r"TL;DR\*{0,2}\s*:", text)`；**头部过程词惩罚在文本含契约行时
+     豁免**（F2 端到端必需：否则 findings 引用过程词时 −400 惩罚仍压到 −116 判空）
+   - `_is_process_paragraph`：契约行 fullmatch 命中 → 不判过程段（F2 sanitize 层）
+3. `orchestrator.py` `_parse_review_result`（闸门 2）：
+   - 候选行选择：剔除纯分隔行后取最后一个非摘要行；摘要行识别换
+     `REVIEW_TLDR_LINE_RE`；**候选索引与 `result_line_indexes` 必须同一索引空间**
+     （v2 审查提示：原始索引或过滤重建二选一，不可混用）
+   - fence 检查/fullmatch/verdict+blockers 一致性校验全部保留（fail-closed 不变）
+   - 删除本地 `_REVIEW_RESULT_LINE_RE` 定义，改从 constants 导入
+
+## 4. 测试（required lane，先红后绿）
+
+`tests/unit/test_autonomous_review_verdict.py` 新增：
+- 三例决定性红测：契约行+`---`+`**TL;DR**:` / +plain `TL;DR:` / 无分隔粗体 →
+  `_review_is_approved == True`
+- 守门：`REQUEST_CHANGES` + 分隔 + 粗体 TL;DR 仍 False
+- 守门（金丝雀，抓索引空间混用）：**多契约行 + 分隔行穿插仍 fail-closed**
+- 既有 fence/多契约/旧 marker fail-closed 测试不动
+
+`tests/unit/test_artifact_text_helpers.py` 新增 `TestMachineContractVerdicts`：
+- 红：`pick_best_artifact_text(三段落最小合规)` 非空且含契约行
+- 红：`score_artifact_text(sanitize(最小合规))` > −1
+- 红：`AutonomousOrchestrator._artifact_text(AgentTaskResult(response_text=最小合规))`
+  非空（直接覆盖 pr_review 取文路径）
+- 红（F1 端到端）：过程性开头 + 契约行 + 后文标题 → 结果仍含 `REVIEW_RESULT`
+- 红（F2 端到端）：findings 含 "let me"+"working directory" → `_artifact_text`
+  非空
+- 绿守门：纯过程噪声 `pick_best` 仍 `""`
+- 绿守门：sanitize 保留契约行与 TL;DR 行
+
+## 5. 风险与回退
+
+- 噪声门：契约行需完整 JSON 形态才计结构分；纯噪声不含契约行仍被拒（守门测试
+  锁定）。头部惩罚豁免仅在文本含契约行时生效，且此类文本仅 review phase 产出。
+- 解析器：分隔行剔除只影响候选行选择；fence/形态/verdict 校验保留，fail-closed
+  语义不变（多契约行金丝雀 + REQUEST_CHANGES 守门锁定）。
+- 回退：三层各自单点收紧即可，无 schema/接口变更。
+
+## 6. 流程约束
+
+- 隔离 worktree `/private/tmp/fix-review-verdict-artifact-gate`
+  （branch `fix/pr-review-verdict-artifact-gate`，base origin/main 8d1e4aeb）
+- TDD：先写失败测试看红 → 最小实现看绿 → 重构
+- PR 文本禁 `closes|fixes|resolves` + #N（`fix(#N)` 前缀也算）
+- CI required：lint / test(3.10) / test(3.11) / test(3.12) / build 全绿后 merge
+- 部署：app/ 热补丁 cp+chown openace + `systemctl restart openace-scheduler.service`
+  （无 DB 迁移，不动 alembic）
+- 部署后 reset workflow `02dae370`：status=`pr_review`（pickup 态），恢复
+  worktree_path（COALESCE preferred），清 ci_repair 计数/锁/error
+- PR #2578 lint/test 全红属第一类（预先存在的基础设施问题）：reset 后交自主系统
+  CI-repair，不手动改 PR

--- a/tests/unit/test_artifact_text_helpers.py
+++ b/tests/unit/test_artifact_text_helpers.py
@@ -17,6 +17,11 @@ without instantiating ``AutonomousOrchestrator`` (whose ``__init__`` needs a
 workflow id + DB).
 """
 
+from app.modules.workspace.autonomous.artifact_text import (
+    pick_best_artifact_text,
+    sanitize_artifact_text,
+    score_artifact_text,
+)
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
@@ -145,3 +150,77 @@ class TestArtifactStatusTag:
 
     def test_none_result_returns_empty(self):
         assert AutonomousOrchestrator._artifact_status_tag(None, "test_status") == ""
+
+
+MINIMAL_COMPLIANT_REVIEW = (
+    'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n'
+    "\n---\n\n"
+    "**TL;DR**: 代码审查通过，CI 失败是预先存在的基础设施问题。"
+)
+
+
+class TestMachineContractVerdicts:
+    """The review prompt's machine-readable verdict line is contract output,
+    not process noise. It must survive cleaning, score above the publishable
+    threshold, and reach ``_artifact_text`` — the exact path pr_review uses
+    before declaring "PR review agent returned no result".
+
+    Regression: workflow 02dae370 / PR #2578 (2026-08-16) failed with exactly
+    this minimal compliant shape — the scorer graded it −58 (paragraph
+    penalty, no markdown structure), so the gate returned an empty string."""
+
+    def test_minimal_compliant_review_passes_artifact_gate(self):
+        result = pick_best_artifact_text(MINIMAL_COMPLIANT_REVIEW.strip(), MINIMAL_COMPLIANT_REVIEW)
+
+        assert "REVIEW_RESULT" in result
+
+    def test_minimal_compliant_review_scores_above_threshold(self):
+        assert score_artifact_text(sanitize_artifact_text(MINIMAL_COMPLIANT_REVIEW)) > -1
+
+    def test_artifact_text_extracts_minimal_compliant_verdict(self):
+        result = AgentTaskResult(response_text=MINIMAL_COMPLIANT_REVIEW, success=True)
+
+        extracted = AutonomousOrchestrator._artifact_text(result)
+
+        assert "REVIEW_RESULT" in extracted
+
+    def test_contract_line_survives_despite_later_heading(self):
+        # A process preamble plus a later markdown heading must not slice away
+        # an earlier contract line (both _slice_from_structured_start and
+        # clean_agent_text slice to the first structured line).
+        text = (
+            "Let me check the working directory first.\n\n"
+            'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n\n'
+            "## Summary\n\nAll acceptance criteria are met."
+        )
+
+        assert "REVIEW_RESULT" in sanitize_artifact_text(text)
+
+    def test_findings_quoting_process_words_survive_end_to_end(self):
+        # Blocking findings that quote agent chatter ("let me … working
+        # directory") land in the scoring head and used to wipe the contract
+        # paragraph (process-paragraph filter) or push the score to −116
+        # (head-marker penalty). The verdict must still reach the gate exit.
+        text = (
+            'REVIEW_RESULT: {"verdict":"REQUEST_CHANGES","blocking_findings":'
+            '["agent kept saying let me check the working directory"]}\n\n'
+            "**TL;DR**: 存在阻塞项。"
+        )
+        result = AgentTaskResult(response_text=text, success=True)
+
+        assert "REVIEW_RESULT" in AutonomousOrchestrator._artifact_text(result)
+
+    def test_pure_process_noise_is_still_rejected(self):
+        noise = (
+            "Let me check the working directory.\n\n"
+            "Hmm, actually I need to think about this more.\n\n"
+            "Wait, let me look at the conversation start again."
+        )
+
+        assert pick_best_artifact_text(noise.strip(), noise) == ""
+
+    def test_sanitize_preserves_contract_and_tldr_lines(self):
+        cleaned = sanitize_artifact_text(MINIMAL_COMPLIANT_REVIEW)
+
+        assert "REVIEW_RESULT" in cleaned
+        assert "TL;DR" in cleaned

--- a/tests/unit/test_autonomous_review_verdict.py
+++ b/tests/unit/test_autonomous_review_verdict.py
@@ -115,3 +115,60 @@ def test_tldr_is_the_only_allowed_line_after_result():
     )
 
     assert _approved(text)
+
+
+# ── Minimal compliant verdicts: separator lines + bold TL;DR ────────────────
+# The review prompt only constrains the contract line's position ("last
+# non-summary line before the TL;DR"); nothing forbids a decorative ``---``
+# separator or a bolded ``**TL;DR**:`` summary around it. Workflow 02dae370 /
+# PR #2578 (2026-08-16) failed with exactly that minimal compliant shape.
+
+
+def test_minimal_verdict_with_separator_and_bold_tldr_approves():
+    text = (
+        'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n'
+        "\n---\n\n"
+        "**TL;DR**: 代码审查通过，CI 失败是预先存在的基础设施问题。"
+    )
+
+    assert _approved(text)
+
+
+def test_minimal_verdict_with_separator_and_plain_tldr_approves():
+    text = (
+        'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n'
+        "\n---\n\n"
+        "TL;DR: approved"
+    )
+
+    assert _approved(text)
+
+
+def test_minimal_verdict_with_bold_tldr_without_separator_approves():
+    text = 'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n\n**TL;DR**: approved'
+
+    assert _approved(text)
+
+
+def test_request_changes_with_separator_and_bold_tldr_still_rejected():
+    text = (
+        'REVIEW_RESULT: {"verdict":"REQUEST_CHANGES",'
+        '"blocking_findings":["P0 tests missing"]}\n'
+        "\n---\n\n"
+        "**TL;DR**: 存在阻塞项。"
+    )
+
+    assert not _approved(text)
+
+
+def test_separator_lines_do_not_mask_a_second_contract_line():
+    # Canary against index-space mixing when separator lines are skipped: the
+    # candidate must still be the LAST contract line, and multiple contract
+    # lines keep failing closed.
+    text = (
+        'REVIEW_RESULT: {"verdict":"APPROVE","blocking_findings":[]}\n'
+        "\n---\n\n"
+        'REVIEW_RESULT: {"verdict":"REQUEST_CHANGES","blocking_findings":["P0"]}'
+    )
+
+    assert not _approved(text)


### PR DESCRIPTION
## Summary

The review prompt requires a machine-readable single-line `REVIEW_RESULT` JSON verdict, but a minimal compliant response was killed twice downstream, failing the workflow with `PR review agent returned no result` (autonomous workflow 02dae370, PR 2578, 2026-08-16).

**Gate 1 — extraction.** `pick_best_artifact_text` only accepts candidates scoring above −1. A minimal compliant verdict (contract line + separator + TL;DR, no markdown headings) scored −58 via the multi-paragraph penalty, so the review phase saw an empty artifact.

**Gate 2 — parsing.** `_parse_review_result` mis-located the contract line when a decorative `---` separator preceded the summary, or when the summary was bolded (`**TL;DR**:`). Even after extraction, an APPROVE verdict would have read as not-passed and driven pointless fix rounds on an approved PR.

## Changes

- `artifact_text.py`: the contract verdict line is first-class structured content —
  - counts toward the structure bonus in `score_artifact_text`, with the head process-marker penalty exempted when a contract line is present (blocking findings may quote agent chatter);
  - survives process-paragraph filtering (`_is_process_paragraph`);
  - wins earliest-match slicing (`_slice_from_structured_start`, `clean_agent_text`) ahead of later markdown headings;
  - the TL;DR bonus accepts the bolded form.
- `orchestrator.py` `_parse_review_result`: decorative separator lines are skipped in a single index space when locating the candidate line; the summary-line check accepts bolded TL;DR. Fence / shape / verdict-consistency checks are unchanged (fail-closed preserved).
- Shared patterns centralized in `constants.py` (`REVIEW_RESULT_LINE_FULLMATCH_RE` moved from orchestrator unchanged).
- Regression tests: 8 new (3 parser variants, artifact gate, end-to-end extraction, F1 heading-slice, F2 quoted-chatter findings) plus guards that pure process noise is still rejected, REQUEST_CHANGES still fails closed, and multiple contract lines still fail closed.

## Test evidence

- New + existing target tests: 47/47 pass (red confirmed before implementation).
- Related suites (pr_review phases, orchestrator characterization, issue tests touching changed symbols): 148/148 pass.
- Full `tests/unit` lane: 4540 pass; 2 pre-existing failures in `test_scheduler_batch_order_tiebreak.py` reproduced on clean origin/main (unrelated).
- End-to-end repro: the exact production failure text now extracts (non-empty) and approves (`_review_is_approved == True`).

Design/verification plan and two rounds of independent review notes: `docs/superpowers/plans/2026-08-17-pr-review-verdict-artifact-gate.md`