### PR TITLE
fix(tests): realign 822 merge-conflict tests with evolved guards (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -586,46 +586,6 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "822",
-      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_no_b_flag",
-      "outcome": "failure",
-      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "822",
-      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_returns_path_and_branch",
-      "outcome": "failure",
-      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "822",
-      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestDoMergeDeferredRetry::test_uses_graph_merge_base_and_backfills_stale_scope_base",
-      "outcome": "failure",
-      "summary": "AssertionError: assert [call(['fetch... check=False)] == [call(['fetch... check=False)]"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "822",
-      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_removes_existing_worktree_before_adding_temp",
-      "outcome": "failure",
-      "summary": "AssertionError: mock({'worktree_path': ''}) call not found"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "822",
-      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_restores_worktree_even_on_resolution_failure",
-      "outcome": "failure",
-      "summary": "AssertionError: mock({'worktree_path': '/srv/repo/.worktrees/wf-822'}) call not found"
-    },
-    {
-      "category": "test_body_exception",
       "exception_type": "GitHubOpsError",
       "issue_number": "826",
       "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_approved_review_skips_refinement",
@@ -763,8 +723,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-19 prune 5 resolved issue-1857 duplicate-PR-create entries: three stacked seam drifts after the pr_review phase extraction (#2044 T11). (a) The migrated handler validates change scope BEFORE creating the PR; the test orchestrator never stubbed it, so the real validator ran git against the fake project_path and every test failed in an early PhaseResult.failed with create_pr called 0 times (the recorded 'expected call not found'/no-raise failures) — _make_orchestrator now stubs the validator (1816-cluster pattern). (b) github_pr_number rides workflow_patch committed with the terminal PhaseResult; the old stop-after-PR-block trick aborted before the commit — the three recovery tests now let the flow complete (review APPROVE + summary). (c) Agent seam renamed to _run_agent_with_context_recovery and the find-retry sleep moved into phases/pr_review.py (patch target 'time.sleep'). Resolution evidence: run 32251776518 resolved list is exactly these 5 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting reproduces the 5. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32251776518",
+    "prune_note": "2026-08-19 prune 5 resolved issue-822 merge-conflict entries: three guard evolutions. (a) add_worktree gained a containment guard (worktree paths must live under the repo root; GitHubOpsError otherwise) — tests moved their worktree paths inside the root. (b) _resolve_merge_conflicts worktree transitions now carry worktree_transition_state metadata; bare-dict assert_any_call became value-based any() on worktree_path guarding the same invariant (cleared during transition, restored after — including on resolution failure). (c) The effective-round-delta derivation (in _validate_autonomous_change_scope, wrapping get_changed_files) now detects merge commits via rev-parse <pr>^2 and re-derives the merge base; the exact 2-call expectation became entrypoint-prefix + probe-membership assertions. Resolution evidence: run 32256893077 resolved list is exactly these 5 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting reproduces the 5. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32256893077",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -388,10 +388,11 @@ class TestDoMergeDeferredRetry:
             == ""
         )
 
-        # get_changed_files now derives the effective round delta itself:
-        # it detects merge commits (rev-parse <pr>^2) and re-derives the
-        # merge base (fetch + merge-base vs the fetched head, falling back
-        # to origin/main). The graph merge-base fetch stays the entrypoint.
+        # _validate_autonomous_change_scope (wrapping get_changed_files)
+        # now derives the effective round delta itself: it detects merge
+        # commits (rev-parse <pr>^2) and re-derives the merge base (fetch +
+        # merge-base vs the fetched head, falling back to origin/main). The
+        # graph merge-base fetch stays the entrypoint.
         assert gh._run_git.call_args_list[:2] == [
             call(["fetch", "origin", "main"]),
             call(["merge-base", "resolved-pr-head", "fetched-main-head"], check=False),

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -374,10 +374,13 @@ class TestDoMergeDeferredRetry:
         o._ensure_pr_head_local = MagicMock(return_value=True)
         gh = MagicMock()
         gh.resolve_commit.return_value = "fetched-main-head"
-        gh._run_git.side_effect = [
-            MagicMock(returncode=0, stdout="", stderr=""),
-            MagicMock(returncode=0, stdout="fetched-main-head\n", stderr=""),
-        ]
+
+        def run_git(args, **kw):
+            if args[:1] == ["merge-base"]:
+                return MagicMock(returncode=0, stdout="fetched-main-head\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        gh._run_git.side_effect = run_git
         gh.get_changed_files.return_value = [f"business/file-{index}.py" for index in range(16)]
 
         assert (
@@ -385,10 +388,15 @@ class TestDoMergeDeferredRetry:
             == ""
         )
 
-        assert gh._run_git.call_args_list == [
+        # get_changed_files now derives the effective round delta itself:
+        # it detects merge commits (rev-parse <pr>^2) and re-derives the
+        # merge base (fetch + merge-base vs the fetched head, falling back
+        # to origin/main). The graph merge-base fetch stays the entrypoint.
+        assert gh._run_git.call_args_list[:2] == [
             call(["fetch", "origin", "main"]),
             call(["merge-base", "resolved-pr-head", "fetched-main-head"], check=False),
         ]
+        assert call(["rev-parse", "resolved-pr-head^2"], check=False) in gh._run_git.call_args_list
         gh.get_changed_files.assert_called_once_with("fetched-main-head", "resolved-pr-head")
         o._update_workflow.assert_called_once_with({"base_commit_sha": "fetched-main-head"})
         assert wf["base_commit_sha"] == "fetched-main-head"
@@ -1939,7 +1947,9 @@ class TestResolveMergeConflictsWorktreeIsolation:
         # First removal is the original worktree_path.
         assert remove_calls[0].args[0] == wf["worktree_path"]
         # worktree_path was cleared in DB.
-        o._update_workflow.assert_any_call({"worktree_path": ""})
+        # Transition updates carry worktree_transition_state metadata now;
+        # assert on the worktree_path value the original assertion guarded.
+        assert any(c.args[0].get("worktree_path") == "" for c in o._update_workflow.call_args_list)
         # Then the temp worktree was added (branch now free).
         assert main_gh.add_worktree.call_count == 2  # temp + restore
         temp_path = main_gh.add_worktree.call_args_list[0].args[0]
@@ -1948,7 +1958,10 @@ class TestResolveMergeConflictsWorktreeIsolation:
         # Original worktree restored in finally block.
         restore_path = main_gh.add_worktree.call_args_list[1].args[0]
         assert restore_path == wf["worktree_path"]
-        o._update_workflow.assert_any_call({"worktree_path": wf["worktree_path"]})
+        assert any(
+            c.args[0].get("worktree_path") == wf["worktree_path"]
+            for c in o._update_workflow.call_args_list
+        )
         # self._gh rebound to the restored worktree.
         assert o._gh is restored_gh
         # _resolve_merge_conflicts only pushes now — merge is deferred to
@@ -1999,7 +2012,10 @@ class TestResolveMergeConflictsWorktreeIsolation:
         main_gh.remove_worktree.assert_called()
         # Original worktree was restored despite the failure.
         main_gh.add_worktree.assert_called_with(wf["worktree_path"], "auto-dev/fc82f22a")
-        o._update_workflow.assert_any_call({"worktree_path": wf["worktree_path"]})
+        assert any(
+            c.args[0].get("worktree_path") == wf["worktree_path"]
+            for c in o._update_workflow.call_args_list
+        )
         assert o._gh is restored_gh
 
 
@@ -2008,20 +2024,25 @@ class TestResolveMergeConflictsWorktreeIsolation:
 
 class TestAddWorktreeExistingBranch:
     def test_add_worktree_no_b_flag(self):
-        """add_worktree checks out an existing branch (no -b)."""
+        """add_worktree checks out an existing branch (no -b).
+
+        The worktree path must live under the repo root (containment guard).
+        """
+        wt = "/tmp/repo/.worktrees/wt"
         gh = GitHubOps("/tmp/repo")
         with patch.object(gh, "_run_git") as mock_run:
-            gh.add_worktree("/tmp/wt", "feature/existing")
+            gh.add_worktree(wt, "feature/existing")
             cmd = mock_run.call_args.args[0]
-            assert cmd == ["worktree", "add", "/tmp/wt", "feature/existing"]
+            assert cmd == ["worktree", "add", wt, "feature/existing"]
             # No -b flag — the branch already exists.
             assert "-b" not in cmd
 
     def test_add_worktree_returns_path_and_branch(self):
+        wt = "/tmp/repo/.worktrees/wt"
         gh = GitHubOps("/tmp/repo")
         with patch.object(gh, "_run_git"):
-            result = gh.add_worktree("/tmp/wt", "feature/x")
-            assert result == {"worktree_path": "/tmp/wt", "branch": "feature/x"}
+            result = gh.add_worktree(wt, "feature/x")
+            assert result == {"worktree_path": wt, "branch": "feature/x"}
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_stale_dirty_when_branch_has_main_does_not_resolve(self, mock_gh_cls):


### PR DESCRIPTION
Refs #2457

## Cluster: 822 (5 entries; baseline 95 → 90)

Three drifts behind the 5 baseline entries in `tests/issues/822/test_merge_conflict_detection.py`:

1. **add_worktree containment guard (2 tests):** `github_ops` now rejects worktree paths outside the repo root (`_assert_worktree_contained` → `GitHubOpsError`); the tests used `/tmp/wt` against repo `/tmp/repo` — now `/tmp/repo/.worktrees/wt`.
2. **Worktree-transition payload (2 tests):** `_resolve_merge_conflicts` transition updates now carry `worktree_transition_state`/`transition_updated_at` metadata alongside `worktree_path`; the bare-dict `assert_any_call` forms became value-based `any()` assertions guarding the same invariant (path cleared during transition, restored after).
3. **Graph merge-base (1 test):** `get_changed_files` now derives the effective round delta itself (merge-commit detection `rev-parse <pr>^2` + its own fetch/merge-base with origin/main fallback). Expected exact 2-call list → entrypoint fetch+merge-base prefix + presence of the `^2` probe; side effects moved to a handler.

## Evidence

- File run: **75 passed** (was 5 failed + 70 passed).
- Lane (`--category issues --issue-numbers 822 --server auto --isolated-home`): **75 passed**.
- Negative control (stash-revert → rerun → restore): the original 5 reproduce exactly.
- Branch verification run (fix commit c9434d0c): to be attached on completion. (Run 32256823965 was dispatched on the pre-push empty branch and is void; cancelled by concurrency.)

## Baseline

Shrink-only prune of the 5 entries (95 → 90) follows once the verification run completes; authoritative all-zero diff then verified on the final head.