### PR TITLE
fix(audit): 浅色主题下已处理异常记录文字对比度过低 (#2744)

### DIFF
--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -942,7 +942,9 @@ export const AuditCenter: React.FC = () => {
                       .map((anomaly, index) => (
                         <tr
                           key={anomaly.anomaly_id ?? `${anomaly.anomaly_type}-${index}`}
-                          className={anomaly.status === 'processed' ? 'opacity-50' : ''}
+                          className={cn({
+                            'anomaly-row-processed': anomaly.status === 'processed',
+                          })}
                         >
                           <td>
                             <span className="badge bg-secondary">{anomaly.anomaly_type}</span>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1945,6 +1945,18 @@ table .latency-row:hover td {
 }
 
 /* Audit Analysis page - same overrides (standalone page) */
+
+/* Anomaly row processed state - Issue #2744 */
+.audit-center .anomaly-row-processed {
+  --bs-table-bg: #f8fafc;
+  --bs-table-hover-bg: #f1f5f9;
+  border-left: 3px solid var(--color-success);
+}
+
+[data-theme='dark'] .audit-center .anomaly-row-processed {
+  --bs-table-bg: rgba(16, 185, 129, 0.08);
+  --bs-table-hover-bg: rgba(16, 185, 129, 0.13);
+}
 [data-theme='dark'] .audit-analysis .table {
   --bs-table-color: var(--text-primary);
   --bs-table-bg: transparent;


### PR DESCRIPTION
## 修复说明

关联 Issue：#2744

## 根因

管理端审计页面异常检测列表中，已处理状态的记录整行使用 Bootstrap `opacity-50` 类，导致所有子元素透明度降低。浅色主题下 `#64748b` (`text-muted`) 在白色背景上原本约 4.6:1 对比度，应用 50% 透明度后降至约 1.9:1，明显不满足 WCAG AA 可读性要求。

## 修复方案

- 移除 `opacity-50` 条件类名
- 使用语义化类名 `anomaly-row-processed`
- 通过浅色背景和左侧绿色边线表达已处理状态
- 同时覆盖浅色和深色主题
- 确保 `text-muted` 保持正常对比度

## 主要变更

- `frontend/src/components/features/management/AuditCenter.tsx`：将 `opacity-50` 替换为语义化类名
- `frontend/src/styles/main.css`：添加 `.audit-center .anomaly-row-processed` 样式

## 测试

- 测试执行的主机：本地构建，测试环境验证
- 已运行的测试：前端构建成功
- 视觉验证：浅色主题下已处理记录文字清晰可读
- 视觉验证：深色主题样式正确
- 交互验证：hover 状态正常

## 风险

- 兼容性风险：无
- 性能风险：无
- 安全风险：无
- 回归风险：低

Generated with Qwen Code (1-shotted by Qwen-Coder)