### PR TITLE
fix(autonomous): defer merge-policy pause while required checks are absent on a fresh head

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -26,6 +26,26 @@ from app.utils.workspace import OPENACE_RM_WRAPPER
 
 logger = logging.getLogger(__name__)
 
+
+def parse_github_iso_datetime(raw) -> datetime | None:
+    """Parse a GitHub API ISO-8601 timestamp into an aware datetime.
+
+    GitHub timestamps end in ``Z``; ``datetime.fromisoformat`` only parses
+    that suffix from 3.11 while this repo supports 3.10, so normalize first.
+    Returns None for empty/unparseable input — callers fail closed.
+    """
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        logger.warning("unparseable GitHub datetime: %r", raw)
+        return None
+
+
 # ============================================================================
 # 【Issue #2334】审计日志配置
 # ============================================================================
@@ -1591,6 +1611,22 @@ class GitHubOps:
             "mergeable": data.get("mergeable"),
             "mergeable_state": str(data.get("mergeable_state") or "").strip().lower(),
         }
+
+    def get_commit_committed_at(self, sha: str) -> datetime | None:
+        """A commit's committer date (≈ push time) as an aware UTC datetime.
+
+        Used by the merge phase's policy-settle check to tell a freshly
+        pushed head (check-runs may not exist yet) from a stale one. Returns
+        None when the date is missing or unparseable — callers fail closed.
+        """
+        repo = self.get_repo_name()
+        result = self._run_gh(
+            self._gh_api_args([f"repos/{repo}/commits/{sha}"]),
+            repo_scoped=False,
+        )
+        data = json.loads((result.stdout or "").strip() or "{}")
+        raw = ((data.get("commit") or {}).get("committer") or {}).get("date")
+        return parse_github_iso_datetime(raw)
 
     @staticmethod
     def _is_not_found(stderr: str) -> bool:

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -32,7 +32,10 @@ def parse_github_iso_datetime(raw) -> datetime | None:
 
     GitHub timestamps end in ``Z``; ``datetime.fromisoformat`` only parses
     that suffix from 3.11 while this repo supports 3.10, so normalize first.
-    Returns None for empty/unparseable input — callers fail closed.
+    A parsed value without a UTC offset is rejected too — callers subtract
+    it from an aware ``now()`` and aware-minus-naive raises, which would
+    escape their fail-closed contract. Returns None for empty, unparseable
+    or offset-less input — callers fail closed.
     """
     if not isinstance(raw, str):
         return None
@@ -40,10 +43,14 @@ def parse_github_iso_datetime(raw) -> datetime | None:
     if not text:
         return None
     try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
     except ValueError:
         logger.warning("unparseable GitHub datetime: %r", raw)
         return None
+    if parsed.tzinfo is None:
+        logger.warning("GitHub datetime without UTC offset: %r", raw)
+        return None
+    return parsed
 
 
 # ============================================================================

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -83,6 +83,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 
 from app.modules.workspace.autonomous.constants import MERGE_POLICY_PAUSE_REASON_PREFIX
 from app.modules.workspace.autonomous.evidence import Verdict
@@ -92,6 +93,12 @@ from app.modules.workspace.autonomous.phase_contract import PhaseResult
 NAME = "merge"
 
 logger = logging.getLogger(__name__)
+
+# Bound on how long a freshly pushed head may take before its required
+# check-runs exist. Mirrors ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR in the
+# orchestrator — the codebase's measured bound for the same CI provisioning
+# lag (#2673); half of it here would re-freeze slow-provisioning heads.
+_POLICY_SETTLE_GRACE_SECONDS = 1200
 
 
 def _required_contexts(gh, pr_number: int, base_branch: str) -> set[str] | None:
@@ -111,6 +118,39 @@ def _required_contexts(gh, pr_number: int, base_branch: str) -> set[str] | None:
         )
         return None
     return set((protection.get("required_status_checks") or {}).get("contexts") or [])
+
+
+def _head_freshly_pushed(gh, pr_head_sha: str) -> bool:
+    """Whether the PR head commit is younger than the settle grace window.
+
+    Right after a push (typically a CI-repair commit), check-runs for the new
+    head SHA may not exist yet, so a refreshed rollup shows no pending entry
+    while GitHub already reports ``blocked`` (required contexts missing for
+    that SHA). A fresh head there means "CI has not settled", not a policy
+    block.
+
+    Fail-closed: an empty SHA, an API failure or an unparseable date returns
+    False so the caller keeps the legacy pause (the monitor sweep
+    re-classifies) — #1989 fail-closed spirit.
+    """
+    sha = (pr_head_sha or "").strip()
+    if not sha:
+        return False
+    try:
+        committed_at = gh.get_commit_committed_at(sha)
+    except Exception as exc:  # noqa: BLE001 — degrade to the legacy pause
+        logger.warning(
+            "PR head %s: could not resolve commit time for policy-settle check: %s",
+            sha[:8],
+            exc,
+        )
+        return False
+    if committed_at is None:
+        return False
+    age = (datetime.now(timezone.utc) - committed_at).total_seconds()
+    # A negative age (clock skew / future committer date) reads as fresh —
+    # the safer direction for a transient-vs-permanent discriminator.
+    return bool(age < _POLICY_SETTLE_GRACE_SECONDS)
 
 
 def _blocking_pending(gh, checks: list[dict], pr_number: int, base_branch: str) -> list[dict]:
@@ -494,6 +534,29 @@ def handle(ctx, deps) -> PhaseResult:
                         any_pending,
                     )
                     return PhaseResult.retry()
+                # Residual #27 race (workflow #2778 / PR #2804): seconds after
+                # a CI-repair push, the new head has runs only for fast
+                # non-required jobs — the required aggregate gate has no run
+                # yet, so no bucket is pending while state is ``blocked``.
+                # Required contexts ABSENT from the rollup (not pending, not
+                # failed) on a freshly pushed head are unsettled CI: keep
+                # deferring. Beyond the grace window the absence is the
+                # repo-misconfig signature (required context with no
+                # provider) and still pauses for a human. Literal name
+                # matching only — the same limitation _blocking_pending has.
+                required = _required_contexts(gh, pr_number, base_branch)
+                if required:
+                    missing_required = required - {(c.get("name") or "") for c in refreshed_checks}
+                    if missing_required and _head_freshly_pushed(gh, pr_head_sha):
+                        logger.info(
+                            "PR #%s: merge rejected by policy with required "
+                            "context(s) %s absent on a head pushed within "
+                            "%ds; deferring",
+                            pr_number,
+                            ", ".join(sorted(missing_required)),
+                            _POLICY_SETTLE_GRACE_SECONDS,
+                        )
+                        return PhaseResult.retry()
                 # No pending checks and GitHub has finished computing, yet
                 # repository policy still requires external action (approval,
                 # marking ready, or a rule change). Persist a manually

--- a/docs/superpowers/plans/2026-08-19-merge-policy-unsettled-blindspot.md
+++ b/docs/superpowers/plans/2026-08-19-merge-policy-unsettled-blindspot.md
@@ -1,0 +1,90 @@
+# Plan: merge-policy pause 的"未结算盲区"(required 缺席 ≠ 已结算)
+
+日期:2026-08-19 · 分类:class-2(自主系统自身 bug)· 分支:`fix/merge-policy-unsettled-blindspot`(base origin/main @ da452a06)
+
+## 1. 事故(主证据)
+
+- 工作流 9676f33f(issue #2778)/ PR #2804,2026-08-19 01:44:29(服务器本地)在 merge 阶段被 pause:
+  `Merge blocked by repository policy: PR #2804 is not merge-ready (state=blocked).`
+- 时间线(统一 UTC;journalctl 原文为服务器本地 UTC+8,已换算):
+  - 17:38:04 `PR #2804: merge rejected by policy but CI has not settled (state=blocked, any_pending=True); deferring` —— #2503 的守卫正常工作
+  - 17:38:37 CI-repair agent 启动;**17:43 推送 `c89d2b39 auto: ci repair (attempt 1)`**(新 head SHA,gh committedDate 为 UTC)
+  - 17:44:15 merge 阶段推进;**17:44:29(推送后 ~90s)误 pause**
+  - 18:08 人工核验:PR #2804 全绿 CLEAN;reset 后 18:19 一次 merge 成功 → pause 依据纯属瞬态
+- 误判链:新 SHA 的检查 run 部分创建(快速检查已有,**required 聚合门 `PR Gate` 尚未创建**)→
+  `zero_check_runs_fallback` 因 `if checks: return False` 跳过(它只管"完全零 run"的 #2673 事件丢失场景)→
+  无 pending 桶、无 fail 桶 → 尝试 merge 被拒(required 缺席)→ refresh 后仍无 pending →
+  `any_pending=False` + `state=blocked` → 进入"真实策略阻塞"分支 → 不可自恢复 pause。
+
+## 2. 根因
+
+`phases/merge.py` 策略-pause 分支把"rollup 中无 pending"等价于"CI 已结算"。但**required 上下文对当前
+head SHA 完全缺席**(非 pending、非 fail)有两种语义:
+
+1. 推送后检查 run 创建延迟(瞬态,分钟级自愈)——本例;
+2. required 上下文配置了但没有任何 provider(仓库配置错误,永不到来)。
+
+现有代码无法区分,一律 pause。#2503 已修"underlying job pending 被过滤"的窗口,本缺口是其注释
+(``aggregate gate ... propagation window``)承认的残余。
+
+## 3. 方案(选定:required 完备性 + head 新鲜度双条件 defer)
+
+在策略-pause 分支、`any_pending`/`unknown` defer 之后、pause 之前增加:
+
+```python
+required = _required_contexts(gh, pr_number, base_branch)
+if required:
+    missing = required - {(c.get("name") or "") for c in refreshed_checks}
+    if missing and _head_freshly_pushed(gh, pr_head_sha):   # head commit < 宽限窗
+        return PhaseResult.retry()   # 未结算,继续轮询
+```
+
+- `_head_freshly_pushed`:新增 `GitHubOps.get_commit_committed_at(sha)`
+  (`gh api repos/{repo}/commits/{sha}` → `commit.committer.date`,解析为 aware datetime)。
+  在**罕见的被拒路径**才调用,非热路径;取不到时间 → 返回 False(fail-closed,维持 pause,
+  监控兜底再分类——与 #1989 fail-closed 精神一致)。
+  🔴 **py3.10 兼容**(独立审查 blocking):GitHub 时间戳带 `Z` 后缀,`fromisoformat`
+  3.11+ 才支持;必须先 `replace("Z", "+00:00")`,并给解析函数加直接单测(真实 `...Z`
+  字符串 + 不可解析 → None),否则修复在 3.10 上静默 no-op。
+- 宽限窗常量 `_POLICY_SETTLE_GRACE_SECONDS = 1200`:**对齐 orchestrator 既有的
+  `ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR = 1200`**(独立审查 blocking:同一类"检查 run
+  创建/provisioning 延迟",代码库经验值就是 20 分钟;取 600 无依据且慢 provisioning
+  场景会复发)。超窗仍缺席 → 维持 pause(保留"永不到来的 required = 仓库配置错误,
+  需人工修 ruleset"的既有保证)。commit 时间为未来值(时钟偏移)→ 负差值 < 窗 →
+  视为 fresh,defer(偏安全方向)。
+- 名字匹配为字面比对(与 `_blocking_pending` 同款局限):matrix 展开名/门改名会造成
+  永久 missing → 至多多 defer 一个宽限窗后仍 pause,与现状同向,可接受(实现注释注明)。
+- `_required_contexts` 返回 None(不可观测)→ 不 defer,维持 pause(现状,降级不越权)。
+
+### 备选与否决理由
+
+- **空 rollup 才 defer**(`if not refreshed_checks`):覆盖不了部分创建场景(本例 rollup 非空)。否决。
+- **永久 defer 所有 required 缺席**:破坏"配置错误需人工介入"保证,未配置 provider 的 required 上下文会无限轮询。否决。
+- **复用 #2673 的 zero_check_runs milestone 状态机**:那是 orchestrator 侧、针对"完全零 run"的重触发机制(_CLOSE/REOPEN),语义不同且重;本修只需在 pause 前多一次判别。否决。
+- **用 refreshed_checks 里最新完成时间推断活跃度**:缺席的 run 没有时间戳,推断不可靠。否决。
+
+## 4. 测试(TDD,先红后绿;tests/autonomous/phases/test_merge.py)
+
+1. `test_merge_policy_block_with_missing_required_on_fresh_head_defers_not_pauses`
+   —— checks=[非 required 快速检查 pass],protection required=["PR Gate"],state=blocked,
+   merge 抛 policy 拒绝,`get_commit_committed_at` 回 90s 前 → **retry**(现状 pause,先红)。
+2. `test_merge_policy_block_with_missing_required_on_stale_head_still_pauses`
+   —— 同上但 commit 时间 2h 前 → **pause**(配置错误路径不回归)。
+3. `test_merge_policy_block_with_required_present_still_pauses`
+   —— required 全在场且无 pending(既有 settled 场景,L323 已有,确保不被新逻辑扰动——跑既有测试即可)。
+4. commit 时间不可得(helper 抛异常/返回 None)→ pause(fail-closed)。
+5. (审查补充)protection 查询抛异常(required 不可观测)→ 仍 pause,锁住降级契约。
+6. (审查补充)required 齐全时 `get_commit_committed_at` **不被调用**(短路顺序)。
+7. (审查补充,github_ops 层)`parse_github_iso_datetime`:真实 `2026-08-18T17:43:12Z`
+   → aware datetime;空串/乱串 → None。py3.10 下 Z 解析是修复生效的前提。
+
+## 5. 验证 Gap 对应
+
+- lane:`tests/autonomous/phases/` 在 CI `test(3.x)` 收集范围(非 tests/issues opt-in)。
+- 本地全量跑 `tests/autonomous/phases/test_merge.py`;对照 clean origin/main worktree 排除环境性失败。
+- PR 文本**不含** closes/fixes/resolves + #N(auto-close 陷阱)。
+
+## 6. 部署与收尾
+
+- app/ 热补丁 cp + chown openace(`github_ops.py`、`phases/merge.py`);`systemctl restart openace-scheduler.service`(编排改动);无迁移。
+- prod 验证:观察后续 auto-dev merge 周期不再出现同签名误 pause;既有 deferring 日志语义不变。

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -10,7 +10,7 @@ orchestrator concrete class.
 from __future__ import annotations
 
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 from app.modules.workspace.autonomous import phases as phases_pkg
@@ -336,6 +336,103 @@ def test_merge_policy_block_with_settled_ci_still_pauses():
     result = merge_phase.handle(_ctx(_workflow()), deps)
 
     assert result.outcome == "pause"
+    host.emit_status_change.assert_called_once()
+
+
+# ── policy block vs unsettled head (residual #27 race, workflow #2778) ────
+
+
+def _policy_unsettled_deps(*, checks: list, committed_at) -> tuple:
+    """Shared fixture: merge rejected by policy, state=blocked, ``PR Gate``
+    required — the residual-race setup where some checks exist for the head
+    but the required aggregate gate has not reported yet."""
+    deps, host = _build_deps(
+        checks=checks,
+        merge_state={"mergeable": True, "mergeable_state": "blocked"},
+        merge_raises=GitHubOpsError("base branch policy prohibits the merge"),
+    )
+    deps.gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": ["PR Gate"]}
+    }
+    deps.gh.get_commit_committed_at.return_value = committed_at
+    return deps, host
+
+
+def test_merge_policy_block_with_missing_required_on_fresh_head_defers():
+    """~90s after a CI-repair push the new head SHA has runs only for fast
+    non-required jobs — the required aggregate gate has no run yet, so the
+    rollup shows no pending bucket while GitHub reports ``blocked``. A head
+    pushed within the settle-grace window is unsettled CI, not a policy
+    block: defer instead of freezing at a manual-recovery pause (reproduced
+    by workflow #2778 / PR #2804 on 2026-08-19)."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "Select suites", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc) - timedelta(seconds=90),
+    )
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    host.emit_status_change.assert_not_called()  # did not pause
+
+
+def test_merge_policy_block_with_missing_required_on_stale_head_pauses():
+    """A required context still absent long after the push is the repo-
+    misconfig signature (required context with no provider): the manual-
+    recovery pause must keep firing so a human fixes the ruleset."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "Select suites", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    host.emit_status_change.assert_called_once()
+
+
+def test_merge_policy_block_with_unresolvable_commit_time_pauses():
+    """Fail-closed: an unresolvable head commit time (missing date, or the
+    API call failing) must not arm the freshness defer — pause as before and
+    let the monitor sweep re-classify (#1989 fail-closed spirit)."""
+    deps, _ = _policy_unsettled_deps(
+        checks=[{"name": "Select suites", "bucket": "pass"}],
+        committed_at=None,
+    )
+    assert merge_phase.handle(_ctx(_workflow()), deps).outcome == "pause"
+
+    deps_raise, _ = _policy_unsettled_deps(
+        checks=[{"name": "Select suites", "bucket": "pass"}],
+        committed_at=None,
+    )
+    deps_raise.gh.get_commit_committed_at.side_effect = GitHubOpsError("api down")
+    assert merge_phase.handle(_ctx(_workflow()), deps_raise).outcome == "pause"
+
+
+def test_merge_policy_block_with_unobservable_required_still_pauses():
+    """Degraded contract: when the required set cannot be observed (branch
+    protection query fails), no completeness judgment is possible — keep the
+    legacy pause."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "Select suites", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc),
+    )
+    deps.gh.get_branch_protection.side_effect = GitHubOpsError("no access")
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    host.emit_status_change.assert_called_once()
+
+
+def test_merge_policy_block_with_required_present_skips_commit_time_lookup():
+    """Short-circuit: when every required context has already reported, the
+    freshness machinery must not even consult the commit-time API."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc),
+    )
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    deps.gh.get_commit_committed_at.assert_not_called()
     host.emit_status_change.assert_called_once()
 
 

--- a/tests/autonomous/test_github_ops_date_parse.py
+++ b/tests/autonomous/test_github_ops_date_parse.py
@@ -29,3 +29,10 @@ def test_parse_garbage_and_empty_returns_none():
     assert parse_github_iso_datetime("   ") is None
     assert parse_github_iso_datetime("not-a-date") is None
     assert parse_github_iso_datetime(None) is None
+
+
+def test_parse_offsetless_datetime_rejected():
+    """A parseable but offset-less value would blow up the caller's aware
+    ``now() - committed_at`` subtraction with a TypeError, escaping its
+    fail-closed contract — reject it here instead (PR review finding)."""
+    assert parse_github_iso_datetime("2026-08-18 17:43:12") is None

--- a/tests/autonomous/test_github_ops_date_parse.py
+++ b/tests/autonomous/test_github_ops_date_parse.py
@@ -1,0 +1,31 @@
+"""GitHubOps ISO-8601 date parsing (Z-suffix normalization).
+
+GitHub API timestamps end in ``Z``; ``datetime.fromisoformat`` only parses
+that suffix from Python 3.11, while this repo supports 3.10. The merge-phase
+freshness defer depends on this parser — a silent parse failure there would
+disable the defer exactly on 3.10 deployments.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.modules.workspace.autonomous.github_ops import parse_github_iso_datetime
+
+
+def test_parse_z_suffix_yields_aware_utc():
+    parsed = parse_github_iso_datetime("2026-08-18T17:43:12Z")
+    assert parsed == datetime(2026, 8, 18, 17, 43, 12, tzinfo=timezone.utc)
+
+
+def test_parse_explicit_offset():
+    parsed = parse_github_iso_datetime("2026-08-18T17:43:12+08:00")
+    assert parsed is not None
+    assert parsed.utcoffset().total_seconds() == 8 * 3600
+
+
+def test_parse_garbage_and_empty_returns_none():
+    assert parse_github_iso_datetime("") is None
+    assert parse_github_iso_datetime("   ") is None
+    assert parse_github_iso_datetime("not-a-date") is None
+    assert parse_github_iso_datetime(None) is None


### PR DESCRIPTION
## Summary

Residual gap in the merge-phase policy guard (class-2, follow-up to the #2503 defer): right after a CI-repair push, the new head SHA can have check-runs only for fast non-required jobs while the required aggregate gate (e.g. `PR Gate`) has no run yet. The refreshed rollup then shows **no pending bucket** while GitHub reports `blocked`, and the guard read that as a settled genuine policy block — freezing the workflow at a manual-recovery pause it could never exit on its own.

Reproduced by workflow 9676f33f (issue #2778) / PR #2804 on 2026-08-19: CI-repair commit pushed 17:43 UTC, spurious pause 90s later; the PR was fully CLEAN minutes after, and the reset retry merged cleanly in one attempt.

## Change

- `phases/merge.py`: in the policy-pause branch, before pausing — if required contexts are **absent** from the refreshed rollup (not pending, not failed) AND the head commit is younger than the settle grace window, defer (`PhaseResult.retry`) instead of pausing.
  - Grace window `_POLICY_SETTLE_GRACE_SECONDS = 1200`, aligned with the codebase's own `ZERO_CHECK_RUNS_WALL_CLOCK_FLOOR` (same CI provisioning lag class).
  - Beyond the window, absence keeps the legacy pause (required-context-without-provider misconfig still needs a human).
  - `_head_freshly_pushed` fails closed: empty SHA / API error / unparseable date → no defer → legacy pause.
- `github_ops.py`: new `parse_github_iso_datetime` (Z-suffix normalization — `fromisoformat` only parses `Z` from 3.11, this repo supports 3.10) and `get_commit_committed_at(sha)` (committer date ≈ push time). Called only on the rare rejected-merge path, not the hot loop.

## Test plan

- RED→GREEN: `test_merge_policy_block_with_missing_required_on_fresh_head_defers` (the #2778 regression) — failed on main behavior, passes now.
- Guard rails: stale head (misconfig path) still pauses; unresolvable commit time fails closed to pause; unobservable required set keeps legacy pause; required-present short-circuits the commit-time lookup.
- `tests/autonomous/test_github_ops_date_parse.py`: real `...Z` timestamp parses to aware UTC; offsets parse; garbage/empty/None → None.
- Full `tests/autonomous/` suite: 170 passed; black/isort/ruff/mypy clean.

Plan doc: `docs/superpowers/plans/2026-08-19-merge-policy-unsettled-blindspot.md` (root-cause evidence timeline + rejected alternatives).