### PR TITLE
fix: 统一 Models 层时间字段序列化，添加 UTC 时区标识 (#2766)

### DIFF
--- a/app/models/message.py
+++ b/app/models/message.py
@@ -8,6 +8,8 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from app.utils.datetime_utils import ensure_utc_suffix
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,14 +55,14 @@ class Message:
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "model": self.model,
-            "timestamp": self.timestamp.isoformat() if self.timestamp else None,
+            "timestamp": ensure_utc_suffix(self.timestamp),
             "sender_id": self.sender_id,
             "sender_name": self.sender_name,
             "message_source": self.message_source,
             "feishu_conversation_id": self.feishu_conversation_id,
             "group_subject": self.group_subject,
             "is_group_chat": self.is_group_chat,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
         }
 
     @classmethod

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from app.models.user import User
+from app.utils.datetime_utils import ensure_utc_suffix
 
 
 @dataclass
@@ -32,8 +33,8 @@ class Session:
             "email": self.email,
             "role": self.role,
             "token": self.token,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "expires_at": ensure_utc_suffix(self.expires_at),
         }
 
     @classmethod

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
+from app.utils.datetime_utils import ensure_utc_suffix
+
 
 class UserRole(Enum):
     """User role enumeration."""
@@ -69,8 +71,8 @@ class User:
             "email": self.email,
             "role": self.role,
             "is_active": self.is_active,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "last_login": self.last_login.isoformat() if self.last_login else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "last_login": ensure_utc_suffix(self.last_login),
             "tenant_id": self.tenant_id,
             "daily_token_quota": self.daily_token_quota,
             "monthly_token_quota": self.monthly_token_quota,

--- a/app/modules/sso/provider.py
+++ b/app/modules/sso/provider.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, cast
 
+from app.utils.datetime_utils import ensure_utc_suffix
+
 
 class ProviderType(Enum):
     """SSO provider types."""
@@ -133,7 +135,7 @@ class SSOToken:
             "refresh_token": "***" if self.refresh_token else None,
             "id_token": "***" if self.id_token else None,
             "scope": self.scope,
-            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "expires_at": ensure_utc_suffix(self.expires_at),
         }
 
     def is_expired(self) -> bool:

--- a/app/modules/workspace/collaboration.py
+++ b/app/modules/workspace/collaboration.py
@@ -21,6 +21,7 @@ from app.repositories.database import (
     get_database_url,
     is_postgresql,
 )
+from app.utils.datetime_utils import ensure_utc_suffix
 from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ class TeamMember:
             "user_id": self.user_id,
             "username": self.username,
             "role": self.role,
-            "joined_at": self.joined_at.isoformat() if self.joined_at else None,
+            "joined_at": ensure_utc_suffix(self.joined_at),
         }
 
 
@@ -86,8 +87,8 @@ class Team:
             "owner_id": self.owner_id,
             "members": [m.to_dict() for m in self.members],
             "settings": self.settings,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
         }
 
 
@@ -123,12 +124,12 @@ class SharedSession:
             "share_type": self.share_type,
             "target_id": self.target_id,
             "target_name": self.target_name,
-            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "expires_at": ensure_utc_suffix(self.expires_at),
             "allow_comments": self.allow_comments,
             "allow_copy": self.allow_copy,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
             "access_count": self.access_count,
-            "last_accessed": self.last_accessed.isoformat() if self.last_accessed else None,
+            "last_accessed": ensure_utc_suffix(self.last_accessed),
         }
 
     def is_expired(self) -> bool:
@@ -192,8 +193,8 @@ class Annotation:
             "annotation_type": self.annotation_type,
             "position": self.position,
             "parent_id": self.parent_id,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
         }
 
 
@@ -229,8 +230,8 @@ class KnowledgeEntry:
             "author_name": self.author_name,
             "is_published": self.is_published,
             "view_count": self.view_count,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
         }
 
 

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -22,6 +22,7 @@ from app.repositories.database import (
     get_database_url,
     is_postgresql,
 )
+from app.utils.datetime_utils import ensure_utc_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +73,8 @@ class PromptTemplate:
             "is_public": self.is_public,
             "is_featured": self.is_featured,
             "use_count": self.use_count,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
         }
 
     @classmethod

--- a/app/modules/workspace/state_sync.py
+++ b/app/modules/workspace/state_sync.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Any
 
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
+from app.utils.datetime_utils import ensure_utc_suffix
 from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ class SyncEvent:
         return {
             "event_id": self.event_id,
             "event_type": self.event_type,
-            "timestamp": self.timestamp.isoformat(),
+            "timestamp": ensure_utc_suffix(self.timestamp),
             "source": self.source,
             "session_id": self.session_id,
             "user_id": self.user_id,
@@ -112,8 +113,8 @@ class SyncState:
         """Convert to dictionary."""
         return {
             "client_id": self.client_id,
-            "connected_at": self.connected_at.isoformat(),
-            "last_activity": self.last_activity.isoformat(),
+            "connected_at": ensure_utc_suffix(self.connected_at),
+            "last_activity": ensure_utc_suffix(self.last_activity),
             "subscriptions": list(self.subscriptions),
             "user_id": self.user_id,
             "session_id": self.session_id,

--- a/tests/unit/test_models_message.py
+++ b/tests/unit/test_models_message.py
@@ -97,8 +97,8 @@ class TestMessage:
         assert d["message_id"] == "m1"
         assert d["role"] == "user"
         assert d["host_name"] == "localhost"
-        assert d["timestamp"] == "2025-03-10T12:00:00"
-        assert d["created_at"] == "2025-03-10T12:00:01"
+        assert d["timestamp"] == "2025-03-10T12:00:00Z"
+        assert d["created_at"] == "2025-03-10T12:00:01Z"
         assert d["parent_id"] is None
         assert d["content"] is None
         assert d["tokens_used"] == 0

--- a/tests/unit/test_models_session.py
+++ b/tests/unit/test_models_session.py
@@ -93,8 +93,8 @@ class TestSession:
         assert d["email"] == "test@test.com"
         assert d["role"] == "user"
         assert d["token"] == "tok-xyz"
-        assert d["created_at"] == "2025-03-10T12:00:00"
-        assert d["expires_at"] == "2025-03-11T12:00:00"
+        assert d["created_at"] == "2025-03-10T12:00:00Z"
+        assert d["expires_at"] == "2025-03-11T12:00:00Z"
 
     def test_to_dict_none_timestamps(self):
         s = Session(username="bob")


### PR DESCRIPTION
Closes #2766

## 修复内容

统一 Models 层时间字段序列化，添加 UTC 时区标识，修复浏览器将 UTC 时间误为本地时间的问题。

## 修改详情

### 第一批次：Models 层高优先级文件（7 个文件，约 25 个时间字段）

**1. app/models/session.py**
- `Session.to_dict()`: `created_at`, `expires_at` 字段

**2. app/models/user.py**
- `User.to_dict()`: `created_at`, `last_login` 字段

**3. app/models/message.py**
- `Message.to_dict()`: `timestamp`, `created_at` 字段

**4. app/modules/workspace/collaboration.py**
- `TeamMember.to_dict()`: `joined_at` 字段
- `Team.to_dict()`: `created_at`, `updated_at` 字段
- `SharedSession.to_dict()`: `expires_at`, `created_at`, `last_accessed` 字段
- `Annotation.to_dict()`: `created_at`, `updated_at` 字段
- `KnowledgeEntry.to_dict()`: `created_at`, `updated_at` 字段

**5. app/modules/workspace/prompt_library.py**
- `PromptTemplate.to_dict()`: `created_at`, `updated_at` 字段

**6. app/modules/workspace/state_sync.py**
- `SyncEvent.to_dict()`: `timestamp` 字段
- `SyncState.to_dict()`: `connected_at`, `last_activity` 字段

**7. app/modules/sso/provider.py**
- `SSOToken.to_dict()`: `expires_at` 字段

## 修复方案

详见 Issue 评论：https://github.com/open-ace/open-ace/issues/2766#issuecomment-5338701634

## 效果

- 修复前：API 返回 `2026-08-17T08:06:59`（无时区标识）
- 修复后：API 返回 `2026-08-17T08:06:59Z`（UTC 标识）
- 浏览器将正确识别为 UTC 时间并转换为本地时间显示

## 测试

- 运行单元测试：`pytest tests/unit/models/ tests/unit/modules/`
- 运行集成测试：`pytest tests/integration/`
- 手动验证：用户管理页面、团队协作页面、会话管理页面