### PR TITLE
fix(install): verify physical schema after migration (#2770)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -5009,9 +5009,39 @@ do_fresh_install() {
                 fi
                 print_info "Running database migrations..."
                 if [ "$EUID" -eq 0 ] && [ -n "$install_user" ] && [ "$install_user" != "root" ]; then
-                    su - "$install_user" -c "cd '$target_path' && python3 -m alembic upgrade head" && print_success "Database upgraded to latest version" || print_warning "alembic upgrade failed"
+                    if su - "$install_user" -c "cd '$target_path' && python3 -m alembic upgrade head"; then
+                        print_success "Database upgraded to latest version"
+                    else
+                        print_error "Database migration failed. Installation aborted."
+                        exit 1
+                    fi
+                    # Issue #2770: Verify physical schema after migration
+                    print_info "Verifying database schema integrity..."
+                    if su - "$install_user" -c "cd '$target_path' && python3 scripts/verify_schema_integrity.py"; then
+                        print_success "Schema integrity verified"
+                    else
+                        print_error "Schema integrity check failed. Installation aborted."
+                        exit 1
+                    fi
                 else
-                    python3 -m alembic upgrade head && print_success "Database upgraded to latest version" || print_warning "alembic upgrade failed"
+                    cd "$target_path"
+                    if python3 -m alembic upgrade head; then
+                        print_success "Database upgraded to latest version"
+                    else
+                        print_error "Database migration failed. Installation aborted."
+                        cd - > /dev/null
+                        exit 1
+                    fi
+                    # Issue #2770: Verify physical schema after migration
+                    print_info "Verifying database schema integrity..."
+                    if python3 scripts/verify_schema_integrity.py; then
+                        print_success "Schema integrity verified"
+                    else
+                        print_error "Schema integrity check failed. Installation aborted."
+                        cd - > /dev/null
+                        exit 1
+                    fi
+                    cd - > /dev/null
                 fi
             else
                 # Fresh database: execute schema + stamp
@@ -5446,14 +5476,38 @@ with open('$config_dir/config.json', 'w') as f:
             if su - "$install_user" -c "cd '$target_path' && python3 -m alembic upgrade head"; then
                 print_success "Database migrations applied"
             else
-                print_warning "Database migration failed. You may need to run 'alembic upgrade head' manually."
+                print_error "Database migration failed. Service will not be restarted."
+                print_info "Manual recovery: fix migration issues and re-run upgrade."
+                exit 1
+            fi
+            # Issue #2770: Verify physical schema after migration
+            print_info "Verifying database schema integrity..."
+            if su - "$install_user" -c "cd '$target_path' && python3 scripts/verify_schema_integrity.py"; then
+                print_success "Schema integrity verified"
+            else
+                print_error "Schema integrity check failed. Service will not be restarted."
+                print_info "Manual recovery: run 'python3 scripts/verify_schema_integrity.py' to diagnose."
+                exit 1
             fi
         else
             cd "$target_path"
             if python3 -m alembic upgrade head; then
                 print_success "Database migrations applied"
             else
-                print_warning "Database migration failed. You may need to run 'alembic upgrade head' manually."
+                print_error "Database migration failed. Service will not be restarted."
+                print_info "Manual recovery: fix migration issues and re-run upgrade."
+                cd - > /dev/null
+                exit 1
+            fi
+            # Issue #2770: Verify physical schema after migration
+            print_info "Verifying database schema integrity..."
+            if python3 scripts/verify_schema_integrity.py; then
+                print_success "Schema integrity verified"
+            else
+                print_error "Schema integrity check failed. Service will not be restarted."
+                print_info "Manual recovery: run 'python3 scripts/verify_schema_integrity.py' to diagnose."
+                cd - > /dev/null
+                exit 1
             fi
             cd - > /dev/null
         fi
@@ -5656,7 +5710,20 @@ print(f\"db_pass='{pw}'\")
                         exit 1
                     fi
                     echo 'Running database migrations...'
-                    python3 -m alembic upgrade head || echo 'ERROR: alembic upgrade failed'
+                    if python3 -m alembic upgrade head; then
+                        echo 'Database migrations applied'
+                        # Issue #2770: Verify physical schema after migration
+                        echo 'Verifying database schema integrity...'
+                        if python3 scripts/verify_schema_integrity.py; then
+                            echo 'Schema integrity verified'
+                        else
+                            echo 'ERROR: Schema integrity check failed.'
+                            exit 1
+                        fi
+                    else
+                        echo 'ERROR: alembic upgrade failed'
+                        exit 1
+                    fi
                 else
                     echo 'Executing full schema for fresh database...'
                     if PGPASSWORD=\"\$db_pass\" psql -h \"\$db_host\" -p \"\$db_port\" -U \"\$db_user\" -d \"\$db_name\" -f \"\$schema_file\"; then
@@ -5880,8 +5947,19 @@ do_upgrade_remote() {
         if [ -f 'alembic.ini' ] && [ -d 'migrations' ]; then
             if python3 -m alembic upgrade head; then
                 echo 'Database migrations applied'
+                # Issue #2770: Verify physical schema after migration
+                echo 'Verifying database schema integrity...'
+                if python3 scripts/verify_schema_integrity.py; then
+                    echo 'Schema integrity verified'
+                else
+                    echo 'ERROR: Schema integrity check failed. Service will not be restarted.'
+                    echo 'Manual recovery: run python3 scripts/verify_schema_integrity.py to diagnose.'
+                    exit 1
+                fi
             else
-                echo 'Warning: Database migration failed. You may need to run alembic upgrade head manually.'
+                echo 'ERROR: Database migration failed. Service will not be restarted.'
+                echo 'Manual recovery: fix migration issues and re-run upgrade.'
+                exit 1
             fi
         else
             echo 'Warning: Alembic not found, skipping database migrations'

--- a/scripts/verify_schema_integrity.py
+++ b/scripts/verify_schema_integrity.py
@@ -41,6 +41,9 @@ EXPECTED_TABLES = [
     "autonomous_workflows",
     "projects",
     "tenants",
+    # Issue #2770: Tables with critical columns for delayed token revocation
+    "agent_tokens",
+    "remote_machines",
 ]
 
 # Expected columns for critical tables
@@ -68,6 +71,22 @@ EXPECTED_COLUMNS = {
         "content_blocks",
         "milestone_id",
     ],
+    # Issue #2770: Critical columns for delayed token revocation
+    # These may be missing if migration 20260811_001 was skipped
+    "agent_tokens": [
+        "id",
+        "machine_id",
+        "is_revoked",
+        "pending_revoke",
+        "revoke_after",
+        "rotation_id",
+        "token_version",
+    ],
+    "remote_machines": [
+        "id",
+        "agent_version",
+        "token_revoke_timeout",
+    ],
 }
 
 # Critical indexes to verify
@@ -75,6 +94,12 @@ EXPECTED_INDEXES = {
     "agent_sessions": [
         "idx_agent_sessions_tenant_user",
         "idx_agent_sessions_tenant_updated",
+    ],
+    # Issue #2770: Critical indexes for delayed token revocation
+    "agent_tokens": [
+        "idx_agent_tokens_one_active_per_machine",
+        "idx_agent_tokens_pending_revoke_timeout",
+        "idx_agent_tokens_machine_pending",
     ],
 }
 


### PR DESCRIPTION
## 修复说明

关联 Issue：#2770

## 根因

迁移历史重写导致已升级的数据库缺少 `pending_revoke` 等关键列。修复迁移 `20260818_001_repair_pending_revoke_drift.py` 已存在，但缺少物理 schema 验证步骤。

## 修复方案

### 1. 更新 `verify_schema_integrity.py`

添加检查：
- `agent_tokens` 表的 `pending_revoke`、`revoke_after`、`rotation_id` 列
- `remote_machines` 表的 `agent_version`、`token_revoke_timeout` 列
- `agent_tokens` 表的关键索引

### 2. 修改 `install.sh`

在所有升级路径中添加 schema 验证：
- `do_fresh_install()` PostgreSQL 路径
- `do_upgrade()` PostgreSQL 路径
- `do_upgrade_remote()` PostgreSQL 路径

### 3. 使升级 "fail-closed"

- 迁移失败时中止安装
- schema 验证失败时中止安装
- 提供明确的错误消息和恢复建议

## 主要变更

- `scripts/verify_schema_integrity.py`: 添加 agent_tokens 和 remote_machines 列/索引检查
- `scripts/install-central/package-method/install.sh`: 添加 schema 验证步骤

## 测试

- 本地 Python 语法检查：通过
- 本地 Shell 语法检查：通过
- 单元测试 `test_alembic_sqlite_upgrade.py`：通过

## 风险

- **兼容性风险**：无。新增检查不影响已有逻辑
- **性能风险**：无。schema 验证执行时间很短
- **回归风险**：低。只有 schema 不一致时才会失败（预期行为）