### PR TITLE
fix: 为 scheduler 添加多用户配置以同步系统用户 (#2742)

### DIFF
--- a/app/scheduler_worker.py
+++ b/app/scheduler_worker.py
@@ -283,9 +283,64 @@ class SchedulerWorker:
         except Exception as e:
             logger.warning(f"Failed to start metrics server: {e}")
 
+    def _sync_system_users(self) -> None:
+        """同步数据库中的系统用户到容器。
+
+        Issue #2742: 在 Docker 多用户模式下，scheduler 容器需要拥有与
+        open-ace 容器相同的系统用户，才能通过 sudo -u <account> 执行命令。
+
+        每个容器有独立的 /etc/passwd，数据库中创建的系统用户不会自动同步。
+        此函数在 scheduler 启动时查询数据库中所有有 system_account 的用户，
+        并调用 ensure_system_user() 确保它们存在于当前容器中。
+        """
+        try:
+            from app.utils.workspace import _is_docker_multi_user_mode, ensure_system_user
+
+            # 只在 Docker 多用户模式下执行同步
+            if not _is_docker_multi_user_mode():
+                logger.info("Not in Docker multi-user mode, skipping system user sync")
+                return
+
+            logger.info("Syncing system users for Docker multi-user mode...")
+
+            # 查询所有有 system_account 的用户
+            if not self._db:
+                logger.warning("Database not initialized, cannot sync system users")
+                return
+
+            users = self._db.fetch_all(
+                "SELECT DISTINCT system_account FROM users WHERE system_account IS NOT NULL AND system_account != ''"
+            )
+
+            if not users:
+                logger.info("No system_account users found in database")
+                return
+
+            sync_count = 0
+            for user in users:
+                system_account = user.get("system_account")
+                if system_account:
+                    try:
+                        if ensure_system_user(system_account):
+                            sync_count += 1
+                            logger.info(f"System user synced: {system_account}")
+                        else:
+                            logger.warning(f"Failed to sync system user: {system_account}")
+                    except Exception as e:
+                        logger.error(f"Error syncing system user {system_account}: {e}")
+
+            logger.info(f"System user sync complete: {sync_count} users processed")
+
+        except Exception as e:
+            # 同步失败不应阻止 scheduler 启动，但需要记录错误
+            logger.error(f"Failed to sync system users: {e}")
+
     def _start_schedulers(self) -> None:
         """Start all background schedulers."""
         logger.info("Starting background schedulers...")
+
+        # Issue #2742: 同步系统用户到容器（必须在 scheduler 启动前执行）
+        self._sync_system_users()
 
         # Import scheduler modules
         # Note: These will use leader election internally (Issue #2187)

--- a/docker-compose.multi-user.yml
+++ b/docker-compose.multi-user.yml
@@ -47,10 +47,19 @@ services:
 
   # Issue #2729: Scheduler service for multi-user mode
   # Needs access to /home to collect Qwen sessions from users' .qwen/projects
+  # Issue #2742: Must run as root to sync system users
   scheduler:
     extends:
       file: docker-compose.yml
       service: scheduler
+    user: "0"
+    environment:
+      # Multi-user workspace mode (required)
+      - WORKSPACE_MULTI_USER_MODE=true
+      # Explicit root opt-in (Issue #1893)
+      - OPENACE_ALLOW_ROOT_MULTI_USER=1
+      # Security mode - recommend production for actual deployments
+      - OPENACE_SECURITY_MODE=${OPENACE_SECURITY_MODE:-production}
     volumes:
       - home-data:/home
 


### PR DESCRIPTION
Closes #2742

## 修复内容
为 docker-compose.multi-user.yml 中的 scheduler 服务添加多用户配置，确保 scheduler 容器能够同步系统用户。

## 修复方案
参见 Issue 评论：https://github.com/open-ace/open-ace/issues/2742#issuecomment-5324310180

## 问题根因
在 Docker 多用户模式下，独立 scheduler 容器没有同步系统用户，导致执行 sudo -u 命令时报错 `unknown user`。

## 修改内容
为 scheduler 服务添加与 open-ace 服务相同的多用户配置：
- `user: "0"` 以 root 运行
- `WORKSPACE_MULTI_USER_MODE=true` 启用多用户模式
- `OPENACE_ALLOW_ROOT_MULTI_USER=1` 允许 root 运行多用户模式
- `OPENACE_SECURITY_MODE=${OPENACE_SECURITY_MODE:-production}` 安全模式

## 测试验证
1. 重新部署：```bash
   docker compose -f docker-compose.yml -f docker-compose.multi-user.yml --profile scheduler up -d --build
```
2. 使用普通用户创建 AI 自主开发任务
3. 验证任务能正常进入仓库初始化阶段

Generated with Qwen Code (1-shotted by Qwen-Coder)