### PR TITLE
fix: /api/data-status PostgreSQL 部署下正确返回数据库状态 (#2769)

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -366,13 +366,41 @@ def api_fetch_remote():
 def api_data_status():
     """Get data status information."""
     try:
-        # Check database exists
-        db_exists = os.path.exists(DB_PATH)
+        from app.repositories.database import Database, is_postgresql
+
+        db = Database()
+
+        # Check database exists - different logic for PostgreSQL vs SQLite
+        if is_postgresql():
+            # PostgreSQL: test connection availability
+            try:
+                with db.connection() as conn:
+                    cursor = conn.cursor()
+                    cursor.execute("SELECT 1")
+                db_exists = True
+            except Exception as e:
+                logger.warning(f"PostgreSQL connection test failed: {e}")
+                db_exists = False
+        else:
+            # SQLite: check file existence
+            db_exists = os.path.exists(DB_PATH)
 
         # Get last update time
         last_update = None
         if db_exists:
-            last_update = datetime.fromtimestamp(os.path.getmtime(DB_PATH)).isoformat()
+            if is_postgresql():
+                # PostgreSQL: query latest timestamp from daily_messages table
+                try:
+                    result = db.fetch_one(
+                        'SELECT MAX("timestamp") as latest FROM daily_messages'
+                    )
+                    if result and result.get("latest"):
+                        last_update = result["latest"].isoformat()
+                except Exception as e:
+                    logger.warning(f"Failed to query last_update: {e}")
+            else:
+                # SQLite: use file modification time
+                last_update = datetime.fromtimestamp(os.path.getmtime(DB_PATH)).isoformat()
 
         # Get data counts
         from app.repositories.message_repo import MessageRepository

--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -391,9 +391,7 @@ def api_data_status():
             if is_postgresql():
                 # PostgreSQL: query latest timestamp from daily_messages table
                 try:
-                    result = db.fetch_one(
-                        'SELECT MAX("timestamp") as latest FROM daily_messages'
-                    )
+                    result = db.fetch_one('SELECT MAX("timestamp") as latest FROM daily_messages')
                     if result and result.get("latest"):
                         last_update = result["latest"].isoformat()
                 except Exception as e:


### PR DESCRIPTION
Closes #2769

## 修复内容
- PostgreSQL 模式下使用实际连接测试判断数据库可用性
- PostgreSQL 的 last_update 从 daily_messages.timestamp 字段获取
- SQLite 模式保持原有文件存在性和修改时间检查

## 修复方案
详见 Issue #2769 评论中的 🔧 修复方案2

## 变更详情
**文件**: \`app/routes/fetch.py\`

### database_exists 判断逻辑
- **PostgreSQL**: 使用 \`Database.connection()\` 上下文管理器,执行 \`SELECT 1\` 测试连接
- **SQLite**: 保持原有 \`os.path.exists(DB_PATH)\` 检查

### last_update 查询逻辑
- **PostgreSQL**: 查询 \`SELECT MAX(\"timestamp\") FROM daily_messages\`
- **SQLite**: 保持原有文件修改时间逻辑

### 异常处理
- 使用 \`Database\` 类的上下文管理器,连接失败时 \`database_exists = False\`
- 空数据库场景:查询返回 \`NULL\` → 接口返回 \`null\`

## 测试场景
1. PostgreSQL 正常数据:验证 \`database_exists=true\`,\`last_update\` 非空
2. SQLite 部署:验证接口行为不变(回归测试)
3. 空数据库场景:验证 \`database_exists=true\`,\`last_update=null\`
4. 连接失败场景:验证 \`database_exists=false\`