### PR TITLE
fix: 配额调整错误信息增强，区分"不修改"和"设为unlimited"语义

### DIFF
--- a/app/constants/__init__.py
+++ b/app/constants/__init__.py
@@ -6,4 +6,11 @@ Constants used across the application.
 
 from app.constants.request_stats_meta import REQUEST_STATS_META
 
-__all__ = ["REQUEST_STATS_META"]
+# Sentinel object to distinguish "explicitly set to null" from "field not provided"
+# Used in quota update API to differentiate:
+# - Field omitted: keep current value (no change)
+# - Field with null value: set to unlimited
+# - Field with integer value: set to specified value
+EXPLICIT_NULL = object()
+
+__all__ = ["REQUEST_STATS_META", "EXPLICIT_NULL"]

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -634,20 +634,20 @@ def api_update_user_quota(user_id):
                         f"{validation_result['error']}"
                     )
                     # Build enhanced error response with detailed context
+                    error_details = dict(validation_result.get("details", {}))
+                    if validation_result.get("available"):
+                        error_details["available"] = validation_result["available"]
+                    if validation_result.get("is_unlimited_tenant") is not None:
+                        error_details["is_unlimited_tenant"] = validation_result[
+                            "is_unlimited_tenant"
+                        ]
                     error_response = {
                         "error": "Tenant quota exceeded",
                         "message": validation_result.get(
                             "error", "Quota allocation exceeds tenant limit"
                         ),
-                        "details": validation_result.get("details", {}),
+                        "details": error_details,
                     }
-                    # Include available quota info
-                    if validation_result.get("available"):
-                        error_response["details"]["available"] = validation_result["available"]
-                    if validation_result.get("is_unlimited_tenant") is not None:
-                        error_response["details"]["is_unlimited_tenant"] = validation_result[
-                            "is_unlimited_tenant"
-                        ]
 
                     return jsonify(error_response), 400
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -19,6 +19,7 @@ from app.auth.decorators import (
     same_tenant_user_required,
 )
 from app.auth.permissions import is_platform_level_role
+from app.constants import EXPLICIT_NULL
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
@@ -525,27 +526,49 @@ def api_update_user_quota(user_id):
     if not tenant_id:
         return jsonify({"error": "User has no tenant assigned"}), 400
 
-    # Step 3: Determine which quota fields are increasing
-    # Decision D3: For quota decreases, skip tenant allocation check
-    # For mixed updates (some increase, some decrease), only validate increasing fields
-    new_daily_token = data.get("daily_token_quota")
-    new_monthly_token = data.get("monthly_token_quota")
-    new_daily_request = data.get("daily_request_quota")
-    new_monthly_request = data.get("monthly_request_quota")
+    # Step 3: Parse quota fields with explicit semantics
+    # Three possible values for each field:
+    # - Field omitted (not in request): None - keep current value (no change)
+    # - Field with null value: EXPLICIT_NULL - set to unlimited
+    # - Field with integer value: integer - set to specified value
+    
+    def parse_quota_field(field_name: str) -> int | None | object:
+        """Parse quota field from request, distinguishing three semantics."""
+        if field_name not in data:
+            return None  # Field omitted - no change
+        value = data[field_name]
+        if value is None:
+            return EXPLICIT_NULL  # Explicit null - set to unlimited
+        return value  # Integer value - set to specified value
+
+    new_daily_token = parse_quota_field("daily_token_quota")
+    new_monthly_token = parse_quota_field("monthly_token_quota")
+    new_daily_request = parse_quota_field("daily_request_quota")
+    new_monthly_request = parse_quota_field("monthly_request_quota")
 
     current_daily_token = current_user.get("daily_token_quota")
     current_monthly_token = current_user.get("monthly_token_quota")
     current_daily_request = current_user.get("daily_request_quota")
     current_monthly_request = current_user.get("monthly_request_quota")
 
-    # Helper function to check if a quota value is increasing
-    def is_quota_increase(new_val: int | None, current_val: int | None) -> bool:
-        """Check if quota value is increasing (needs validation)."""
+    # Helper function to check if a quota value is increasing (needs validation)
+    def is_quota_increase(new_val: int | None | object, current_val: int | None) -> bool:
+        """Check if quota value is increasing (needs validation).
+        
+        Args:
+            new_val: None (no change), EXPLICIT_NULL (unlimited), or int (specific value)
+            current_val: Current quota value (None = unlimited, or int)
+        
+        Returns:
+            True if validation is needed, False otherwise.
+        """
         if new_val is None:
-            return False  # No change or setting to unlimited
+            return False  # No change - skip validation
+        if new_val is EXPLICIT_NULL:
+            return False  # Setting to unlimited - doesn't increase limit usage
         if current_val is None:
             return True  # Setting from unlimited to limited - needs validation
-        return new_val > current_val
+        return new_val > current_val  # Increasing specific value - needs validation
 
     # Check which fields are increasing
     has_increase = (
@@ -606,31 +629,41 @@ def api_update_user_quota(user_id):
                         f"Tenant quota allocation rejected for user {user_id}: "
                         f"{validation_result['error']}"
                     )
-                    return (
-                        jsonify(
-                            {
-                                "error": "Tenant quota exceeded",
-                                "message": validation_result.get(
-                                    "error", "Quota allocation exceeds tenant limit"
-                                ),
-                                "details": {
-                                    "available": validation_result.get("available", {}),
-                                    "is_unlimited_tenant": validation_result.get(
-                                        "is_unlimited_tenant", False
-                                    ),
-                                },
-                            }
+                    # Build enhanced error response with detailed context
+                    error_response = {
+                        "error": "Tenant quota exceeded",
+                        "message": validation_result.get(
+                            "error", "Quota allocation exceeds tenant limit"
                         ),
-                        400,
-                    )
+                        "details": validation_result.get("details", {}),
+                    }
+                    # Include available quota info
+                    if validation_result.get("available"):
+                        error_response["details"]["available"] = validation_result["available"]
+                    if validation_result.get("is_unlimited_tenant") is not None:
+                        error_response["details"]["is_unlimited_tenant"] = validation_result["is_unlimited_tenant"]
+                    
+                    return jsonify(error_response), 400
 
                 # Step 6: Update user quota (within transaction)
+                # Convert EXPLICIT_NULL to None for database storage (unlimited)
+                def to_db_value(val):
+                    """Convert quota value for database storage.
+                    
+                    - None -> keep current (shouldn't reach here in update)
+                    - EXPLICIT_NULL -> None (unlimited)
+                    - int -> int
+                    """
+                    if val is EXPLICIT_NULL:
+                        return None  # Store as NULL in database (unlimited)
+                    return val
+                
                 success = user_repo.update_user_quota(
                     user_id=user_id,
-                    daily_token_quota=new_daily_token,
-                    monthly_token_quota=new_monthly_token,
-                    daily_request_quota=new_daily_request,
-                    monthly_request_quota=new_monthly_request,
+                    daily_token_quota=to_db_value(new_daily_token),
+                    monthly_token_quota=to_db_value(new_monthly_token),
+                    daily_request_quota=to_db_value(new_daily_request),
+                    monthly_request_quota=to_db_value(new_monthly_request),
                 )
 
                 if not success:
@@ -656,12 +689,18 @@ def api_update_user_quota(user_id):
             return jsonify({"error": "Failed to update quota"}), 500
     else:
         # Quota decrease or no change: update directly without tenant check
+        # Convert EXPLICIT_NULL to None for database storage
+        def to_db_value_else(val):
+            if val is EXPLICIT_NULL:
+                return None
+            return val
+        
         success = user_repo.update_user_quota(
             user_id=user_id,
-            daily_token_quota=new_daily_token,
-            monthly_token_quota=new_monthly_token,
-            daily_request_quota=new_daily_request,
-            monthly_request_quota=new_monthly_request,
+            daily_token_quota=to_db_value_else(new_daily_token),
+            monthly_token_quota=to_db_value_else(new_monthly_token),
+            daily_request_quota=to_db_value_else(new_daily_request),
+            monthly_request_quota=to_db_value_else(new_monthly_request),
         )
 
         if not success:

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -641,7 +641,9 @@ def api_update_user_quota(user_id):
                     if validation_result.get("available"):
                         error_response["details"]["available"] = validation_result["available"]
                     if validation_result.get("is_unlimited_tenant") is not None:
-                        error_response["details"]["is_unlimited_tenant"] = validation_result["is_unlimited_tenant"]
+                        error_response["details"]["is_unlimited_tenant"] = validation_result[
+                            "is_unlimited_tenant"
+                        ]
 
                     return jsonify(error_response), 400
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -634,7 +634,7 @@ def api_update_user_quota(user_id):
                         f"{validation_result['error']}"
                     )
                     # Build enhanced error response with detailed context
-                    error_details = dict(validation_result.get("details", {}))
+                    error_details: dict[str, Any] = dict(validation_result.get("details", {}))
                     if validation_result.get("available"):
                         error_details["available"] = validation_result["available"]
                     if validation_result.get("is_unlimited_tenant") is not None:

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -539,7 +539,9 @@ def api_update_user_quota(user_id):
         value = data[field_name]
         if value is None:
             return EXPLICIT_NULL  # Explicit null - set to unlimited
-        return value  # Integer value - set to specified value
+        if isinstance(value, int):
+            return value
+        return int(value) if value else 0  # type: ignore[call-overload]
 
     new_daily_token = parse_quota_field("daily_token_quota")
     new_monthly_token = parse_quota_field("monthly_token_quota")
@@ -568,6 +570,8 @@ def api_update_user_quota(user_id):
             return False  # Setting to unlimited - doesn't increase limit usage
         if current_val is None:
             return True  # Setting from unlimited to limited - needs validation
+        # At this point, new_val must be an int
+        assert isinstance(new_val, int), f"Expected int, got {type(new_val)}"
         return new_val > current_val  # Increasing specific value - needs validation
 
     # Check which fields are increasing

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -531,7 +531,7 @@ def api_update_user_quota(user_id):
     # - Field omitted (not in request): None - keep current value (no change)
     # - Field with null value: EXPLICIT_NULL - set to unlimited
     # - Field with integer value: integer - set to specified value
-    
+
     def parse_quota_field(field_name: str) -> int | None | object:
         """Parse quota field from request, distinguishing three semantics."""
         if field_name not in data:
@@ -554,11 +554,11 @@ def api_update_user_quota(user_id):
     # Helper function to check if a quota value is increasing (needs validation)
     def is_quota_increase(new_val: int | None | object, current_val: int | None) -> bool:
         """Check if quota value is increasing (needs validation).
-        
+
         Args:
             new_val: None (no change), EXPLICIT_NULL (unlimited), or int (specific value)
             current_val: Current quota value (None = unlimited, or int)
-        
+
         Returns:
             True if validation is needed, False otherwise.
         """
@@ -642,14 +642,14 @@ def api_update_user_quota(user_id):
                         error_response["details"]["available"] = validation_result["available"]
                     if validation_result.get("is_unlimited_tenant") is not None:
                         error_response["details"]["is_unlimited_tenant"] = validation_result["is_unlimited_tenant"]
-                    
+
                     return jsonify(error_response), 400
 
                 # Step 6: Update user quota (within transaction)
                 # Convert EXPLICIT_NULL to None for database storage (unlimited)
                 def to_db_value(val):
                     """Convert quota value for database storage.
-                    
+
                     - None -> keep current (shouldn't reach here in update)
                     - EXPLICIT_NULL -> None (unlimited)
                     - int -> int
@@ -657,7 +657,7 @@ def api_update_user_quota(user_id):
                     if val is EXPLICIT_NULL:
                         return None  # Store as NULL in database (unlimited)
                     return val
-                
+
                 success = user_repo.update_user_quota(
                     user_id=user_id,
                     daily_token_quota=to_db_value(new_daily_token),
@@ -694,7 +694,7 @@ def api_update_user_quota(user_id):
             if val is EXPLICIT_NULL:
                 return None
             return val
-        
+
         success = user_repo.update_user_quota(
             user_id=user_id,
             daily_token_quota=to_db_value_else(new_daily_token),

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -430,7 +430,9 @@ def validate_tenant_allocation(
             result["error"] = "Tenant daily token quota exceeded"
             result["available"]["daily_token"] = available_daily
             result["details"] = build_quota_error_details(
-                "daily_token", daily_token_limit, allocated_daily_token,
+                "daily_token",
+                daily_token_limit,
+                allocated_daily_token,
                 new_daily_token_quota if new_daily_token_quota is not EXPLICIT_NULL else None,
                 TOKEN_QUOTA_MULTIPLIER,
             )
@@ -462,7 +464,9 @@ def validate_tenant_allocation(
             result["error"] = "Tenant monthly token quota exceeded"
             result["available"]["monthly_token"] = available_monthly
             result["details"] = build_quota_error_details(
-                "monthly_token", monthly_token_limit, allocated_monthly_token,
+                "monthly_token",
+                monthly_token_limit,
+                allocated_monthly_token,
                 new_monthly_token_quota if new_monthly_token_quota is not EXPLICIT_NULL else None,
                 TOKEN_QUOTA_MULTIPLIER,
             )
@@ -489,7 +493,9 @@ def validate_tenant_allocation(
             result["error"] = "Tenant daily request quota exceeded"
             result["available"]["daily_request"] = available_daily
             result["details"] = build_quota_error_details(
-                "daily_request", daily_request_limit, allocated_daily_request,
+                "daily_request",
+                daily_request_limit,
+                allocated_daily_request,
                 new_daily_request_quota if new_daily_request_quota is not EXPLICIT_NULL else None,
             )
             logger.warning(
@@ -511,8 +517,14 @@ def validate_tenant_allocation(
             result["error"] = "Tenant monthly request quota exceeded"
             result["available"]["monthly_request"] = available_monthly
             result["details"] = build_quota_error_details(
-                "monthly_request", monthly_request_limit, allocated_monthly_request,
-                new_monthly_request_quota if new_monthly_request_quota is not EXPLICIT_NULL else None,
+                "monthly_request",
+                monthly_request_limit,
+                allocated_monthly_request,
+                (
+                    new_monthly_request_quota
+                    if new_monthly_request_quota is not EXPLICIT_NULL
+                    else None
+                ),
             )
             logger.warning(
                 f"Tenant {tenant_id} monthly request quota exceeded: "

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -289,7 +289,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "daily_token_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": daily_token_limit,  # type: ignore[misc]
+            "tenant_limit": daily_token_limit,  # type: ignore[dict-item]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -304,7 +304,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "monthly_token_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": monthly_token_limit,  # type: ignore[misc]
+            "tenant_limit": monthly_token_limit,  # type: ignore[dict-item]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -319,7 +319,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "daily_request_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": daily_request_limit,  # type: ignore[misc]
+            "tenant_limit": daily_request_limit,  # type: ignore[dict-item]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -334,7 +334,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "monthly_request_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": monthly_request_limit,  # type: ignore[misc]
+            "tenant_limit": monthly_request_limit,  # type: ignore[dict-item]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -524,7 +524,7 @@ def validate_tenant_allocation(
                 allocated_monthly_request,
                 (
                     new_monthly_request_quota
-                    if new_monthly_request_quota is not EXPLICIT_NULL
+                    if isinstance(new_monthly_request_quota, int)
                     else None
                 ),
             )

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -522,11 +522,7 @@ def validate_tenant_allocation(
                 "monthly_request",
                 monthly_request_limit,
                 allocated_monthly_request,
-                (
-                    new_monthly_request_quota
-                    if isinstance(new_monthly_request_quota, int)
-                    else None
-                ),
+                (new_monthly_request_quota if isinstance(new_monthly_request_quota, int) else None),
             )
             logger.warning(
                 f"Tenant {tenant_id} monthly request quota exceeded: "

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -281,7 +281,7 @@ def validate_tenant_allocation(
     # Decision D1: For limited tenants, reject unlimited user quota (EXPLICIT_NULL)
     # Important: None means "no change", EXPLICIT_NULL means "set to unlimited"
     # Only validate fields that are being modified (not None)
-    
+
     # Check daily_token_quota
     if new_daily_token_quota is EXPLICIT_NULL and daily_token_limit not in (None, 0):
         result["is_valid"] = False
@@ -373,7 +373,7 @@ def validate_tenant_allocation(
 
     def calculate_total(new_val: int | None | object, allocated: int) -> int | None:
         """Calculate total allocation for limit comparison.
-        
+
         Returns:
             int: Total allocation to check against limit
             None: Skip validation (field not being modified)

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -289,7 +289,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "daily_token_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": daily_token_limit,
+            "tenant_limit": daily_token_limit,  # type: ignore[misc]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -304,7 +304,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "monthly_token_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": monthly_token_limit,
+            "tenant_limit": monthly_token_limit,  # type: ignore[misc]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -319,7 +319,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "daily_request_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": daily_request_limit,
+            "tenant_limit": daily_request_limit,  # type: ignore[misc]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -334,7 +334,7 @@ def validate_tenant_allocation(
         result["details"] = {
             "field": "monthly_request_quota",
             "reason": "explicit_null_not_allowed",
-            "tenant_limit": monthly_request_limit,
+            "tenant_limit": monthly_request_limit,  # type: ignore[misc]
             "suggestion": "Provide a specific value or set tenant to unlimited",
         }
         logger.warning(
@@ -382,6 +382,8 @@ def validate_tenant_allocation(
             return None  # No change, skip validation
         if new_val is EXPLICIT_NULL:
             return allocated  # Unlimited user doesn't count against limit
+        # At this point, new_val must be an int (not None and not EXPLICIT_NULL)
+        assert isinstance(new_val, int)
         return allocated + new_val  # Add new user's quota to allocated
 
     total_daily_token = calculate_total(new_daily_token_quota, allocated_daily_token)
@@ -433,7 +435,7 @@ def validate_tenant_allocation(
                 "daily_token",
                 daily_token_limit,
                 allocated_daily_token,
-                new_daily_token_quota if new_daily_token_quota is not EXPLICIT_NULL else None,
+                new_daily_token_quota if isinstance(new_daily_token_quota, int) else None,
                 TOKEN_QUOTA_MULTIPLIER,
             )
             logger.warning(
@@ -467,7 +469,7 @@ def validate_tenant_allocation(
                 "monthly_token",
                 monthly_token_limit,
                 allocated_monthly_token,
-                new_monthly_token_quota if new_monthly_token_quota is not EXPLICIT_NULL else None,
+                new_monthly_token_quota if isinstance(new_monthly_token_quota, int) else None,
                 TOKEN_QUOTA_MULTIPLIER,
             )
             logger.warning(
@@ -496,7 +498,7 @@ def validate_tenant_allocation(
                 "daily_request",
                 daily_request_limit,
                 allocated_daily_request,
-                new_daily_request_quota if new_daily_request_quota is not EXPLICIT_NULL else None,
+                new_daily_request_quota if isinstance(new_daily_request_quota, int) else None,
             )
             logger.warning(
                 f"Tenant {tenant_id} daily request quota exceeded: "

--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypedDict
 
+from app.constants import EXPLICIT_NULL
+
 if TYPE_CHECKING:
     from app.repositories.database import Database, adapt_boolean_condition
 else:
@@ -38,6 +40,7 @@ class QuotaAllocationResult(TypedDict):
     error: str
     available: dict[str, int]
     is_unlimited_tenant: bool
+    details: dict[str, int | str]  # Enhanced error details for better diagnostics
 
 
 def validate_token_quota(value: int | None, quota_name: str = "token_quota") -> tuple[bool, str]:
@@ -183,10 +186,10 @@ def get_quota_limits() -> dict:
 def validate_tenant_allocation(
     tenant_id: int,
     user_id: int | None = None,
-    new_daily_token_quota: int | None = None,
-    new_monthly_token_quota: int | None = None,
-    new_daily_request_quota: int | None = None,
-    new_monthly_request_quota: int | None = None,
+    new_daily_token_quota: int | None | object = None,
+    new_monthly_token_quota: int | None | object = None,
+    new_daily_request_quota: int | None | object = None,
+    new_monthly_request_quota: int | None | object = None,
     db: Database | None = None,
 ) -> QuotaAllocationResult:
     """
@@ -195,13 +198,18 @@ def validate_tenant_allocation(
     This function checks if allocating new quota values to a user would cause
     the total allocated quota to exceed the tenant's limits.
 
+    Field semantics (important - distinguishes None from EXPLICIT_NULL):
+        - None: No change, keep current value (skip validation for this field)
+        - EXPLICIT_NULL: Set to unlimited (validate against tenant limits)
+        - int value: Set to specified value (validate against tenant limits)
+
     Args:
         tenant_id: ID of the tenant.
         user_id: ID of the user being updated (None for new users).
-        new_daily_token_quota: New daily token quota in M units (None for unlimited).
-        new_monthly_token_quota: New monthly token quota in M units (None for unlimited).
-        new_daily_request_quota: New daily request quota (None for unlimited).
-        new_monthly_request_quota: New monthly request quota (None for unlimited).
+        new_daily_token_quota: New daily token quota in M units.
+        new_monthly_token_quota: New monthly token quota in M units.
+        new_daily_request_quota: New daily request quota.
+        new_monthly_request_quota: New monthly request quota.
         db: Database instance for queries.
 
     Returns:
@@ -210,6 +218,7 @@ def validate_tenant_allocation(
             - error: Optional[str] - Error message key (i18n) if invalid
             - available: Dict with remaining available quota values
             - is_unlimited_tenant: bool - Whether tenant has unlimited quota
+            - details: Dict with enhanced error information for diagnostics
     """
     # Import Database at runtime to avoid circular imports
     if db is None:
@@ -227,7 +236,14 @@ def validate_tenant_allocation(
             "monthly_request": 0,
         },
         "is_unlimited_tenant": False,
+        "details": {},
     }
+
+    logger.debug(
+        f"Validating tenant allocation: tenant_id={tenant_id}, user_id={user_id}, "
+        f"daily_token={new_daily_token_quota}, monthly_token={new_monthly_token_quota}, "
+        f"daily_request={new_daily_request_quota}, monthly_request={new_monthly_request_quota}"
+    )
 
     # Get tenant quota limits from tenant_quotas table
     tenant_quota_row = db.fetch_one(
@@ -262,26 +278,68 @@ def validate_tenant_allocation(
         result["is_unlimited_tenant"] = True
         return result
 
-    # Decision D1: For limited tenants, reject unlimited user quota (null values)
-    # Exception: If the tenant has unlimited quota (handled above), null is allowed
-    if new_daily_token_quota is None and daily_token_limit not in (None, 0):
+    # Decision D1: For limited tenants, reject unlimited user quota (EXPLICIT_NULL)
+    # Important: None means "no change", EXPLICIT_NULL means "set to unlimited"
+    # Only validate fields that are being modified (not None)
+    
+    # Check daily_token_quota
+    if new_daily_token_quota is EXPLICIT_NULL and daily_token_limit not in (None, 0):
         result["is_valid"] = False
         result["error"] = "Cannot set unlimited quota for a tenant with quota limits"
+        result["details"] = {
+            "field": "daily_token_quota",
+            "reason": "explicit_null_not_allowed",
+            "tenant_limit": daily_token_limit,
+            "suggestion": "Provide a specific value or set tenant to unlimited",
+        }
+        logger.warning(
+            f"Tenant {tenant_id} rejects unlimited daily_token_quota: tenant_limit={daily_token_limit}"
+        )
         return result
 
-    if new_monthly_token_quota is None and monthly_token_limit not in (None, 0):
+    # Check monthly_token_quota
+    if new_monthly_token_quota is EXPLICIT_NULL and monthly_token_limit not in (None, 0):
         result["is_valid"] = False
         result["error"] = "Cannot set unlimited quota for a tenant with quota limits"
+        result["details"] = {
+            "field": "monthly_token_quota",
+            "reason": "explicit_null_not_allowed",
+            "tenant_limit": monthly_token_limit,
+            "suggestion": "Provide a specific value or set tenant to unlimited",
+        }
+        logger.warning(
+            f"Tenant {tenant_id} rejects unlimited monthly_token_quota: tenant_limit={monthly_token_limit}"
+        )
         return result
 
-    if new_daily_request_quota is None and daily_request_limit not in (None, 0):
+    # Check daily_request_quota
+    if new_daily_request_quota is EXPLICIT_NULL and daily_request_limit not in (None, 0):
         result["is_valid"] = False
         result["error"] = "Cannot set unlimited quota for a tenant with quota limits"
+        result["details"] = {
+            "field": "daily_request_quota",
+            "reason": "explicit_null_not_allowed",
+            "tenant_limit": daily_request_limit,
+            "suggestion": "Provide a specific value or set tenant to unlimited",
+        }
+        logger.warning(
+            f"Tenant {tenant_id} rejects unlimited daily_request_quota: tenant_limit={daily_request_limit}"
+        )
         return result
 
-    if new_monthly_request_quota is None and monthly_request_limit not in (None, 0):
+    # Check monthly_request_quota
+    if new_monthly_request_quota is EXPLICIT_NULL and monthly_request_limit not in (None, 0):
         result["is_valid"] = False
         result["error"] = "Cannot set unlimited quota for a tenant with quota limits"
+        result["details"] = {
+            "field": "monthly_request_quota",
+            "reason": "explicit_null_not_allowed",
+            "tenant_limit": monthly_request_limit,
+            "suggestion": "Provide a specific value or set tenant to unlimited",
+        }
+        logger.warning(
+            f"Tenant {tenant_id} rejects unlimited monthly_request_quota: tenant_limit={monthly_request_limit}"
+        )
         return result
 
     # Calculate currently allocated quota (excluding current user)
@@ -307,19 +365,60 @@ def validate_tenant_allocation(
     allocated_daily_request = allocated_row.get("daily_request", 0) if allocated_row else 0
     allocated_monthly_request = allocated_row.get("monthly_request", 0) if allocated_row else 0
 
-    # Add new quota values to calculate total
-    total_daily_token = allocated_daily_token + (new_daily_token_quota or 0)
-    total_monthly_token = allocated_monthly_token + (new_monthly_token_quota or 0)
-    total_daily_request = allocated_daily_request + (new_daily_request_quota or 0)
-    total_monthly_request = allocated_monthly_request + (new_monthly_request_quota or 0)
+    # Calculate total allocation for validation
+    # Important: Only validate if field is being modified (not None)
+    # - None: No change, skip validation (return None)
+    # - EXPLICIT_NULL: Unlimited, doesn't count against limit (total = allocated)
+    # - int: Specific value, count against limit (total = allocated + new)
+
+    def calculate_total(new_val: int | None | object, allocated: int) -> int | None:
+        """Calculate total allocation for limit comparison.
+        
+        Returns:
+            int: Total allocation to check against limit
+            None: Skip validation (field not being modified)
+        """
+        if new_val is None:
+            return None  # No change, skip validation
+        if new_val is EXPLICIT_NULL:
+            return allocated  # Unlimited user doesn't count against limit
+        return allocated + new_val  # Add new user's quota to allocated
+
+    total_daily_token = calculate_total(new_daily_token_quota, allocated_daily_token)
+    total_monthly_token = calculate_total(new_monthly_token_quota, allocated_monthly_token)
+    total_daily_request = calculate_total(new_daily_request_quota, allocated_daily_request)
+    total_monthly_request = calculate_total(new_monthly_request_quota, allocated_monthly_request)
 
     # Token quotas are stored in M units, need to convert for comparison
     # Tenant limits are in actual token counts
     TOKEN_QUOTA_MULTIPLIER = 1_000_000
 
-    # Check daily token quota
-    if daily_token_limit and daily_token_limit > 0:
-        # Convert allocated (M units) to actual tokens for comparison
+    # Helper function to build enhanced error details
+    def build_quota_error_details(
+        quota_type: str,
+        tenant_limit: int,
+        allocated: int,
+        user_new_quota: int | None,
+        multiplier: int = 1,
+    ):
+        """Build detailed error information for quota exceeded."""
+        total = allocated * multiplier + (user_new_quota or 0) * multiplier
+        over_by = total - tenant_limit
+        return {
+            "quota_type": quota_type,
+            "tenant_limit": tenant_limit,
+            "currently_allocated": allocated * multiplier,
+            "user_new_quota": user_new_quota * multiplier if user_new_quota else None,
+            "over_by": over_by,
+            "suggestion": f"Reduce other users' quotas or increase tenant limit to at least {total}",
+        }
+
+    # Check daily token quota - only if being modified (total is not None)
+    if total_daily_token is not None and daily_token_limit and daily_token_limit > 0:
+        logger.debug(
+            f"Validating daily_token: allocated={allocated_daily_token}M, "
+            f"new={new_daily_token_quota}, limit={daily_token_limit}"
+        )
         total_daily_tokens_actual = total_daily_token * TOKEN_QUOTA_MULTIPLIER
         if total_daily_tokens_actual > daily_token_limit:
             available_daily = max(
@@ -330,6 +429,15 @@ def validate_tenant_allocation(
             result["is_valid"] = False
             result["error"] = "Tenant daily token quota exceeded"
             result["available"]["daily_token"] = available_daily
+            result["details"] = build_quota_error_details(
+                "daily_token", daily_token_limit, allocated_daily_token,
+                new_daily_token_quota if new_daily_token_quota is not EXPLICIT_NULL else None,
+                TOKEN_QUOTA_MULTIPLIER,
+            )
+            logger.warning(
+                f"Tenant {tenant_id} daily token quota exceeded: "
+                f"allocated={allocated_daily_token}M, new={new_daily_token_quota}, limit={daily_token_limit}"
+            )
             return result
         result["available"]["daily_token"] = max(
             0,
@@ -337,8 +445,12 @@ def validate_tenant_allocation(
             // TOKEN_QUOTA_MULTIPLIER,
         )
 
-    # Check monthly token quota
-    if monthly_token_limit and monthly_token_limit > 0:
+    # Check monthly token quota - only if being modified (total is not None)
+    if total_monthly_token is not None and monthly_token_limit and monthly_token_limit > 0:
+        logger.debug(
+            f"Validating monthly_token: allocated={allocated_monthly_token}M, "
+            f"new={new_monthly_token_quota}, limit={monthly_token_limit}"
+        )
         total_monthly_tokens_actual = total_monthly_token * TOKEN_QUOTA_MULTIPLIER
         if total_monthly_tokens_actual > monthly_token_limit:
             available_monthly = max(
@@ -349,6 +461,15 @@ def validate_tenant_allocation(
             result["is_valid"] = False
             result["error"] = "Tenant monthly token quota exceeded"
             result["available"]["monthly_token"] = available_monthly
+            result["details"] = build_quota_error_details(
+                "monthly_token", monthly_token_limit, allocated_monthly_token,
+                new_monthly_token_quota if new_monthly_token_quota is not EXPLICIT_NULL else None,
+                TOKEN_QUOTA_MULTIPLIER,
+            )
+            logger.warning(
+                f"Tenant {tenant_id} monthly token quota exceeded: "
+                f"allocated={allocated_monthly_token}M, new={new_monthly_token_quota}, limit={monthly_token_limit}"
+            )
             return result
         result["available"]["monthly_token"] = max(
             0,
@@ -356,23 +477,47 @@ def validate_tenant_allocation(
             // TOKEN_QUOTA_MULTIPLIER,
         )
 
-    # Check daily request quota
-    if daily_request_limit and daily_request_limit > 0:
+    # Check daily request quota - only if being modified (total is not None)
+    if total_daily_request is not None and daily_request_limit and daily_request_limit > 0:
+        logger.debug(
+            f"Validating daily_request: allocated={allocated_daily_request}, "
+            f"new={new_daily_request_quota}, limit={daily_request_limit}"
+        )
         if total_daily_request > daily_request_limit:
             available_daily = max(0, daily_request_limit - allocated_daily_request)
             result["is_valid"] = False
             result["error"] = "Tenant daily request quota exceeded"
             result["available"]["daily_request"] = available_daily
+            result["details"] = build_quota_error_details(
+                "daily_request", daily_request_limit, allocated_daily_request,
+                new_daily_request_quota if new_daily_request_quota is not EXPLICIT_NULL else None,
+            )
+            logger.warning(
+                f"Tenant {tenant_id} daily request quota exceeded: "
+                f"allocated={allocated_daily_request}, new={new_daily_request_quota}, limit={daily_request_limit}"
+            )
             return result
         result["available"]["daily_request"] = max(0, daily_request_limit - allocated_daily_request)
 
-    # Check monthly request quota
-    if monthly_request_limit and monthly_request_limit > 0:
+    # Check monthly request quota - only if being modified (total is not None)
+    if total_monthly_request is not None and monthly_request_limit and monthly_request_limit > 0:
+        logger.debug(
+            f"Validating monthly_request: allocated={allocated_monthly_request}, "
+            f"new={new_monthly_request_quota}, limit={monthly_request_limit}"
+        )
         if total_monthly_request > monthly_request_limit:
             available_monthly = max(0, monthly_request_limit - allocated_monthly_request)
             result["is_valid"] = False
             result["error"] = "Tenant monthly request quota exceeded"
             result["available"]["monthly_request"] = available_monthly
+            result["details"] = build_quota_error_details(
+                "monthly_request", monthly_request_limit, allocated_monthly_request,
+                new_monthly_request_quota if new_monthly_request_quota is not EXPLICIT_NULL else None,
+            )
+            logger.warning(
+                f"Tenant {tenant_id} monthly request quota exceeded: "
+                f"allocated={allocated_monthly_request}, new={new_monthly_request_quota}, limit={monthly_request_limit}"
+            )
             return result
         result["available"]["monthly_request"] = max(
             0, monthly_request_limit - allocated_monthly_request

--- a/tests/unit/test_quota_tenant_allocation.py
+++ b/tests/unit/test_quota_tenant_allocation.py
@@ -6,6 +6,11 @@ Tests validation of tenant allocation limits including:
 - Unlimited tenant handling
 - Multiple users allocation
 - Quota decrease scenarios
+
+Field semantics (important):
+- None: No change, keep current value (skip validation for this field)
+- EXPLICIT_NULL: Set to unlimited (validate against tenant limits)
+- int value: Set to specified value (validate against tenant limits)
 """
 
 from unittest.mock import MagicMock, patch
@@ -60,7 +65,8 @@ class TestValidateTenantAllocation:
         assert result["is_unlimited_tenant"] is True
 
     def test_limited_tenant_rejects_unlimited_user_quota(self):
-        """Test that limited tenant rejects null user quota."""
+        """Test that limited tenant rejects EXPLICIT_NULL user quota."""
+        from app.constants import EXPLICIT_NULL
         from app.schemas.quota import validate_tenant_allocation
 
         # Mock database with limited tenant
@@ -75,12 +81,35 @@ class TestValidateTenantAllocation:
         result = validate_tenant_allocation(
             tenant_id=1,
             user_id=None,
-            new_daily_token_quota=None,  # Unlimited
+            new_daily_token_quota=EXPLICIT_NULL,  # Explicit unlimited
             db=mock_db,
         )
 
         assert result["is_valid"] is False
         assert "unlimited" in result["error"].lower()
+
+    def test_none_field_skips_validation(self):
+        """Test that None field skips validation (no change)."""
+        from app.schemas.quota import validate_tenant_allocation
+
+        # Mock database with limited tenant
+        mock_db = MagicMock()
+        mock_db.fetch_one.return_value = {
+            "daily_token_limit": 10000000,  # 10M
+            "monthly_token_limit": 100000000,  # 100M
+            "daily_request_limit": 1000,
+            "monthly_request_limit": 10000,
+        }
+
+        result = validate_tenant_allocation(
+            tenant_id=1,
+            user_id=None,
+            new_daily_token_quota=None,  # None means "no change", should skip validation
+            db=mock_db,
+        )
+
+        # Should be valid because None means "no change" - no validation performed
+        assert result["is_valid"] is True
 
     def test_allocation_within_limit(self):
         """Test allocation that fits within tenant limit."""


### PR DESCRIPTION
Closes #2811

## 修复内容

### 问题背景
管理员在调整用户配额时，错误信息过于笼统，无法帮助用户定位问题和确定调整方向。

### 核心问题
1. **错误信息不明确**：缺少哪个配额类型超限、当前限制、已分配量等关键信息
2. **语义混淆**：缺失字段被误判为"设置 unlimited"，与用户实际意图"不修改"冲突
3. **验证逻辑耦合过紧**：修改任何字段都要校验所有维度，导致跨维度阻塞

### 解决方案

#### 1. 引入 EXPLICIT_NULL 标记，区分三种字段语义
- `None`: 不修改，保持原值（跳过校验）
- `EXPLICIT_NULL`: 设为 unlimited（需校验租户是否允许）
- `int`: 设为指定值（需校验）

#### 2. 只校验正在修改的维度
解耦验证逻辑，允许跨维度修改（如只修改 monthly_token 不被 daily_request 超限阻塞）

#### 3. 增强错误信息
返回完整上下文：
```json
{
  "error": "Tenant quota exceeded",
  "message": "Tenant daily token quota exceeded",
  "details": {
    "quota_type": "daily_token",
    "tenant_limit": 1500000000,
    "currently_allocated": 1510000000,
    "over_by": 10000000,
    "suggestion": "Reduce other users' quotas or increase tenant limit to at least 1520000000"
  }
}
```

#### 4. 添加日志和API文档
- 在关键分支添加调试日志
- 明确说明字段缺失和传 null 的语义差异

## 代码变更
- `app/constants/__init__.py`: 添加 EXPLICIT_NULL 标记
- `app/schemas/quota.py`: 修改 validate_tenant_allocation 函数
- `app/routes/admin.py`: 修改 update_user_quota API
- `tests/unit/test_quota_tenant_allocation.py`: 更新测试用例

## 测试
- ✅ 所有单元测试通过
- ✅ 新增 test_none_field_skips_validation 测试用例