### PR TITLE
fix(audit): prevent sensitive content leak in audit details (#2747)

### DIFF
--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -62,11 +62,7 @@ def _sanitize_details(obj: Any) -> Any:
     are returned as-is.
     """
     if isinstance(obj, dict):
-        return {
-            k: _sanitize_details(v)
-            for k, v in obj.items()
-            if k not in _AUDIT_DETAILS_DENYLIST
-        }
+        return {k: _sanitize_details(v) for k, v in obj.items() if k not in _AUDIT_DETAILS_DENYLIST}
     if isinstance(obj, list):
         return [_sanitize_details(item) for item in obj]
     return obj

--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -31,6 +31,46 @@ from app.repositories.database import Database, adapt_boolean_value, adapt_sql
 
 logger = logging.getLogger(__name__)
 
+# ── Sensitive-key denylist for audit details (Issue #2747) ──────────────────
+# Keys that must NEVER appear in persisted audit-log ``details``.
+# Applied recursively to nested dicts/lists so that fields inside
+# ``matched_rules`` (e.g. ``sample``) are also stripped.
+_AUDIT_DETAILS_DENYLIST: frozenset[str] = frozenset(
+    {
+        "original_content",
+        "redacted_content",
+        "password",
+        "secret",
+        "api_key",
+        "apikey",
+        "access_token",
+        "auth_token",
+        "private_key",
+        "ssh_key",
+        "credential",
+        "token",
+        "sample",
+        "keywords",
+    }
+)
+
+
+def _sanitize_details(obj: Any) -> Any:
+    """Recursively remove denylisted keys from audit details (Issue #2747).
+
+    Returns a deep copy with sensitive keys stripped.  Non-dict/list values
+    are returned as-is.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: _sanitize_details(v)
+            for k, v in obj.items()
+            if k not in _AUDIT_DETAILS_DENYLIST
+        }
+    if isinstance(obj, list):
+        return [_sanitize_details(item) for item in obj]
+    return obj
+
 
 class AuditAction(Enum):
     """Enumeration of auditable actions."""
@@ -172,7 +212,7 @@ class AuditLog:
             "severity": self.severity,
             "resource_type": self.resource_type,
             "resource_id": self.resource_id,
-            "details": self.details,
+            "details": _sanitize_details(self.details) if self.details else self.details,
             "ip_address": self.ip_address,
             "user_agent": self.user_agent,
             "session_id": self.session_id,
@@ -363,6 +403,9 @@ class AuditLogger:
             if resource_name:
                 details = dict(details or {})
                 details.setdefault("resource_name", resource_name)
+            # Strip sensitive keys before persisting (Issue #2747)
+            if details:
+                details = _sanitize_details(details)
             details_json = json.dumps(details) if details else None
             effective_tenant_id = self._resolve_tenant_id(tenant_id=tenant_id, user_id=user_id)
 

--- a/app/modules/governance/content_filter.py
+++ b/app/modules/governance/content_filter.py
@@ -52,7 +52,9 @@ class FilterResult:
     action: str = "none"  # none, warn, block, redact
     matched_rules: list[dict[str, Any]] = field(default_factory=list)
     redacted_content: str | None = None
-    original_content: str | None = None  # Always None — never persist original content (Issue #2747)
+    original_content: str | None = (
+        None  # Always None — never persist original content (Issue #2747)
+    )
     message: str | None = None
     suggestion: str | None = None
     timestamp: datetime = field(

--- a/app/modules/governance/content_filter.py
+++ b/app/modules/governance/content_filter.py
@@ -52,7 +52,7 @@ class FilterResult:
     action: str = "none"  # none, warn, block, redact
     matched_rules: list[dict[str, Any]] = field(default_factory=list)
     redacted_content: str | None = None
-    original_content: str | None = None  # For audit logging with redact
+    original_content: str | None = None  # Always None — never persist original content (Issue #2747)
     message: str | None = None
     suggestion: str | None = None
     timestamp: datetime = field(
@@ -546,7 +546,6 @@ class ContentFilter:
                         "type": pattern_name,
                         "count": len(matches),
                         "risk": risk,
-                        "sample": matches[0] if matches else None,
                         "source": "builtin",
                     }
                 )
@@ -621,7 +620,7 @@ class ContentFilter:
             action=overall_action,
             matched_rules=matched_rules,
             redacted_content=redacted if overall_action == "redact" else None,
-            original_content=content if overall_action == "redact" else None,
+            original_content=None,  # Never persist original content (Issue #2747)
             message=message,
             suggestion=suggestion,
         )

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -798,6 +798,51 @@ def _is_autonomous_request(token_payload: dict | None) -> bool:
     return token_payload.get("session_type") == "agent"
 
 
+def _sanitize_matched_rules(rules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return a copy of matched_rules with sensitive fields removed (Issue #2747).
+
+    Strips ``sample``, ``keywords``, ``pattern`` and any other fields that
+    could leak actual sensitive content.  Keeps type, count, risk, source
+    and description — sufficient for audit trail purposes.
+    """
+    safe: list[dict[str, Any]] = []
+    for rule in rules:
+        safe_rule: dict[str, Any] = {}
+        for key in ("type", "count", "risk", "severity", "source", "description", "action"):
+            if key in rule:
+                safe_rule[key] = rule[key]
+        safe.append(safe_rule)
+    return safe
+
+
+def _build_safe_content_details(
+    result: Any,
+    *,
+    include_content_meta: bool = False,
+    content: str | None = None,
+) -> dict[str, Any]:
+    """Build audit details dict that never contains raw content (Issue #2747).
+
+    Args:
+        result: FilterResult from ContentFilter.check_content().
+        include_content_meta: If True, add content_length and content_hash
+            (used for content_redacted events).
+        content: Original combined content (for computing hash/length only).
+    """
+    import hashlib
+
+    details: dict[str, Any] = {
+        "risk_level": result.risk_level,
+        "matched_rules": _sanitize_matched_rules(result.matched_rules),
+        "message": result.message,
+    }
+    if include_content_meta and content is not None:
+        details["content_length"] = len(content)
+        details["content_hash"] = hashlib.sha256(content.encode()).hexdigest()[:16]
+        details["redacted"] = True
+    return details
+
+
 def _check_content_filter(
     user_id: int,
     username: str | None,
@@ -860,18 +905,14 @@ def _check_content_filter(
         result = content_filter.check_content(combined_content, tenant_config=tenant_config)
 
         if result.action == "block":
-            # Log the block action
+            # Log the block action — never persist raw content or samples (Issue #2747)
             audit_logger.log_action(
                 action=AuditAction.CONTENT_BLOCKED,
                 user_id=user_id,
                 username=username,
                 resource_type="content",
                 severity="high",
-                details={
-                    "risk_level": result.risk_level,
-                    "matched_rules": result.matched_rules,
-                    "message": result.message,
-                },
+                details=_build_safe_content_details(result),
             )
             return (
                 jsonify(
@@ -879,7 +920,7 @@ def _check_content_filter(
                         "error": {
                             "message": result.message or "Content blocked by content filter",
                             "type": "content_blocked",
-                            "matched_rules": result.matched_rules,
+                            "matched_rules": _sanitize_matched_rules(result.matched_rules),
                             "suggestion": result.suggestion,
                         }
                     }
@@ -888,37 +929,30 @@ def _check_content_filter(
             )
 
         if result.action == "warn":
-            # Log the warn action
+            # Log the warn action — never persist raw content or samples (Issue #2747)
             audit_logger.log_action(
                 action=AuditAction.CONTENT_WARNED,
                 user_id=user_id,
                 username=username,
                 resource_type="content",
                 severity="medium",
-                details={
-                    "risk_level": result.risk_level,
-                    "matched_rules": result.matched_rules,
-                    "message": result.message,
-                },
+                details=_build_safe_content_details(result),
             )
             # Warn: continue normally, the warning is logged but not returned to user
             # (Frontend will show toast based on response headers or separate API)
             return None
 
         if result.action == "redact":
-            # Log the redact action
+            # Log the redact action — never persist original/redacted content (Issue #2747)
             audit_logger.log_action(
                 action=AuditAction.CONTENT_REDACTED,
                 user_id=user_id,
                 username=username,
                 resource_type="content",
                 severity="medium",
-                details={
-                    "risk_level": result.risk_level,
-                    "matched_rules": result.matched_rules,
-                    "original_content": result.original_content,
-                    "redacted_content": result.redacted_content,
-                },
+                details=_build_safe_content_details(
+                    result, include_content_meta=True, content=combined_content
+                ),
             )
             # Redact: return redacted content for caller to modify request
             return result.redacted_content or combined_content

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -103,6 +103,47 @@ const RESOURCE_TYPE_LABELS: Record<string, string> = {
 
 type TabType = 'log' | 'analysis';
 
+// Issue #2747: Allowlist of safe detail fields for content-filter events.
+// The backend already strips sensitive keys, but the frontend enforces a
+// second layer so that historical data or unexpected fields never leak.
+const CONTENT_EVENT_ACTIONS = new Set([
+  'content_redacted',
+  'content_blocked',
+  'content_warned',
+]);
+const CONTENT_DETAIL_ALLOWLIST = new Set([
+  'risk_level',
+  'matched_rules',
+  'message',
+  'suggestion',
+  'content_length',
+  'content_hash',
+  'redacted',
+  'resource_name',
+]);
+
+/**
+ * Return a sanitised copy of ``details`` for display.
+ * For content-filter events only allowlisted keys are kept;
+ * all other event types are returned as-is.
+ */
+const sanitizeDetailsForDisplay = (
+  action: string | null | undefined,
+  details: Record<string, unknown> | null | undefined,
+): Record<string, unknown> => {
+  if (!details || typeof details !== 'object') return {};
+  if (action && CONTENT_EVENT_ACTIONS.has(action)) {
+    const safe: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(details)) {
+      if (CONTENT_DETAIL_ALLOWLIST.has(k)) {
+        safe[k] = v;
+      }
+    }
+    return safe;
+  }
+  return details;
+};
+
 export const AuditCenter: React.FC = () => {
   const language = useLanguage();
   const { data: users, isLoading: usersLoading } = useUsers();
@@ -650,24 +691,30 @@ export const AuditCenter: React.FC = () => {
                           )}
                         </tbody>
                       </table>
-                      {selectedLog.details &&
-                        typeof selectedLog.details === 'object' &&
-                        Object.keys(selectedLog.details).length > 0 && (
-                          <div className="mt-3">
-                            <h6>{t('tableDetails', language)}</h6>
-                            <pre
-                              className="audit-detail-pre p-3 rounded"
-                              style={{
-                                maxHeight: '300px',
-                                overflow: 'auto',
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-word',
-                              }}
-                            >
-                              {JSON.stringify(selectedLog.details, null, 2)}
-                            </pre>
-                          </div>
-                        )}
+                      {(() => {
+                        const safeDetails = sanitizeDetailsForDisplay(
+                          selectedLog.action,
+                          selectedLog.details,
+                        );
+                        return (
+                          Object.keys(safeDetails).length > 0 && (
+                            <div className="mt-3">
+                              <h6>{t('tableDetails', language)}</h6>
+                              <pre
+                                className="audit-detail-pre p-3 rounded"
+                                style={{
+                                  maxHeight: '300px',
+                                  overflow: 'auto',
+                                  whiteSpace: 'pre-wrap',
+                                  wordBreak: 'break-word',
+                                }}
+                              >
+                                {JSON.stringify(safeDetails, null, 2)}
+                              </pre>
+                            </div>
+                          )
+                        );
+                      })()}
                     </div>
                     <div className="modal-footer">
                       <Button variant="secondary" onClick={() => setSelectedLog(null)}>

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -106,11 +106,7 @@ type TabType = 'log' | 'analysis';
 // Issue #2747: Allowlist of safe detail fields for content-filter events.
 // The backend already strips sensitive keys, but the frontend enforces a
 // second layer so that historical data or unexpected fields never leak.
-const CONTENT_EVENT_ACTIONS = new Set([
-  'content_redacted',
-  'content_blocked',
-  'content_warned',
-]);
+const CONTENT_EVENT_ACTIONS = new Set(['content_redacted', 'content_blocked', 'content_warned']);
 const CONTENT_DETAIL_ALLOWLIST = new Set([
   'risk_level',
   'matched_rules',
@@ -129,7 +125,7 @@ const CONTENT_DETAIL_ALLOWLIST = new Set([
  */
 const sanitizeDetailsForDisplay = (
   action: string | null | undefined,
-  details: Record<string, unknown> | null | undefined,
+  details: Record<string, unknown> | null | undefined
 ): Record<string, unknown> => {
   if (!details || typeof details !== 'object') return {};
   if (action && CONTENT_EVENT_ACTIONS.has(action)) {
@@ -694,7 +690,7 @@ export const AuditCenter: React.FC = () => {
                       {(() => {
                         const safeDetails = sanitizeDetailsForDisplay(
                           selectedLog.action,
-                          selectedLog.details,
+                          selectedLog.details
                         );
                         return (
                           Object.keys(safeDetails).length > 0 && (

--- a/tests/issues/2747/test_audit_content_redaction_leak.py
+++ b/tests/issues/2747/test_audit_content_redaction_leak.py
@@ -1,0 +1,396 @@
+"""Tests for Issue #2747 — content_redacted audit details must not leak sensitive content.
+
+Verifies that:
+- ContentFilter no longer stores ``sample`` in matched_rules.
+- ContentFilter no longer stores ``original_content`` in FilterResult.
+- AuditLogger strips sensitive keys from ``details`` on write.
+- AuditLog.to_dict() strips sensitive keys on read (historical data safety).
+- The ``_sanitize_details`` helper handles nested dicts/lists.
+- The llm_proxy_handler helpers build safe audit details.
+"""
+
+import hashlib
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.governance.audit_logger import (
+    AuditAction,
+    AuditLog,
+    AuditLogger,
+    _sanitize_details,
+    _AUDIT_DETAILS_DENYLIST,
+)
+from app.modules.governance.content_filter import ContentFilter, FilterResult
+
+
+# ── ContentFilter tests ──────────────────────────────────────────────────────
+
+
+class TestContentFilterNoSampleLeak:
+    """Issue #2747: matched_rules must not contain ``sample``."""
+
+    def test_email_rule_has_no_sample(self):
+        cf = ContentFilter()
+        result = cf.check_content("Email me at alice@example.com please")
+        email_rules = [r for r in result.matched_rules if r.get("type") == "pii_email"]
+        assert len(email_rules) >= 1
+        for rule in email_rules:
+            assert "sample" not in rule, "matched_rules must not contain 'sample'"
+
+    def test_phone_rule_has_no_sample(self):
+        cf = ContentFilter()
+        result = cf.check_content("Call me at +1-555-123-4567")
+        phone_rules = [r for r in result.matched_rules if "phone" in r.get("type", "")]
+        assert len(phone_rules) >= 1
+        for rule in phone_rules:
+            assert "sample" not in rule
+
+    def test_ssn_rule_has_no_sample(self):
+        cf = ContentFilter()
+        result = cf.check_content("My SSN is 123-45-6789")
+        ssn_rules = [r for r in result.matched_rules if r.get("type") == "pii_ssn"]
+        assert len(ssn_rules) >= 1
+        for rule in ssn_rules:
+            assert "sample" not in rule
+
+    def test_credit_card_rule_has_no_sample(self):
+        cf = ContentFilter()
+        # Use a Luhn-valid number so it passes the false-positive filter
+        result = cf.check_content("Card: 4111-1111-1111-1111")
+        cc_rules = [r for r in result.matched_rules if "credit_card" in r.get("type", "")]
+        assert len(cc_rules) >= 1
+        for rule in cc_rules:
+            assert "sample" not in rule
+
+    def test_matched_rules_keep_type_and_count(self):
+        """Even without sample, rules must retain audit-useful fields."""
+        cf = ContentFilter()
+        result = cf.check_content("Email: bob@test.org, phone: +1-212-555-0100")
+        for rule in result.matched_rules:
+            assert "type" in rule
+            assert "count" in rule
+            assert rule["count"] >= 1
+
+
+class TestContentFilterNoOriginalContent:
+    """Issue #2747: FilterResult.original_content must always be None."""
+
+    def test_redact_action_no_original_content(self):
+        cf = ContentFilter(config={"redact_pii": True})
+        result = cf.check_content("My email is test@example.com")
+        # redact_pii=True + medium-risk PII → action should be "redact"
+        if result.action == "redact":
+            assert result.original_content is None
+
+    def test_filter_result_original_content_always_none(self):
+        """Even for high-risk content that triggers redact, no original stored."""
+        cf = ContentFilter(config={"redact_pii": True, "block_high_risk": False})
+        result = cf.check_content("SSN: 123-45-6789, email: a@b.com")
+        assert result.original_content is None
+
+
+# ── AuditLogger sanitize tests ───────────────────────────────────────────────
+
+
+class TestSanitizeDetails:
+    """Issue #2747: _sanitize_details recursively strips denylisted keys."""
+
+    def test_strips_original_content(self):
+        details = {"original_content": "secret text", "risk_level": "medium"}
+        safe = _sanitize_details(details)
+        assert "original_content" not in safe
+        assert safe["risk_level"] == "medium"
+
+    def test_strips_redacted_content(self):
+        details = {"redacted_content": "***", "content_length": 42}
+        safe = _sanitize_details(details)
+        assert "redacted_content" not in safe
+        assert safe["content_length"] == 42
+
+    def test_strips_sample_from_nested_list(self):
+        details = {
+            "matched_rules": [
+                {"type": "pii_email", "count": 1, "sample": "alice@example.com"},
+                {"type": "pii_phone", "count": 2, "sample": "+1-555-0000"},
+            ]
+        }
+        safe = _sanitize_details(details)
+        for rule in safe["matched_rules"]:
+            assert "sample" not in rule
+            assert "type" in rule
+            assert "count" in rule
+
+    def test_strips_password_and_token(self):
+        details = {"password": "hunter2", "token": "abc123", "action": "login"}
+        safe = _sanitize_details(details)
+        assert "password" not in safe
+        assert "token" not in safe
+        assert safe["action"] == "login"
+
+    def test_strips_nested_dict(self):
+        details = {
+            "outer": {
+                "inner": {"secret": "value", "safe_key": "ok"},
+            }
+        }
+        safe = _sanitize_details(details)
+        assert "secret" not in safe["outer"]["inner"]
+        assert safe["outer"]["inner"]["safe_key"] == "ok"
+
+    def test_preserves_non_sensitive_data(self):
+        details = {
+            "risk_level": "high",
+            "matched_rules": [{"type": "pii_ssn", "count": 1, "risk": "critical"}],
+            "content_length": 100,
+            "content_hash": "abcdef0123456789",
+        }
+        safe = _sanitize_details(details)
+        assert safe == details  # Nothing should be stripped
+
+    def test_handles_empty_input(self):
+        assert _sanitize_details({}) == {}
+        assert _sanitize_details([]) == []
+        assert _sanitize_details("string") == "string"
+        assert _sanitize_details(42) == 42
+        assert _sanitize_details(None) is None
+
+    def test_all_denylist_keys_covered(self):
+        """Verify the denylist includes the expected keys."""
+        expected = {
+            "original_content", "redacted_content", "password", "secret",
+            "api_key", "apikey", "access_token", "auth_token", "private_key",
+            "ssh_key", "credential", "token", "sample", "keywords",
+        }
+        assert _AUDIT_DETAILS_DENYLIST == frozenset(expected)
+
+
+class TestAuditLoggerWriteSanitize:
+    """Issue #2747: AuditLogger.log() sanitizes details before persisting."""
+
+    def _make_logger(self):
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_db.connection.return_value = mock_conn
+        logger = AuditLogger(db=mock_db)
+        return logger, mock_cursor
+
+    def test_log_strips_original_content(self):
+        logger, cursor = self._make_logger()
+        logger.log(
+            action="content_redacted",
+            user_id=1,
+            details={
+                "original_content": "my secret email a@b.com",
+                "redacted_content": "my secret email ***",
+                "risk_level": "medium",
+            },
+        )
+        # Inspect the JSON that was persisted
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]  # second positional arg is the params tuple
+        details_json = params[7]  # details is the 8th parameter (index 7)
+        details = json.loads(details_json)
+        assert "original_content" not in details
+        assert "redacted_content" not in details
+        assert details["risk_level"] == "medium"
+
+    def test_log_strips_sample_from_matched_rules(self):
+        logger, cursor = self._make_logger()
+        logger.log(
+            action="content_blocked",
+            user_id=1,
+            details={
+                "matched_rules": [
+                    {"type": "pii_email", "count": 1, "sample": "alice@example.com"},
+                ],
+                "risk_level": "medium",
+            },
+        )
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]
+        details_json = params[7]
+        details = json.loads(details_json)
+        for rule in details["matched_rules"]:
+            assert "sample" not in rule
+
+
+class TestAuditLogToDictSanitize:
+    """Issue #2747: AuditLog.to_dict() sanitizes details for historical data."""
+
+    def test_to_dict_strips_original_content(self):
+        log = AuditLog(
+            id=1,
+            action="content_redacted",
+            details={
+                "original_content": "should not appear",
+                "redacted_content": "also removed",
+                "risk_level": "medium",
+                "content_length": 50,
+            },
+        )
+        d = log.to_dict()
+        assert "original_content" not in d["details"]
+        assert "redacted_content" not in d["details"]
+        assert d["details"]["risk_level"] == "medium"
+        assert d["details"]["content_length"] == 50
+
+    def test_to_dict_strips_nested_sample(self):
+        log = AuditLog(
+            id=2,
+            action="content_redacted",
+            details={
+                "matched_rules": [
+                    {"type": "pii_email", "sample": "real@email.com", "count": 1},
+                ],
+            },
+        )
+        d = log.to_dict()
+        for rule in d["details"]["matched_rules"]:
+            assert "sample" not in rule
+            assert "type" in rule
+
+    def test_to_dict_preserves_safe_details(self):
+        safe_details = {
+            "risk_level": "low",
+            "matched_rules": [{"type": "sensitive_keyword", "count": 2}],
+            "resource_name": "test-resource",
+        }
+        log = AuditLog(id=3, action="content_warned", details=safe_details)
+        d = log.to_dict()
+        assert d["details"] == safe_details
+
+
+# ── llm_proxy_handler helper tests ───────────────────────────────────────────
+
+
+class TestLlmProxyHandlerHelpers:
+    """Issue #2747: llm_proxy_handler helpers build safe audit details."""
+
+    def test_sanitize_matched_rules(self):
+        from app.modules.workspace.llm_proxy_handler import _sanitize_matched_rules
+
+        rules = [
+            {
+                "type": "pii_email",
+                "count": 1,
+                "risk": "medium",
+                "sample": "alice@example.com",
+                "source": "builtin",
+            },
+            {
+                "type": "sensitive_keyword",
+                "count": 2,
+                "keywords": ["password", "secret"],
+                "source": "builtin",
+            },
+        ]
+        safe = _sanitize_matched_rules(rules)
+        assert len(safe) == 2
+        # First rule: sample removed, safe fields kept
+        assert "sample" not in safe[0]
+        assert safe[0]["type"] == "pii_email"
+        assert safe[0]["count"] == 1
+        # Second rule: keywords removed
+        assert "keywords" not in safe[1]
+        assert safe[1]["type"] == "sensitive_keyword"
+
+    def test_build_safe_content_details_no_content(self):
+        from app.modules.workspace.llm_proxy_handler import _build_safe_content_details
+
+        result = FilterResult(
+            passed=True,
+            risk_level="medium",
+            action="warn",
+            matched_rules=[{"type": "pii_email", "count": 1, "sample": "a@b.com"}],
+            message="Content warning",
+        )
+        details = _build_safe_content_details(result)
+        assert "original_content" not in details
+        assert "redacted_content" not in details
+        assert details["risk_level"] == "medium"
+        assert len(details["matched_rules"]) == 1
+        assert "sample" not in details["matched_rules"][0]
+
+    def test_build_safe_content_details_with_content_meta(self):
+        from app.modules.workspace.llm_proxy_handler import _build_safe_content_details
+
+        result = FilterResult(
+            passed=True,
+            risk_level="medium",
+            action="redact",
+            matched_rules=[{"type": "pii_email", "count": 1}],
+            message="Content redacted",
+        )
+        content = "my email is test@example.com"
+        details = _build_safe_content_details(
+            result, include_content_meta=True, content=content
+        )
+        assert "original_content" not in details
+        assert "redacted_content" not in details
+        assert details["content_length"] == len(content)
+        expected_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+        assert details["content_hash"] == expected_hash
+        assert details["redacted"] is True
+
+
+# ── Integration: full pipeline ───────────────────────────────────────────────
+
+
+class TestFullPipeline:
+    """End-to-end: content with PII → audit log → API response, no leaks."""
+
+    def test_redact_pipeline_no_sensitive_data_in_audit(self):
+        """Simulate the full content filter → audit log pipeline."""
+        cf = ContentFilter(config={"redact_pii": True, "block_high_risk": False})
+        content = "My email is alice@example.com and SSN is 123-45-6789"
+        result = cf.check_content(content)
+
+        # FilterResult must not contain original_content
+        assert result.original_content is None
+
+        # matched_rules must not contain sample
+        for rule in result.matched_rules:
+            assert "sample" not in rule
+
+        # Simulate what llm_proxy_handler does for content_redacted
+        from app.modules.workspace.llm_proxy_handler import _build_safe_content_details
+
+        if result.action == "redact":
+            details = _build_safe_content_details(
+                result, include_content_meta=True, content=content
+            )
+        else:
+            details = _build_safe_content_details(result)
+
+        # Verify no sensitive data in details
+        assert "original_content" not in details
+        assert "redacted_content" not in details
+        serialized = json.dumps(details)
+        assert "alice@example.com" not in serialized
+        assert "123-45-6789" not in serialized
+
+        # Simulate AuditLog.to_dict() on historical data with leaked fields
+        log = AuditLog(
+            id=999,
+            action="content_redacted",
+            details={
+                "original_content": content,
+                "redacted_content": "My email is *** and SSN is ***",
+                "matched_rules": [
+                    {"type": "pii_email", "sample": "alice@example.com", "count": 1},
+                    {"type": "pii_ssn", "sample": "123-45-6789", "count": 1},
+                ],
+            },
+        )
+        d = log.to_dict()
+        serialized = json.dumps(d["details"])
+        assert "alice@example.com" not in serialized
+        assert "123-45-6789" not in serialized
+        assert "original_content" not in d["details"]
+        assert "redacted_content" not in d["details"]

--- a/tests/issues/2747/test_audit_content_redaction_leak.py
+++ b/tests/issues/2747/test_audit_content_redaction_leak.py
@@ -16,14 +16,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.modules.governance.audit_logger import (
+    _AUDIT_DETAILS_DENYLIST,
     AuditAction,
     AuditLog,
     AuditLogger,
     _sanitize_details,
-    _AUDIT_DETAILS_DENYLIST,
 )
 from app.modules.governance.content_filter import ContentFilter, FilterResult
-
 
 # ── ContentFilter tests ──────────────────────────────────────────────────────
 
@@ -159,11 +158,22 @@ class TestSanitizeDetails:
     def test_all_denylist_keys_covered(self):
         """Verify the denylist includes the expected keys."""
         expected = {
-            "original_content", "redacted_content", "password", "secret",
-            "api_key", "apikey", "access_token", "auth_token", "private_key",
-            "ssh_key", "credential", "token", "sample", "keywords",
+            "original_content",
+            "redacted_content",
+            "password",
+            "secret",
+            "api_key",
+            "apikey",
+            "access_token",
+            "auth_token",
+            "private_key",
+            "ssh_key",
+            "credential",
+            "token",
+            "sample",
+            "keywords",
         }
-        assert _AUDIT_DETAILS_DENYLIST == frozenset(expected)
+        assert frozenset(expected) == _AUDIT_DETAILS_DENYLIST
 
 
 class TestAuditLoggerWriteSanitize:
@@ -328,9 +338,7 @@ class TestLlmProxyHandlerHelpers:
             message="Content redacted",
         )
         content = "my email is test@example.com"
-        details = _build_safe_content_details(
-            result, include_content_meta=True, content=content
-        )
+        details = _build_safe_content_details(result, include_content_meta=True, content=content)
         assert "original_content" not in details
         assert "redacted_content" not in details
         assert details["content_length"] == len(content)

--- a/tests/unit/test_audit_content_redaction_leak_2747.py
+++ b/tests/unit/test_audit_content_redaction_leak_2747.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2747)]
+
 from app.modules.governance.audit_logger import (
     _AUDIT_DETAILS_DENYLIST,
     AuditAction,


### PR DESCRIPTION
## 修复说明

关联 Issue：#2747

## 根因

`content_redacted`/`content_blocked`/`content_warned` 审计事件将完整原文（`original_content`）、脱敏后内容（`redacted_content`）和未脱敏匹配样本（`matched_rules[].sample`）一并持久化到审计数据库。API 和前端直接展示整个 `details` 对象，没有任何字段级脱敏，导致已过滤的敏感信息通过审计日志二次泄露。

## 修复方案

采用纵深防御策略，从写入端到读取端多层防护：

### 第 1 层：写入端 — 阻止敏感数据进入

**`app/modules/governance/content_filter.py`**：
- 移除 `matched_rules` 中的 `sample` 字段（不再保存实际匹配值）
- `FilterResult.original_content` 始终为 `None`

**`app/modules/workspace/llm_proxy_handler.py`**：
- 新增 `_sanitize_matched_rules()` 辅助函数：移除 `sample`、`keywords`、`pattern` 等敏感字段
- 新增 `_build_safe_content_details()` 辅助函数：构建安全的审计 details（不含原文，用 `content_length` + `content_hash` 替代）
- `content_blocked`/`content_warned`/`content_redacted` 三种事件均使用安全 details

### 第 2 层：通用防线 — AuditLogger denylist

**`app/modules/governance/audit_logger.py`**：
- 新增 `_AUDIT_DETAILS_DENYLIST` 常量：包含 `original_content`、`redacted_content`、`password`、`token`、`sample` 等 14 个敏感键
- 新增 `_sanitize_details()` 递归函数：深度清理嵌套 dict/list 中的敏感键
- `log()` 写入前清理 details（阻止新数据泄露）
- `to_dict()` 读取时清理 details（保护历史数据）

### 第 3 层：前端 — 字段 allowlist

**`frontend/src/components/features/management/AuditCenter.tsx`**：
- 新增 `CONTENT_DETAIL_ALLOWLIST`：定义内容过滤事件允许展示的字段
- 对 `content_redacted`/`content_blocked`/`content_warned` 事件使用 allowlist 过滤

## 主要变更

| 文件 | 变更 |
|------|------|
| `app/modules/governance/content_filter.py` | 移除 `sample`、`original_content` 赋值 |
| `app/modules/workspace/llm_proxy_handler.py` | 新增安全 details 构建函数 |
| `app/modules/governance/audit_logger.py` | 新增 denylist + 递归清理函数 |
| `frontend/src/.../AuditCenter.tsx` | 前端字段 allowlist |
| `tests/issues/2747/test_audit_content_redaction_leak.py` | 24 个新测试 |

## 测试

- ✅ 24 个新测试覆盖所有脱敏路径（写入端、读取端、嵌套结构、历史数据、完整管线）
- ✅ 96 个现有 content_filter + audit_logger 单元测试全部通过
- ✅ 35 个 audit_actions_sync 测试全部通过
- ✅ 集成测试通过

## 风险

- **兼容性**：`FilterResult.original_content` 字段保留但始终为 `None`，不影响其他代码路径
- **回归**：内容过滤的核心功能（检测、脱敏、阻断）不受影响
- **历史数据**：通过 `to_dict()` 的读取时脱敏，API 和导出自动保护已有的含敏感字段的历史记录