### PR TITLE
[Auto] Dev round 2: 2760-2

### DIFF
--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -318,6 +318,7 @@ def run_auto_mapping():
 
     Issue #2180: Tenant admin can only run for their tenant.
     Issue #2374: Changed to fail-closed pattern for consistency.
+    Issue #2760: Return detailed stats to distinguish zero-result reasons.
     """
     data = request.get_json() or {}
     dry_run = data.get("dry_run", False)
@@ -327,20 +328,26 @@ def run_auto_mapping():
 
     service = ToolAccountAutoMappingService()
 
+    # Issue #2760: Use new method with detailed stats
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        results, still_unmapped = service.run_auto_mapping(
+        stats = service.run_auto_mapping_with_stats(
             dry_run=dry_run, tenant_id=user_tenant_id
         )
     else:
-        results, still_unmapped = service.run_auto_mapping(dry_run=dry_run)
+        stats = service.run_auto_mapping_with_stats(dry_run=dry_run)
 
     return jsonify(
         {
-            "mapped_count": len(results),
-            "unmapped_count": len(still_unmapped),
-            "mappings": [r.__dict__ for r in results],
+            "discovered_count": stats.discovered_count,
+            "already_mapped_count": stats.already_mapped_count,
+            "candidate_count": stats.candidate_count,
+            "mapped_count": stats.mapped_count,
+            "unmatched_count": stats.unmatched_count,
+            "excluded_count": stats.excluded_count,
+            "exclusion_reasons": stats.exclusion_reasons,
+            "mappings": stats.mappings,
             "dry_run": dry_run,
         }
     )

--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -332,9 +332,7 @@ def run_auto_mapping():
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        stats = service.run_auto_mapping_with_stats(
-            dry_run=dry_run, tenant_id=user_tenant_id
-        )
+        stats = service.run_auto_mapping_with_stats(dry_run=dry_run, tenant_id=user_tenant_id)
     else:
         stats = service.run_auto_mapping_with_stats(dry_run=dry_run)
 

--- a/app/services/tool_account_auto_mapping_service.py
+++ b/app/services/tool_account_auto_mapping_service.py
@@ -34,6 +34,23 @@ class AutoMappingResult:
 
 
 @dataclass
+class AutoMappingStats:
+    """Detailed statistics for auto-mapping operation.
+
+    Issue #2760: Extend result model to distinguish zero-result reasons.
+    """
+
+    discovered_count: int  # Total accounts discovered from daily_messages
+    already_mapped_count: int  # Accounts that already have mapping
+    candidate_count: int  # Unmapped candidates before rules
+    mapped_count: int  # Successfully mapped in this run
+    unmatched_count: int  # No rule matched
+    excluded_count: int  # Filtered by tenant/restrictions
+    exclusion_reasons: dict[str, int]  # Breakdown by reason
+    mappings: list[dict]  # Successful mappings
+
+
+@dataclass
 class GenerateDefaultRulesResult:
     """Result of generating default mapping rules for a user."""
 
@@ -297,6 +314,86 @@ class ToolAccountAutoMappingService:
                 still_unmapped.append(account)
 
         return results, still_unmapped
+
+    def run_auto_mapping_with_stats(
+        self, dry_run: bool = False, tenant_id: int | None = None
+    ) -> AutoMappingStats:
+        """
+        Run auto-mapping with detailed statistics.
+
+        Issue #2760: Extend result model to distinguish zero-result reasons.
+
+        Returns detailed stats including:
+        - discovered_count: Total accounts from daily_messages
+        - already_mapped_count: Already have mapping
+        - candidate_count: Unmapped before rules
+        - mapped_count: Successfully mapped
+        - unmatched_count: No rule matched
+        - excluded_count: Filtered by tenant
+        - exclusion_reasons: Breakdown by reason
+        """
+        # Clear cache to ensure fresh user data
+        self._users_cache = None
+
+        # Get all unique sender_names from daily_messages
+        discovered_query = """
+            SELECT DISTINCT sender_name FROM daily_messages
+            WHERE sender_name IS NOT NULL AND sender_name != ''
+        """
+        discovered_rows = self.db.fetch_all(discovered_query)
+        discovered_count = len(discovered_rows)
+
+        # Count already mapped
+        mapped_query = "SELECT COUNT(*) as cnt FROM user_tool_accounts"
+        mapped_row = self.db.fetch_one(mapped_query)
+        already_mapped_count = mapped_row["cnt"] if mapped_row else 0
+
+        # Get unmapped candidates (already filtered by tenant in the query)
+        unmapped = self.get_unmapped_accounts(tenant_id=tenant_id)
+        candidate_count = len(unmapped)
+
+        # Track exclusion reasons
+        exclusion_reasons: dict[str, int] = {}
+
+        # If tenant_id, estimate how many were excluded by tenant filter
+        if tenant_id is not None:
+            # Get all unmapped without tenant filter
+            all_unmapped = self.get_unmapped_accounts(tenant_id=None)
+            excluded_by_tenant = len(all_unmapped) - candidate_count
+            if excluded_by_tenant > 0:
+                exclusion_reasons["tenant_filter"] = excluded_by_tenant
+
+        results = []
+        unmatched_count = 0
+
+        for account in unmapped:
+            tool_account = account.get("sender_name", "")
+            tool_type = self._infer_tool_type(tool_account)
+
+            result = self.auto_map_account(tool_account, tool_type, tenant_id=tenant_id)
+
+            if result:
+                if not dry_run:
+                    mapping_id = self.apply_mapping(result)
+                    result.created_mapping_id = mapping_id
+                    logger.info(
+                        f"Auto-mapped {tool_account} to user {result.username} "
+                        f"via {result.matched_by}"
+                    )
+                results.append(result)
+            else:
+                unmatched_count += 1
+
+        return AutoMappingStats(
+            discovered_count=discovered_count,
+            already_mapped_count=already_mapped_count,
+            candidate_count=candidate_count,
+            mapped_count=len(results),
+            unmatched_count=unmatched_count,
+            excluded_count=sum(exclusion_reasons.values()),
+            exclusion_reasons=exclusion_reasons,
+            mappings=[r.__dict__ for r in results],
+        )
 
     def _infer_tool_type(self, tool_account: str) -> str | None:
         """Infer tool type from tool_account suffix."""

--- a/tests/integration/test_tenant_isolation_mapping_rules.py
+++ b/tests/integration/test_tenant_isolation_mapping_rules.py
@@ -847,18 +847,32 @@ class TestAdminWithTenantIdNotScoped:
         self, mock_service_class, admin_with_tenant_client
     ):
         """Admin with tenant_id should run auto-mapping globally, not tenant-scoped."""
+        from app.services.tool_account_auto_mapping_service import AutoMappingStats
+
         mock_service = MagicMock()
-        mock_service.run_auto_mapping.return_value = ([], [])
+        # Issue #2760: Mock the new method with stats
+        mock_stats = AutoMappingStats(
+            discovered_count=0,
+            already_mapped_count=0,
+            candidate_count=0,
+            mapped_count=0,
+            unmatched_count=0,
+            excluded_count=0,
+            exclusion_reasons={},
+            mappings=[],
+        )
+        mock_service.run_auto_mapping_with_stats.return_value = mock_stats
         mock_service_class.return_value = mock_service
 
-        admin_with_tenant_client.post(
+        response = admin_with_tenant_client.post(
             "/api/mapping-rules/auto-map",
             data=json.dumps({"dry_run": True}),
             content_type="application/json",
         )
 
-        # Should NOT pass tenant_id to run_auto_mapping
-        mock_service.run_auto_mapping.assert_called_once_with(dry_run=True)
+        # Should NOT pass tenant_id to run_auto_mapping_with_stats
+        mock_service.run_auto_mapping_with_stats.assert_called_once_with(dry_run=True)
+        assert response.status_code == 200
 
     @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
     def test_admin_with_tenant_sees_all_rules(self, mock_repo_class, admin_with_tenant_client):

--- a/tests/integration/test_user_tool_account_repo_pg.py
+++ b/tests/integration/test_user_tool_account_repo_pg.py
@@ -10,17 +10,40 @@ pytestmark = pytest.mark.postgres
 from app.repositories.user_tool_account_repo import UserToolAccountRepository
 
 
-def _insert_user(pg_db, username="testuser", email=None):
-    """Insert a user and return the id."""
+def _insert_user(pg_db, username="testuser", email=None, system_account=None, tenant_id=None):
+    """Insert a user and return the id.
+
+    Issue #2760: Added system_account and tenant_id parameters.
+    """
     if email is None:
         email = f"{username}@example.com"
     row = pg_db.fetch_one(
-        "INSERT INTO users (username, email, password_hash, role) "
-        "VALUES (%s, %s, %s, %s) RETURNING id",
-        (username, email, "hashed_pw", "user"),
+        "INSERT INTO users (username, email, password_hash, role, system_account, tenant_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s) RETURNING id",
+        (username, email, "hashed_pw", "user", system_account, tenant_id),
         commit=True,
     )
     return row["id"]
+
+
+def _insert_tenant(pg_db, name="test_tenant"):
+    """Insert a tenant and return the id."""
+    row = pg_db.fetch_one(
+        "INSERT INTO tenants (name) VALUES (%s) RETURNING id",
+        (name,),
+        commit=True,
+    )
+    return row["id"]
+
+
+def _insert_daily_message(pg_db, sender_name, date="2026-01-01", message_source=None):
+    """Insert a daily_messages row for testing unmapped accounts."""
+    pg_db.fetch_one(
+        "INSERT INTO daily_messages (date, sender_name, message_source, message_count) "
+        "VALUES (%s, %s, %s, 1)",
+        (date, sender_name, message_source),
+        commit=True,
+    )
 
 
 class TestUserToolAccountCRUD:
@@ -98,3 +121,172 @@ class TestUserToolAccountCRUD:
 
         second = repo.create(user_id=user_id, tool_account="grace_qwen")
         assert second is None
+
+
+class TestGetUnmappedToolAccountsTenantFilter:
+    """
+    Issue #2760: Tests for get_unmapped_tool_accounts with tenant filtering.
+
+    Covers:
+    - Non-ASCII display names
+    - Different system_account from username
+    - Custom mapping rules
+    - Cross-tenant duplicate names
+    """
+
+    def test_non_ascii_username_matches_sender_name(self, pg_db):
+        """User with non-ASCII display name can still be matched.
+
+        Issue #2760: sender_name with system_account prefix should match
+        even when username contains non-ASCII characters.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_id = _insert_tenant(pg_db, name="tenant_a")
+
+        # User has Chinese display name but English system_account
+        _insert_user(
+            pg_db,
+            username="张三",  # Chinese display name
+            system_account="zhangsan",
+            tenant_id=tenant_id,
+        )
+
+        # Tool account uses system_account prefix, not username
+        _insert_daily_message(pg_db, sender_name="zhangsan-host-qwen")
+
+        unmapped = repo.get_unmapped_tool_accounts(tenant_id=tenant_id)
+        assert len(unmapped) == 1
+        assert unmapped[0]["sender_name"] == "zhangsan-host-qwen"
+
+    def test_system_account_differs_from_username(self, pg_db):
+        """Sender name uses system_account, not username.
+
+        Issue #2760: Tool accounts typically follow {system_account}-{hostname}-{tool}
+        format, which differs from the display username.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_id = _insert_tenant(pg_db, name="tenant_b")
+
+        # User has different username and system_account
+        _insert_user(
+            pg_db,
+            username="user_a",  # Display name
+            system_account="acct-a",  # System account
+            tenant_id=tenant_id,
+        )
+
+        # Tool account uses system_account prefix
+        _insert_daily_message(pg_db, sender_name="acct-a-host-qwen")
+
+        unmapped = repo.get_unmapped_tool_accounts(tenant_id=tenant_id)
+        assert len(unmapped) == 1
+        assert unmapped[0]["sender_name"] == "acct-a-host-qwen"
+
+    def test_null_system_account_fallback_to_username(self, pg_db):
+        """When system_account is NULL, fallback to username prefix matching.
+
+        Issue #2760: Handle users without system_account set.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_id = _insert_tenant(pg_db, name="tenant_c")
+
+        # User without system_account
+        _insert_user(
+            pg_db,
+            username="fallback_user",
+            system_account=None,
+            tenant_id=tenant_id,
+        )
+
+        # Sender name uses username prefix
+        _insert_daily_message(pg_db, sender_name="fallback_user-host-qwen")
+
+        unmapped = repo.get_unmapped_tool_accounts(tenant_id=tenant_id)
+        assert len(unmapped) == 1
+        assert unmapped[0]["sender_name"] == "fallback_user-host-qwen"
+
+    def test_cross_tenant_duplicate_names(self, pg_db):
+        """Different tenants can have users with same username.
+
+        Issue #2760: Tenant isolation ensures each tenant only sees
+        their own unmapped accounts, even with duplicate usernames.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_a = _insert_tenant(pg_db, name="tenant_d")
+        tenant_b = _insert_tenant(pg_db, name="tenant_e")
+
+        # Both tenants have user with same username
+        _insert_user(
+            pg_db,
+            username="shared_user",
+            system_account="shared-acct-a",
+            tenant_id=tenant_a,
+        )
+        _insert_user(
+            pg_db,
+            username="shared_user",
+            system_account="shared-acct-b",
+            tenant_id=tenant_b,
+        )
+
+        # Messages from both tenants
+        _insert_daily_message(pg_db, sender_name="shared-acct-a-host-qwen")
+        _insert_daily_message(pg_db, sender_name="shared-acct-b-host-qwen")
+
+        # Each tenant only sees their own
+        unmapped_a = repo.get_unmapped_tool_accounts(tenant_id=tenant_a)
+        unmapped_b = repo.get_unmapped_tool_accounts(tenant_id=tenant_b)
+
+        assert len(unmapped_a) == 1
+        assert unmapped_a[0]["sender_name"] == "shared-acct-a-host-qwen"
+
+        assert len(unmapped_b) == 1
+        assert unmapped_b[0]["sender_name"] == "shared-acct-b-host-qwen"
+
+    def test_exact_username_match_included(self, pg_db):
+        """Exact username match should still work.
+
+        Issue #2760: While we prefer system_account, exact username
+        matches should still be included in results.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_id = _insert_tenant(pg_db, name="tenant_f")
+
+        _insert_user(
+            pg_db,
+            username="exactuser",
+            system_account="exact-acct",
+            tenant_id=tenant_id,
+        )
+
+        # Sender name exactly matches username (no prefix)
+        _insert_daily_message(pg_db, sender_name="exactuser")
+
+        unmapped = repo.get_unmapped_tool_accounts(tenant_id=tenant_id)
+        assert len(unmapped) == 1
+        assert unmapped[0]["sender_name"] == "exactuser"
+
+    def test_postgres_like_percent_escape(self, pg_db):
+        """PostgreSQL LIKE pattern uses %% for literal %.
+
+        Issue #2760: The query should use '-%%' which works correctly
+        with psycopg2 parameter handling.
+        """
+        repo = UserToolAccountRepository(db=pg_db)
+        tenant_id = _insert_tenant(pg_db, name="tenant_g")
+
+        _insert_user(
+            pg_db,
+            username="testuser",
+            system_account="testacct",
+            tenant_id=tenant_id,
+        )
+
+        # Normal sender name pattern
+        _insert_daily_message(pg_db, sender_name="testacct-host-qwen")
+
+        # This should NOT cause IndexError from parameter mismatch
+        unmapped = repo.get_unmapped_tool_accounts(tenant_id=tenant_id)
+
+        assert len(unmapped) == 1
+        assert unmapped[0]["sender_name"] == "testacct-host-qwen"

--- a/tests/unit/test_mapping_rules_api.py
+++ b/tests/unit/test_mapping_rules_api.py
@@ -277,15 +277,25 @@ class TestAutoMapping:
     @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
     def test_run_auto_mapping_success(self, mock_service_class, admin_client):
         """POST /api/mapping-rules/auto-map should run auto-mapping."""
+        from app.services.tool_account_auto_mapping_service import AutoMappingStats
+
         mock_service = MagicMock()
-        mock_result = MagicMock()
-        mock_result.__dict__ = {
-            "tool_account": "test-account",
-            "user_id": 1,
-            "username": "test_user",
-            "matched_by": "username",
-        }
-        mock_service.run_auto_mapping.return_value = ([mock_result], [])
+        mock_stats = AutoMappingStats(
+            discovered_count=10,
+            already_mapped_count=5,
+            candidate_count=5,
+            mapped_count=1,
+            unmatched_count=4,
+            excluded_count=0,
+            exclusion_reasons={},
+            mappings=[{
+                "tool_account": "test-account",
+                "user_id": 1,
+                "username": "test_user",
+                "matched_by": "username",
+            }],
+        )
+        mock_service.run_auto_mapping_with_stats.return_value = mock_stats
         mock_service_class.return_value = mock_service
 
         response = admin_client.post(
@@ -296,13 +306,25 @@ class TestAutoMapping:
         assert response.status_code == 200
         data = json.loads(response.data)
         assert data["mapped_count"] == 1
-        assert data["unmapped_count"] == 0
+        assert data["unmatched_count"] == 4
 
     @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
     def test_run_auto_mapping_dry_run(self, mock_service_class, admin_client):
         """POST /api/mapping-rules/auto-map should support dry_run mode."""
+        from app.services.tool_account_auto_mapping_service import AutoMappingStats
+
         mock_service = MagicMock()
-        mock_service.run_auto_mapping.return_value = ([], [])
+        mock_stats = AutoMappingStats(
+            discovered_count=0,
+            already_mapped_count=0,
+            candidate_count=0,
+            mapped_count=0,
+            unmatched_count=0,
+            excluded_count=0,
+            exclusion_reasons={},
+            mappings=[],
+        )
+        mock_service.run_auto_mapping_with_stats.return_value = mock_stats
         mock_service_class.return_value = mock_service
 
         response = admin_client.post(

--- a/tests/unit/test_mapping_rules_api.py
+++ b/tests/unit/test_mapping_rules_api.py
@@ -288,12 +288,14 @@ class TestAutoMapping:
             unmatched_count=4,
             excluded_count=0,
             exclusion_reasons={},
-            mappings=[{
-                "tool_account": "test-account",
-                "user_id": 1,
-                "username": "test_user",
-                "matched_by": "username",
-            }],
+            mappings=[
+                {
+                    "tool_account": "test-account",
+                    "user_id": 1,
+                    "username": "test_user",
+                    "matched_by": "username",
+                }
+            ],
         )
         mock_service.run_auto_mapping_with_stats.return_value = mock_stats
         mock_service_class.return_value = mock_service


### PR DESCRIPTION
Autonomous development for dev round 2.

## Changes

This PR addresses the remaining acceptance criteria from Issue #2760:

### 1. API Response Model Extension

Added `AutoMappingStats` dataclass with detailed zero-result reasons:
- `discovered_count`: Total accounts from daily_messages
- `already_mapped_count`: Already have mapping
- `candidate_count`: Unmapped before rules
- `mapped_count`: Successfully mapped
- `unmatched_count`: No rule matched
- `excluded_count`: Filtered by tenant
- `exclusion_reasons`: Breakdown by reason

Updated `/api/mapping-rules/auto-map` endpoint to return detailed stats.

### 2. PostgreSQL Integration Tests

Added comprehensive tests for:
- Non-ASCII display names with system_account
- Different system_account from username
- NULL system_account fallback to username
- Cross-tenant duplicate names
- Exact username match
- PostgreSQL LIKE percent escape (`-%%`)

## Verification

- ✅ Ruff check passed
- ✅ Unit tests passed

Implements #2760