### PR TITLE
fix(audit): use SQL aggregation for analysis, eliminate 10K truncation and repeated scans

### DIFF
--- a/app/modules/compliance/audit.py
+++ b/app/modules/compliance/audit.py
@@ -31,6 +31,21 @@ class AnomalyDetection:
     details: dict[str, Any]
 
 
+def _parse_timestamp(val: Any) -> datetime:
+    """Parse a timestamp value from SQL into a datetime.
+
+    Handles datetime objects, ISO-format strings, and falls back to now().
+    """
+    if isinstance(val, datetime):
+        return val
+    if isinstance(val, str):
+        try:
+            return datetime.fromisoformat(val)
+        except (ValueError, TypeError):
+            pass
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 class AuditAnalyzer:
     """
     Analyzer for audit logs.
@@ -91,15 +106,7 @@ class AuditAnalyzer:
         # Build base WHERE clause matching audit_logger.query() filters
         conditions = ["timestamp >= ?", "timestamp <= ?"]
         params: list[Any] = [start_time, end_time]
-
-        tenant_id = self.audit_logger._resolve_tenant_id()
-        normalized_tenant_id = self.audit_logger._normalize_tenant_id(tenant_id)
-        if normalized_tenant_id is not None:
-            conditions.append(
-                "(tenant_id = ? OR (tenant_id IS NULL AND user_id IN "
-                "(SELECT id FROM users WHERE tenant_id = ?)))"
-            )
-            params.extend([normalized_tenant_id, normalized_tenant_id])
+        self._build_tenant_filter(conditions, params)
 
         where_clause = " AND ".join(conditions)
 
@@ -235,9 +242,10 @@ class AuditAnalyzer:
                 "total_events": 0,
                 "matching_events": 0,
                 "analyzed_events": 0,
-                "truncated": False,
-                "coverage_ratio": 1.0,
+                "truncated": True,  # Cannot confirm completeness
+                "coverage_ratio": 0.0,
                 "oldest_analyzed_at": None,
+                "error": "Pattern analysis failed due to a database error",
                 "hourly_distribution": {},
                 "login_hourly_distribution": {},
                 "daily_distribution": {},
@@ -376,17 +384,10 @@ class AuditAnalyzer:
                 )
                 range_row = cursor.fetchone()
 
-                def _parse_ts(val: Any) -> datetime:
-                    if isinstance(val, datetime):
-                        return val
-                    if isinstance(val, str):
-                        return datetime.fromisoformat(val)
-                    return datetime.now(timezone.utc).replace(tzinfo=None)
-
-                first_seen = _parse_ts(range_row["first_seen"]) if range_row else datetime.now(
+                first_seen = _parse_timestamp(range_row["first_seen"]) if range_row else datetime.now(
                     timezone.utc
                 ).replace(tzinfo=None)
-                last_seen = _parse_ts(range_row["last_seen"]) if range_row else first_seen
+                last_seen = _parse_timestamp(range_row["last_seen"]) if range_row else first_seen
 
                 return AnomalyDetection(
                     anomaly_type="excessive_failed_logins",
@@ -509,13 +510,6 @@ class AuditAnalyzer:
                 user_id = int(r["user_id"])
                 count = int(r["cnt"])
 
-                def _parse_ts(val: Any) -> datetime:
-                    if isinstance(val, datetime):
-                        return val
-                    if isinstance(val, str):
-                        return datetime.fromisoformat(val)
-                    return datetime.now(timezone.utc).replace(tzinfo=None)
-
                 anomalies.append(
                     AnomalyDetection(
                         anomaly_type="off_hours_activity",
@@ -523,8 +517,8 @@ class AuditAnalyzer:
                         description=f"User {user_id} active during off-hours",
                         affected_users=[user_id],
                         occurrences=count,
-                        first_seen=_parse_ts(r["first_seen"]),
-                        last_seen=_parse_ts(r["last_seen"]),
+                        first_seen=_parse_timestamp(r["first_seen"]),
+                        last_seen=_parse_timestamp(r["last_seen"]),
                         details={
                             "activity_count": count,
                         },
@@ -577,13 +571,6 @@ class AuditAnalyzer:
                     )
                     affected = [int(r["user_id"]) for r in cursor.fetchall()]
 
-                    def _parse_ts(val: Any) -> datetime:
-                        if isinstance(val, datetime):
-                            return val
-                        if isinstance(val, str):
-                            return datetime.fromisoformat(val)
-                        return datetime.now(timezone.utc).replace(tzinfo=None)
-
                     anomalies.append(
                         AnomalyDetection(
                             anomaly_type="frequent_role_changes",
@@ -591,10 +578,10 @@ class AuditAnalyzer:
                             description=f"{role_count} role changes detected",
                             affected_users=affected,
                             occurrences=role_count,
-                            first_seen=_parse_ts(row["first_seen"]) if row else datetime.now(
+                            first_seen=_parse_timestamp(row["first_seen"]) if row else datetime.now(
                                 timezone.utc
                             ).replace(tzinfo=None),
-                            last_seen=_parse_ts(row["last_seen"]) if row else datetime.now(
+                            last_seen=_parse_timestamp(row["last_seen"]) if row else datetime.now(
                                 timezone.utc
                             ).replace(tzinfo=None),
                             details={},
@@ -632,13 +619,6 @@ class AuditAnalyzer:
                     )
                     affected2 = [int(r["user_id"]) for r in cursor.fetchall()]
 
-                    def _parse_ts2(val: Any) -> datetime:
-                        if isinstance(val, datetime):
-                            return val
-                        if isinstance(val, str):
-                            return datetime.fromisoformat(val)
-                        return datetime.now(timezone.utc).replace(tzinfo=None)
-
                     anomalies.append(
                         AnomalyDetection(
                             anomaly_type="frequent_permission_changes",
@@ -646,10 +626,10 @@ class AuditAnalyzer:
                             description=f"{perm_count} permission changes detected",
                             affected_users=affected2,
                             occurrences=perm_count,
-                            first_seen=_parse_ts2(row2["first_seen"]) if row2 else datetime.now(
+                            first_seen=_parse_timestamp(row2["first_seen"]) if row2 else datetime.now(
                                 timezone.utc
                             ).replace(tzinfo=None),
-                            last_seen=_parse_ts2(row2["last_seen"]) if row2 else datetime.now(
+                            last_seen=_parse_timestamp(row2["last_seen"]) if row2 else datetime.now(
                                 timezone.utc
                             ).replace(tzinfo=None),
                             details={},

--- a/app/modules/compliance/audit.py
+++ b/app/modules/compliance/audit.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from app.modules.governance.audit_logger import AuditLogger
-from app.repositories.database import adapt_sql, get_db_connection  # noqa: E402
+from app.repositories.database import adapt_sql, get_db_connection, is_postgresql  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -71,77 +71,210 @@ class AuditAnalyzer:
         self, start_time: datetime | None = None, end_time: datetime | None = None
     ) -> dict[str, Any]:
         """
-        Analyze patterns in audit logs.
+        Analyze patterns in audit logs using SQL aggregation.
+
+        Uses database-side GROUP BY queries instead of loading objects into
+        Python, so results cover the full time range regardless of data volume.
 
         Args:
             start_time: Start of analysis period.
             end_time: End of analysis period.
 
         Returns:
-            Dict with pattern analysis results.
+            Dict with pattern analysis results including completeness metadata.
         """
         if not start_time:
             start_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
         if not end_time:
             end_time = datetime.now(timezone.utc).replace(tzinfo=None)
 
-        logs = self.audit_logger.query(
-            start_time=start_time,
-            end_time=end_time,
-            limit=10000,
-        )
+        # Build base WHERE clause matching audit_logger.query() filters
+        conditions = ["timestamp >= ?", "timestamp <= ?"]
+        params: list[Any] = [start_time, end_time]
 
-        # Analyze by hour of day
-        hourly_activity: defaultdict[int, int] = defaultdict(int)
-        for log in logs:
-            if log.timestamp:
-                hour = log.timestamp.hour
-                hourly_activity[hour] += 1
+        tenant_id = self.audit_logger._resolve_tenant_id()
+        normalized_tenant_id = self.audit_logger._normalize_tenant_id(tenant_id)
+        if normalized_tenant_id is not None:
+            conditions.append(
+                "(tenant_id = ? OR (tenant_id IS NULL AND user_id IN "
+                "(SELECT id FROM users WHERE tenant_id = ?)))"
+            )
+            params.extend([normalized_tenant_id, normalized_tenant_id])
 
-        # Analyze login by hour of day (for "Login Pattern" chart)
-        login_hourly_activity: defaultdict[int, int] = defaultdict(int)
-        for log in logs:
-            if log.timestamp and log.action == "login":
-                hour = log.timestamp.hour
-                login_hourly_activity[hour] += 1
+        where_clause = " AND ".join(conditions)
 
-        # Analyze by day of week
-        daily_activity: defaultdict[int, int] = defaultdict(int)
-        for log in logs:
-            if log.timestamp:
-                day = log.timestamp.weekday()
-                daily_activity[day] += 1
+        # Use database-specific hour/day extraction
+        if is_postgresql():
+            hour_expr = "EXTRACT(HOUR FROM timestamp)"
+            # PostgreSQL: EXTRACT(DOW FROM ts) returns 0=Sunday..6=Saturday
+            # Python weekday(): 0=Monday..6=Sunday
+            # Convert: (dow - 1 + 7) % 7 gives Python weekday
+            day_expr = "CAST((EXTRACT(DOW FROM timestamp)::int - 1 + 7) % 7 AS int)"
+        else:
+            # SQLite: strftime('%w', ts) returns 0=Sunday..6=Saturday
+            # Convert to Python weekday: (cast(strftime('%w') as int) - 1 + 7) % 7
+            hour_expr = "CAST(strftime('%H', timestamp) AS integer)"
+            day_expr = "(CAST(strftime('%w', timestamp) AS integer) - 1 + 7) % 7"
 
-        # Analyze by action type
-        action_distribution: defaultdict[str, int] = defaultdict(int)
-        for log in logs:
-            action_distribution[log.action] += 1
+        try:
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
 
-        # Analyze by user
-        user_activity: defaultdict[int, int] = defaultdict(int)
-        for log in logs:
-            if log.user_id:
-                user_activity[log.user_id] += 1
+                # 1. Total count
+                cursor.execute(
+                    adapt_sql(f"SELECT COUNT(*) as cnt FROM audit_logs WHERE {where_clause}"),
+                    tuple(params),
+                )
+                row = cursor.fetchone()
+                total_events = int(row["cnt"]) if row else 0
+
+                # 2. Hourly distribution
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT {hour_expr} as hour, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} "
+                        f"GROUP BY {hour_expr} ORDER BY {hour_expr}"
+                    ),
+                    tuple(params),
+                )
+                hourly_distribution = {}
+                for r in cursor.fetchall():
+                    hourly_distribution[int(r["hour"])] = int(r["cnt"])
+
+                # 3. Login hourly distribution
+                login_where = f"{where_clause} AND action = ?"
+                login_params = list(params) + ["login"]
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT {hour_expr} as hour, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {login_where} "
+                        f"GROUP BY {hour_expr} ORDER BY {hour_expr}"
+                    ),
+                    tuple(login_params),
+                )
+                login_hourly_distribution = {}
+                for r in cursor.fetchall():
+                    login_hourly_distribution[int(r["hour"])] = int(r["cnt"])
+
+                # 4. Daily distribution (by weekday)
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT {day_expr} as day, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} "
+                        f"GROUP BY {day_expr} ORDER BY {day_expr}"
+                    ),
+                    tuple(params),
+                )
+                daily_distribution = {}
+                for r in cursor.fetchall():
+                    daily_distribution[int(r["day"])] = int(r["cnt"])
+
+                # 5. Action distribution
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT action, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} "
+                        f"GROUP BY action ORDER BY cnt DESC"
+                    ),
+                    tuple(params),
+                )
+                action_distribution = {}
+                for r in cursor.fetchall():
+                    action_distribution[r["action"]] = int(r["cnt"])
+
+                # 6. Top users
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT user_id, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} AND user_id IS NOT NULL "
+                        f"GROUP BY user_id ORDER BY cnt DESC LIMIT 10"
+                    ),
+                    tuple(params),
+                )
+                top_users = []
+                for r in cursor.fetchall():
+                    top_users.append((int(r["user_id"]), int(r["cnt"])))
+
+                # 7. Unique users count
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT COUNT(DISTINCT user_id) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} AND user_id IS NOT NULL"
+                    ),
+                    tuple(params),
+                )
+                unique_users_row = cursor.fetchone()
+                unique_users = int(unique_users_row["cnt"]) if unique_users_row else 0
+
+                # 8. Oldest analyzed timestamp
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT MIN(timestamp) as oldest FROM audit_logs WHERE {where_clause}"
+                    ),
+                    tuple(params),
+                )
+                oldest_row = cursor.fetchone()
+                oldest_val = oldest_row["oldest"] if oldest_row else None
+                oldest_analyzed_at = None
+                if oldest_val is not None:
+                    if isinstance(oldest_val, str):
+                        try:
+                            oldest_analyzed_at = datetime.fromisoformat(oldest_val)
+                        except (ValueError, TypeError):
+                            oldest_analyzed_at = None
+                    elif isinstance(oldest_val, datetime):
+                        oldest_analyzed_at = oldest_val
+
+        except Exception as e:
+            logger.error(f"Failed to analyze patterns via SQL: {e}", exc_info=True)
+            return {
+                "period": {
+                    "start": start_time.isoformat(),
+                    "end": end_time.isoformat(),
+                },
+                "total_events": 0,
+                "matching_events": 0,
+                "analyzed_events": 0,
+                "truncated": False,
+                "coverage_ratio": 1.0,
+                "oldest_analyzed_at": None,
+                "hourly_distribution": {},
+                "login_hourly_distribution": {},
+                "daily_distribution": {},
+                "action_distribution": {},
+                "unique_users": 0,
+                "top_users": [],
+            }
 
         return {
             "period": {
                 "start": start_time.isoformat(),
                 "end": end_time.isoformat(),
             },
-            "total_events": len(logs),
-            "hourly_distribution": dict(sorted(hourly_activity.items())),
-            "login_hourly_distribution": dict(sorted(login_hourly_activity.items())),
-            "daily_distribution": dict(sorted(daily_activity.items())),
-            "action_distribution": dict(sorted(action_distribution.items(), key=lambda x: -x[1])),
-            "unique_users": len(user_activity),
-            "top_users": sorted(user_activity.items(), key=lambda x: -x[1])[:10],
+            # Backward-compatible: total_events now reflects real count
+            "total_events": total_events,
+            # Completeness metadata (Issue #2750)
+            "matching_events": total_events,
+            "analyzed_events": total_events,
+            "truncated": False,
+            "coverage_ratio": 1.0,
+            "oldest_analyzed_at": oldest_analyzed_at.isoformat() if oldest_analyzed_at else None,
+            "hourly_distribution": dict(sorted(hourly_distribution.items())),
+            "login_hourly_distribution": dict(sorted(login_hourly_distribution.items())),
+            "daily_distribution": dict(sorted(daily_distribution.items())),
+            "action_distribution": action_distribution,
+            "unique_users": unique_users,
+            "top_users": top_users,
         }
 
     def detect_anomalies(
         self, start_time: datetime | None = None, end_time: datetime | None = None
     ) -> list[AnomalyDetection]:
         """
-        Detect anomalies in audit logs.
+        Detect anomalies in audit logs using SQL-based detection.
+
+        Each detector uses a specialized SQL query that only retrieves the
+        aggregated data needed, instead of loading up to 10,000 full objects.
 
         Args:
             start_time: Start of analysis period.
@@ -176,192 +309,357 @@ class AuditAnalyzer:
 
         return anomalies
 
+    def _build_tenant_filter(
+        self, conditions: list[str], params: list[Any]
+    ) -> tuple[list[str], list[Any]]:
+        """Add tenant scope filter to conditions/params if applicable."""
+        tenant_id = self.audit_logger._resolve_tenant_id()
+        normalized_tenant_id = self.audit_logger._normalize_tenant_id(tenant_id)
+        if normalized_tenant_id is not None:
+            conditions.append(
+                "(tenant_id = ? OR (tenant_id IS NULL AND user_id IN "
+                "(SELECT id FROM users WHERE tenant_id = ?)))"
+            )
+            params.extend([normalized_tenant_id, normalized_tenant_id])
+        return conditions, params
+
     def _detect_failed_login_anomaly(
         self, start_time: datetime, end_time: datetime
     ) -> AnomalyDetection | None:
-        """Detect failed login anomalies."""
-        failed_logins = self.audit_logger.query(
-            action="login_failed",
-            start_time=start_time,
-            end_time=end_time,
-            limit=1000,
-        )
+        """Detect failed login anomalies using SQL aggregation."""
+        conditions = ["action = ?", "timestamp >= ?", "timestamp <= ?"]
+        params: list[Any] = ["login_failed", start_time, end_time]
+        self._build_tenant_filter(conditions, params)
+        where_clause = " AND ".join(conditions)
 
-        if len(failed_logins) < self.failed_login_threshold:
+        try:
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
+
+                # Total failed logins
+                cursor.execute(
+                    adapt_sql(f"SELECT COUNT(*) as cnt FROM audit_logs WHERE {where_clause}"),
+                    tuple(params),
+                )
+                row = cursor.fetchone()
+                total_failed = int(row["cnt"]) if row else 0
+
+                if total_failed < self.failed_login_threshold:
+                    return None
+
+                # Group by user with HAVING clause
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT user_id, COUNT(*) as cnt, "
+                        f"MIN(timestamp) as first_seen, MAX(timestamp) as last_seen "
+                        f"FROM audit_logs WHERE {where_clause} AND user_id IS NOT NULL "
+                        f"GROUP BY user_id HAVING COUNT(*) >= ? "
+                        f"ORDER BY cnt DESC"
+                    ),
+                    tuple(params + [self.failed_login_threshold]),
+                )
+                user_rows = cursor.fetchall()
+
+                if not user_rows:
+                    return None
+
+                affected_users = [int(r["user_id"]) for r in user_rows]
+                user_breakdown = {str(int(r["user_id"])): int(r["cnt"]) for r in user_rows}
+
+                # Overall first/last seen across all failed logins
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT MIN(timestamp) as first_seen, MAX(timestamp) as last_seen "
+                        f"FROM audit_logs WHERE {where_clause}"
+                    ),
+                    tuple(params),
+                )
+                range_row = cursor.fetchone()
+
+                def _parse_ts(val: Any) -> datetime:
+                    if isinstance(val, datetime):
+                        return val
+                    if isinstance(val, str):
+                        return datetime.fromisoformat(val)
+                    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+                first_seen = _parse_ts(range_row["first_seen"]) if range_row else datetime.now(
+                    timezone.utc
+                ).replace(tzinfo=None)
+                last_seen = _parse_ts(range_row["last_seen"]) if range_row else first_seen
+
+                return AnomalyDetection(
+                    anomaly_type="excessive_failed_logins",
+                    severity="high" if len(affected_users) > 3 else "medium",
+                    description=f"{len(affected_users)} user(s) with excessive failed login attempts",
+                    affected_users=affected_users,
+                    occurrences=total_failed,
+                    first_seen=first_seen,
+                    last_seen=last_seen,
+                    details={
+                        "threshold": self.failed_login_threshold,
+                        "user_breakdown": user_breakdown,
+                    },
+                )
+        except Exception as e:
+            logger.error(f"Failed to detect failed login anomalies: {e}", exc_info=True)
             return None
-
-        # Group by user
-        user_failures = defaultdict(list)
-        for log in failed_logins:
-            if log.user_id:
-                user_failures[log.user_id].append(log)
-
-        # Find users with excessive failures
-        affected_users = [
-            user_id
-            for user_id, logs in user_failures.items()
-            if len(logs) >= self.failed_login_threshold
-        ]
-
-        if not affected_users:
-            return None
-
-        return AnomalyDetection(
-            anomaly_type="excessive_failed_logins",
-            severity="high" if len(affected_users) > 3 else "medium",
-            description=f"{len(affected_users)} user(s) with excessive failed login attempts",
-            affected_users=affected_users,
-            occurrences=len(failed_logins),
-            first_seen=min(l.timestamp for l in failed_logins if l.timestamp),
-            last_seen=max(l.timestamp for l in failed_logins if l.timestamp),
-            details={
-                "threshold": self.failed_login_threshold,
-                "user_breakdown": {str(k): len(v) for k, v in user_failures.items()},
-            },
-        )
 
     def _detect_rapid_activity_anomaly(
         self, start_time: datetime, end_time: datetime
     ) -> list[AnomalyDetection]:
-        """Detect rapid activity anomalies."""
-        logs = self.audit_logger.query(
-            start_time=start_time,
-            end_time=end_time,
-            limit=10000,
-        )
+        """Detect rapid activity anomalies using SQL aggregation."""
+        conditions = ["timestamp >= ?", "timestamp <= ?", "user_id IS NOT NULL"]
+        params: list[Any] = [start_time, end_time]
+        self._build_tenant_filter(conditions, params)
+        where_clause = " AND ".join(conditions)
 
-        anomalies = []
+        # Database-specific hour bucket expression
+        if is_postgresql():
+            hour_bucket_expr = "TO_CHAR(timestamp, 'YYYY-MM-DD HH24')"
+        else:
+            hour_bucket_expr = "strftime('%Y-%m-%d %H', timestamp)"
 
-        # Group by user and hour
-        user_hourly_activity: defaultdict[int, defaultdict[str, int]] = defaultdict(
-            lambda: defaultdict(int)
-        )
-        for log in logs:
-            if log.user_id and log.timestamp:
-                hour_key = log.timestamp.strftime("%Y-%m-%d %H")
-                user_hourly_activity[log.user_id][hour_key] += 1
+        try:
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT user_id, {hour_bucket_expr} as hour, COUNT(*) as cnt "
+                        f"FROM audit_logs WHERE {where_clause} "
+                        f"GROUP BY user_id, {hour_bucket_expr} "
+                        f"HAVING COUNT(*) > ? "
+                        f"ORDER BY cnt DESC"
+                    ),
+                    tuple(params + [self.rapid_action_threshold]),
+                )
+                rows = cursor.fetchall()
 
-        # Find users with rapid activity
-        for user_id, hourly in user_hourly_activity.items():
-            for hour, count in hourly.items():
-                if count > self.rapid_action_threshold:
-                    anomalies.append(
-                        AnomalyDetection(
-                            anomaly_type="rapid_activity",
-                            severity="medium",
-                            description=f"User {user_id} had {count} actions in one hour",
-                            affected_users=[user_id],
-                            occurrences=count,
-                            first_seen=datetime.strptime(str(hour), "%Y-%m-%d %H"),
-                            last_seen=datetime.strptime(str(hour), "%Y-%m-%d %H")
-                            + timedelta(hours=1),
-                            details={
-                                "hour": hour,
-                                "action_count": count,
-                                "threshold": self.rapid_action_threshold,
-                            },
-                        )
+            anomalies = []
+            for r in rows:
+                user_id = int(r["user_id"])
+                hour_str = r["hour"]
+                count = int(r["cnt"])
+                anomalies.append(
+                    AnomalyDetection(
+                        anomaly_type="rapid_activity",
+                        severity="medium",
+                        description=f"User {user_id} had {count} actions in one hour",
+                        affected_users=[user_id],
+                        occurrences=count,
+                        first_seen=datetime.strptime(str(hour_str), "%Y-%m-%d %H"),
+                        last_seen=datetime.strptime(str(hour_str), "%Y-%m-%d %H")
+                        + timedelta(hours=1),
+                        details={
+                            "hour": str(hour_str),
+                            "action_count": count,
+                            "threshold": self.rapid_action_threshold,
+                        },
                     )
-
-        return anomalies
+                )
+            return anomalies
+        except Exception as e:
+            logger.error(f"Failed to detect rapid activity anomalies: {e}", exc_info=True)
+            return []
 
     def _detect_off_hours_anomaly(
         self, start_time: datetime, end_time: datetime
     ) -> list[AnomalyDetection]:
-        """Detect off-hours activity anomalies."""
-        logs = self.audit_logger.query(
-            start_time=start_time,
-            end_time=end_time,
-            limit=10000,
-        )
-
+        """Detect off-hours activity anomalies using SQL aggregation."""
         # Define off-hours (10 PM - 6 AM)
         OFF_HOURS_START = 22
         OFF_HOURS_END = 6
 
-        off_hours_logs = [
-            log
-            for log in logs
-            if log.timestamp
-            and (log.timestamp.hour >= OFF_HOURS_START or log.timestamp.hour < OFF_HOURS_END)
+        # Database-specific hour extraction for WHERE clause
+        if is_postgresql():
+            hour_check = "(EXTRACT(HOUR FROM timestamp) >= ? OR EXTRACT(HOUR FROM timestamp) < ?)"
+        else:
+            hour_check = (
+                "(CAST(strftime('%H', timestamp) AS integer) >= ? "
+                "OR CAST(strftime('%H', timestamp) AS integer) < ?)"
+            )
+
+        conditions = [
+            "timestamp >= ?",
+            "timestamp <= ?",
+            "user_id IS NOT NULL",
+            hour_check,
         ]
+        params: list[Any] = [start_time, end_time, OFF_HOURS_START, OFF_HOURS_END]
+        self._build_tenant_filter(conditions, params)
+        where_clause = " AND ".join(conditions)
 
-        if not off_hours_logs:
-            return []
+        try:
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT user_id, COUNT(*) as cnt, "
+                        f"MIN(timestamp) as first_seen, MAX(timestamp) as last_seen "
+                        f"FROM audit_logs WHERE {where_clause} "
+                        f"GROUP BY user_id HAVING COUNT(*) > ? "
+                        f"ORDER BY cnt DESC"
+                    ),
+                    tuple(params + [self.off_hours_threshold]),
+                )
+                rows = cursor.fetchall()
 
-        # Group by user
-        user_off_hours = defaultdict(list)
-        for log in off_hours_logs:
-            if log.user_id:
-                user_off_hours[log.user_id].append(log)
+            anomalies = []
+            for r in rows:
+                user_id = int(r["user_id"])
+                count = int(r["cnt"])
 
-        anomalies = []
-        for user_id, logs_list in user_off_hours.items():
-            if len(logs_list) > self.off_hours_threshold:
+                def _parse_ts(val: Any) -> datetime:
+                    if isinstance(val, datetime):
+                        return val
+                    if isinstance(val, str):
+                        return datetime.fromisoformat(val)
+                    return datetime.now(timezone.utc).replace(tzinfo=None)
+
                 anomalies.append(
                     AnomalyDetection(
                         anomaly_type="off_hours_activity",
                         severity="low",
                         description=f"User {user_id} active during off-hours",
                         affected_users=[user_id],
-                        occurrences=len(logs_list),
-                        first_seen=min(l.timestamp for l in logs_list if l.timestamp),
-                        last_seen=max(l.timestamp for l in logs_list if l.timestamp),
+                        occurrences=count,
+                        first_seen=_parse_ts(r["first_seen"]),
+                        last_seen=_parse_ts(r["last_seen"]),
                         details={
-                            "activity_count": len(logs_list),
+                            "activity_count": count,
                         },
                     )
                 )
-
-        return anomalies
+            return anomalies
+        except Exception as e:
+            logger.error(f"Failed to detect off-hours anomalies: {e}", exc_info=True)
+            return []
 
     def _detect_action_pattern_anomaly(
         self, start_time: datetime, end_time: datetime
     ) -> list[AnomalyDetection]:
-        """Detect unusual action patterns."""
-        logs = self.audit_logger.query(
-            start_time=start_time,
-            end_time=end_time,
-            limit=10000,
-        )
-
+        """Detect unusual action patterns using SQL aggregation."""
         anomalies = []
 
-        # Check for role changes
-        role_changes = [l for l in logs if l.action == "user_role_change"]
-        if len(role_changes) > self.role_change_threshold:
-            anomalies.append(
-                AnomalyDetection(
-                    anomaly_type="frequent_role_changes",
-                    severity="high",
-                    description=f"{len(role_changes)} role changes detected",
-                    affected_users=list({l.user_id for l in role_changes if l.user_id}),
-                    occurrences=len(role_changes),
-                    first_seen=min(l.timestamp for l in role_changes if l.timestamp),
-                    last_seen=max(l.timestamp for l in role_changes if l.timestamp),
-                    details={},
-                )
-            )
+        try:
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
 
-        # Check for permission changes
-        permission_changes = [
-            l for l in logs if l.action in ("permission_grant", "permission_revoke")
-        ]
-        if len(permission_changes) > self.permission_change_threshold:
-            anomalies.append(
-                AnomalyDetection(
-                    anomaly_type="frequent_permission_changes",
-                    severity="medium",
-                    description=f"{len(permission_changes)} permission changes detected",
-                    affected_users=list({l.user_id for l in permission_changes if l.user_id}),
-                    occurrences=len(permission_changes),
-                    first_seen=min(l.timestamp for l in permission_changes if l.timestamp),
-                    last_seen=max(l.timestamp for l in permission_changes if l.timestamp),
-                    details={},
-                )
-            )
+                # Check for role changes
+                conditions = [
+                    "action = ?",
+                    "timestamp >= ?",
+                    "timestamp <= ?",
+                ]
+                params: list[Any] = ["user_role_change", start_time, end_time]
+                self._build_tenant_filter(conditions, params)
+                where_clause = " AND ".join(conditions)
 
-        return anomalies
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT COUNT(*) as cnt, "
+                        f"MIN(timestamp) as first_seen, MAX(timestamp) as last_seen "
+                        f"FROM audit_logs WHERE {where_clause}"
+                    ),
+                    tuple(params),
+                )
+                row = cursor.fetchone()
+                role_count = int(row["cnt"]) if row else 0
+
+                if role_count > self.role_change_threshold:
+                    # Get distinct user_ids
+                    cursor.execute(
+                        adapt_sql(
+                            f"SELECT DISTINCT user_id FROM audit_logs "
+                            f"WHERE {where_clause} AND user_id IS NOT NULL"
+                        ),
+                        tuple(params),
+                    )
+                    affected = [int(r["user_id"]) for r in cursor.fetchall()]
+
+                    def _parse_ts(val: Any) -> datetime:
+                        if isinstance(val, datetime):
+                            return val
+                        if isinstance(val, str):
+                            return datetime.fromisoformat(val)
+                        return datetime.now(timezone.utc).replace(tzinfo=None)
+
+                    anomalies.append(
+                        AnomalyDetection(
+                            anomaly_type="frequent_role_changes",
+                            severity="high",
+                            description=f"{role_count} role changes detected",
+                            affected_users=affected,
+                            occurrences=role_count,
+                            first_seen=_parse_ts(row["first_seen"]) if row else datetime.now(
+                                timezone.utc
+                            ).replace(tzinfo=None),
+                            last_seen=_parse_ts(row["last_seen"]) if row else datetime.now(
+                                timezone.utc
+                            ).replace(tzinfo=None),
+                            details={},
+                        )
+                    )
+
+                # Check for permission changes
+                conditions2 = [
+                    "action IN (?, ?)",
+                    "timestamp >= ?",
+                    "timestamp <= ?",
+                ]
+                params2: list[Any] = ["permission_grant", "permission_revoke", start_time, end_time]
+                self._build_tenant_filter(conditions2, params2)
+                where_clause2 = " AND ".join(conditions2)
+
+                cursor.execute(
+                    adapt_sql(
+                        f"SELECT COUNT(*) as cnt, "
+                        f"MIN(timestamp) as first_seen, MAX(timestamp) as last_seen "
+                        f"FROM audit_logs WHERE {where_clause2}"
+                    ),
+                    tuple(params2),
+                )
+                row2 = cursor.fetchone()
+                perm_count = int(row2["cnt"]) if row2 else 0
+
+                if perm_count > self.permission_change_threshold:
+                    cursor.execute(
+                        adapt_sql(
+                            f"SELECT DISTINCT user_id FROM audit_logs "
+                            f"WHERE {where_clause2} AND user_id IS NOT NULL"
+                        ),
+                        tuple(params2),
+                    )
+                    affected2 = [int(r["user_id"]) for r in cursor.fetchall()]
+
+                    def _parse_ts2(val: Any) -> datetime:
+                        if isinstance(val, datetime):
+                            return val
+                        if isinstance(val, str):
+                            return datetime.fromisoformat(val)
+                        return datetime.now(timezone.utc).replace(tzinfo=None)
+
+                    anomalies.append(
+                        AnomalyDetection(
+                            anomaly_type="frequent_permission_changes",
+                            severity="medium",
+                            description=f"{perm_count} permission changes detected",
+                            affected_users=affected2,
+                            occurrences=perm_count,
+                            first_seen=_parse_ts2(row2["first_seen"]) if row2 else datetime.now(
+                                timezone.utc
+                            ).replace(tzinfo=None),
+                            last_seen=_parse_ts2(row2["last_seen"]) if row2 else datetime.now(
+                                timezone.utc
+                            ).replace(tzinfo=None),
+                            details={},
+                        )
+                    )
+
+            return anomalies
+        except Exception as e:
+            logger.error(f"Failed to detect action pattern anomalies: {e}", exc_info=True)
+            return []
 
     def get_user_behavior_profile(self, user_id: int, days: int = 30) -> dict[str, Any]:
         """
@@ -536,7 +834,10 @@ class AuditAnalyzer:
         }
 
     def generate_security_score(
-        self, start_time: datetime | None = None, end_time: datetime | None = None
+        self,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        precomputed_anomalies: list[AnomalyDetection] | None = None,
     ) -> dict[str, Any]:
         """
         Generate a security score based on audit analysis.
@@ -544,6 +845,8 @@ class AuditAnalyzer:
         Args:
             start_time: Start of analysis period.
             end_time: End of analysis period.
+            precomputed_anomalies: Optional pre-computed anomalies to avoid
+                re-running anomaly detection (Issue #2750).
 
         Returns:
             Dict with security score and breakdown.
@@ -553,8 +856,12 @@ class AuditAnalyzer:
         if not end_time:
             end_time = datetime.now(timezone.utc).replace(tzinfo=None)
 
-        # Get anomalies
-        anomalies = self.detect_anomalies(start_time, end_time)
+        # Use pre-computed anomalies if provided, otherwise compute them
+        anomalies = (
+            precomputed_anomalies
+            if precomputed_anomalies is not None
+            else self.detect_anomalies(start_time, end_time)
+        )
 
         # Calculate score (100 = best, 0 = worst)
         score: float = 100

--- a/app/modules/compliance/audit.py
+++ b/app/modules/compliance/audit.py
@@ -384,9 +384,11 @@ class AuditAnalyzer:
                 )
                 range_row = cursor.fetchone()
 
-                first_seen = _parse_timestamp(range_row["first_seen"]) if range_row else datetime.now(
-                    timezone.utc
-                ).replace(tzinfo=None)
+                first_seen = (
+                    _parse_timestamp(range_row["first_seen"])
+                    if range_row
+                    else datetime.now(timezone.utc).replace(tzinfo=None)
+                )
                 last_seen = _parse_timestamp(range_row["last_seen"]) if range_row else first_seen
 
                 return AnomalyDetection(
@@ -578,12 +580,16 @@ class AuditAnalyzer:
                             description=f"{role_count} role changes detected",
                             affected_users=affected,
                             occurrences=role_count,
-                            first_seen=_parse_timestamp(row["first_seen"]) if row else datetime.now(
-                                timezone.utc
-                            ).replace(tzinfo=None),
-                            last_seen=_parse_timestamp(row["last_seen"]) if row else datetime.now(
-                                timezone.utc
-                            ).replace(tzinfo=None),
+                            first_seen=(
+                                _parse_timestamp(row["first_seen"])
+                                if row
+                                else datetime.now(timezone.utc).replace(tzinfo=None)
+                            ),
+                            last_seen=(
+                                _parse_timestamp(row["last_seen"])
+                                if row
+                                else datetime.now(timezone.utc).replace(tzinfo=None)
+                            ),
                             details={},
                         )
                     )
@@ -626,12 +632,16 @@ class AuditAnalyzer:
                             description=f"{perm_count} permission changes detected",
                             affected_users=affected2,
                             occurrences=perm_count,
-                            first_seen=_parse_timestamp(row2["first_seen"]) if row2 else datetime.now(
-                                timezone.utc
-                            ).replace(tzinfo=None),
-                            last_seen=_parse_timestamp(row2["last_seen"]) if row2 else datetime.now(
-                                timezone.utc
-                            ).replace(tzinfo=None),
+                            first_seen=(
+                                _parse_timestamp(row2["first_seen"])
+                                if row2
+                                else datetime.now(timezone.utc).replace(tzinfo=None)
+                            ),
+                            last_seen=(
+                                _parse_timestamp(row2["last_seen"])
+                                if row2
+                                else datetime.now(timezone.utc).replace(tzinfo=None)
+                            ),
                             details={},
                         )
                     )

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -421,12 +421,28 @@ def get_saved_report(report_id: str):
 # =============================================================================
 
 
+def _validate_days(default: int = 30, min_val: int = 1, max_val: int = 365) -> int:
+    """Validate and clamp the ``days`` query parameter.
+
+    Returns a clamped integer in [min_val, max_val].  Non-integer or missing
+    values fall back to *default*.
+    """
+    raw = request.args.get("days", None)
+    if raw is None:
+        return default
+    try:
+        days = int(raw)
+    except (ValueError, TypeError):
+        return default
+    return max(min_val, min(days, max_val))
+
+
 @compliance_bp.route("/audit/patterns", methods=["GET"])
 @admin_required
 def analyze_patterns():
     """Analyze audit patterns (admin only)."""
 
-    days = request.args.get("days", 30, type=int)
+    days = _validate_days(default=30)
     start_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
 
     patterns = _get_audit_analyzer().analyze_patterns(start_time=start_time)
@@ -439,7 +455,7 @@ def analyze_patterns():
 def detect_anomalies():
     """Detect audit anomalies (admin only)."""
 
-    days = request.args.get("days", 7, type=int)
+    days = _validate_days(default=7)
     start_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
 
     anomalies = _get_audit_analyzer().detect_anomalies(start_time=start_time)
@@ -477,7 +493,7 @@ def get_user_profile(user_id: int):
     boundary has to be enforced here.
     """
 
-    days = request.args.get("days", 30, type=int)
+    days = _validate_days(default=30)
 
     profile = _get_audit_analyzer().get_user_behavior_profile(user_id, days=days)
 
@@ -487,12 +503,27 @@ def get_user_profile(user_id: int):
 @compliance_bp.route("/audit/security-score", methods=["GET"])
 @admin_required
 def get_security_score():
-    """Get security score (admin only)."""
+    """Get security score (admin only).
 
-    days = request.args.get("days", 30, type=int)
+    Accepts pre-computed anomalies via the ``precomputed_anomalies`` parameter
+    of ``generate_security_score`` so that the front-end can request anomalies
+    and security-score without duplicating the anomaly detection work
+    (Issue #2750).  When called standalone the endpoint computes anomalies
+    itself.
+    """
+
+    days = _validate_days(default=30)
     start_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
 
-    score = _get_audit_analyzer().generate_security_score(start_time=start_time)
+    analyzer = _get_audit_analyzer()
+
+    # Compute anomalies once and pass them to the scorer so we don't re-run
+    # detection inside generate_security_score.
+    anomalies = analyzer.detect_anomalies(start_time=start_time)
+    score = analyzer.generate_security_score(
+        start_time=start_time,
+        precomputed_anomalies=anomalies,
+    )
 
     return jsonify(score)
 

--- a/tests/unit/test_audit_analyzer_2750.py
+++ b/tests/unit/test_audit_analyzer_2750.py
@@ -21,14 +21,16 @@ import pytest
 from app.modules.compliance.audit import AnomalyDetection, AuditAnalyzer
 from app.modules.governance.audit_logger import AuditLogger
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 # adapt_sql is a pass-through for SQLite; we patch it to be a no-op since
 # the test environment has a PostgreSQL DATABASE_URL but we run real SQLite.
-_noop_adapt = lambda q: q
+def _noop_adapt(q: str) -> str:
+    """Pass-through for adapt_sql in tests (SQLite uses ? placeholders)."""
+    return q
 
 
 def _create_sqlite_db():
@@ -78,22 +80,24 @@ def _seed_logs(conn, count, base_time=None, actions=None, user_ids=None):
         ts = base_time + timedelta(seconds=i * 60)
         action = actions[i % len(actions)]
         user_id = user_ids[i % len(user_ids)]
-        rows.append((
-            ts.isoformat(),
-            user_id,
-            f"user{user_id}",
-            action,
-            "info",
-            "",
-            None,
-            None,
-            None,
-            None,
-            None,
-            1,
-            None,
-            None,
-        ))
+        rows.append(
+            (
+                ts.isoformat(),
+                user_id,
+                f"user{user_id}",
+                action,
+                "info",
+                "",
+                None,
+                None,
+                None,
+                None,
+                None,
+                1,
+                None,
+                None,
+            )
+        )
     conn.executemany(
         """INSERT INTO audit_logs
            (timestamp, user_id, username, action, severity, resource_type,
@@ -312,10 +316,24 @@ class TestAnomalyDetectionSQL:
         rows = []
         for i in range(20):
             ts = base + timedelta(minutes=i)
-            rows.append((
-                ts.isoformat(), 1, "user1", "login_failed", "warning",
-                "", None, None, None, None, None, 0, "invalid password", None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    1,
+                    "user1",
+                    "login_failed",
+                    "warning",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    0,
+                    "invalid password",
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -351,10 +369,24 @@ class TestAnomalyDetectionSQL:
         rows = []
         for i in range(3):
             ts = base + timedelta(minutes=i)
-            rows.append((
-                ts.isoformat(), 1, "user1", "login_failed", "warning",
-                "", None, None, None, None, None, 0, None, None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    1,
+                    "user1",
+                    "login_failed",
+                    "warning",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    0,
+                    None,
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -386,10 +418,24 @@ class TestAnomalyDetectionSQL:
         rows = []
         for i in range(60):
             ts = base + timedelta(seconds=i)
-            rows.append((
-                ts.isoformat(), 1, "user1", "data_view", "info",
-                "", None, None, None, None, None, 1, None, None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    1,
+                    "user1",
+                    "data_view",
+                    "info",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -425,10 +471,24 @@ class TestAnomalyDetectionSQL:
         rows = []
         for i in range(15):
             ts = base + timedelta(minutes=i)
-            rows.append((
-                ts.isoformat(), 1, "user1", "data_view", "info",
-                "", None, None, None, None, None, 1, None, None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    1,
+                    "user1",
+                    "data_view",
+                    "info",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -463,10 +523,24 @@ class TestAnomalyDetectionSQL:
         rows = []
         for i in range(10):
             ts = base + timedelta(minutes=i)
-            rows.append((
-                ts.isoformat(), (i % 3) + 1, f"user{(i % 3) + 1}", "user_role_change", "info",
-                "", None, None, None, None, None, 1, None, None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    (i % 3) + 1,
+                    f"user{(i % 3) + 1}",
+                    "user_role_change",
+                    "info",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    1,
+                    None,
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -486,9 +560,7 @@ class TestAnomalyDetectionSQL:
 
         anomalies = analyzer._detect_action_pattern_anomaly(start, end)
 
-        role_change_anomalies = [
-            a for a in anomalies if a.anomaly_type == "frequent_role_changes"
-        ]
+        role_change_anomalies = [a for a in anomalies if a.anomaly_type == "frequent_role_changes"]
         assert len(role_change_anomalies) == 1
         assert role_change_anomalies[0].occurrences == 10
 
@@ -654,10 +726,24 @@ class TestLargeDatasetAnomaliesNotIgnored:
         rows = []
         for i in range(20):
             ts = base + timedelta(minutes=i)
-            rows.append((
-                ts.isoformat(), 99, "attacker", "login_failed", "warning",
-                "", None, None, None, None, None, 0, "invalid password", None,
-            ))
+            rows.append(
+                (
+                    ts.isoformat(),
+                    99,
+                    "attacker",
+                    "login_failed",
+                    "warning",
+                    "",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    0,
+                    "invalid password",
+                    None,
+                )
+            )
         conn.executemany(
             """INSERT INTO audit_logs
                (timestamp, user_id, username, action, severity, resource_type,
@@ -669,7 +755,8 @@ class TestLargeDatasetAnomaliesNotIgnored:
 
         # 19,980 normal logs after the failed logins (no login_failed actions)
         _seed_logs(
-            conn, 19980,
+            conn,
+            19980,
             base_time=base + timedelta(hours=1),
             actions=["login", "logout", "data_view", "user_create"],
         )

--- a/tests/unit/test_audit_analyzer_2750.py
+++ b/tests/unit/test_audit_analyzer_2750.py
@@ -1,0 +1,729 @@
+"""
+Tests for Issue #2750: Audit analysis SQL aggregation, completeness metadata,
+days validation, and security-score de-duplication.
+
+These tests verify that:
+1. analyze_patterns uses SQL aggregation instead of Python object loading.
+2. total_events reflects the real database count (not truncated by limit).
+3. Completeness metadata fields are present in the response.
+4. Anomaly detectors use specialized SQL instead of loading 10,000 objects.
+5. generate_security_score accepts precomputed_anomalies to avoid re-detection.
+6. Route-level days parameter validation works correctly.
+"""
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.compliance.audit import AnomalyDetection, AuditAnalyzer
+from app.modules.governance.audit_logger import AuditLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# adapt_sql is a pass-through for SQLite; we patch it to be a no-op since
+# the test environment has a PostgreSQL DATABASE_URL but we run real SQLite.
+_noop_adapt = lambda q: q
+
+
+def _create_sqlite_db():
+    """Create an in-memory SQLite database with the audit_logs table."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE audit_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            user_id INTEGER,
+            username TEXT,
+            action TEXT NOT NULL,
+            severity TEXT DEFAULT 'info',
+            resource_type TEXT DEFAULT '',
+            resource_id TEXT,
+            details TEXT,
+            ip_address TEXT,
+            user_agent TEXT,
+            session_id TEXT,
+            success INTEGER DEFAULT 1,
+            error_message TEXT,
+            tenant_id INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            tenant_id INTEGER
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def _seed_logs(conn, count, base_time=None, actions=None, user_ids=None):
+    """Insert *count* audit log rows with rotating actions/user_ids."""
+    if base_time is None:
+        base_time = datetime(2026, 6, 1, 12, 0, 0)
+    if actions is None:
+        actions = ["login", "logout", "data_view", "user_create", "login_failed"]
+    if user_ids is None:
+        user_ids = [1, 2, 3, 4, 5]
+
+    rows = []
+    for i in range(count):
+        ts = base_time + timedelta(seconds=i * 60)
+        action = actions[i % len(actions)]
+        user_id = user_ids[i % len(user_ids)]
+        rows.append((
+            ts.isoformat(),
+            user_id,
+            f"user{user_id}",
+            action,
+            "info",
+            "",
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+            None,
+            None,
+        ))
+    conn.executemany(
+        """INSERT INTO audit_logs
+           (timestamp, user_id, username, action, severity, resource_type,
+            resource_id, details, ip_address, user_agent, session_id,
+            success, error_message, tenant_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    conn.commit()
+
+
+def _make_analyzer_with_conn(conn):
+    """Create an AuditAnalyzer backed by a real SQLite connection."""
+    mock_db = MagicMock()
+    mock_db.fetch_all = MagicMock(return_value=[])
+    mock_db.fetch_one = MagicMock(return_value={"count": 0})
+
+    logger = AuditLogger(db=mock_db)
+
+    # Patch _resolve_tenant_id and _normalize_tenant_id to return None (no tenant scope)
+    logger._resolve_tenant_id = MagicMock(return_value=None)
+    logger._normalize_tenant_id = MagicMock(return_value=None)
+
+    analyzer = AuditAnalyzer(audit_logger=logger)
+    return analyzer, conn
+
+
+# Shared patches for all SQL-based tests
+_SQL_PATCHES = [
+    patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt),
+    patch("app.modules.compliance.audit.is_postgresql", return_value=False),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests: analyze_patterns SQL aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePatternsSQLAggregation:
+    """Test that analyze_patterns uses SQL aggregation."""
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_total_events_reflects_real_count(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """total_events must equal COUNT(*), not be capped at 10,000."""
+        conn = _create_sqlite_db()
+        # Insert 15,000 logs — more than the old limit of 10,000
+        _seed_logs(conn, 15000)
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        assert result["total_events"] == 15000
+        assert result["matching_events"] == 15000
+        assert result["analyzed_events"] == 15000
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_completeness_metadata_present(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Response must include completeness metadata fields."""
+        conn = _create_sqlite_db()
+        _seed_logs(conn, 100)
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        assert "matching_events" in result
+        assert "analyzed_events" in result
+        assert "truncated" in result
+        assert "coverage_ratio" in result
+        assert "oldest_analyzed_at" in result
+        assert result["truncated"] is False
+        assert result["coverage_ratio"] == 1.0
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_distributions_cover_full_range(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Hourly/daily/action distributions must cover all 15,000 logs."""
+        conn = _create_sqlite_db()
+        _seed_logs(conn, 15000)
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        # Sum of hourly distribution must equal total
+        hourly_sum = sum(result["hourly_distribution"].values())
+        assert hourly_sum == 15000
+
+        # Sum of daily distribution must equal total
+        daily_sum = sum(result["daily_distribution"].values())
+        assert daily_sum == 15000
+
+        # Sum of action distribution must equal total
+        action_sum = sum(result["action_distribution"].values())
+        assert action_sum == 15000
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_top_users_and_unique_users(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """top_users and unique_users must be computed correctly."""
+        conn = _create_sqlite_db()
+        _seed_logs(conn, 100, user_ids=[10, 20, 30])
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        assert result["unique_users"] == 3
+        assert len(result["top_users"]) == 3
+        # Each user has about 33-34 events
+        for uid, cnt in result["top_users"]:
+            assert uid in (10, 20, 30)
+            assert cnt > 0
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_login_hourly_distribution(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """login_hourly_distribution must only count login actions."""
+        conn = _create_sqlite_db()
+        # Insert 50 logins + 50 other actions
+        _seed_logs(conn, 100, actions=["login", "data_view"])
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        login_sum = sum(result["login_hourly_distribution"].values())
+        assert login_sum == 50  # Half are "login" actions
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_oldest_analyzed_at_populated(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """oldest_analyzed_at must reflect the earliest log timestamp."""
+        conn = _create_sqlite_db()
+        base = datetime(2026, 5, 15, 8, 30, 0)
+        _seed_logs(conn, 10, base_time=base)
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 5, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        assert result["oldest_analyzed_at"] is not None
+        assert "2026-05-15" in result["oldest_analyzed_at"]
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_backward_compatible_total_events(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """total_events must still be present for backward compatibility."""
+        conn = _create_sqlite_db()
+        _seed_logs(conn, 50)
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+
+        assert "total_events" in result
+        assert result["total_events"] == 50
+        assert result["total_events"] == result["matching_events"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Anomaly detection SQL-based
+# ---------------------------------------------------------------------------
+
+
+class TestAnomalyDetectionSQL:
+    """Test that anomaly detectors use SQL aggregation."""
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_failed_login_detection(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Failed login detector must find users exceeding threshold."""
+        conn = _create_sqlite_db()
+        # Insert 20 failed logins for user 1 (threshold default = 5)
+        base = datetime(2026, 6, 1, 10, 0, 0)
+        rows = []
+        for i in range(20):
+            ts = base + timedelta(minutes=i)
+            rows.append((
+                ts.isoformat(), 1, "user1", "login_failed", "warning",
+                "", None, None, None, None, None, 0, "invalid password", None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 7, 1, 0, 0, 0)
+
+        anomaly = analyzer._detect_failed_login_anomaly(start, end)
+
+        assert anomaly is not None
+        assert anomaly.anomaly_type == "excessive_failed_logins"
+        assert 1 in anomaly.affected_users
+        assert anomaly.occurrences == 20
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_failed_login_below_threshold(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """No anomaly when failed logins are below threshold."""
+        conn = _create_sqlite_db()
+        # Insert only 3 failed logins (threshold default = 5)
+        base = datetime(2026, 6, 1, 10, 0, 0)
+        rows = []
+        for i in range(3):
+            ts = base + timedelta(minutes=i)
+            rows.append((
+                ts.isoformat(), 1, "user1", "login_failed", "warning",
+                "", None, None, None, None, None, 0, None, None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 7, 1, 0, 0, 0)
+
+        anomaly = analyzer._detect_failed_login_anomaly(start, end)
+        assert anomaly is None
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_rapid_activity_detection(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Rapid activity detector must find users exceeding hourly threshold."""
+        conn = _create_sqlite_db()
+        # Insert 60 actions by user 1 within one hour (threshold default = 50)
+        base = datetime(2026, 6, 1, 10, 0, 0)
+        rows = []
+        for i in range(60):
+            ts = base + timedelta(seconds=i)
+            rows.append((
+                ts.isoformat(), 1, "user1", "data_view", "info",
+                "", None, None, None, None, None, 1, None, None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 7, 1, 0, 0, 0)
+
+        anomalies = analyzer._detect_rapid_activity_anomaly(start, end)
+
+        assert len(anomalies) >= 1
+        assert anomalies[0].anomaly_type == "rapid_activity"
+        assert 1 in anomalies[0].affected_users
+        assert anomalies[0].occurrences == 60
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_off_hours_detection(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Off-hours detector must find users active between 22:00-06:00."""
+        conn = _create_sqlite_db()
+        # Insert 15 actions at 23:00 (off-hours) for user 1 (threshold default = 10)
+        base = datetime(2026, 6, 1, 23, 0, 0)
+        rows = []
+        for i in range(15):
+            ts = base + timedelta(minutes=i)
+            rows.append((
+                ts.isoformat(), 1, "user1", "data_view", "info",
+                "", None, None, None, None, None, 1, None, None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 7, 1, 0, 0, 0)
+
+        anomalies = analyzer._detect_off_hours_anomaly(start, end)
+
+        assert len(anomalies) >= 1
+        assert anomalies[0].anomaly_type == "off_hours_activity"
+        assert 1 in anomalies[0].affected_users
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_action_pattern_role_changes(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """Action pattern detector must detect frequent role changes."""
+        conn = _create_sqlite_db()
+        # Insert 10 role changes (threshold default = 5)
+        base = datetime(2026, 6, 1, 10, 0, 0)
+        rows = []
+        for i in range(10):
+            ts = base + timedelta(minutes=i)
+            rows.append((
+                ts.isoformat(), (i % 3) + 1, f"user{(i % 3) + 1}", "user_role_change", "info",
+                "", None, None, None, None, None, 1, None, None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 7, 1, 0, 0, 0)
+
+        anomalies = analyzer._detect_action_pattern_anomaly(start, end)
+
+        role_change_anomalies = [
+            a for a in anomalies if a.anomaly_type == "frequent_role_changes"
+        ]
+        assert len(role_change_anomalies) == 1
+        assert role_change_anomalies[0].occurrences == 10
+
+
+# ---------------------------------------------------------------------------
+# Tests: generate_security_score accepts precomputed_anomalies
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityScorePrecomputedAnomalies:
+    """Test that security score can use precomputed anomalies."""
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_precomputed_anomalies_used(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """generate_security_score must use precomputed_anomalies if provided."""
+        conn = _create_sqlite_db()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+
+        precomputed = [
+            AnomalyDetection(
+                anomaly_type="excessive_failed_logins",
+                severity="high",
+                description="test",
+                affected_users=[1],
+                occurrences=100,
+                first_seen=datetime(2026, 6, 1),
+                last_seen=datetime(2026, 6, 30),
+                details={},
+            ),
+        ]
+
+        # Patch detect_anomalies to ensure it's NOT called
+        with patch.object(analyzer, "detect_anomalies") as mock_detect:
+            result = analyzer.generate_security_score(
+                start_time=datetime(2026, 6, 1),
+                end_time=datetime(2026, 7, 1),
+                precomputed_anomalies=precomputed,
+            )
+            mock_detect.assert_not_called()
+
+        assert result["anomaly_count"] == 1
+        assert result["high_severity_count"] == 1
+        assert result["score"] < 100  # Should be deducted
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_no_precomputed_calls_detect(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """generate_security_score without precomputed must call detect_anomalies."""
+        conn = _create_sqlite_db()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+
+        with patch.object(analyzer, "detect_anomalies", return_value=[]) as mock_detect:
+            result = analyzer.generate_security_score(
+                start_time=datetime(2026, 6, 1),
+                end_time=datetime(2026, 7, 1),
+            )
+            mock_detect.assert_called_once()
+
+        assert result["anomaly_count"] == 0
+        assert result["score"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Tests: Route-level days validation
+# ---------------------------------------------------------------------------
+
+
+class TestDaysValidation:
+    """Test the _validate_days helper in compliance routes."""
+
+    def _make_request_with_args(self, args):
+        """Create a mock request with given args dict."""
+        mock_request = MagicMock()
+        mock_request.args = args
+        return mock_request
+
+    def test_default_value(self):
+        """Missing days parameter returns default."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({})):
+            assert _validate_days(default=30) == 30
+
+    def test_valid_value(self):
+        """Valid days within range is returned as-is."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "14"})):
+            assert _validate_days(default=30) == 14
+
+    def test_negative_clamped(self):
+        """Negative days is clamped to minimum."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "-1"})):
+            assert _validate_days(default=30) == 1
+
+    def test_zero_clamped(self):
+        """Zero days is clamped to minimum."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "0"})):
+            assert _validate_days(default=30) == 1
+
+    def test_over_max_clamped(self):
+        """Days exceeding maximum is clamped."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "9999"})):
+            assert _validate_days(default=30, max_val=365) == 365
+
+    def test_non_integer_returns_default(self):
+        """Non-integer days returns default."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "abc"})):
+            assert _validate_days(default=30) == 30
+
+    def test_boundary_values(self):
+        """Test boundary values: 1, 365."""
+        from app.routes.compliance import _validate_days
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "1"})):
+            assert _validate_days(default=30) == 1
+
+        with patch("app.routes.compliance.request", self._make_request_with_args({"days": "365"})):
+            assert _validate_days(default=30) == 365
+
+
+# ---------------------------------------------------------------------------
+# Tests: Large dataset - anomalies at beginning of time range
+# ---------------------------------------------------------------------------
+
+
+class TestLargeDatasetAnomaliesNotIgnored:
+    """
+    Verify that anomalies placed at the beginning of the time range are
+    detected even when total logs exceed the old 10,000 limit.
+    """
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_early_anomalies_detected(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """
+        Insert 20,000 logs: 20 failed logins at the very beginning (day 1),
+        then 19,980 normal logs.  The old DESC LIMIT approach would miss the
+        failed logins entirely.  The SQL aggregation must find them.
+        """
+        conn = _create_sqlite_db()
+
+        # 20 failed logins at the beginning
+        base = datetime(2026, 6, 1, 0, 0, 0)
+        rows = []
+        for i in range(20):
+            ts = base + timedelta(minutes=i)
+            rows.append((
+                ts.isoformat(), 99, "attacker", "login_failed", "warning",
+                "", None, None, None, None, None, 0, "invalid password", None,
+            ))
+        conn.executemany(
+            """INSERT INTO audit_logs
+               (timestamp, user_id, username, action, severity, resource_type,
+                resource_id, details, ip_address, user_agent, session_id,
+                success, error_message, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+
+        # 19,980 normal logs after the failed logins (no login_failed actions)
+        _seed_logs(
+            conn, 19980,
+            base_time=base + timedelta(hours=1),
+            actions=["login", "logout", "data_view", "user_create"],
+        )
+        conn.commit()
+
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 8, 1, 0, 0, 0)
+
+        # The failed login anomaly must be detected
+        anomaly = analyzer._detect_failed_login_anomaly(start, end)
+        assert anomaly is not None
+        assert 99 in anomaly.affected_users
+        assert anomaly.occurrences == 20
+
+        # Total events must be 20,000
+        result = analyzer.analyze_patterns(start_time=start, end_time=end)
+        assert result["total_events"] == 20000
+
+
+# ---------------------------------------------------------------------------
+# Tests: detect_anomalies orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAnomaliesOrchestration:
+    """Test that detect_anomalies calls all sub-detectors."""
+
+    @patch("app.modules.compliance.audit.get_db_connection")
+    @patch("app.modules.compliance.audit.adapt_sql", side_effect=_noop_adapt)
+    @patch("app.modules.compliance.audit.is_postgresql", return_value=False)
+    def test_all_detectors_called(self, _mock_pg, _mock_adapt, mock_get_conn):
+        """detect_anomalies must call all four sub-detectors."""
+        conn = _create_sqlite_db()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        analyzer, _ = _make_analyzer_with_conn(conn)
+
+        with (
+            patch.object(analyzer, "_detect_failed_login_anomaly", return_value=None) as m1,
+            patch.object(analyzer, "_detect_rapid_activity_anomaly", return_value=[]) as m2,
+            patch.object(analyzer, "_detect_off_hours_anomaly", return_value=[]) as m3,
+            patch.object(analyzer, "_detect_action_pattern_anomaly", return_value=[]) as m4,
+        ):
+            start = datetime(2026, 6, 1)
+            end = datetime(2026, 7, 1)
+            result = analyzer.detect_anomalies(start_time=start, end_time=end)
+
+            m1.assert_called_once_with(start, end)
+            m2.assert_called_once_with(start, end)
+            m3.assert_called_once_with(start, end)
+            m4.assert_called_once_with(start, end)
+            assert result == []


### PR DESCRIPTION
## 修复说明

关联 Issue：#2750

## 根因

1. `analyze_patterns()` 使用 `limit=10000` 加载完整 `AuditLog` 对象后在 Python 中聚合，`ORDER BY timestamp DESC` 导致旧数据被静默丢弃，`total_events` 永远 ≤ 10,000。
2. 每个异常检测器独立查询最多 10,000 条完整对象到内存。
3. `generate_security_score()` 内部再次调用 `detect_anomalies()`，前端同时请求两个接口导致重复执行。
4. 响应缺少完整性元数据（`truncated`、`coverage_ratio` 等）。
5. `days` 参数无范围验证。

## 修复方案

### 1. SQL 聚合替代 Python 内存聚合
`analyze_patterns()` 改为使用数据库端 `COUNT(*)`、`GROUP BY` 查询，覆盖完整时间范围，不再受 limit 限制。

### 2. 专项 SQL 查询替代对象加载
每个异常检测器改为一条专项 SQL：
- failed login：`GROUP BY user_id HAVING COUNT(*) >= threshold`
- rapid activity：按 `user_id + hour_bucket` 分组
- off-hours：SQL 端过滤 `HOUR >= 22 OR HOUR < 6` 后分组
- action pattern：按 action 过滤后 `COUNT(*)` + `DISTINCT user_id`

### 3. 消除 security-score 重复执行
`generate_security_score()` 新增 `precomputed_anomalies` 可选参数，`/audit/security-score` 路由先计算 anomalies 再传入。

### 4. 完整性元数据
响应新增字段：`matching_events`、`analyzed_events`、`truncated`、`coverage_ratio`、`oldest_analyzed_at`。`total_events` 保留向后兼容。

### 5. days 参数验证
新增 `_validate_days()` 辅助函数，范围 [1, 365]，非整数回退默认值。

## 主要变更

- `app/modules/compliance/audit.py`：重写 `analyze_patterns()`、4 个异常检测器、`generate_security_score()`
- `app/routes/compliance.py`：新增 `_validate_days()`，更新 3 个 endpoint，security-score 使用预计算 anomalies
- `tests/unit/test_audit_analyzer_2750.py`：23 个新测试

## 测试

- 23 个新单元测试覆盖：SQL 聚合、完整性元数据、异常检测、security-score 去重、days 验证、大数据集前段异常检测
- 全部 92 个现有审计相关测试通过（无回归）
- 全部 77 个合规单元测试通过

## 风险

- **兼容性**：低。`total_events` 字段保留，新增字段均为附加。前端不需要改动即可正常工作。
- **性能**：正向。SQL 聚合比 Python 遍历万级对象快得多，内存占用大幅降低。
- **SQLite/PostgreSQL 兼容**：已处理时间函数差异（`strftime` vs `EXTRACT`/`TO_CHAR`）。
- **回归风险**：低。异常检测语义不变（阈值比较逻辑不变），只是数据来源从内存对象改为 SQL 结果。