### PR TITLE
fix: unify request counting to daily_messages table

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -883,6 +883,10 @@ class UsageRepository:
         """
         Get today's request statistics.
 
+        A "request" is defined as an AI assistant response message (role='assistant'),
+        representing a completed user-to-AI interaction. This aligns with
+        get_request_stats_by_user() for data consistency.
+
         Args:
             host_name: Optional host name filter.
             tenant_id: Optional tenant ID filter. If None, returns all tenants (admin).
@@ -892,26 +896,30 @@ class UsageRepository:
 
         Note:
             Issue #1852: Added tenant_id parameter for tenant filtering.
+            Issue #2752: Changed data source from daily_usage to daily_messages for
+                         consistency with get_request_stats_by_user().
         """
         today = datetime.now().strftime("%Y-%m-%d")
 
-        conditions = ["date = ?"]
-        params: list[Any] = [today]
+        conditions = ["dm.date = ?", "dm.role = ?"]
+        params: list[Any] = [today, "assistant"]
         normalized_tenant_id = self._normalize_tenant_id(tenant_id)
 
         if normalized_tenant_id is not None:
-            conditions.append("tenant_id = ?")
+            conditions.append(self._tenant_user_condition("dm.user_id"))
             params.append(normalized_tenant_id)
 
         if host_name:
-            conditions.append("host_name = ?")
+            conditions.append("dm.host_name = ?")
             params.append(host_name)
 
-        # Get total
+        where_clause = f"WHERE {' AND '.join(conditions)}"
+
+        # Get total requests
         total_query = f"""
-            SELECT SUM(request_count) as total_requests
-            FROM daily_usage
-            WHERE {" AND ".join(conditions)}
+            SELECT COUNT(*) as total_requests
+            FROM daily_messages dm
+            {where_clause}
         """
         total_result = self.db.fetch_one(total_query, tuple(params))
         total_requests = int(total_result.get("total_requests", 0) or 0) if total_result else 0
@@ -919,11 +927,11 @@ class UsageRepository:
         # Get by tool
         by_tool_query = f"""
             SELECT
-                tool_name,
-                SUM(request_count) as requests
-            FROM daily_usage
-            WHERE {" AND ".join(conditions)}
-            GROUP BY tool_name
+                dm.tool_name,
+                COUNT(*) as requests
+            FROM daily_messages dm
+            {where_clause}
+            GROUP BY dm.tool_name
             ORDER BY requests DESC
         """
         by_tool_rows = self.db.fetch_all(by_tool_query, tuple(params))

--- a/app/utils/db_optimize.py
+++ b/app/utils/db_optimize.py
@@ -32,6 +32,8 @@ RECOMMENDED_INDEXES = {
         # New composite indexes for better coverage
         ("idx_messages_conversation", ["date", "conversation_id", "agent_session_id"]),
         ("idx_messages_date_sender_id", ["date", "sender_id"]),
+        # Index for request counting by date, role, and tool (Issue #2752)
+        ("idx_messages_date_role_tool", ["date", "role", "tool_name"]),
     ],
     "users": [
         ("idx_users_username", ["username"]),


### PR DESCRIPTION
## Summary

Fixes #2752

Unifies request counting data source to `daily_messages` table, using `role='assistant'` to count requests.

## Changes

- **`app/repositories/usage_repo.py`**: Modified `get_today_request_stats()` method
  - Changed data source from `daily_usage` to `daily_messages`
  - Uses `COUNT(*) WHERE role='assistant'` to count requests
  - Aligns with `get_request_stats_by_user()` for data consistency

- **`app/utils/db_optimize.py`**: Added composite index recommendation
  - New index: `idx_messages_date_role_tool` on `["date", "role", "tool_name"]`

## Rationale

Before this fix, `get_today_request_stats()` used `daily_usage.request_count` while `get_request_stats_by_user()` counted `daily_messages` with `role='assistant'`. This inconsistency caused discrepancies between dashboard totals and per-user breakdowns.

By unifying to `daily_messages` with `role='assistant'`, both methods now use the same data source and counting logic.

## Test Plan

- CI tests will verify the changes
- Manual testing: Dashboard request count should match per-user totals