### PR TITLE
fix(security): skip DB_PASSWORD check for SQLite in /security-status (#2810)

### DIFF
--- a/app/utils/security_baseline.py
+++ b/app/utils/security_baseline.py
@@ -257,6 +257,8 @@ def check_all() -> dict:
     Run all security baseline checks.
 
     Uses unified security mode detection from security_mode.py (Issue #2185).
+    Issue #2810: Detects database backend to skip password checks for SQLite,
+    which does not use server-side password authentication.
 
     Returns:
         dict: Dictionary with check results and overall status.
@@ -265,14 +267,48 @@ def check_all() -> dict:
     mode = get_security_mode()
 
     # Get environment values
-    db_password = os.environ.get("DB_PASSWORD")
     secret_key = os.environ.get("SECRET_KEY")
     encryption_key = os.environ.get("OPENACE_ENCRYPTION_KEY")
     multi_user_mode = os.environ.get("WORKSPACE_MULTI_USER_MODE", "").lower() == "true"
     allow_root_multi_user = os.environ.get("OPENACE_ALLOW_ROOT_MULTI_USER", "").lower() == "1"
 
+    # Issue #2810: Detect database backend to determine if password check applies.
+    # SQLite does not use server-side password authentication, so the check is
+    # not applicable. Only PostgreSQL (and other password-authenticated backends)
+    # require DB_PASSWORD validation.
+    try:
+        from app.repositories.database import is_postgresql
+
+        use_postgresql = is_postgresql()
+    except Exception:
+        # If backend detection fails, default to PostgreSQL for safety
+        # (fail-closed: assume password check is needed)
+        use_postgresql = True
+
+    if use_postgresql:
+        db_password = os.environ.get("DB_PASSWORD")
+        db_result = check_database_password(db_password, mode)
+        db_entry = {
+            "status": db_result.status,
+            "message": db_result.message,
+            "recommendation": db_result.recommendation,
+            "backend": "postgresql",
+            "applicable": True,
+        }
+        effective_db_status = db_result.status
+    else:
+        # SQLite does not use server-side password authentication
+        db_entry = {
+            "status": "not_applicable",
+            "message": "SQLite does not use server-side password authentication.",
+            "recommendation": None,
+            "backend": "sqlite",
+            "applicable": False,
+        }
+        # not_applicable is treated as pass for overall status determination
+        effective_db_status = "pass"
+
     # Run checks
-    db_result = check_database_password(db_password, mode)
     secret_result = check_secret_key(secret_key, mode)
     encryption_result = check_encryption_key(encryption_key, mode)
 
@@ -283,11 +319,7 @@ def check_all() -> dict:
     # Determine overall status
     results = {
         "mode": mode.value,
-        "database_password": {
-            "status": db_result.status,
-            "message": db_result.message,
-            "recommendation": db_result.recommendation,
-        },
+        "database_password": db_entry,
         "secret_key": {
             "status": secret_result.status,
             "message": secret_result.message,
@@ -305,9 +337,9 @@ def check_all() -> dict:
         },
     }
 
-    # Overall status
+    # Overall status (Issue #2810: not_applicable for SQLite is treated as pass)
     statuses = [
-        db_result.status,
+        effective_db_status,
         secret_result.status,
         encryption_result.status,
         root_result.status,

--- a/tests/test_security_baseline.py
+++ b/tests/test_security_baseline.py
@@ -337,6 +337,10 @@ class TestCheckAll:
         monkeypatch.setenv("DB_PASSWORD", "ace-secret")
         monkeypatch.setenv("SECRET_KEY", "")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "")
+        # Simulate PostgreSQL backend (DB_PASSWORD matters only for PostgreSQL)
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: True
+        )
 
         result = check_all()
         assert result["status"] == "unhealthy"
@@ -352,6 +356,157 @@ class TestCheckAll:
 
         result = check_all()
         assert result["status"] in ["warning", "healthy"]  # Depends on auto-generation
+
+    # Issue #2810: SQLite backend tests
+    def test_check_all_sqlite_production_no_password_healthy(self, monkeypatch):
+        """Test that production + SQLite + no DB_PASSWORD returns healthy (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate SQLite backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: False
+        )
+
+        result = check_all()
+        assert result["status"] == "healthy"
+        assert result["database_password"]["status"] == "not_applicable"
+        assert result["database_password"]["backend"] == "sqlite"
+        assert result["database_password"]["applicable"] is False
+        assert "sqlite" in result["database_password"]["message"].lower()
+
+    def test_check_all_sqlite_production_with_password_ignored(self, monkeypatch):
+        """Test that SQLite ignores DB_PASSWORD even if set (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.setenv("DB_PASSWORD", "ace-secret")  # Weak/forbidden password
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate SQLite backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: False
+        )
+
+        result = check_all()
+        assert result["status"] == "healthy"
+        assert result["database_password"]["status"] == "not_applicable"
+        assert result["database_password"]["backend"] == "sqlite"
+        assert result["database_password"]["applicable"] is False
+
+    def test_check_all_sqlite_development_no_password(self, monkeypatch):
+        """Test that development + SQLite returns not_applicable (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "development")
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("OPENACE_ENCRYPTION_KEY", raising=False)
+        # Simulate SQLite backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: False
+        )
+
+        result = check_all()
+        assert result["database_password"]["status"] == "not_applicable"
+        assert result["database_password"]["backend"] == "sqlite"
+        assert result["database_password"]["applicable"] is False
+
+    # Issue #2810: PostgreSQL backend tests
+    def test_check_all_postgresql_production_no_password_fails(self, monkeypatch):
+        """Test that production + PostgreSQL + no DB_PASSWORD returns unhealthy (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate PostgreSQL backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: True
+        )
+
+        result = check_all()
+        assert result["status"] == "unhealthy"
+        assert result["database_password"]["status"] == "fail"
+        assert result["database_password"]["backend"] == "postgresql"
+        assert result["database_password"]["applicable"] is True
+
+    def test_check_all_postgresql_production_weak_password_fails(self, monkeypatch):
+        """Test that production + PostgreSQL + weak DB_PASSWORD returns unhealthy (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.setenv("DB_PASSWORD", "ace-secret")
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate PostgreSQL backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: True
+        )
+
+        result = check_all()
+        assert result["status"] == "unhealthy"
+        assert result["database_password"]["status"] == "fail"
+        assert result["database_password"]["backend"] == "postgresql"
+        assert result["database_password"]["applicable"] is True
+
+    def test_check_all_postgresql_production_strong_password_passes(self, monkeypatch):
+        """Test that production + PostgreSQL + strong DB_PASSWORD passes (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.setenv("DB_PASSWORD", "my-strong-password-123!")
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate PostgreSQL backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: True
+        )
+
+        result = check_all()
+        assert result["status"] == "healthy"
+        assert result["database_password"]["status"] == "pass"
+        assert result["database_password"]["backend"] == "postgresql"
+        assert result["database_password"]["applicable"] is True
+
+    def test_check_all_not_applicable_does_not_affect_overall_status(self, monkeypatch):
+        """Test that not_applicable status does not make overall status unhealthy (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate SQLite backend
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", lambda: False
+        )
+
+        result = check_all()
+        # not_applicable should not cause unhealthy
+        assert result["status"] == "healthy"
+        # Verify no "fail" in effective statuses
+        assert result["database_password"]["status"] == "not_applicable"
+
+    def test_check_all_backend_detection_failure_fail_closed(self, monkeypatch):
+        """Test that backend detection failure defaults to PostgreSQL (fail-closed) (Issue #2810)."""
+        reset_security_mode_cache()
+        monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
+        # Simulate backend detection raising an exception -> should default to PostgreSQL
+        # (fail-closed: if we can't determine the backend, assume password is needed)
+
+        def _raise_error():
+            raise RuntimeError("Database not available")
+
+        monkeypatch.setattr(
+            "app.repositories.database.is_postgresql", _raise_error
+        )
+
+        result = check_all()
+        # Should fall back to PostgreSQL behavior (require password)
+        assert result["database_password"]["status"] == "fail"
+        assert result["database_password"]["backend"] == "postgresql"
+        assert result["database_password"]["applicable"] is True
 
 
 class TestCheckResult:

--- a/tests/test_security_baseline.py
+++ b/tests/test_security_baseline.py
@@ -338,9 +338,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "")
         # Simulate PostgreSQL backend (DB_PASSWORD matters only for PostgreSQL)
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: True
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: True)
 
         result = check_all()
         assert result["status"] == "unhealthy"
@@ -366,9 +364,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate SQLite backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: False
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
 
         result = check_all()
         assert result["status"] == "healthy"
@@ -385,9 +381,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate SQLite backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: False
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
 
         result = check_all()
         assert result["status"] == "healthy"
@@ -403,9 +397,7 @@ class TestCheckAll:
         monkeypatch.delenv("SECRET_KEY", raising=False)
         monkeypatch.delenv("OPENACE_ENCRYPTION_KEY", raising=False)
         # Simulate SQLite backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: False
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
 
         result = check_all()
         assert result["database_password"]["status"] == "not_applicable"
@@ -421,9 +413,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate PostgreSQL backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: True
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: True)
 
         result = check_all()
         assert result["status"] == "unhealthy"
@@ -439,9 +429,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate PostgreSQL backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: True
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: True)
 
         result = check_all()
         assert result["status"] == "unhealthy"
@@ -457,9 +445,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate PostgreSQL backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: True
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: True)
 
         result = check_all()
         assert result["status"] == "healthy"
@@ -475,9 +461,7 @@ class TestCheckAll:
         monkeypatch.setenv("SECRET_KEY", "a-strong-random-secret-key-for-prod-1234567890")
         monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "a-strong-encryption-key-1234567890ab")
         # Simulate SQLite backend
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", lambda: False
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
 
         result = check_all()
         # not_applicable should not cause unhealthy
@@ -498,9 +482,7 @@ class TestCheckAll:
         def _raise_error():
             raise RuntimeError("Database not available")
 
-        monkeypatch.setattr(
-            "app.repositories.database.is_postgresql", _raise_error
-        )
+        monkeypatch.setattr("app.repositories.database.is_postgresql", _raise_error)
 
         result = check_all()
         # Should fall back to PostgreSQL behavior (require password)


### PR DESCRIPTION
## 修复说明

关联 Issue：#2810

## 根因

`app/utils/security_baseline.py::check_all()` 无条件检查 `DB_PASSWORD` 环境变量，没有检测实际数据库后端类型。SQLite 不使用服务端密码认证，因此 production 模式的 SQLite 部署被错误标记为 `unhealthy`（HTTP 503）。

## 修复方案

在 `check_all()` 中调用仓库已有的 `is_postgresql()` 检测数据库后端类型：
- **SQLite**：返回 `status="not_applicable"`，附加 `backend: "sqlite"` 和 `applicable: false` 元数据
- **PostgreSQL**：保持现有密码验证逻辑不变
- **后端检测失败**：默认回退到 PostgreSQL 行为（fail-closed 安全策略）
- `not_applicable` 状态在整体健康判定中视为 `pass`

## 主要变更

- `app/utils/security_baseline.py`：修改 `check_all()` 函数，增加后端检测逻辑
- `tests/test_security_baseline.py`：新增 9 个测试用例覆盖 SQLite 和 PostgreSQL 两种后端

## 测试

- 测试环境：本地测试环境
- 已运行的测试：`tests/test_security_baseline.py`（56 个测试全部通过）
- 已运行的测试：`tests/unit/test_security_model.py` + `tests/unit/test_security_mode_enforcement.py`（共 120 个测试全部通过）
- 新增测试：
  - `test_check_all_sqlite_production_no_password_healthy` — production + SQLite 无密码 → healthy
  - `test_check_all_sqlite_production_with_password_ignored` — production + SQLite 有密码 → ignored
  - `test_check_all_sqlite_development_no_password` — development + SQLite → not_applicable
  - `test_check_all_postgresql_production_no_password_fails` — production + PostgreSQL 无密码 → unhealthy
  - `test_check_all_postgresql_production_weak_password_fails` — production + PostgreSQL 弱密码 → unhealthy
  - `test_check_all_postgresql_production_strong_password_passes` — production + PostgreSQL 强密码 → healthy
  - `test_check_all_not_applicable_does_not_affect_overall_status` — not_applicable 不影响整体状态
  - `test_check_all_backend_detection_failure_fail_closed` — 后端检测失败 → fail-closed

## 风险

- **兼容性**：`database_password.status` 字段新增 `not_applicable` 值。消费 `/security-status` 的外部系统需能处理此新值。JSON 结构不变，不会导致序列化错误。
- **性能**：无。`is_postgresql()` 仅做字符串前缀检查。
- **安全**：无。不引入新的安全问题。后端检测失败时 fail-closed 到 PostgreSQL 行为。
- **回归**：低。PostgreSQL 路径代码完全不变。所有现有测试通过。