### PR TITLE
test: pin effective concurrency cap in scheduler tiebreak tests

### DIFF
--- a/tests/unit/test_scheduler_batch_order_tiebreak.py
+++ b/tests/unit/test_scheduler_batch_order_tiebreak.py
@@ -11,6 +11,22 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(2706)]
 CREATED_AT = "2026-08-15 12:00:00"
 
 
+@pytest.fixture(autouse=True)
+def _cap_one_concurrent_workflow(monkeypatch):
+    """Pin the EFFECTIVE concurrency cap to 1.
+
+    Slot selection consults ``get_max_concurrent_workflows()``, which resolves
+    OPENACE_LAUNCHER_CONF env -> /etc/openace -> ~/.open-ace/agent-launcher.conf;
+    a user-level conf (agent_max_concurrent_workflows=3) overrides the module
+    constant, so patching ``MAX_CONCURRENT_WORKFLOWS`` is environment-dependent
+    — these tests were born red on any dev machine holding such a conf while CI
+    (clean HOME) stayed green. Patching the resolver pins the cap regardless of
+    host config. Same pattern as
+    tests/issues/2295/test_scheduler_per_user_concurrency.py.
+    """
+    monkeypatch.setattr("app.services.autonomous_scheduler.get_max_concurrent_workflows", lambda: 1)
+
+
 def _wf(workflow_id, batch_id, batch_order, **overrides):
     base = {
         "workflow_id": workflow_id,
@@ -39,9 +55,8 @@ def _run_one_cycle(scheduler, workflows):
     return [call.args[0] for call in advance.call_args_list]
 
 
-def test_same_created_at_batch_siblings_selected_in_batch_order(monkeypatch):
+def test_same_created_at_batch_siblings_selected_in_batch_order():
     """Identical created_at + reverse DB order: batch_order 0 must win the batch's single slot."""
-    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [
         _wf("wf-later", "batch-1", 1),
@@ -53,9 +68,8 @@ def test_same_created_at_batch_siblings_selected_in_batch_order(monkeypatch):
     assert selected == ["wf-earlier"]
 
 
-def test_batch_order_tiebreak_honors_waiting_priority_first(monkeypatch):
+def test_batch_order_tiebreak_honors_waiting_priority_first():
     """Waiting-last priority is unchanged: pending beats waiting regardless of batch_order."""
-    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [
         _wf("wf-waiting", "batch-1", 0, status="waiting"),
@@ -67,9 +81,8 @@ def test_batch_order_tiebreak_honors_waiting_priority_first(monkeypatch):
     assert selected == ["wf-pending"]
 
 
-def test_null_batch_order_same_created_at_falls_back_to_workflow_id(monkeypatch):
+def test_null_batch_order_same_created_at_falls_back_to_workflow_id():
     """NULL batch_order + identical created_at orders by workflow_id: stable total order, no None-vs-int TypeError."""
-    monkeypatch.setattr("app.services.autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS", 1)
     scheduler = AutonomousScheduler()
     workflows = [
         _wf("wf-b", "", None),


### PR DESCRIPTION
## Summary

Two of the three #2706 scheduler tiebreak regression tests fail on any dev machine holding `~/.open-ace/agent-launcher.conf` with `agent_max_concurrent_workflows > 1`, while CI (clean HOME) stays green. Root cause is test isolation, not a product regression: the tests monkeypatch the `MAX_CONCURRENT_WORKFLOWS` module constant, but slot selection consults `get_max_concurrent_workflows()`, whose three-level conf resolution (`OPENACE_LAUNCHER_CONF` → `/etc/openace` → user conf) overrides the constant — so the effective cap stayed at the conf value and the single-slot assertions saw two workflows selected.

Timeline: cap became conf-driven in #2020 (4478b2a1), user-level conf fallback added in #2154 (ef973484), tests added in #2706 (2026-08-16) patching only the constant — born red on conf-holding machines.

## Change

Test-only: replace the three per-test constant patches with one autouse fixture patching `get_max_concurrent_workflows` to return 1 (pattern already used by `tests/issues/2295/test_scheduler_per_user_concurrency.py`).

## Verification

- On a machine WITH the conf (previously 2 failed): 3/3 pass.
- With empty HOME (CI-like): 3/3 pass.

Known follow-up (not in scope here): `tests/issues/2020` and `tests/issues/716` contain ~10 more raw-constant patches with the same latent host-config dependency (opt-in lanes, not required CI).