### PR TITLE
[Feat] Issue #2761: 前端 UI 支持工具账号状态可视化和高级预配置

### DIFF
--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -5,6 +5,22 @@
 import { apiClient } from './client';
 
 // Types
+export type MappingSource =
+  | 'manual'
+  | 'auto'
+  | 'predeclared'
+  | 'import'
+  | 'discovered'
+  | 'legacy_predeclared';
+
+export type MappingStatus =
+  | 'pending'
+  | 'active'
+  | 'stale'
+  | 'conflict_type'
+  | 'conflict_owner'
+  | 'conflict_tenant';
+
 export interface ToolAccount {
   id: number;
   user_id: number;
@@ -14,6 +30,15 @@ export interface ToolAccount {
   description: string | null;
   created_at: string | null;
   updated_at: string | null;
+  // Issue #2761: New fields
+  mapping_source?: MappingSource | null;
+  mapping_status?: MappingStatus | null;
+  discovered_at?: string | null;
+  last_activity_at?: string | null;
+  observed_message_count?: number;
+  created_by?: number | null;
+  tenant_id?: number | null;
+  version?: number;
 }
 
 export interface UnmappedAccount {
@@ -63,6 +88,9 @@ export const toolAccountsApi = {
     tool_account: string;
     tool_type?: string;
     description?: string;
+    // Issue #2761: New fields for predeclared accounts
+    mapping_source?: MappingSource;
+    mapping_status?: MappingStatus;
   }): Promise<{ mapping: ToolAccount; updated_messages: number }> {
     return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>(
       '/api/tool-accounts',

--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -60,7 +60,7 @@ export const toolAccountsApi = {
   },
 
   async getByUser(userId: number): Promise<ToolAccount[]> {
-    return apiClient.get<ToolAccount[]>(\`/api/tool-accounts/user/\${userId}\`);
+    return apiClient.get<ToolAccount[]>(`/api/tool-accounts/user/${userId}`);
   },
 
   async getUnmapped(): Promise<UnmappedAccount[]> {
@@ -80,10 +80,7 @@ export const toolAccountsApi = {
     mapping_source?: MappingSource;
     mapping_status?: MappingStatus;
   }): Promise<{ mapping: ToolAccount; updated_messages: number }> {
-    return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>(
-      '/api/tool-accounts',
-      data
-    );
+    return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>('/api/tool-accounts', data);
   },
 
   async update(
@@ -95,11 +92,11 @@ export const toolAccountsApi = {
       description?: string;
     }
   ): Promise<ToolAccount> {
-    return apiClient.put<ToolAccount>(\`/api/tool-accounts/\${id}\`, data);
+    return apiClient.put<ToolAccount>(`/api/tool-accounts/${id}`, data);
   },
 
   async delete(id: number): Promise<void> {
-    await apiClient.delete(\`/api/tool-accounts/\${id}\`);
+    await apiClient.delete(`/api/tool-accounts/${id}`);
   },
 
   async batchCreate(
@@ -111,7 +108,7 @@ export const toolAccountsApi = {
     }>
   ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
     return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
-      \`/api/tool-accounts/user/\${userId}/batch\`,
+      `/api/tool-accounts/user/${userId}/batch`,
       { tool_accounts: toolAccounts }
     );
   },

--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -5,9 +5,11 @@
 import { apiClient } from './client';
 
 // Types
-export type MappingSource = 'manual' | 'auto' | 'predeclared' | 'import' | 'discovered' | 'legacy_predeclared';
+export type MappingSource =
+  'manual' | 'auto' | 'predeclared' | 'import' | 'discovered' | 'legacy_predeclared';
 
-export type MappingStatus = 'pending' | 'active' | 'stale' | 'conflict_type' | 'conflict_owner' | 'conflict_tenant';
+export type MappingStatus =
+  'pending' | 'active' | 'stale' | 'conflict_type' | 'conflict_owner' | 'conflict_tenant';
 
 export interface ToolAccount {
   id: number;
@@ -80,7 +82,10 @@ export const toolAccountsApi = {
     mapping_source?: MappingSource;
     mapping_status?: MappingStatus;
   }): Promise<{ mapping: ToolAccount; updated_messages: number }> {
-    return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>('/api/tool-accounts', data);
+    return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>(
+      '/api/tool-accounts',
+      data
+    );
   },
 
   async update(
@@ -107,8 +112,9 @@ export const toolAccountsApi = {
       description?: string;
     }>
   ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
-    return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(`/api/tool-accounts/user/${userId}/batch`, {
-      tool_accounts: toolAccounts,
-    });
+    return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
+      `/api/tool-accounts/user/${userId}/batch`,
+      { tool_accounts: toolAccounts }
+    );
   },
 };

--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -107,9 +107,8 @@ export const toolAccountsApi = {
       description?: string;
     }>
   ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
-    return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
-      `/api/tool-accounts/user/${userId}/batch`,
-      { tool_accounts: toolAccounts }
-    );
+    return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(`/api/tool-accounts/user/${userId}/batch`, {
+      tool_accounts: toolAccounts,
+    });
   },
 };

--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -5,21 +5,9 @@
 import { apiClient } from './client';
 
 // Types
-export type MappingSource =
-  | 'manual'
-  | 'auto'
-  | 'predeclared'
-  | 'import'
-  | 'discovered'
-  | 'legacy_predeclared';
+export type MappingSource = 'manual' | 'auto' | 'predeclared' | 'import' | 'discovered' | 'legacy_predeclared';
 
-export type MappingStatus =
-  | 'pending'
-  | 'active'
-  | 'stale'
-  | 'conflict_type'
-  | 'conflict_owner'
-  | 'conflict_tenant';
+export type MappingStatus = 'pending' | 'active' | 'stale' | 'conflict_type' | 'conflict_owner' | 'conflict_tenant';
 
 export interface ToolAccount {
   id: number;
@@ -72,7 +60,7 @@ export const toolAccountsApi = {
   },
 
   async getByUser(userId: number): Promise<ToolAccount[]> {
-    return apiClient.get<ToolAccount[]>(`/api/tool-accounts/user/${userId}`);
+    return apiClient.get<ToolAccount[]>(\`/api/tool-accounts/user/\${userId}\`);
   },
 
   async getUnmapped(): Promise<UnmappedAccount[]> {
@@ -107,11 +95,11 @@ export const toolAccountsApi = {
       description?: string;
     }
   ): Promise<ToolAccount> {
-    return apiClient.put<ToolAccount>(`/api/tool-accounts/${id}`, data);
+    return apiClient.put<ToolAccount>(\`/api/tool-accounts/\${id}\`, data);
   },
 
   async delete(id: number): Promise<void> {
-    await apiClient.delete(`/api/tool-accounts/${id}`);
+    await apiClient.delete(\`/api/tool-accounts/\${id}\`);
   },
 
   async batchCreate(
@@ -123,7 +111,7 @@ export const toolAccountsApi = {
     }>
   ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
     return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
-      `/api/tool-accounts/user/${userId}/batch`,
+      \`/api/tool-accounts/user/\${userId}/batch\`,
       { tool_accounts: toolAccounts }
     );
   },

--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -49,7 +49,7 @@ const getStatusBadgeVariant = (
 /**
  * Get status display text
  */
-const getStatusDisplay = (status?: MappingStatus | null, language: string): string => {
+const getStatusDisplay = (status?: MappingStatus | null, language: string = 'en'): string => {
   switch (status) {
     case 'active':
       return language === 'zh' ? '活跃' : 'Active';
@@ -208,7 +208,6 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
                 {account.mapping_status && (
                   <Badge
                     variant={getStatusBadgeVariant(account.mapping_status)}
-                    size="sm"
                     className="me-1"
                     style={{ fontSize: '0.65rem' }}
                   >
@@ -243,7 +242,6 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
         {/* Issue #2761: Change "Add" to "Advanced Preconfigure" */}
         <Button
           variant="outline-secondary"
-          size="sm"
           onClick={() => {
             setAddError(null);
             setShowPredeclaredConfirm(true);
@@ -253,7 +251,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
           {language === 'zh' ? '高级预配置' : 'Advanced Preconfigure'}
         </Button>
         {unmappedAccounts.length > 0 && (
-          <Button variant="outline-primary" size="sm" onClick={() => setShowUnmappedModal(true)}>
+          <Button variant="outline-primary" onClick={() => setShowUnmappedModal(true)}>
             <i className="bi bi-link me-1" />
             {t('mapToUser', language)}
             <Badge variant="secondary" className="ms-1">

--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -1,5 +1,10 @@
 /**
  * ToolAccountsEditor Component - Edit tool accounts for a user
+ *
+ * Issue #2761: Enhanced with:
+ * - Status visualization (pending/active/stale/conflict)
+ * - Message count display
+ * - Advanced predeclared account creation with confirmation
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
@@ -11,12 +16,57 @@ import {
   type ToolAccount,
   type UnmappedAccount,
   type ToolType,
+  type MappingStatus,
 } from '@/api/toolAccounts';
 
 interface ToolAccountsEditorProps {
   userId: number;
   onChange?: () => void;
 }
+
+/**
+ * Get badge variant based on mapping status
+ */
+const getStatusBadgeVariant = (
+  status?: MappingStatus | null
+): 'success' | 'warning' | 'danger' | 'secondary' => {
+  switch (status) {
+    case 'active':
+      return 'success';
+    case 'pending':
+      return 'warning';
+    case 'stale':
+      return 'secondary';
+    case 'conflict_type':
+    case 'conflict_owner':
+    case 'conflict_tenant':
+      return 'danger';
+    default:
+      return 'secondary';
+  }
+};
+
+/**
+ * Get status display text
+ */
+const getStatusDisplay = (status?: MappingStatus | null, language: string): string => {
+  switch (status) {
+    case 'active':
+      return language === 'zh' ? '活跃' : 'Active';
+    case 'pending':
+      return language === 'zh' ? '待激活' : 'Pending';
+    case 'stale':
+      return language === 'zh' ? '无活动' : 'Stale';
+    case 'conflict_type':
+      return language === 'zh' ? '类型冲突' : 'Type Conflict';
+    case 'conflict_owner':
+      return language === 'zh' ? '归属冲突' : 'Owner Conflict';
+    case 'conflict_tenant':
+      return language === 'zh' ? '租户冲突' : 'Tenant Conflict';
+    default:
+      return '';
+  }
+};
 
 export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, onChange }) => {
   const language = useLanguage();
@@ -34,6 +84,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   const [selectedUnmapped, setSelectedUnmapped] = useState<string[]>([]);
   const [isAdding, setIsAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+  const [showPredeclaredConfirm, setShowPredeclaredConfirm] = useState(false);
   const toast = useToast();
 
   const loadData = useCallback(async () => {
@@ -61,7 +112,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   const handleAddAccount = async () => {
     setAddError(null);
 
-    // 验证必填字段
+    // Validate required fields
     if (!newAccount.tool_account.trim()) {
       setAddError(t('toolAccountRequired', language));
       return;
@@ -69,14 +120,18 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
 
     setIsAdding(true);
     try {
+      // Issue #2761: Create as predeclared account with pending status
       await toolAccountsApi.create({
         user_id: userId,
         tool_account: newAccount.tool_account,
         tool_type: newAccount.tool_type || undefined,
         description: newAccount.description || undefined,
+        mapping_source: 'predeclared',
+        mapping_status: 'pending',
       });
       setNewAccount({ tool_account: '', tool_type: '', description: '' });
       setShowAddModal(false);
+      setShowPredeclaredConfirm(false);
       loadData();
       onChange?.();
       toast.success(t('addToolAccountSuccess', language));
@@ -137,7 +192,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
 
   return (
     <div className="tool-accounts-editor">
-      {/* Current tool accounts */}
+      {/* Current tool accounts with status visualization */}
       <div className="mb-2">
         <div className="d-flex align-items-center gap-2 flex-wrap">
           {toolAccounts.length === 0 ? (
@@ -149,9 +204,27 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
                 variant="secondary"
                 className="d-flex align-items-center gap-1"
               >
+                {/* Issue #2761: Show status badge */}
+                {account.mapping_status && (
+                  <Badge
+                    variant={getStatusBadgeVariant(account.mapping_status)}
+                    size="sm"
+                    className="me-1"
+                    style={{ fontSize: '0.65rem' }}
+                  >
+                    {getStatusDisplay(account.mapping_status, language)}
+                  </Badge>
+                )}
                 {account.tool_type_display ?? account.tool_type ?? ''}
                 {account.tool_type ? ': ' : ''}
                 {account.tool_account}
+                {/* Issue #2761: Show message count */}
+                {account.observed_message_count !== undefined &&
+                  account.observed_message_count > 0 && (
+                    <span className="ms-1 text-muted" style={{ fontSize: '0.65rem' }}>
+                      ({account.observed_message_count})
+                    </span>
+                  )}
                 <button
                   type="button"
                   className="btn-close btn-close-white ms-1"
@@ -167,19 +240,20 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
 
       {/* Action buttons */}
       <div className="d-flex gap-2">
+        {/* Issue #2761: Change "Add" to "Advanced Preconfigure" */}
         <Button
-          variant="outline-primary"
+          variant="outline-secondary"
           size="sm"
           onClick={() => {
             setAddError(null);
-            setShowAddModal(true);
+            setShowPredeclaredConfirm(true);
           }}
         >
-          <i className="bi bi-plus-lg me-1" />
-          {t('addToolAccount', language)}
+          <i className="bi bi-gear me-1" />
+          {language === 'zh' ? '高级预配置' : 'Advanced Preconfigure'}
         </Button>
         {unmappedAccounts.length > 0 && (
-          <Button variant="outline-secondary" size="sm" onClick={() => setShowUnmappedModal(true)}>
+          <Button variant="outline-primary" size="sm" onClick={() => setShowUnmappedModal(true)}>
             <i className="bi bi-link me-1" />
             {t('mapToUser', language)}
             <Badge variant="secondary" className="ms-1">
@@ -189,11 +263,66 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
         )}
       </div>
 
+      {/* Issue #2761: Predeclared account confirmation modal */}
+      <Modal
+        isOpen={showPredeclaredConfirm}
+        onClose={() => setShowPredeclaredConfirm(false)}
+        title={language === 'zh' ? '高级预配置确认' : 'Advanced Preconfigure Confirmation'}
+        size="md"
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => setShowPredeclaredConfirm(false)}>
+              {t('cancel', language)}
+            </Button>
+            <Button
+              variant="warning"
+              onClick={() => {
+                setShowPredeclaredConfirm(false);
+                setShowAddModal(true);
+              }}
+            >
+              {language === 'zh' ? '我了解，继续' : 'I Understand, Continue'}
+            </Button>
+          </>
+        }
+      >
+        <div className="alert alert-warning">
+          <strong>{language === 'zh' ? '重要提示：' : 'Important:'}</strong>
+        </div>
+        <ul className="mb-3">
+          <li>
+            {language === 'zh'
+              ? '预配置账号当前未在数据中发现，需要等待采集数据到达后才会激活。'
+              : 'The predeclared account is not currently found in the data. It will only activate when matching data arrives.'}
+          </li>
+          <li>
+            {language === 'zh'
+              ? '保存此配置不会创建 Linux 用户、工具进程或历史数据。'
+              : 'Saving this configuration does NOT create a Linux user, tool process, or historical data.'}
+          </li>
+          <li>
+            {language === 'zh'
+              ? '只有未来收到完全相同的账号标识时才会生效。'
+              : 'It will only take effect when an identical account identifier is received in the future.'}
+          </li>
+          <li>
+            {language === 'zh'
+              ? '错误的预配置可能导致数据归属错误。'
+              : 'Incorrect preconfiguration may cause incorrect data attribution.'}
+          </li>
+        </ul>
+        <p className="text-muted small">
+          {language === 'zh'
+            ? '建议：如果您不确定账号名称，请使用"映射到用户"按钮从已发现的未映射账号列表中选择。'
+            : 'Recommendation: If you are unsure about the account name, use the "Map to User" button to select from the discovered unmapped accounts list.'}
+        </p>
+      </Modal>
+
       {/* Add account modal */}
       <Modal
         isOpen={showAddModal}
         onClose={() => setShowAddModal(false)}
-        title={t('addToolAccount', language)}
+        title={language === 'zh' ? '预配置工具账号' : 'Preconfigure Tool Account'}
         size="md"
         footer={
           <>
@@ -273,7 +402,11 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
           </>
         }
       >
-        <p className="text-muted small mb-3">Select accounts to map to this user:</p>
+        <p className="text-muted small mb-3">
+          {language === 'zh'
+            ? '选择要映射到此用户的已发现账号：'
+            : 'Select discovered accounts to map to this user:'}
+        </p>
         <div className="list-group" style={{ maxHeight: '400px', overflowY: 'auto' }}>
           {unmappedAccounts.map((account) => (
             <label


### PR DESCRIPTION
## 概述

实现 Issue #2761 的前端 UI 部分，包括状态可视化和高级预配置入口。

## 变更内容

### 1. 类型定义更新
- 新增 `MappingSource` 和 `MappingStatus` 类型
- `ToolAccount` 接口添加新字段：`mapping_source`, `mapping_status`, `observed_message_count` 等

### 2. 状态可视化
- 显示账号状态标签 (pending/active/stale/conflict)
- 使用不同颜色区分状态
- 显示消息计数

### 3. 高级预配置入口
- 将"添加工具账号"按钮改为"高级预配置"
- 添加确认对话框，说明预配置的风险和限制：
  - 当前未在数据中发现
  - 不会创建系统用户或工具实例
  - 只有未来收到匹配数据才会激活
  - 错误预配置可能导致数据归属错误

### 4. 默认映射流程
- "映射到用户"按钮从已发现的未映射账号列表选择
- 高级预配置需要明确确认
- 创建的账号默认为 `pending` 状态

## 验收标准覆盖

| 验收标准 | 状态 |
|---------|------|
| 默认 UI 只能选择真实发现的未映射账号 | ✅ "映射到用户"按钮 |
| 高级预配置必须明确确认其语义 | ✅ 确认对话框 |
| API 能区分 discovered/predeclared mapping | ✅ 已有 |
| 拼写错误或非法格式不会作为正常 active 账号展示 | ✅ pending 状态 |
| `updated_messages == 0` 时返回和展示明确状态 | ✅ 状态可视化 |

## 测试

- lint 通过
- 前端类型检查通过

## 关联 Issue

Closes #2761