### PR TITLE
fix(tests): realign 559 terminal-ws cluster with evolved guards (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -561,70 +561,6 @@
       "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
     },
     {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_binary_echo",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 133"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_invalid_token_rejected",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 169"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_multiple_messages",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 151"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_text_echo",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 118"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_unknown_terminal_rejected",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 191"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_cookie_token_can_authenticate_proxy_ws",
-      "outcome": "failure",
-      "summary": "AssertionError: expected call not found."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_invalid_proxy_ws_token_closes",
-      "outcome": "failure",
-      "summary": "AssertionError: expected call not found."
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "559",
-      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_proxy_path_bridges_to_matching_remote_path",
-      "outcome": "failure",
-      "summary": "AssertionError: expected call not found."
-    },
-    {
       "category": "test_body_exception",
       "exception_type": "AttributeError",
       "issue_number": "72",
@@ -923,8 +859,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-19 prune 1 resolved issue-1071 entry: ccf3407a (#2728) rewrote the X-Session-Id privilege-escalation test to patch the real session-manager seam (app.modules.workspace.session_manager.get_session_manager) instead of the nonexistent app.routes.workspace.Database attribute, so the webui filtered-out assertion now passes. Resolution observed in the 2026-08-18 nightly diff and verified on this branch. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32166980663",
+    "prune_note": "2026-08-19 prune 8 resolved issue-559 terminal-ws entries: two stacked layers. (a) e2e_terminal_ws_handler.py is a manual gevent script whose check functions take plain args pytest misread as fixtures (5 setup errors); in-process conversion is impossible without gevent monkey-patching (the bridge relay's websockets.sync calls block the server thread's hub, starving the pump greenlet), so the checks are now script-internal _check_* steps and pytest runs the whole script in an isolated subprocess requiring a full pass. (b) TestHandleVSCodeWs: #2253 added cs_password to bridge_vscode_ws_raw and a close reason to the vscode invalid-token path; assertions realigned (terminal path still 2-arg send_close). Resolution evidence: run 32242194145 resolved list is exactly these 8 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting both files reproduces the 8. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32242194145",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/559/e2e_terminal_ws_handler.py
+++ b/tests/issues/559/e2e_terminal_ws_handler.py
@@ -119,11 +119,32 @@ def start_gevent_server(app):
 
 
 # ═══════════════════════════════════════════════════════════
-# Tests
+# Checks (script-internal steps, called from main())
+#
+# These are NOT pytest tests: the bridge relay (websockets.sync inside
+# gevent greenlets) only works under gevent monkey-patching, which must
+# never run in the shared pytest process (see the guard at the top).
+# pytest runs the whole script in a subprocess below and requires a
+# full pass; the child's monkey-patch is fully isolated.
 # ═══════════════════════════════════════════════════════════
 
 
-def test_text_echo(upstream_port, server_port, terminal_id, token):
+def test_e2e_terminal_ws_handler_script():
+    """Run the manual e2e script in a subprocess and require a full pass."""
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    tail = f"stdout tail:\n{proc.stdout[-1500:]}\nstderr tail:\n{proc.stderr[-1500:]}"
+    assert proc.returncode == 0, f"e2e script failed:\n{tail}"
+    assert "All E2E tests passed!" in proc.stdout, f"e2e script incomplete:\n{tail}"
+
+
+def _check_text_echo(upstream_port, server_port, terminal_id, token):
     """Browser sends text -> upstream echoes -> browser receives text."""
     import socket
 
@@ -138,7 +159,7 @@ def test_text_echo(upstream_port, server_port, terminal_id, token):
     log("PASS", "text echo")
 
 
-def test_binary_echo(upstream_port, server_port, terminal_id, token):
+def _check_binary_echo(upstream_port, server_port, terminal_id, token):
     """Browser sends binary -> upstream echoes -> browser receives binary."""
     import socket
 
@@ -156,7 +177,7 @@ def test_binary_echo(upstream_port, server_port, terminal_id, token):
     log("PASS", "binary echo")
 
 
-def test_multiple_messages(upstream_port, server_port, terminal_id, token):
+def _check_multiple_messages(upstream_port, server_port, terminal_id, token):
     """Send multiple messages in sequence, verify order."""
     import socket
 
@@ -174,7 +195,7 @@ def test_multiple_messages(upstream_port, server_port, terminal_id, token):
     log("PASS", "multiple messages in order")
 
 
-def test_invalid_token_rejected(server_port, terminal_id):
+def _check_invalid_token_rejected(server_port, terminal_id):
     """Invalid token should cause the server to close the connection."""
     import socket
 
@@ -196,7 +217,7 @@ def test_invalid_token_rejected(server_port, terminal_id):
     log("PASS", "invalid token rejected")
 
 
-def test_unknown_terminal_rejected(server_port):
+def _check_unknown_terminal_rejected(server_port):
     """Unknown terminal_id should cause the server to close the connection."""
     import socket
 
@@ -258,11 +279,11 @@ def main():
     log("Setup", f"Registered terminal {terminal_id[:8]} -> upstream {upstream_url}")
 
     try:
-        test_text_echo(upstream_port, server_port, terminal_id, token)
-        test_binary_echo(upstream_port, server_port, terminal_id, token)
-        test_multiple_messages(upstream_port, server_port, terminal_id, token)
-        test_invalid_token_rejected(server_port, terminal_id)
-        test_unknown_terminal_rejected(server_port)
+        _check_text_echo(upstream_port, server_port, terminal_id, token)
+        _check_binary_echo(upstream_port, server_port, terminal_id, token)
+        _check_multiple_messages(upstream_port, server_port, terminal_id, token)
+        _check_invalid_token_rejected(server_port, terminal_id)
+        _check_unknown_terminal_rejected(server_port)
     finally:
         terminal_info_store.pop(machine_id, terminal_id)
         server.stop()

--- a/tests/issues/559/test_terminal_ws_handler.py
+++ b/tests/issues/559/test_terminal_ws_handler.py
@@ -366,6 +366,7 @@ class TestHandleVSCodeWs:
             self.UUID,
             handler.socket,
             "ws://remote:45678/stable/ws?folder=%2Froot%2Fworkspace",
+            "",  # cs_password: absent in this session's store entry (#2253)
         )
         mock_send_close.assert_not_called()
         assert handler.close_connection is True
@@ -398,6 +399,7 @@ class TestHandleVSCodeWs:
             self.UUID,
             handler.socket,
             "ws://remote:45678/stable/ws?reconnectionToken=abc",
+            "",  # cs_password: absent in this session's store entry (#2253)
         )
         mock_send_close.assert_not_called()
 
@@ -417,5 +419,5 @@ class TestHandleVSCodeWs:
 
         RemoteWSHandler._handle_vscode_ws(handler)
 
-        mock_send_close.assert_called_once_with(handler.socket, 4001)
+        mock_send_close.assert_called_once_with(handler.socket, 4001, "Invalid token")
         assert handler.close_connection is True


### PR DESCRIPTION
Refs #2457

## Cluster: 559 (8 entries, baseline 115 → 107)

Two stacked layers behind the 8 baseline entries (5 × `setup_error` in `e2e_terminal_ws_handler.py` + 3 × `assertion_failure` in `TestHandleVSCodeWs`):

### 1. e2e file: manual gevent script mis-collected as pytest tests (5 setup errors)

The file is a manual-run script (`python tests/issues/559/e2e_terminal_ws_handler.py`, per its docstring); its check functions take plain arguments that pytest misreads as fixtures (`upstream_port`/`server_port`/`terminal_id`/`token`) → setup errors since forever.

Making it run in-process is architecturally impossible: the browser↔remote relay (`websockets.sync` inside gevent greenlets, `vscode_ws_bridge.py`) requires gevent monkey-patching, which must never run in the shared pytest process (`46a437bf` documented this for manual runs). Verified empirically: unpatched, the server handshake works but the relay starves (native blocking wait in the server thread's greenlet starves the pump greenlet).

**Fix:** rename the five checks to `_check_*` (script-internal steps; `main()` unchanged and still works standalone, exit-0 verified) and add ONE pytest test that runs the whole script in an isolated subprocess requiring exit-0 + the success banner. 1 collected test replaces 5 phantom-fixture tests.

### 2. TestHandleVSCodeWs: #2253 signature drift (3 assertion failures)

- `bridge_vscode_ws_raw` gained a 4th arg `cs_password` ('' in these tests)
- vscode invalid-token path now sends a close reason: `send_close(socket, 4001, "Invalid token")`
- terminal path unchanged (`send_close(socket, 4001)`, 2-arg) — that test was passing and is untouched.

## Evidence

- Lane (`--category issues --issue-numbers 559 --server auto --isolated-home`): **110 passed** (pre-fix: 3 failed + 5 errors + 106 passed).
- Manual script standalone: exit-0, "All E2E tests passed!".
- Negative control (stash-revert both files → rerun → restore): the original 8 reproduce exactly (5 fixture errors + 3 `expected call not found`).
- Branch verification run A (fix commit, pruned-baseline run to follow): https://github.com/open-ace/open-ace/actions/runs/32242194145

## Baseline

Shrink-only prune of the 8 entries follows as a second commit once run A completes (its `resolved` list is the prune evidence), with the authoritative all-zero diff verified on the final head.