### PR TITLE
Add nightly full E2E governance gate for #2491

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       critical_e2e: ${{ steps.select.outputs.critical_e2e }}
       default_collection: ${{ steps.select.outputs.default_collection }}
       dependency_audit: ${{ steps.select.outputs.dependency_audit }}
+      e2e_governance: ${{ steps.select.outputs.e2e_governance }}
       frontend: ${{ steps.select.outputs.frontend }}
       issue_collection: ${{ steps.select.outputs.issue_collection }}
       legacy_pr: ${{ steps.select.outputs.legacy_pr }}
@@ -140,6 +141,10 @@ jobs:
       - name: Validate legacy issue collection baseline
         if: matrix.suite == 'python-core' && needs.changes.outputs.issue_collection == 'true'
         run: python scripts/ci.py run issue-collection
+
+      - name: Validate E2E governance artifacts
+        if: matrix.suite == 'python-core' && needs.changes.outputs.e2e_governance == 'true'
+        run: python scripts/ci.py run e2e-governance
 
       - name: Run promoted legacy regressions
         if: matrix.suite == 'python-core' && needs.changes.outputs.legacy_pr == 'true'

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -185,8 +185,17 @@ jobs:
           pip install -r requirements-ci.lock
           playwright install chromium --with-deps
 
-      - name: Run full E2E tests
+      - name: Build nightly E2E selection
         run: |
+          mkdir -p test-results
+          python scripts/e2e/selector.py \
+            --event nightly \
+            --out test-results/full-e2e-selection.json
+
+      - name: Run full E2E tests
+        continue-on-error: true
+        run: |
+          set +e
           # Issue #2189: Validate collection before running
           python scripts/run_extended_tests.py \
             --category e2e \
@@ -197,7 +206,10 @@ jobs:
             --isolated-home \
             --reruns 1 \
             --timeout 240 \
-            --junitxml test-results/full-e2e.xml
+            --junitxml test-results/full-e2e.xml \
+            --e2e-attempts test-results/full-e2e-attempts.jsonl \
+            --envelope-json test-results/full-e2e-envelope.json
+          echo $? > test-results/full-e2e.exit-code
         env:
           CI: true
           HEADLESS: true
@@ -210,6 +222,50 @@ jobs:
           path: |
             test-results/
             screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  full-e2e-governance:
+    name: Full E2E Governance
+    if: >-
+      always() &&
+      needs.full-e2e.result != 'skipped'
+    needs: [full-e2e]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Download full E2E artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: full-e2e
+          path: artifacts
+      - name: Validate governance ledgers
+        run: |
+          python scripts/e2e/governance.py validate \
+            --json-output test-results/full-e2e-governance-report.json
+      - name: Compare nightly selection against observed outcomes
+        run: |
+          python scripts/e2e/comparator.py compare \
+            --selection artifacts/test-results/full-e2e-selection.json \
+            --envelope artifacts/test-results/full-e2e-envelope.json \
+            --json-output test-results/full-e2e-diff.json \
+            --markdown-output test-results/full-e2e-summary.md \
+            --governance-report test-results/full-e2e-governance-report.json
+      - name: Upload governance artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-e2e-governance
+          path: |
+            test-results/full-e2e-governance-report.json
+            test-results/full-e2e-diff.json
+            test-results/full-e2e-summary.md
+            artifacts/
           if-no-files-found: ignore
           retention-days: 14
 
@@ -424,13 +480,13 @@ jobs:
   nightly-summary:
     name: Nightly Quality Gate
     if: always() && github.event_name == 'schedule'
-    needs: [nightly-python, full-e2e, issue-tests, legacy-issue-baseline]
+    needs: [nightly-python, full-e2e-governance, issue-tests, legacy-issue-baseline]
     runs-on: ubuntu-24.04
     steps:
       - name: Publish nightly result
         env:
           PYTHON_RESULT: ${{ needs.nightly-python.result }}
-          E2E_RESULT: ${{ needs.full-e2e.result }}
+          E2E_RESULT: ${{ needs.full-e2e-governance.result }}
           LEGACY_RESULT: ${{ needs.legacy-issue-baseline.result }}
         run: |
           {

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -199,10 +199,12 @@ jobs:
           # Issue #2189: Validate collection before running
           python scripts/run_extended_tests.py \
             --category e2e \
-            --dry-run 2>&1 | grep -E "Collected|Total files" || true
+            --selection-json test-results/full-e2e-selection.json \
+            --dry-run 2>&1 | grep -E "Collected|Total targets" || true
 
           python scripts/run_extended_tests.py \
             --category e2e \
+            --selection-json test-results/full-e2e-selection.json \
             --isolated-home \
             --reruns 1 \
             --timeout 240 \

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -64,7 +64,7 @@
     },
     "compatibility-smoke": {
       "description": "Fast minimum/maximum Python compatibility coverage",
-      "timeout_seconds": 360,
+      "timeout_seconds": 420,
       "commands": [
         ["{python}", "-m", "compileall", "-q", "app", "scripts", "cli.py", "server.py"],
         ["{python}", "-m", "pytest", "tests/unit/", "-q", "--maxfail=1", "-m", "not performance"]

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -12,6 +12,7 @@
     "critical-e2e",
     "default-collection",
     "dependency-audit",
+    "e2e-governance",
     "frontend",
     "issue-collection",
     "legacy-pr",
@@ -39,6 +40,18 @@
           "working_directory": "frontend",
           "command": ["bash", "../scripts/ci/npm_audit_with_whitelist.sh"]
         }
+      ]
+    },
+    "e2e-governance": {
+      "description": "Validate E2E governance artifacts, ledgers, and lane closures",
+      "timeout_seconds": 180,
+      "commands": [
+        ["{python}", "scripts/e2e/inventory.py", "validate"],
+        ["{python}", "scripts/e2e/manifest.py", "validate"],
+        ["{python}", "scripts/e2e/governance.py", "validate"],
+        ["{python}", "scripts/e2e/selector.py", "--event", "pr"],
+        ["{python}", "scripts/e2e/selector.py", "--event", "nightly"],
+        ["{python}", "scripts/e2e/selector.py", "--event", "weekly"]
       ]
     },
     "python-core": {

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -57,7 +57,13 @@ E2E_PATTERNS = (
     "app/routes/**",
     "app/remote_ws_handler.py",
     "frontend/**",
+    "scripts/run_extended_tests.py",
     "tests/e2e/**",
+)
+E2E_GOVERNANCE_PATTERNS = (
+    "ci/e2e-*.json",
+    "scripts/e2e/**",
+    "scripts/run_extended_tests.py",
 )
 PACKAGE_PATTERNS = (
     "Dockerfile",
@@ -196,6 +202,8 @@ def select_pr_suites(changed_files: list[str]) -> list[str]:
         selected.add("postgres")
     if any(matches(path, E2E_PATTERNS) for path in clean):
         selected.add("critical-e2e")
+    if any(matches(path, E2E_GOVERNANCE_PATTERNS) for path in clean):
+        selected.add("e2e-governance")
     if any(matches(path, PACKAGE_PATTERNS) for path in clean):
         selected.add("package")
     if any(matches(path, DEPENDENCY_PATTERNS) for path in clean):

--- a/scripts/e2e/common.py
+++ b/scripts/e2e/common.py
@@ -23,6 +23,8 @@ STATE_SCHEMA_NAME = "openace-e2e-state"
 PROMOTION_SCHEMA_NAME = "openace-e2e-promotion"
 CONTRACT_SCHEMA_NAME = "openace-e2e-contract"
 MANIFEST_SCHEMA_NAME = "openace-e2e-expected-nodeids"
+RUN_ENVELOPE_SCHEMA_NAME = "openace-e2e-run-envelope"
+COMPARE_RESULT_SCHEMA_NAME = "openace-e2e-compare-result"
 
 MODES = ("pytest-automated", "standalone-automated", "manual-demo")
 EXECUTORS = ("pytest", "standalone")

--- a/scripts/e2e/comparator.py
+++ b/scripts/e2e/comparator.py
@@ -416,9 +416,9 @@ def compare_selection_run(
         diff["invalid"]["__closure__"] = "; ".join(selection["closure_errors"])
         diff["verdict_exit_code"] = 1
     if selection.get("invalid"):
-        diff["invalid"]["__selection__"] = (
-            f"{len(selection['invalid'])} invalid item(s) selected before execution"
-        )
+        diff["invalid"][
+            "__selection__"
+        ] = f"{len(selection['invalid'])} invalid item(s) selected before execution"
         diff["verdict_exit_code"] = 1
     return diff, budget_errors
 
@@ -427,7 +427,9 @@ def run_cli(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    compare = sub.add_parser("compare", help="compare one full-E2E envelope against the nightly selection")
+    compare = sub.add_parser(
+        "compare", help="compare one full-E2E envelope against the nightly selection"
+    )
     compare.add_argument("--selection", type=Path, required=True)
     compare.add_argument("--envelope", type=Path, required=True)
     compare.add_argument("--state", type=Path, default=DEFAULT_STATE)
@@ -455,7 +457,9 @@ def run_cli(argv: list[str] | None = None) -> int:
         "governance_report": governance_report,
     }
     args.json_output.parent.mkdir(parents=True, exist_ok=True)
-    args.json_output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    args.json_output.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     args.markdown_output.write_text(
         _render_markdown(selection, envelope, diff, budget_errors, governance_report) + "\n",
         encoding="utf-8",

--- a/scripts/e2e/comparator.py
+++ b/scripts/e2e/comparator.py
@@ -404,6 +404,17 @@ def compare_selection_run(
         for nodeid in duplicates:
             diff["invalid"][nodeid] = f"duplicate observed results ({seen_counts[nodeid]})"
         diff["verdict_exit_code"] = 1
+    if not expected_ids:
+        diff["invalid"]["__coverage__"] = "nightly selection is empty (no governed coverage)"
+        diff["verdict_exit_code"] = 1
+    if envelope.get("error"):
+        diff["invalid"]["__execution__"] = f"runner error: {envelope['error']}"
+        diff["verdict_exit_code"] = 1
+    if int(envelope.get("return_code") or 0) != 0 and not raw_outcomes:
+        diff["invalid"][
+            "__execution__"
+        ] = f"runner exited {envelope.get('return_code')} without observed outcomes"
+        diff["verdict_exit_code"] = 1
     per_item = {
         item["nodeid"]: float(item.get("duration_seconds") or 0)
         for item in raw_outcomes

--- a/scripts/e2e/comparator.py
+++ b/scripts/e2e/comparator.py
@@ -385,7 +385,8 @@ def compare_selection_run(
         from governance import check_budgets  # type: ignore[no-redef]
 
     expected_ids = sorted((selection.get("normal") or []) + (selection.get("advisory") or []))
-    observed = {entry["nodeid"]: entry for entry in envelope.get("outcomes") or [] if entry.get("nodeid")}
+    raw_outcomes = [entry for entry in envelope.get("outcomes") or [] if entry.get("nodeid")]
+    observed = {entry["nodeid"]: entry for entry in raw_outcomes}
     diff = compare_run(
         expected_ids,
         observed,
@@ -393,9 +394,18 @@ def compare_selection_run(
         job_conclusion=envelope.get("job_conclusion"),
         envelope_present=True,
     )
+    seen_counts: dict[str, int] = {}
+    for entry in raw_outcomes:
+        nodeid = str(entry["nodeid"])
+        seen_counts[nodeid] = seen_counts.get(nodeid, 0) + 1
+    duplicates = sorted(nodeid for nodeid, count in seen_counts.items() if count > 1)
+    if duplicates:
+        for nodeid in duplicates:
+            diff["invalid"][nodeid] = f"duplicate observed results ({seen_counts[nodeid]})"
+        diff["verdict_exit_code"] = 1
     per_item = {
         item["nodeid"]: float(item.get("duration_seconds") or 0)
-        for item in envelope.get("outcomes") or []
+        for item in raw_outcomes
         if item.get("nodeid")
     }
     budget_errors = check_budgets("nightly", float(envelope.get("duration_minutes") or 0), per_item)

--- a/scripts/e2e/comparator.py
+++ b/scripts/e2e/comparator.py
@@ -17,17 +17,32 @@ Two responsibilities:
 
 from __future__ import annotations
 
+import argparse
+import json
+import sys
+from pathlib import Path
 from typing import Any
 
 try:  # package-style import (tests) vs direct-script import (CLI)
-    from .common import OUTCOME_CATEGORIES, GovernanceError, failure_fingerprint, normalize_message
-except ImportError:  # pragma: no cover - exercised via CLI
-    from common import (  # type: ignore[no-redef]
-        OUTCOME_CATEGORIES,
+    from .common import (
+        COMPARE_RESULT_SCHEMA_NAME,
+        RUN_ENVELOPE_SCHEMA_NAME,
         GovernanceError,
         failure_fingerprint,
+        load_artifact,
         normalize_message,
     )
+    from .state import DEFAULT_STATE, load_state
+except ImportError:  # pragma: no cover - exercised via CLI
+    from common import (  # type: ignore[no-redef]
+        COMPARE_RESULT_SCHEMA_NAME,
+        RUN_ENVELOPE_SCHEMA_NAME,
+        GovernanceError,
+        failure_fingerprint,
+        load_artifact,
+        normalize_message,
+    )
+    from state import DEFAULT_STATE, load_state  # type: ignore[no-redef]
 
 INFRA = "infrastructure_error"
 LANE_KILLED_CONCLUSIONS = ("cancelled", "timed_out")
@@ -284,3 +299,162 @@ def compare_run(
     )
     diff["verdict_exit_code"] = 1 if blocking else 0
     return diff
+
+
+def load_run_envelope(path: Path) -> dict[str, Any]:
+    return load_artifact(path, RUN_ENVELOPE_SCHEMA_NAME)
+
+
+def _render_markdown(
+    selection: dict[str, Any],
+    envelope: dict[str, Any],
+    diff: dict[str, Any],
+    budget_errors: list[str],
+    governance_report: dict[str, Any],
+) -> str:
+    outcomes = sorted(
+        envelope.get("outcomes") or [],
+        key=lambda item: float(item.get("duration_seconds") or 0),
+        reverse=True,
+    )
+    slowest = outcomes[:10]
+    server = envelope.get("server") or {}
+    lines = [
+        "## Full E2E Governance",
+        "",
+        f"- exit code: **{diff['verdict_exit_code']}**",
+        f"- event: `{selection.get('event', 'nightly')}`",
+        f"- selected: normal `{len(selection.get('normal') or [])}` / advisory `{len(selection.get('advisory') or [])}` / invalid `{len(selection.get('invalid') or {})}`",
+        f"- observed outcomes: `{len(envelope.get('outcomes') or [])}`",
+        f"- known-only clean run: `{diff['known_only']}`",
+        "",
+        "### Status",
+        "",
+        f"- new failures: `{len(diff['new_failures'])}`",
+        f"- changed failures: `{len(diff['changed'])}`",
+        f"- missing results: `{len(diff['missing'])}`",
+        f"- unexpected results: `{len(diff['unexpected'])}`",
+        f"- unexpected skips: `{len(diff['unexpected_skips'])}`",
+        f"- invalid results: `{len(diff['invalid'])}`",
+        f"- resolved awaiting shrink: `{len(diff['resolved_pending_shrink'])}`",
+        "",
+        "### Budget",
+        "",
+        *([f"- {line}" for line in budget_errors] or ["- nightly budget checks passed"]),
+        "",
+        "### Service Evidence",
+        "",
+        f"- readiness achieved: `{server.get('readiness_achieved')}`",
+        f"- server abnormal exit: `{(server.get('exit') or {}).get('abnormal')}`",
+        f"- server exit code: `{(server.get('exit') or {}).get('code')}`",
+        f"- server log: `{server.get('log_path')}`",
+        "",
+        "### Slowest Items",
+        "",
+    ]
+    if slowest:
+        for item in slowest:
+            lines.append(
+                f"- `{item['nodeid']}` — {item.get('duration_seconds', 0)}s / "
+                f"attempts `{item.get('attempts', 0)}` / final `{item.get('final_outcome')}`"
+            )
+    else:
+        lines.append("- no observed items")
+    lines += ["", "### Governance Report", ""]
+    counts = (governance_report.get("counts") or {}) if governance_report else {}
+    for key, value in counts.items():
+        lines.append(f"- {key}: `{value}`")
+    lines.append("")
+    if diff["invalid"]:
+        lines.append("### Invalid Details")
+        lines.append("")
+        for item_id, reason in sorted(diff["invalid"].items()):
+            lines.append(f"- `{item_id}` — {reason}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def compare_selection_run(
+    selection: dict[str, Any],
+    envelope: dict[str, Any],
+    state_entries: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[str]]:
+    try:
+        from .governance import check_budgets
+    except ImportError:  # pragma: no cover - exercised via CLI
+        from governance import check_budgets  # type: ignore[no-redef]
+
+    expected_ids = sorted((selection.get("normal") or []) + (selection.get("advisory") or []))
+    observed = {entry["nodeid"]: entry for entry in envelope.get("outcomes") or [] if entry.get("nodeid")}
+    diff = compare_run(
+        expected_ids,
+        observed,
+        state_entries,
+        job_conclusion=envelope.get("job_conclusion"),
+        envelope_present=True,
+    )
+    per_item = {
+        item["nodeid"]: float(item.get("duration_seconds") or 0)
+        for item in envelope.get("outcomes") or []
+        if item.get("nodeid")
+    }
+    budget_errors = check_budgets("nightly", float(envelope.get("duration_minutes") or 0), per_item)
+    if budget_errors:
+        diff["invalid"]["__budget__"] = "; ".join(budget_errors)
+        diff["verdict_exit_code"] = 1
+    if selection.get("closure_errors"):
+        diff["invalid"]["__closure__"] = "; ".join(selection["closure_errors"])
+        diff["verdict_exit_code"] = 1
+    if selection.get("invalid"):
+        diff["invalid"]["__selection__"] = (
+            f"{len(selection['invalid'])} invalid item(s) selected before execution"
+        )
+        diff["verdict_exit_code"] = 1
+    return diff, budget_errors
+
+
+def run_cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    compare = sub.add_parser("compare", help="compare one full-E2E envelope against the nightly selection")
+    compare.add_argument("--selection", type=Path, required=True)
+    compare.add_argument("--envelope", type=Path, required=True)
+    compare.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    compare.add_argument("--json-output", type=Path, required=True)
+    compare.add_argument("--markdown-output", type=Path, required=True)
+    compare.add_argument("--governance-report", type=Path, default=None)
+
+    args = parser.parse_args(argv)
+    if args.cmd != "compare":
+        return 1
+
+    selection = json.loads(args.selection.read_text(encoding="utf-8"))
+    envelope = load_run_envelope(args.envelope)
+    state = load_state(args.state)
+    governance_report: dict[str, Any] = {}
+    if args.governance_report and args.governance_report.exists():
+        governance_report = json.loads(args.governance_report.read_text(encoding="utf-8"))
+    diff, budget_errors = compare_selection_run(selection, envelope, state.get("entries") or {})
+    payload = {
+        "schema_name": COMPARE_RESULT_SCHEMA_NAME,
+        "schema_version": 1,
+        "selection_counts": selection.get("counts", {}),
+        "diff": diff,
+        "budget_errors": budget_errors,
+        "governance_report": governance_report,
+    }
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    args.markdown_output.write_text(
+        _render_markdown(selection, envelope, diff, budget_errors, governance_report) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"verdict_exit_code": diff["verdict_exit_code"]}, indent=2))
+    for item_id, reason in sorted(diff["invalid"].items()):
+        print(f"INVALID: {item_id}: {reason}", file=sys.stderr)
+    return int(diff["verdict_exit_code"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(run_cli())

--- a/scripts/e2e/comparator.py
+++ b/scripts/e2e/comparator.py
@@ -400,6 +400,7 @@ def compare_selection_run(
         seen_counts[nodeid] = seen_counts.get(nodeid, 0) + 1
     duplicates = sorted(nodeid for nodeid, count in seen_counts.items() if count > 1)
     if duplicates:
+        diff["duplicates"] = duplicates
         for nodeid in duplicates:
             diff["invalid"][nodeid] = f"duplicate observed results ({seen_counts[nodeid]})"
         diff["verdict_exit_code"] = 1

--- a/scripts/e2e/governance.py
+++ b/scripts/e2e/governance.py
@@ -524,6 +524,7 @@ def main(argv: list[str] | None = None) -> int:
     val.add_argument("--state", type=Path, default=DEFAULT_STATE)
     val.add_argument("--promotion", type=Path, default=DEFAULT_PROMOTION)
     val.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    val.add_argument("--json-output", type=Path, default=None)
     val.set_defaults(func=lambda a: _run_validate(a))
 
     sd = sub.add_parser("set-disposition", help="set a file's inventory disposition")
@@ -590,6 +591,9 @@ def _run_validate(args: argparse.Namespace) -> int:
         promotion_path=args.promotion,
         manifest_path=args.manifest,
     )
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(report, indent=2))
     for line in errors:
         print(f"ERROR: {line}", file=sys.stderr)

--- a/scripts/e2e/governance.py
+++ b/scripts/e2e/governance.py
@@ -438,7 +438,10 @@ def cmd_classify(args: argparse.Namespace) -> int:
     Refuses (infra count must be 0) when any run carries an
     infrastructure_error classification - infra is never legalized as debt.
     """
-    from .comparator import classify_three_way
+    try:
+        from .comparator import classify_three_way
+    except ImportError:  # pragma: no cover - exercised via CLI
+        from comparator import classify_three_way  # type: ignore[no-redef]
 
     runs = [json.loads(Path(p).read_text(encoding="utf-8")) for p in args.runs]
     errors = validate_reference_runs(runs)

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -159,24 +159,30 @@ def inventory_entries_by_path() -> dict[str, dict[str, object]]:
     }
 
 
-def target_requires_server(target: str, inventory_by_path: dict[str, dict[str, object]]) -> bool:
+def target_requires_server(
+    target: str, inventory_by_path: dict[str, dict[str, object]]
+) -> bool | None:
     if target.startswith("standalone::"):
         path = _standalone_script_path(target)
     else:
         path = target_path(target)
     entry = inventory_by_path.get(path)
     if not entry:
-        return False
+        return None
     return "server" in (entry.get("capabilities") or [])
 
 
 def execution_needs_server(args: argparse.Namespace, targets: list[str]) -> bool:
+    default_needs_server = category_needs_server(args.category)
     if not args.selection_json:
-        return category_needs_server(args.category)
+        return default_needs_server
     inventory_by_path = inventory_entries_by_path()
     if not inventory_by_path:
-        return category_needs_server(args.category)
-    return any(target_requires_server(target, inventory_by_path) for target in targets)
+        return default_needs_server
+    resolved = [target_requires_server(target, inventory_by_path) for target in targets]
+    if any(value is None for value in resolved):
+        return default_needs_server
+    return any(bool(value) for value in resolved)
 
 
 def parse_issue_numbers(args: argparse.Namespace) -> list[str]:

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -698,11 +698,19 @@ def _load_attempt_records(path: str) -> list[dict[str, object]]:
     if not attempts_path.exists():
         return []
     records: list[dict[str, object]] = []
-    for line in attempts_path.read_text(encoding="utf-8").splitlines():
+    for line_number, line in enumerate(
+        attempts_path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1
+    ):
         line = line.strip()
         if not line:
             continue
-        records.append(json.loads(line))
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            print(
+                f"WARNING: skipping malformed attempt record {attempts_path}:{line_number}: {exc}",
+                file=sys.stderr,
+            )
     return records
 
 
@@ -730,23 +738,48 @@ def _summarize_attempt_records(
     for nodeid in sorted(by_node):
         node_records = by_node[nodeid]
         attempts = sorted({int(record.get("attempt", 1)) for record in node_records})
-        final = node_records[-1]
-        call_records = [record for record in node_records if record.get("phase") == "call"]
-        decision = call_records[-1] if call_records else final
+        final_attempt = attempts[-1]
+        final_attempt_records = [
+            record for record in node_records if int(record.get("attempt", 1)) == final_attempt
+        ]
+        final = final_attempt_records[-1]
+        call_records = [record for record in final_attempt_records if record.get("phase") == "call"]
+        failed_attempt_records = [
+            record
+            for record in final_attempt_records
+            if record.get("outcome") not in ("passed", "rerun")
+        ]
+        decision = (
+            call_records[-1]
+            if call_records
+            else failed_attempt_records[-1] if failed_attempt_records else final
+        )
         first_attempt_records = [
             record for record in node_records if int(record.get("attempt", 1)) == attempts[0]
         ]
         first_passed = all(record.get("outcome") == "passed" for record in first_attempt_records)
         final_outcome = _canonical_outcome(str(decision.get("outcome", "failed")))
-        total_duration = round(
-            sum(float(record.get("duration_seconds") or 0.0) for record in node_records), 3
-        )
+        per_attempt_durations = {
+            attempt: round(
+                sum(
+                    float(record.get("duration_seconds") or 0.0)
+                    for record in node_records
+                    if int(record.get("attempt", 1)) == attempt
+                ),
+                3,
+            )
+            for attempt in attempts
+        }
+        max_attempt_duration = max(per_attempt_durations.values(), default=0.0)
+        total_duration = round(sum(per_attempt_durations.values()), 3)
         summary: dict[str, object] = {
             "nodeid": nodeid,
             "attempts": len(attempts),
             "first_attempt_outcome": "pass" if first_passed else "fail",
             "final_outcome": final_outcome,
-            "duration_seconds": total_duration,
+            "duration_seconds": max_attempt_duration,
+            "total_duration_seconds": total_duration,
+            "attempt_durations_seconds": per_attempt_durations,
         }
         if final_outcome == "fail":
             failed_records = [
@@ -938,6 +971,7 @@ def main(argv: list[str] | None = None) -> int:
         print("Pytest command:")
         print(" ".join(cmd))
         if args.dry_run:
+            return_code = 0
             return 0
         server_handle = start_server_if_needed(args, env, needs_server)
         return_code = 0
@@ -958,20 +992,23 @@ def main(argv: list[str] | None = None) -> int:
         raise
     finally:
         completed_at = _utc_now()
-        _write_run_envelope(
-            args.envelope_json,
-            args=args,
-            env=env,
-            cmd=cmd,
-            selected_targets=selected_targets,
-            needs_server=needs_server,
-            server_handle=server_handle,
-            return_code=return_code,
-            started_at=started_at,
-            completed_at=completed_at,
-            standalone_outcomes=standalone_outcomes,
-            error_message=error_message,
-        )
+        try:
+            _write_run_envelope(
+                args.envelope_json,
+                args=args,
+                env=env,
+                cmd=cmd,
+                selected_targets=selected_targets,
+                needs_server=needs_server,
+                server_handle=server_handle,
+                return_code=return_code,
+                started_at=started_at,
+                completed_at=completed_at,
+                standalone_outcomes=standalone_outcomes,
+                error_message=error_message,
+            )
+        except Exception as exc:
+            print(f"WARNING: failed to write run envelope: {exc}", file=sys.stderr)
         stop_server(server_handle)
         if test_home is not None:
             test_home.cleanup()

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -146,6 +146,39 @@ def category_needs_server(category: str) -> bool:
     return category in SERVER_CATEGORIES
 
 
+def inventory_entries_by_path() -> dict[str, dict[str, object]]:
+    inventory_path = PROJECT_ROOT / "ci" / "e2e-inventory.json"
+    if not inventory_path.exists():
+        return {}
+    payload = json.loads(inventory_path.read_text(encoding="utf-8"))
+    entries = payload.get("entries") or []
+    return {
+        str(entry.get("path")): entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("path")
+    }
+
+
+def target_requires_server(target: str, inventory_by_path: dict[str, dict[str, object]]) -> bool:
+    if target.startswith("standalone::"):
+        path = _standalone_script_path(target)
+    else:
+        path = target_path(target)
+    entry = inventory_by_path.get(path)
+    if not entry:
+        return False
+    return "server" in (entry.get("capabilities") or [])
+
+
+def execution_needs_server(args: argparse.Namespace, targets: list[str]) -> bool:
+    if not args.selection_json:
+        return category_needs_server(args.category)
+    inventory_by_path = inventory_entries_by_path()
+    if not inventory_by_path:
+        return category_needs_server(args.category)
+    return any(target_requires_server(target, inventory_by_path) for target in targets)
+
+
 def parse_issue_numbers(args: argparse.Namespace) -> list[str]:
     numbers: list[str] = []
     numbers.extend(args.issues)
@@ -423,8 +456,8 @@ def frontend_dist_index() -> Path:
     return PROJECT_ROOT / "static" / "js" / "dist" / "index.html"
 
 
-def ensure_frontend_built(category: str) -> None:
-    if not category_needs_server(category):
+def ensure_frontend_built(needs_server: bool) -> None:
+    if not needs_server:
         return
     if frontend_dist_index().exists():
         return
@@ -549,10 +582,12 @@ def configure_server_address(env: dict[str, str], base_url: str) -> None:
     config_path.write_text(json.dumps(config, indent=2) + "\n")
 
 
-def start_server_if_needed(args: argparse.Namespace, env: dict[str, str]) -> ServerHandle | None:
-    if not category_needs_server(args.category) or args.server == "skip":
+def start_server_if_needed(
+    args: argparse.Namespace, env: dict[str, str], needs_server: bool
+) -> ServerHandle | None:
+    if not needs_server or args.server == "skip":
         return None
-    ensure_frontend_built(args.category)
+    ensure_frontend_built(needs_server)
     if is_healthy(args.base_url):
         print(f"Reusing healthy Open ACE server at {args.base_url}")
         return None
@@ -801,6 +836,7 @@ def _write_run_envelope(
     env: dict[str, str],
     cmd: list[str],
     selected_targets: list[str],
+    needs_server: bool,
     server_handle: ServerHandle | None,
     return_code: int,
     started_at: str,
@@ -819,7 +855,7 @@ def _write_run_envelope(
     server_ready = None
     server_log = None
     exit_info = {"code": None, "abnormal": False}
-    if category_needs_server(args.category):
+    if needs_server:
         server_ready = server_handle is not None or is_healthy(args.base_url)
     if server_handle is not None:
         server_log = str(server_handle.log_path)
@@ -887,15 +923,17 @@ def main(argv: list[str] | None = None) -> int:
     return_code = 1
     error_message: str | None = None
     started_at = _utc_now()
+    needs_server = category_needs_server(args.category)
 
     try:
         selected_targets = resolved_targets(args)
+        needs_server = execution_needs_server(args, selected_targets)
         cmd = build_pytest_command(args)
         print("Pytest command:")
         print(" ".join(cmd))
         if args.dry_run:
             return 0
-        server_handle = start_server_if_needed(args, env)
+        server_handle = start_server_if_needed(args, env, needs_server)
         return_code = 0
         if cmd:
             return_code = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
@@ -920,6 +958,7 @@ def main(argv: list[str] | None = None) -> int:
             env=env,
             cmd=cmd,
             selected_targets=selected_targets,
+            needs_server=needs_server,
             server_handle=server_handle,
             return_code=return_code,
             started_at=started_at,

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -23,6 +23,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 from urllib.parse import urlsplit, urlunsplit
@@ -67,6 +68,7 @@ class ServerHandle:
     process: subprocess.Popen
     log_file: TextIO
     log_path: Path
+    stopped_by_runner: bool = False
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -102,6 +104,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=0, help="Per-test timeout in seconds.")
     parser.add_argument("--maxfail", type=int, default=0, help="Stop after this many failures.")
     parser.add_argument("--junitxml", default="", help="Write a pytest JUnit XML report.")
+    parser.add_argument(
+        "--e2e-attempts",
+        default="",
+        help="Append authoritative per-attempt JSONL records to this path.",
+    )
+    parser.add_argument(
+        "--envelope-json",
+        default="",
+        help="Write a machine-readable run envelope to this path.",
+    )
     parser.add_argument("--extra-pytest-arg", action="append", default=[], help="Extra pytest arg.")
     parser.add_argument(
         "--server",
@@ -183,6 +195,11 @@ def discover_test_files(targets: list[str]) -> list[str]:
         files.extend(path.rglob("e2e_*.py"))
     unique = sorted({file.relative_to(PROJECT_ROOT).as_posix() for file in files})
     return unique
+
+
+def resolved_targets(args: argparse.Namespace) -> list[str]:
+    targets = select_targets(args)
+    return apply_split(targets, args.split_total, args.split_group)
 
 
 def apply_split(targets: list[str], split_total: int, split_group: int) -> list[str]:
@@ -322,8 +339,7 @@ def _quarantine_nodeids(path=None) -> list[str]:
 
 
 def build_pytest_command(args: argparse.Namespace) -> list[str]:
-    targets = select_targets(args)
-    targets = apply_split(targets, args.split_total, args.split_group)
+    targets = resolved_targets(args)
 
     # Issue #2189: Print the file manifest. Item collection is separately gated
     # by pytest itself; a targeted issue run must not be compared with the full
@@ -358,6 +374,8 @@ def build_pytest_command(args: argparse.Namespace) -> list[str]:
         cmd.append(f"--maxfail={args.maxfail}")
     if args.junitxml:
         cmd.append(f"--junitxml={args.junitxml}")
+    if args.e2e_attempts:
+        cmd.extend(["-p", "scripts.e2e.pytest_attempts", f"--e2e-attempts={args.e2e_attempts}"])
     cmd.extend(args.extra_pytest_arg)
     return cmd
 
@@ -555,6 +573,7 @@ def stop_server(handle: ServerHandle | None) -> None:
         return
     proc = handle.process
     if proc.poll() is None:
+        handle.stopped_by_runner = True
         proc.send_signal(signal.SIGTERM)
         try:
             proc.wait(timeout=15)
@@ -562,6 +581,188 @@ def stop_server(handle: ServerHandle | None) -> None:
             proc.kill()
             proc.wait(timeout=5)
     handle.log_file.close()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _current_head_sha() -> str | None:
+    for value in (os.environ.get("GITHUB_SHA"), os.environ.get("COMMIT_SHA")):
+        if value:
+            return value
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return proc.stdout.strip() or None
+    return None
+
+
+def _current_contract_key() -> str | None:
+    try:
+        from scripts.e2e.common import CONTRACT_SCHEMA_NAME, contract_key_identity, load_artifact
+
+        contract = load_artifact(PROJECT_ROOT / "ci" / "e2e-contract.json", CONTRACT_SCHEMA_NAME)
+        return contract_key_identity(contract)
+    except Exception:
+        return None
+
+
+def _load_attempt_records(path: str) -> list[dict[str, object]]:
+    attempts_path = Path(path)
+    if not attempts_path.exists():
+        return []
+    records: list[dict[str, object]] = []
+    for line in attempts_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        records.append(json.loads(line))
+    return records
+
+
+def _canonical_outcome(report_outcome: str) -> str:
+    if report_outcome == "passed":
+        return "pass"
+    if report_outcome == "skipped":
+        return "skip"
+    return "fail"
+
+
+def _summarize_attempt_records(
+    records: list[dict[str, object]], server_evidence: dict[str, object]
+) -> list[dict[str, object]]:
+    from scripts.e2e.comparator import classify_failure, fingerprint_failure
+
+    by_node: dict[str, list[dict[str, object]]] = {}
+    for record in records:
+        nodeid = str(record.get("nodeid", "")).strip()
+        if not nodeid:
+            continue
+        by_node.setdefault(nodeid, []).append(record)
+
+    outcomes: list[dict[str, object]] = []
+    for nodeid in sorted(by_node):
+        node_records = by_node[nodeid]
+        attempts = sorted({int(record.get("attempt", 1)) for record in node_records})
+        final = node_records[-1]
+        call_records = [record for record in node_records if record.get("phase") == "call"]
+        decision = call_records[-1] if call_records else final
+        first_attempt_records = [
+            record for record in node_records if int(record.get("attempt", 1)) == attempts[0]
+        ]
+        first_passed = all(record.get("outcome") == "passed" for record in first_attempt_records)
+        final_outcome = _canonical_outcome(str(decision.get("outcome", "failed")))
+        total_duration = round(
+            sum(float(record.get("duration_seconds") or 0.0) for record in node_records), 3
+        )
+        summary: dict[str, object] = {
+            "nodeid": nodeid,
+            "attempts": len(attempts),
+            "first_attempt_outcome": "pass" if first_passed else "fail",
+            "final_outcome": final_outcome,
+            "duration_seconds": total_duration,
+        }
+        if final_outcome == "fail":
+            failed_records = [
+                record
+                for record in node_records
+                if record.get("outcome") not in ("passed", "rerun")
+            ]
+            failed = failed_records[-1] if failed_records else decision
+            failure = {
+                "phase": failed.get("phase", "call"),
+                "exception_class": failed.get("exception_class"),
+                "message": failed.get("message"),
+                "timeout": "timeout"
+                in f"{failed.get('exception_class', '')} {failed.get('message', '')}".lower(),
+            }
+            summary["category"] = classify_failure(failure, server_evidence)
+            summary["fingerprint"] = fingerprint_failure(failure)
+            summary["exception_class"] = failed.get("exception_class")
+            summary["message"] = failed.get("message")
+        outcomes.append(summary)
+    return outcomes
+
+
+def _write_run_envelope(
+    path: str,
+    *,
+    args: argparse.Namespace,
+    env: dict[str, str],
+    cmd: list[str],
+    selected_targets: list[str],
+    server_handle: ServerHandle | None,
+    return_code: int,
+    started_at: str,
+    completed_at: str,
+    error_message: str | None = None,
+) -> None:
+    if not path:
+        return
+
+    envelope_path = Path(path)
+    envelope_path.parent.mkdir(parents=True, exist_ok=True)
+    started_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    completed_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+    duration_seconds = max(0.0, (completed_dt - started_dt).total_seconds())
+    server_ready = None
+    server_log = None
+    exit_info = {"code": None, "abnormal": False}
+    if category_needs_server(args.category):
+        server_ready = server_handle is not None or is_healthy(args.base_url)
+    if server_handle is not None:
+        server_log = str(server_handle.log_path)
+        exit_code = server_handle.process.poll()
+        exit_info["code"] = exit_code
+        exit_info["abnormal"] = (
+            exit_code is not None
+            and not server_handle.stopped_by_runner
+            and exit_code != 0
+        )
+    attempts_records = _load_attempt_records(args.e2e_attempts) if args.e2e_attempts else []
+    server_evidence = {
+        "readiness_achieved": server_ready,
+        "exit": exit_info,
+        "environment_missing": False,
+        "liveness_failures": [],
+        "base_url": args.base_url,
+        "log_path": server_log,
+    }
+    outcomes = _summarize_attempt_records(attempts_records, server_evidence)
+    payload = {
+        "schema_name": "openace-e2e-run-envelope",
+        "schema_version": 1,
+        "category": args.category,
+        "base_url": args.base_url,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "duration_seconds": round(duration_seconds, 3),
+        "duration_minutes": round(duration_seconds / 60.0, 3),
+        "commit_sha": _current_head_sha(),
+        "contract_key": _current_contract_key(),
+        "job_conclusion": "success" if return_code == 0 else "failure",
+        "return_code": return_code,
+        "error": error_message,
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "playwright_browsers_path": env.get("PLAYWRIGHT_BROWSERS_PATH"),
+        "isolated_home": env.get("HOME"),
+        "selected_targets": selected_targets,
+        "pytest_command": cmd,
+        "artifacts": {
+            "junitxml": args.junitxml or None,
+            "attempts_jsonl": args.e2e_attempts or None,
+            "server_log": server_log,
+        },
+        "server": server_evidence,
+        "outcomes": outcomes,
+    }
+    envelope_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -572,16 +773,39 @@ def main(argv: list[str] | None = None) -> int:
         args.base_url = isolated_base_url(args.base_url)
     env["BASE_URL"] = args.base_url
     server_handle: ServerHandle | None = None
+    selected_targets: list[str] = []
+    cmd: list[str] = []
+    return_code = 1
+    error_message: str | None = None
+    started_at = _utc_now()
 
     try:
+        selected_targets = resolved_targets(args)
         cmd = build_pytest_command(args)
         print("Pytest command:")
         print(" ".join(cmd))
         if args.dry_run:
             return 0
         server_handle = start_server_if_needed(args, env)
-        return subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+        return_code = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+        return return_code
+    except Exception as exc:
+        error_message = str(exc)
+        raise
     finally:
+        completed_at = _utc_now()
+        _write_run_envelope(
+            args.envelope_json,
+            args=args,
+            env=env,
+            cmd=cmd,
+            selected_targets=selected_targets,
+            server_handle=server_handle,
+            return_code=return_code,
+            started_at=started_at,
+            completed_at=completed_at,
+            error_message=error_message,
+        )
         stop_server(server_handle)
         if test_home is not None:
             test_home.cleanup()

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -29,6 +29,8 @@ from typing import TextIO
 from urllib.parse import urlsplit, urlunsplit
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 DEFAULT_BASE_URL = "http://localhost:19888"
 SERVER_CATEGORIES = {
     "all",
@@ -104,6 +106,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=0, help="Per-test timeout in seconds.")
     parser.add_argument("--maxfail", type=int, default=0, help="Stop after this many failures.")
     parser.add_argument("--junitxml", default="", help="Write a pytest JUnit XML report.")
+    parser.add_argument(
+        "--selection-json",
+        default="",
+        help="Run the exact ids from a selector selection.json instead of a category tree.",
+    )
     parser.add_argument(
         "--e2e-attempts",
         default="",
@@ -184,9 +191,20 @@ def select_targets(args: argparse.Namespace) -> list[str]:
     return existing
 
 
+def load_selection_targets(path: str) -> list[str]:
+    selection_path = Path(path)
+    payload = json.loads(selection_path.read_text(encoding="utf-8"))
+    targets = list(payload.get("normal") or []) + list(payload.get("advisory") or [])
+    if not targets:
+        raise ValueError(f"No executable targets found in selection: {selection_path}")
+    return [str(target) for target in targets]
+
+
 def discover_test_files(targets: list[str]) -> list[str]:
     files: list[Path] = []
     for target in targets:
+        if target.startswith("standalone::"):
+            continue
         path = PROJECT_ROOT / target_path(target)
         if path.is_file():
             files.append(path)
@@ -198,8 +216,25 @@ def discover_test_files(targets: list[str]) -> list[str]:
 
 
 def resolved_targets(args: argparse.Namespace) -> list[str]:
+    if args.selection_json:
+        selected = load_selection_targets(args.selection_json)
+        standalone = [item for item in selected if item.startswith("standalone::")]
+        pytest_targets = [item for item in selected if not item.startswith("standalone::")]
+        if standalone and args.split_total > 1:
+            raise ValueError("--selection-json with standalone targets cannot be sharded")
+        if args.split_total == 1:
+            return pytest_targets + standalone
+        return apply_split(pytest_targets, args.split_total, args.split_group)
     targets = select_targets(args)
     return apply_split(targets, args.split_total, args.split_group)
+
+
+def standalone_targets(targets: list[str]) -> list[str]:
+    return [target for target in targets if target.startswith("standalone::")]
+
+
+def pytest_targets(targets: list[str]) -> list[str]:
+    return [target for target in targets if not target.startswith("standalone::")]
 
 
 def apply_split(targets: list[str], split_total: int, split_group: int) -> list[str]:
@@ -286,11 +321,11 @@ def check_baseline(category: str, file_count: int, split_total: int = 1) -> bool
 
 
 def print_collection_manifest(files: list[str]) -> None:
-    """Print collection manifest with file list and count (Issue #2189)."""
+    """Print the exact execution manifest (files, nodeids, or standalone ids)."""
     print("\n=== Test Collection Manifest ===")
-    print(f"Total files: {len(files)}")
+    print(f"Total targets: {len(files)}")
     if files:
-        print("\nCollected files:")
+        print("\nCollected targets:")
         for file in files:
             print(f"  - {file}")
     print("=" * 40 + "\n")
@@ -340,18 +375,22 @@ def _quarantine_nodeids(path=None) -> list[str]:
 
 def build_pytest_command(args: argparse.Namespace) -> list[str]:
     targets = resolved_targets(args)
+    pytest_only = pytest_targets(targets)
 
     # Issue #2189: Print the file manifest. Item collection is separately gated
     # by pytest itself; a targeted issue run must not be compared with the full
     # legacy-suite baseline.
     print_collection_manifest(targets)
+    if not pytest_only:
+        return []
     targeted_issue_run = args.category == "issues" and bool(parse_issue_numbers(args))
+    file_count = len(discover_test_files(pytest_only)) if args.selection_json else len(pytest_only)
     if not targeted_issue_run and not check_baseline(
-        args.category, len(targets), split_total=args.split_total
+        args.category, file_count, split_total=args.split_total
     ):
         raise ValueError(f"Test file count below baseline threshold for category: {args.category}")
 
-    cmd = [sys.executable, "-m", "pytest", *targets, "-m", "not postgres"]
+    cmd = [sys.executable, "-m", "pytest", *pytest_only, "-m", "not postgres"]
     # Continue past per-file collection errors so every collectable nodeid gets a
     # terminal result; otherwise one bad file aborts the shard and leaves the
     # rest result-less, which the #2457 failure-baseline completeness gate would
@@ -690,6 +729,71 @@ def _summarize_attempt_records(
     return outcomes
 
 
+def _standalone_script_path(item_id: str) -> str:
+    _, _, path = item_id.partition("::")
+    if not path:
+        raise ValueError(f"Invalid standalone target id: {item_id}")
+    return path
+
+
+def _run_standalone_targets(
+    target_ids: list[str],
+    *,
+    env: dict[str, str],
+    timeout_seconds: int,
+) -> list[dict[str, object]]:
+    from scripts.e2e.common import failure_fingerprint
+
+    results: list[dict[str, object]] = []
+    for item_id in target_ids:
+        script_path = _standalone_script_path(item_id)
+        started = time.time()
+        try:
+            completed = subprocess.run(
+                [sys.executable, script_path],
+                cwd=PROJECT_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+            )
+            duration = round(time.time() - started, 3)
+            passed = completed.returncode == 0
+            result: dict[str, object] = {
+                "nodeid": item_id,
+                "attempts": 1,
+                "first_attempt_outcome": "pass" if passed else "fail",
+                "final_outcome": "pass" if passed else "fail",
+                "duration_seconds": duration,
+            }
+            if not passed:
+                message = f"{script_path} exited with code {completed.returncode}"
+                result["category"] = "test_body_exception"
+                result["fingerprint"] = failure_fingerprint("StandaloneExitError", message)
+                result["exception_class"] = "StandaloneExitError"
+                result["message"] = message
+                result["return_code"] = completed.returncode
+            results.append(result)
+        except subprocess.TimeoutExpired:
+            duration = round(time.time() - started, 3)
+            message = f"{script_path} timed out after {timeout_seconds}s"
+            results.append(
+                {
+                    "nodeid": item_id,
+                    "attempts": 1,
+                    "first_attempt_outcome": "fail",
+                    "final_outcome": "fail",
+                    "duration_seconds": duration,
+                    "category": "timeout",
+                    "fingerprint": failure_fingerprint("TimeoutExpired", message),
+                    "exception_class": "TimeoutExpired",
+                    "message": message,
+                }
+            )
+    return results
+
+
 def _write_run_envelope(
     path: str,
     *,
@@ -701,6 +805,7 @@ def _write_run_envelope(
     return_code: int,
     started_at: str,
     completed_at: str,
+    standalone_outcomes: list[dict[str, object]] | None = None,
     error_message: str | None = None,
 ) -> None:
     if not path:
@@ -735,6 +840,9 @@ def _write_run_envelope(
         "log_path": server_log,
     }
     outcomes = _summarize_attempt_records(attempts_records, server_evidence)
+    if standalone_outcomes:
+        outcomes.extend(standalone_outcomes)
+        outcomes.sort(key=lambda item: str(item.get("nodeid", "")))
     payload = {
         "schema_name": "openace-e2e-run-envelope",
         "schema_version": 1,
@@ -775,6 +883,7 @@ def main(argv: list[str] | None = None) -> int:
     server_handle: ServerHandle | None = None
     selected_targets: list[str] = []
     cmd: list[str] = []
+    standalone_outcomes: list[dict[str, object]] = []
     return_code = 1
     error_message: str | None = None
     started_at = _utc_now()
@@ -787,7 +896,18 @@ def main(argv: list[str] | None = None) -> int:
         if args.dry_run:
             return 0
         server_handle = start_server_if_needed(args, env)
-        return_code = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+        return_code = 0
+        if cmd:
+            return_code = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+        standalone_selected = standalone_targets(selected_targets)
+        if standalone_selected:
+            standalone_outcomes = _run_standalone_targets(
+                standalone_selected,
+                env=env,
+                timeout_seconds=args.timeout or 240,
+            )
+            if any(item.get("final_outcome") != "pass" for item in standalone_outcomes):
+                return_code = return_code or 1
         return return_code
     except Exception as exc:
         error_message = str(exc)
@@ -804,6 +924,7 @@ def main(argv: list[str] | None = None) -> int:
             return_code=return_code,
             started_at=started_at,
             completed_at=completed_at,
+            standalone_outcomes=standalone_outcomes,
             error_message=error_message,
         )
         stop_server(server_handle)

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -826,9 +826,7 @@ def _write_run_envelope(
         exit_code = server_handle.process.poll()
         exit_info["code"] = exit_code
         exit_info["abnormal"] = (
-            exit_code is not None
-            and not server_handle.stopped_by_runner
-            and exit_code != 0
+            exit_code is not None and not server_handle.stopped_by_runner and exit_code != 0
         )
     attempts_records = _load_attempt_records(args.e2e_attempts) if args.e2e_attempts else []
     server_evidence = {
@@ -870,7 +868,9 @@ def _write_run_envelope(
         "server": server_evidence,
         "outcomes": outcomes,
     }
-    envelope_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    envelope_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -362,6 +362,103 @@ def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
     assert failed["category"] == "assertion_failure"
     assert failed["final_outcome"] == "fail"
     assert failed["fingerprint"]
+    assert failed["duration_seconds"] == 2.5
+    assert failed["total_duration_seconds"] == 2.5
+
+
+def test_setup_phase_failure_is_not_summarized_as_pass(tmp_path, monkeypatch):
+    attempts = tmp_path / "attempts.jsonl"
+    attempts.write_text(
+        "\n".join(
+            [
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_setup_failure","attempt":1,"phase":"setup","outcome":"failed","duration_seconds":3.0,"exception_class":"RuntimeError","message":"boom"}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_setup_failure","attempt":1,"phase":"teardown","outcome":"passed","duration_seconds":1.0}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "envelope.json"
+    args = run_extended_tests.parse_args(
+        ["--category", "e2e", "--e2e-attempts", str(attempts), "--envelope-json", str(envelope)]
+    )
+    monkeypatch.setattr(run_extended_tests, "_current_head_sha", lambda: "deadbeef")
+    monkeypatch.setattr(run_extended_tests, "_current_contract_key", lambda: "contract-v1")
+    monkeypatch.setattr(run_extended_tests, "is_healthy", lambda _base_url: True)
+
+    run_extended_tests._write_run_envelope(
+        str(envelope),
+        args=args,
+        env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
+        cmd=["pytest", "tests/e2e/browser/test_login.py"],
+        selected_targets=["tests/e2e/browser/test_login.py"],
+        needs_server=True,
+        server_handle=None,
+        return_code=1,
+        started_at="2026-08-18T01:00:00Z",
+        completed_at="2026-08-18T01:00:05Z",
+        standalone_outcomes=None,
+    )
+
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    outcome = payload["outcomes"][0]
+    assert outcome["final_outcome"] == "fail"
+    assert outcome["category"] == "setup_error"
+    assert outcome["duration_seconds"] == 4.0
+
+
+def test_malformed_attempt_line_is_skipped(tmp_path):
+    attempts = tmp_path / "attempts.jsonl"
+    attempts.write_text('{"nodeid":"a","attempt":1}\n{"nodeid":"bad"\n', encoding="utf-8")
+
+    records = run_extended_tests._load_attempt_records(str(attempts))
+
+    assert records == [{"nodeid": "a", "attempt": 1}]
+
+
+def test_rerun_duration_budget_uses_max_attempt_not_sum(tmp_path, monkeypatch):
+    attempts = tmp_path / "attempts.jsonl"
+    attempts.write_text(
+        "\n".join(
+            [
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":1,"phase":"setup","outcome":"passed","duration_seconds":5.0}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":1,"phase":"call","outcome":"failed","duration_seconds":120.0,"exception_class":"AssertionError","message":"boom"}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":1,"phase":"teardown","outcome":"passed","duration_seconds":5.0}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":2,"phase":"setup","outcome":"passed","duration_seconds":5.0}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":2,"phase":"call","outcome":"passed","duration_seconds":120.0}',
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_rerun","attempt":2,"phase":"teardown","outcome":"passed","duration_seconds":5.0}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "envelope.json"
+    args = run_extended_tests.parse_args(
+        ["--category", "e2e", "--e2e-attempts", str(attempts), "--envelope-json", str(envelope)]
+    )
+    monkeypatch.setattr(run_extended_tests, "_current_head_sha", lambda: "deadbeef")
+    monkeypatch.setattr(run_extended_tests, "_current_contract_key", lambda: "contract-v1")
+    monkeypatch.setattr(run_extended_tests, "is_healthy", lambda _base_url: True)
+
+    run_extended_tests._write_run_envelope(
+        str(envelope),
+        args=args,
+        env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
+        cmd=["pytest", "tests/e2e/browser/test_login.py"],
+        selected_targets=["tests/e2e/browser/test_login.py"],
+        needs_server=True,
+        server_handle=None,
+        return_code=0,
+        started_at="2026-08-18T01:00:00Z",
+        completed_at="2026-08-18T01:04:20Z",
+        standalone_outcomes=None,
+    )
+
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    outcome = payload["outcomes"][0]
+    assert outcome["final_outcome"] == "pass"
+    assert outcome["duration_seconds"] == 130.0
+    assert outcome["total_duration_seconds"] == 260.0
 
 
 def test_write_run_envelope_includes_standalone_outcomes(tmp_path, monkeypatch):
@@ -398,6 +495,41 @@ def test_write_run_envelope_includes_standalone_outcomes(tmp_path, monkeypatch):
         "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"
     )
     assert payload["server"]["readiness_achieved"] is None
+
+
+def test_dry_run_envelope_reports_success(tmp_path):
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        __import__("json").dumps(
+            {"normal": ["tests/e2e/browser/test_login.py::test_login_page_loads"], "advisory": []}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "dry-run-envelope.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_extended_tests.py",
+            "--category",
+            "e2e",
+            "--selection-json",
+            str(selection),
+            "--dry-run",
+            "--envelope-json",
+            str(envelope),
+        ],
+        cwd=run_extended_tests.PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    assert payload["return_code"] == 0
+    assert payload["job_conclusion"] == "success"
 
 
 def test_quarantine_loader_bad_schema_fails_closed(tmp_path):

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -238,6 +238,31 @@ def test_execution_needs_server_uses_selected_item_capabilities(tmp_path, monkey
     )
 
 
+def test_execution_needs_server_falls_back_to_category_for_unknown_targets(tmp_path, monkeypatch):
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        __import__("json").dumps(
+            {
+                "normal": ["tests/e2e/browser/test_login.py::test_login_page_loads"],
+                "advisory": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    args = run_extended_tests.parse_args(
+        ["--category", "e2e", "--selection-json", str(selection), "--dry-run"]
+    )
+    monkeypatch.setattr(run_extended_tests, "inventory_entries_by_path", lambda: {})
+
+    assert (
+        run_extended_tests.execution_needs_server(
+            args, ["tests/e2e/browser/test_login.py::test_login_page_loads"]
+        )
+        is True
+    )
+
+
 def test_cli_entrypoint_writes_envelope_with_selection_json(tmp_path):
     selection = tmp_path / "selection.json"
     selection.write_text(

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -253,7 +253,11 @@ def test_execution_needs_server_falls_back_to_category_for_unknown_targets(tmp_p
     args = run_extended_tests.parse_args(
         ["--category", "e2e", "--selection-json", str(selection), "--dry-run"]
     )
-    monkeypatch.setattr(run_extended_tests, "inventory_entries_by_path", lambda: {})
+    monkeypatch.setattr(
+        run_extended_tests,
+        "inventory_entries_by_path",
+        lambda: {"tests/e2e/unrelated.py": {"capabilities": ["browser"]}},
+    )
 
     assert (
         run_extended_tests.execution_needs_server(

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -162,6 +162,83 @@ def test_quarantine_loader_corrupt_fails_closed(tmp_path):
         run_extended_tests._quarantine_nodeids(path=p)
 
 
+def test_e2e_attempts_enable_attempt_plugin():
+    args = run_extended_tests.parse_args(
+        [
+            "--category",
+            "critical",
+            "--dry-run",
+            "--e2e-attempts",
+            "test-results/full-e2e-attempts.jsonl",
+        ]
+    )
+
+    cmd = run_extended_tests.build_pytest_command(args)
+
+    assert "-p" in cmd
+    assert "scripts.e2e.pytest_attempts" in cmd
+    assert "--e2e-attempts=test-results/full-e2e-attempts.jsonl" in cmd
+
+
+def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
+    attempts = tmp_path / "attempts.jsonl"
+    attempts.write_text(
+        "\n".join(
+            [
+                '{"nodeid":"tests/e2e/browser/test_login.py::test_ok","attempt":1,"phase":"call","outcome":"passed","duration_seconds":1.25}',
+                '{"nodeid":"tests/e2e/browser/test_navigation.py::test_fail","attempt":1,"phase":"call","outcome":"failed","duration_seconds":2.5,"exception_class":"AssertionError","message":"boom"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "envelope.json"
+    args = run_extended_tests.parse_args(
+        [
+            "--category",
+            "e2e",
+            "--junitxml",
+            "test-results/full-e2e.xml",
+            "--e2e-attempts",
+            str(attempts),
+            "--envelope-json",
+            str(envelope),
+        ]
+    )
+    monkeypatch.setattr(run_extended_tests, "_current_head_sha", lambda: "deadbeef")
+    monkeypatch.setattr(run_extended_tests, "_current_contract_key", lambda: "contract-v1")
+    monkeypatch.setattr(run_extended_tests, "is_healthy", lambda _base_url: True)
+
+    run_extended_tests._write_run_envelope(
+        str(envelope),
+        args=args,
+        env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
+        cmd=["pytest", "tests/e2e/browser/test_login.py"],
+        selected_targets=["tests/e2e/browser/test_login.py"],
+        server_handle=None,
+        return_code=1,
+        started_at="2026-08-18T01:00:00Z",
+        completed_at="2026-08-18T01:02:30Z",
+    )
+
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    assert payload["schema_name"] == "openace-e2e-run-envelope"
+    assert payload["commit_sha"] == "deadbeef"
+    assert payload["contract_key"] == "contract-v1"
+    assert payload["duration_minutes"] == 2.5
+    assert payload["job_conclusion"] == "failure"
+    assert payload["artifacts"]["attempts_jsonl"] == str(attempts)
+    assert payload["server"]["readiness_achieved"] is True
+    assert [item["nodeid"] for item in payload["outcomes"]] == [
+        "tests/e2e/browser/test_login.py::test_ok",
+        "tests/e2e/browser/test_navigation.py::test_fail",
+    ]
+    failed = payload["outcomes"][1]
+    assert failed["category"] == "assertion_failure"
+    assert failed["final_outcome"] == "fail"
+    assert failed["fingerprint"]
+
+
 def test_quarantine_loader_bad_schema_fails_closed(tmp_path):
     p = _write_q(tmp_path, {"version": 1, "schema": "wrong", "entries": []})
     with pytest.raises(SystemExit):

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -142,7 +142,7 @@ def test_frontend_build_check_fails_fast_when_dist_is_missing(tmp_path, monkeypa
     monkeypatch.setattr(run_extended_tests, "PROJECT_ROOT", tmp_path)
 
     with pytest.raises(RuntimeError, match="Frontend build is missing"):
-        run_extended_tests.ensure_frontend_built("critical")
+        run_extended_tests.ensure_frontend_built(True)
 
 
 def _write_q(tmp_path, obj):
@@ -207,6 +207,35 @@ def test_selection_json_uses_exact_targets_and_skips_standalone_for_pytest(tmp_p
 
     assert "tests/e2e/browser/test_login.py::test_login_page_loads" in cmd
     assert "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py" not in cmd
+
+
+def test_execution_needs_server_uses_selected_item_capabilities(tmp_path, monkeypatch):
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        __import__("json").dumps(
+            {
+                "normal": ["standalone::tests/e2e/custom_standalone.py"],
+                "advisory": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    args = run_extended_tests.parse_args(
+        ["--category", "e2e", "--selection-json", str(selection), "--dry-run"]
+    )
+    monkeypatch.setattr(
+        run_extended_tests,
+        "inventory_entries_by_path",
+        lambda: {"tests/e2e/custom_standalone.py": {"capabilities": ["browser"]}},
+    )
+
+    assert (
+        run_extended_tests.execution_needs_server(
+            args, ["standalone::tests/e2e/custom_standalone.py"]
+        )
+        is False
+    )
 
 
 def test_cli_entrypoint_writes_envelope_with_selection_json(tmp_path):
@@ -280,6 +309,7 @@ def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
         env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
         cmd=["pytest", "tests/e2e/browser/test_login.py"],
         selected_targets=["tests/e2e/browser/test_login.py"],
+        needs_server=True,
         server_handle=None,
         return_code=1,
         started_at="2026-08-18T01:00:00Z",
@@ -318,6 +348,7 @@ def test_write_run_envelope_includes_standalone_outcomes(tmp_path, monkeypatch):
         env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
         cmd=["pytest", "tests/e2e/browser/test_login.py"],
         selected_targets=["standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"],
+        needs_server=False,
         server_handle=None,
         return_code=0,
         started_at="2026-08-18T01:00:00Z",
@@ -337,6 +368,7 @@ def test_write_run_envelope_includes_standalone_outcomes(tmp_path, monkeypatch):
     assert payload["outcomes"][0]["nodeid"] == (
         "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"
     )
+    assert payload["server"]["readiness_achieved"] is None
 
 
 def test_quarantine_loader_bad_schema_fails_closed(tmp_path):

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 
 from scripts import run_extended_tests
@@ -180,6 +183,68 @@ def test_e2e_attempts_enable_attempt_plugin():
     assert "--e2e-attempts=test-results/full-e2e-attempts.jsonl" in cmd
 
 
+def test_selection_json_uses_exact_targets_and_skips_standalone_for_pytest(tmp_path):
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        __import__("json").dumps(
+            {
+                "normal": ["tests/e2e/browser/test_login.py::test_login_page_loads"],
+                "advisory": ["standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    args = run_extended_tests.parse_args(
+        ["--category", "e2e", "--selection-json", str(selection), "--dry-run"]
+    )
+
+    assert run_extended_tests.resolved_targets(args) == [
+        "tests/e2e/browser/test_login.py::test_login_page_loads",
+        "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py",
+    ]
+    cmd = run_extended_tests.build_pytest_command(args)
+
+    assert "tests/e2e/browser/test_login.py::test_login_page_loads" in cmd
+    assert "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py" not in cmd
+
+
+def test_cli_entrypoint_writes_envelope_with_selection_json(tmp_path):
+    selection = tmp_path / "selection.json"
+    selection.write_text(
+        __import__("json").dumps(
+            {"normal": ["tests/e2e/browser/test_login.py::test_login_page_loads"], "advisory": []}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "envelope.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_extended_tests.py",
+            "--category",
+            "e2e",
+            "--selection-json",
+            str(selection),
+            "--dry-run",
+            "--envelope-json",
+            str(envelope),
+        ],
+        cwd=run_extended_tests.PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    assert payload["selected_targets"] == ["tests/e2e/browser/test_login.py::test_login_page_loads"]
+    assert payload["pytest_command"][0] == sys.executable
+
+
 def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
     attempts = tmp_path / "attempts.jsonl"
     attempts.write_text(
@@ -219,6 +284,7 @@ def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
         return_code=1,
         started_at="2026-08-18T01:00:00Z",
         completed_at="2026-08-18T01:02:30Z",
+        standalone_outcomes=None,
     )
 
     payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
@@ -237,6 +303,40 @@ def test_write_run_envelope_summarizes_attempts(tmp_path, monkeypatch):
     assert failed["category"] == "assertion_failure"
     assert failed["final_outcome"] == "fail"
     assert failed["fingerprint"]
+
+
+def test_write_run_envelope_includes_standalone_outcomes(tmp_path, monkeypatch):
+    envelope = tmp_path / "envelope.json"
+    args = run_extended_tests.parse_args(["--category", "e2e", "--envelope-json", str(envelope)])
+    monkeypatch.setattr(run_extended_tests, "_current_head_sha", lambda: "deadbeef")
+    monkeypatch.setattr(run_extended_tests, "_current_contract_key", lambda: "contract-v1")
+    monkeypatch.setattr(run_extended_tests, "is_healthy", lambda _base_url: True)
+
+    run_extended_tests._write_run_envelope(
+        str(envelope),
+        args=args,
+        env={"HOME": str(tmp_path), "PLAYWRIGHT_BROWSERS_PATH": "/pw"},
+        cmd=["pytest", "tests/e2e/browser/test_login.py"],
+        selected_targets=["standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"],
+        server_handle=None,
+        return_code=0,
+        started_at="2026-08-18T01:00:00Z",
+        completed_at="2026-08-18T01:00:05Z",
+        standalone_outcomes=[
+            {
+                "nodeid": "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py",
+                "attempts": 1,
+                "first_attempt_outcome": "pass",
+                "final_outcome": "pass",
+                "duration_seconds": 4.0,
+            }
+        ],
+    )
+
+    payload = __import__("json").loads(envelope.read_text(encoding="utf-8"))
+    assert payload["outcomes"][0]["nodeid"] == (
+        "standalone::tests/e2e/e2e_autonomous_models_error_playwright.py"
+    )
 
 
 def test_quarantine_loader_bad_schema_fails_closed(tmp_path):

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -95,6 +95,17 @@ def test_ci_policy_change_fails_safe_to_all_pr_suites():
     assert "performance" not in selected
 
 
+def test_e2e_governance_change_selects_governance_suite():
+    selected = ci.select_pr_suites(["scripts/e2e/comparator.py"])
+    assert "e2e-governance" in selected
+
+
+def test_extended_runner_change_selects_critical_and_governance_suites():
+    selected = ci.select_pr_suites(["scripts/run_extended_tests.py"])
+    assert "critical-e2e" in selected
+    assert "e2e-governance" in selected
+
+
 def test_test_change_selects_issue_collection():
     selected = ci.select_pr_suites(["tests/unit/test_example.py"])
     assert "default-collection" in selected

--- a/tests/unit/test_e2e_comparator.py
+++ b/tests/unit/test_e2e_comparator.py
@@ -411,4 +411,5 @@ class TestComparatorCli:
         )
 
         assert diff["verdict_exit_code"] == 1
+        assert diff["duplicates"] == ["a"]
         assert diff["invalid"]["a"] == "duplicate observed results (2)"

--- a/tests/unit/test_e2e_comparator.py
+++ b/tests/unit/test_e2e_comparator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -325,3 +326,72 @@ class TestFingerprintNormalization:
             "/runner/xyz/tests/e2e/ui/test_a.py::t[12345678-1234-1234-1234-123456789012]"
         )
         assert n == "tests/e2e/ui/test_a.py::t[<uuid>]"
+
+
+class TestComparatorCli:
+    def test_compare_cli_writes_artifacts_and_fails_closed_on_budget_and_selection_errors(
+        self, tmp_path
+    ):
+        selection = {
+            "event": "nightly",
+            "normal": ["tests/e2e/browser/test_login.py::test_ok"],
+            "advisory": [],
+            "invalid": {"tests/e2e/browser/test_bad.py::test_bad": ["missing metadata"]},
+            "closure_errors": ["nightly lane is not closed"],
+            "counts": {"normal": 1, "advisory": 0, "invalid": 1},
+        }
+        envelope = {
+            "schema_name": common.RUN_ENVELOPE_SCHEMA_NAME,
+            "schema_version": 1,
+            "job_conclusion": "success",
+            "duration_minutes": 130,
+            "server": {"readiness_achieved": True, "exit": {"abnormal": False, "code": 0}},
+            "outcomes": [
+                {
+                    "nodeid": "tests/e2e/browser/test_login.py::test_ok",
+                    "final_outcome": "pass",
+                    "duration_seconds": 10,
+                    "attempts": 1,
+                }
+            ],
+        }
+        state = {"schema_name": "openace-e2e-state", "schema_version": 1, "entries": {}}
+        governance_report = {"counts": {"inventory": 153}}
+        selection_path = tmp_path / "selection.json"
+        envelope_path = tmp_path / "envelope.json"
+        state_path = tmp_path / "state.json"
+        governance_path = tmp_path / "governance.json"
+        json_output = tmp_path / "out" / "diff.json"
+        markdown_output = tmp_path / "out" / "summary.md"
+        selection_path.write_text(json.dumps(selection) + "\n", encoding="utf-8")
+        envelope_path.write_text(json.dumps(envelope) + "\n", encoding="utf-8")
+        state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+        governance_path.write_text(json.dumps(governance_report) + "\n", encoding="utf-8")
+
+        exit_code = comparator.run_cli(
+            [
+                "compare",
+                "--selection",
+                str(selection_path),
+                "--envelope",
+                str(envelope_path),
+                "--state",
+                str(state_path),
+                "--json-output",
+                str(json_output),
+                "--markdown-output",
+                str(markdown_output),
+                "--governance-report",
+                str(governance_path),
+            ]
+        )
+
+        assert exit_code == 1
+        payload = json.loads(json_output.read_text(encoding="utf-8"))
+        assert payload["schema_name"] == common.COMPARE_RESULT_SCHEMA_NAME
+        assert "__budget__" in payload["diff"]["invalid"]
+        assert "__closure__" in payload["diff"]["invalid"]
+        assert "__selection__" in payload["diff"]["invalid"]
+        markdown = markdown_output.read_text(encoding="utf-8")
+        assert "Full E2E Governance" in markdown
+        assert "nightly lane is not closed" in markdown

--- a/tests/unit/test_e2e_comparator.py
+++ b/tests/unit/test_e2e_comparator.py
@@ -395,3 +395,20 @@ class TestComparatorCli:
         markdown = markdown_output.read_text(encoding="utf-8")
         assert "Full E2E Governance" in markdown
         assert "nightly lane is not closed" in markdown
+
+    def test_compare_selection_run_flags_duplicate_outcomes(self):
+        diff, _ = comparator.compare_selection_run(
+            {"normal": ["a"], "advisory": []},
+            {
+                "job_conclusion": "success",
+                "duration_minutes": 1,
+                "outcomes": [
+                    {"nodeid": "a", "final_outcome": "pass", "duration_seconds": 1},
+                    {"nodeid": "a", "final_outcome": "pass", "duration_seconds": 1},
+                ],
+            },
+            {},
+        )
+
+        assert diff["verdict_exit_code"] == 1
+        assert diff["invalid"]["a"] == "duplicate observed results (2)"

--- a/tests/unit/test_e2e_comparator.py
+++ b/tests/unit/test_e2e_comparator.py
@@ -413,3 +413,32 @@ class TestComparatorCli:
         assert diff["verdict_exit_code"] == 1
         assert diff["duplicates"] == ["a"]
         assert diff["invalid"]["a"] == "duplicate observed results (2)"
+
+    def test_compare_selection_run_fails_closed_on_empty_selection(self):
+        diff, _ = comparator.compare_selection_run(
+            {"normal": [], "advisory": []},
+            {"job_conclusion": "failure", "return_code": 1, "outcomes": [], "duration_minutes": 0},
+            {},
+        )
+
+        assert diff["verdict_exit_code"] == 1
+        assert (
+            diff["invalid"]["__coverage__"] == "nightly selection is empty (no governed coverage)"
+        )
+        assert "__execution__" in diff["invalid"]
+
+    def test_compare_selection_run_fails_closed_on_runner_error(self):
+        diff, _ = comparator.compare_selection_run(
+            {"normal": ["a"], "advisory": []},
+            {
+                "job_conclusion": "failure",
+                "return_code": 1,
+                "error": "boom",
+                "outcomes": [{"nodeid": "a", "final_outcome": "pass", "duration_seconds": 1}],
+                "duration_minutes": 1,
+            },
+            {},
+        )
+
+        assert diff["verdict_exit_code"] == 1
+        assert diff["invalid"]["__execution__"] == "runner error: boom"

--- a/tests/unit/test_e2e_governance.py
+++ b/tests/unit/test_e2e_governance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -372,6 +373,51 @@ class TestWriter:
         state = common.load_artifact(state_path, "openace-e2e-state")
         assert state["entries"]["tests/e2e/x.py::passing"]["debt"] == "stable-pass"
         assert state["entries"]["tests/e2e/x.py::failing"]["debt"] == "deterministic-known-fail"
+
+    def test_classify_cli_entrypoint_runs_as_script(self, tmp_path):
+        run_files = []
+        for idx in range(3):
+            path = tmp_path / f"run{idx}.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "commit_sha": "s",
+                        "contract_key": "k",
+                        "outcomes": [
+                            {
+                                "nodeid": "tests/e2e/x.py::passing",
+                                "first_attempt_outcome": "pass",
+                                "category": "assertion_failure",
+                                "fingerprint": None,
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            run_files.append(str(path))
+        state_path = tmp_path / "state.json"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "scripts/e2e/governance.py",
+                "classify",
+                "--runs",
+                *run_files,
+                "--state",
+                str(state_path),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        assert payload["entries"]["tests/e2e/x.py::passing"]["debt"] == "stable-pass"
 
     def test_remove_deletes_from_both_artifacts(self, tmp_path):
         state_path = tmp_path / "state.json"

--- a/tests/unit/test_extended_workflow_contracts.py
+++ b/tests/unit/test_extended_workflow_contracts.py
@@ -112,6 +112,28 @@ def test_issue_dispatch_keeps_fail_closed_baseline_comparator():
     assert '[ "$LEGACY_RESULT" != success ]' in publish_step["run"]
 
 
+def test_full_e2e_governance_job_wraps_full_e2e_and_feeds_nightly_gate():
+    jobs = _workflow()["jobs"]
+    governance = jobs["full-e2e-governance"]
+
+    assert governance["needs"] == ["full-e2e"]
+    assert "needs.full-e2e.result != 'skipped'" in governance["if"]
+    compare_step = next(
+        step
+        for step in governance["steps"]
+        if step.get("name") == "Compare nightly selection against observed outcomes"
+    )
+    assert "--selection artifacts/test-results/full-e2e-selection.json" in compare_step["run"]
+    assert "--envelope artifacts/test-results/full-e2e-envelope.json" in compare_step["run"]
+
+    nightly = jobs["nightly-summary"]
+    assert "full-e2e-governance" in nightly["needs"]
+    publish_step = next(
+        step for step in nightly["steps"] if step["name"] == "Publish nightly result"
+    )
+    assert publish_step["env"]["E2E_RESULT"] == "${{ needs.full-e2e-governance.result }}"
+
+
 @pytest.mark.parametrize("failed_lane", [None, "python", "e2e", "legacy"])
 def test_nightly_gate_returns_nonzero_for_every_failed_lane(tmp_path, failed_lane):
     jobs = _workflow()["jobs"]

--- a/tests/unit/test_extended_workflow_contracts.py
+++ b/tests/unit/test_extended_workflow_contracts.py
@@ -114,10 +114,13 @@ def test_issue_dispatch_keeps_fail_closed_baseline_comparator():
 
 def test_full_e2e_governance_job_wraps_full_e2e_and_feeds_nightly_gate():
     jobs = _workflow()["jobs"]
+    full_e2e = jobs["full-e2e"]
     governance = jobs["full-e2e-governance"]
 
     assert governance["needs"] == ["full-e2e"]
     assert "needs.full-e2e.result != 'skipped'" in governance["if"]
+    run_step = next(step for step in full_e2e["steps"] if step.get("name") == "Run full E2E tests")
+    assert "--selection-json test-results/full-e2e-selection.json" in run_step["run"]
     compare_step = next(
         step
         for step in governance["steps"]


### PR DESCRIPTION
## What changed
- added a nightly Full E2E governance comparator job that validates the nightly selection, run envelope, and governance ledgers before the nightly quality gate passes
- taught the extended E2E runner to emit authoritative attempt records and a machine-readable run envelope for comparison
- added a dedicated `e2e-governance` PR suite plus workflow contract coverage so governance artifact changes are validated on pull requests

## Why
Issue #2491 already established the inventory, selector, and debt model, but nightly Full E2E was still missing the final fail-closed governance handoff. This closes that gap so the scheduled run is checked against the governed selection instead of only uploading raw test artifacts.

## Impact
- nightly Full E2E now produces a comparable evidence package and a separate governance verdict
- PRs that touch governance inputs now run a focused validation suite earlier
- the nightly quality gate now depends on the governance comparator result instead of the raw execution job alone

## Validation
- `./.venv/bin/python -m pytest tests/issues/1469/test_extended_tests_runner.py -q`
- `./.venv/bin/python -m pytest tests/unit/test_e2e_comparator.py tests/unit/test_ci_runner.py tests/unit/test_extended_workflow_contracts.py tests/unit/test_scheduled_workflow_contracts.py -q`
- `./.venv/bin/python -m pytest tests/unit/test_e2e_inventory_manifest.py tests/unit/test_e2e_selector.py tests/unit/test_e2e_governance.py -q`
- `./.venv/bin/python scripts/ci.py run e2e-governance`
