### PR TITLE
fix(scheduler): lease-anchored self-heal for in-progress entries

### DIFF
--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -307,25 +307,38 @@ class AutonomousScheduler:
     _IN_PROGRESS_STALE_SECONDS = 1800
 
     def _reclaim_stale_in_progress(self, workflows: list, repo) -> None:
-        """Self-heal _in_progress entries against the DB lease (liveness truth).
+        """Self-heal leaked _in_progress entries against the DB lease.
 
-        A worker that hangs or dies without its finally never drops its
-        in-memory entry, freezing the workflow — and its batch/workspace/
-        branch conflict keys — until a service restart (observed 2026-08-19,
-        workflow fec4782b: ~50 min frozen, restart healed in 1s). The
-        distributed lease already encodes liveness: heartbeats renew it every
-        60s independent of agent duration.
+        An entry whose worker exited without its finally (exception-class
+        leak in the pre-try section is the observed 2026-08-19 shape,
+        workflow fec4782b: ~50 min frozen, restart healed in 1s) freezes the
+        workflow — and its batch/workspace/branch conflict keys — until a
+        service restart. The distributed lease already encodes liveness
+        (heartbeats renew every 60s independent of agent duration), so an
+        entry with no live lease behind it is fiction: reap it.
+
+        SCOPE (honest): this pass runs at the top of _process_workflows, so
+        it heals leaks whose cycle has returned — exception-class leaks and
+        entries orphaned after their worker exited. A worker HUNG mid-cycle
+        parks the whole cycle inside the executor's shutdown(wait=True) and
+        this pass cannot run; a restart remains the remedy there. The reap
+        WARNING is the discriminator: a frozen workflow WITHOUT a reap
+        warning means the cycle itself is parked (hang) — evidence for a
+        watchdog follow-up.
 
         Rules:
         - Row in the active set with a fresh lease → live worker, keep.
-        - Row in the active set with NULL/stale lease → reap (leaked).
-        - Row NOT in the active set (paused/failed/completed/cancelled are
-          excluded from get_active_workflows) → fetch its status once:
-          paused keeps the entry (#1002 — an in-flight advance() owns the
-          resumption), any other terminal-ish status reaps, a lookup error
-          keeps it (fail-closed).
-        Healthy state pays zero extra queries: the status fetch only happens
-        for entries missing from the active list, i.e. only when leaked.
+        - Row in the active set with no lease → reap (leak signature).
+        - Row in the active set with an unparseable lease → keep
+          (unknown is not stale — fail-closed, matching the lookup-error
+          branch).
+        - Row NOT in the active set (paused/terminal statuses are excluded
+          from get_active_workflows) → fetch it once: paused keeps the
+          entry (#1002 — an in-flight advance() owns the resumption), a
+          fresh lease keeps it (snapshot raced a transition), a lookup
+          error keeps it, anything else reaps.
+        Healthy state pays zero extra queries: the fetch only happens for
+        entries missing from the active list, i.e. only when leaked.
         """
         with self._in_progress_lock:
             if not self._in_progress_ids:
@@ -337,15 +350,18 @@ class AutonomousScheduler:
             if row is not None:
                 if row.get("status") == "paused":
                     continue
-                locked_dt = _lease_timestamp(row.get("locked_at"))
-                age = (
-                    (datetime.now(timezone.utc) - locked_dt).total_seconds()
-                    if locked_dt is not None
-                    else None
-                )
-                if age is not None and age < self._IN_PROGRESS_STALE_SECONDS:
+                raw_lease = row.get("locked_at")
+                locked_dt = _lease_timestamp(raw_lease)
+                if locked_dt is None:
+                    if raw_lease:
+                        continue  # unparseable is unknown, not stale — keep
+                    where = "active, lease=NULL"
+                elif (
+                    datetime.now(timezone.utc) - locked_dt
+                ).total_seconds() < self._IN_PROGRESS_STALE_SECONDS:
                     continue  # fresh lease — live worker
-                where = f"active, lease={row.get('locked_at') or 'NULL'}"
+                else:
+                    where = f"active, lease stale ({raw_lease})"
             else:
                 try:
                     missing = repo.get_workflow(wid) or {}
@@ -359,10 +375,15 @@ class AutonomousScheduler:
                     continue
                 if missing.get("status") == "paused":
                     continue
+                missing_dt = _lease_timestamp(missing.get("locked_at"))
+                if missing_dt is not None and (
+                    (datetime.now(timezone.utc) - missing_dt).total_seconds()
+                    < self._IN_PROGRESS_STALE_SECONDS
+                ):
+                    continue  # live lease behind a snapshot race — keep
                 where = f"not-in-active-set, status={missing.get('status') or 'unknown'}"
             logger.warning(
-                "Reaping stale in-progress entry for workflow %s (%s); "
-                "worker is gone or hung without a live lease",
+                "Reaping stale in-progress entry for workflow %s (%s); " "no live lease behind it",
                 wid[:8],
                 where,
             )
@@ -681,16 +702,17 @@ class AutonomousScheduler:
         # the same worker-thread name. Without a process-unique owner, an old
         # worker's finally could release a newer process's replacement lease.
         lock_owner = f"{socket.gethostname()}/{os.getpid()}/{threading.current_thread().name}"
-        repo = _get_repo()
 
-        # Pre-try section: an exception or hang here bypasses the main
-        # try/finally entirely, so the in-progress entry selected for this
-        # worker would leak and freeze the workflow until a service restart
-        # (observed 2026-08-19, workflow fec4782b). Reap the entry on any
-        # raise and let the executor's future.result() catch log it; a HANG
-        # here is healed by _reclaim_stale_in_progress once the DB lease
-        # proves no live worker holds the workflow.
+        # Pre-try section: an exception here bypasses the main try/finally
+        # entirely, so the in-progress entry selected for this worker would
+        # leak and freeze the workflow until a service restart (observed
+        # 2026-08-19, workflow fec4782b). Discard the entry on any raise and
+        # let the executor's future.result() catch log it; _get_repo is inside
+        # the try for the same reason. A HANG here still parks this cycle's
+        # executor (shutdown waits) — restart territory, see
+        # _reclaim_stale_in_progress's scope note.
         try:
+            repo = _get_repo()
             # Only owner_id is still consumed below (quota gate). Conflict-key
             # and waiting-state cleanup now live in the key map written at
             # selection time — no per-call snapshots needed here anymore.
@@ -1121,9 +1143,10 @@ class AutonomousScheduler:
             logger.error("Failed to query active workflows: %s", e)
             return
 
-        # Self-heal in-progress entries whose DB lease is gone/stale (hung or
-        # leaked worker) so a frozen workflow resumes within the lease window
-        # instead of waiting for a service restart (2026-08-19, fec4782b).
+        # Self-heal _in_progress entries with no live DB lease behind them
+        # (leaked workers; 2026-08-19 fec4782b). Scope: leaks whose cycle has
+        # returned — a hung worker parks this very cycle, see the reclaim's
+        # docstring.
         self._reclaim_stale_in_progress(workflows, repo)
 
         # Filter out paused, already-in-progress workflows, batch workflows

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -186,7 +186,7 @@ def _parse_naive_utc(value: str | None) -> datetime | None:
     """Parse a 'YYYY-MM-DD HH:MM:SS' string persisted as naive UTC, or None.
 
     Tolerates missing/malformed values (legacy rows) — callers treat None as
-    'no age information, do not gate on it'.
+    'no age information, do not gate on that'.
     """
     if not value or not isinstance(value, str):
         return None
@@ -194,6 +194,26 @@ def _parse_naive_utc(value: str | None) -> datetime | None:
         return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
     except ValueError:
         return None
+
+
+def _lease_timestamp(value) -> datetime | None:
+    """Normalize a ``locked_at`` lease value to an aware UTC datetime, or None.
+
+    SQLite returns the persisted string; Postgres (RealDictCursor) returns a
+    ``datetime`` for ``timestamp without time zone`` columns — a plain
+    ``.strip()`` on the Postgres shape raises and would take the whole
+    scheduler cycle down (plan-review B2).
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        try:
+            return datetime.strptime(value.strip()[:19], "%Y-%m-%d %H:%M:%S").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            return None
+    return None
 
 
 class AutonomousScheduler:
@@ -218,6 +238,11 @@ class AutonomousScheduler:
         # owners bucket under 0 and count only against the global ceiling). The
         # scheduler selection gates each user at their tenant max_sessions_per_user.
         self._in_progress_by_user: dict[int, set[str]] = {}
+        # workflow_id -> (batch_id, workspace, branch) reserved at selection
+        # time, so a later teardown can release EXACTLY those keys even after
+        # the row changed shape or left the active set (leak self-heal, cf.
+        # _reclaim_stale_in_progress).
+        self._in_progress_key_map: dict[str, tuple[str | None, str, str]] = {}
         self._in_progress_lock = threading.Lock()
         self._running_orchestrators: dict[str, AutonomousOrchestrator] = {}
         self._orchestrator_lock = threading.Lock()
@@ -273,6 +298,103 @@ class AutonomousScheduler:
         with self._orchestrator_lock:
             return self._running_orchestrators.get(workflow_id)
 
+    # Reap threshold mirrors the repository's LOCK_TIMEOUT_SECONDS: an
+    # in-progress entry whose DB lease is gone/stale cannot belong to a live
+    # worker (the heartbeat renews live leases every 60s regardless of agent
+    # duration), so the memory entry is fiction and safe to drop — acquire_lock
+    # breaks equally-stale leases cross-process anyway, so aligning memory to
+    # lease truth adds no new concurrency exposure.
+    _IN_PROGRESS_STALE_SECONDS = 1800
+
+    def _reclaim_stale_in_progress(self, workflows: list, repo) -> None:
+        """Self-heal _in_progress entries against the DB lease (liveness truth).
+
+        A worker that hangs or dies without its finally never drops its
+        in-memory entry, freezing the workflow — and its batch/workspace/
+        branch conflict keys — until a service restart (observed 2026-08-19,
+        workflow fec4782b: ~50 min frozen, restart healed in 1s). The
+        distributed lease already encodes liveness: heartbeats renew it every
+        60s independent of agent duration.
+
+        Rules:
+        - Row in the active set with a fresh lease → live worker, keep.
+        - Row in the active set with NULL/stale lease → reap (leaked).
+        - Row NOT in the active set (paused/failed/completed/cancelled are
+          excluded from get_active_workflows) → fetch its status once:
+          paused keeps the entry (#1002 — an in-flight advance() owns the
+          resumption), any other terminal-ish status reaps, a lookup error
+          keeps it (fail-closed).
+        Healthy state pays zero extra queries: the status fetch only happens
+        for entries missing from the active list, i.e. only when leaked.
+        """
+        with self._in_progress_lock:
+            if not self._in_progress_ids:
+                return
+            ids_snapshot = list(self._in_progress_ids)
+        rows_by_id = {wf.get("workflow_id"): wf for wf in workflows}
+        for wid in ids_snapshot:
+            row = rows_by_id.get(wid)
+            if row is not None:
+                if row.get("status") == "paused":
+                    continue
+                locked_dt = _lease_timestamp(row.get("locked_at"))
+                age = (
+                    (datetime.now(timezone.utc) - locked_dt).total_seconds()
+                    if locked_dt is not None
+                    else None
+                )
+                if age is not None and age < self._IN_PROGRESS_STALE_SECONDS:
+                    continue  # fresh lease — live worker
+                where = f"active, lease={row.get('locked_at') or 'NULL'}"
+            else:
+                try:
+                    missing = repo.get_workflow(wid) or {}
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping stale-in-progress reclaim for workflow %s "
+                        "(status lookup failed: %s)",
+                        wid[:8],
+                        exc,
+                    )
+                    continue
+                if missing.get("status") == "paused":
+                    continue
+                where = f"not-in-active-set, status={missing.get('status') or 'unknown'}"
+            logger.warning(
+                "Reaping stale in-progress entry for workflow %s (%s); "
+                "worker is gone or hung without a live lease",
+                wid[:8],
+                where,
+            )
+            self._discard_in_progress_entry(wid)
+
+    def _discard_in_progress_entry(self, workflow_id: str, legacy_wf: dict | None = None) -> None:
+        """Remove one workflow's in-progress bookkeeping, keys included.
+
+        Single authority for memory-entry teardown, used by _advance_single's
+        acquire-fail branch and finally, by clear_in_progress, and by the
+        lease-anchored reclaim pass (_reclaim_stale_in_progress). The key map
+        recorded exactly which conflict keys the entry reserved at selection
+        time (waiting workflows reserve none), so teardown releases those and
+        only those — never a key a different workflow holds. ``legacy_wf``
+        covers entries created before a mid-flight deploy introduced the map.
+        Idempotent; callers must NOT hold _in_progress_lock.
+        """
+        with self._in_progress_lock:
+            self._in_progress_ids.discard(workflow_id)
+            for bucket in self._in_progress_by_user.values():
+                bucket.discard(workflow_id)
+            batch_id, workspace, branch = self._in_progress_key_map.pop(workflow_id, (None, "", ""))
+            if not any((batch_id, workspace, branch)) and legacy_wf is not None:
+                workspace, branch = self._conflict_keys(legacy_wf)
+                batch_id = legacy_wf.get("batch_id")
+            if batch_id:
+                self._in_progress_batch_ids.discard(batch_id)
+            if workspace:
+                self._in_progress_workspaces.discard(workspace)
+            if branch:
+                self._in_progress_branches.discard(branch)
+
     def clear_in_progress(self, workflow_id: str, wf: dict | None = None) -> None:
         """Clear stale in-progress state for a workflow.
 
@@ -296,25 +418,9 @@ class AutonomousScheduler:
         with self._orchestrator_lock:
             self._running_orchestrators.pop(workflow_id, None)
 
-        with self._in_progress_lock:
-            self._in_progress_ids.discard(workflow_id)
-            # Also clear git-conflict keys so _process_workflows doesn't skip
-            # the retried workflow on workspace/branch/batch collision. The
-            # workflow dict is available from the retry endpoint.
-            if wf:
-                workspace, branch = self._conflict_keys(wf)
-                if workspace:
-                    self._in_progress_workspaces.discard(workspace)
-                if branch:
-                    self._in_progress_branches.discard(branch)
-                batch_id = wf.get("batch_id")
-                if batch_id:
-                    self._in_progress_batch_ids.discard(batch_id)
-                # Per-user bucket (#2295). wf.get (not wf[]) — legacy/odd rows may
-                # lack the key; the review flagged wf["user_id"] would KeyError.
-                owner_id = wf.get("user_id")
-                if owner_id is not None:
-                    self._in_progress_by_user.get(owner_id, set()).discard(workflow_id)
+        # Memory entry teardown (ids + per-user + the keys this entry reserved
+        # per the key map; falls back to the caller's wf for pre-map entries).
+        self._discard_in_progress_entry(workflow_id, legacy_wf=wf)
 
         # Release the DB-level lock so the next cycle can acquire it.
         try:
@@ -577,40 +683,27 @@ class AutonomousScheduler:
         lock_owner = f"{socket.gethostname()}/{os.getpid()}/{threading.current_thread().name}"
         repo = _get_repo()
 
-        # Get workflow's batch_id and git-conflict keys for cleanup
-        workflow = repo.get_workflow(workflow_id)
-        batch_id = workflow.get("batch_id") if workflow else None
-        # Owner used for per-user in-progress accounting (#2295). Resolved here
-        # (NOT inside the try below) so the Site-A early return + the finally can
-        # both discard from _in_progress_by_user without a NameError.
-        owner_id = workflow.get("user_id") if workflow else None
-        # None owner (legacy rows) buckets under 0; counts only against the global
-        # ceiling, not any per-user cap (the selection gate skips None owners).
-        owner_bucket = owner_id if owner_id is not None else 0
-        workspace, branch = self._conflict_keys(workflow) if workflow else ("", "")
-        # Waiting workflows bypass conflict locks (see _process_workflows).
-        # Capture this so cleanup paths don't release another workflow's keys.
-        #
-        # Load-bearing invariant: this advance-time read of ``status == waiting``
-        # agrees with the selection-time read in ``_process_workflows`` only
-        # because the ``waiting -> developing/merging`` transition happens inside
-        # ``advance()`` below — no other actor flips the status between selection
-        # and this point. If that ever changes, the finally cleanup below could
-        # release (or fail to release) the wrong workflow's conflict keys.
-        was_waiting = bool(workflow and workflow.get("status") == "waiting")
+        # Pre-try section: an exception or hang here bypasses the main
+        # try/finally entirely, so the in-progress entry selected for this
+        # worker would leak and freeze the workflow until a service restart
+        # (observed 2026-08-19, workflow fec4782b). Reap the entry on any
+        # raise and let the executor's future.result() catch log it; a HANG
+        # here is healed by _reclaim_stale_in_progress once the DB lease
+        # proves no live worker holds the workflow.
+        try:
+            # Only owner_id is still consumed below (quota gate). Conflict-key
+            # and waiting-state cleanup now live in the key map written at
+            # selection time — no per-call snapshots needed here anymore.
+            workflow = repo.get_workflow(workflow_id)
+            owner_id = workflow.get("user_id") if workflow else None
+        except Exception:
+            self._discard_in_progress_entry(workflow_id)
+            raise
 
         # Acquire DB-level distributed lock
         if not repo.acquire_lock(workflow_id, lock_owner):
             logger.debug("Workflow %s is locked by another instance, skipping", workflow_id[:8])
-            with self._in_progress_lock:
-                self._in_progress_ids.discard(workflow_id)
-                self._in_progress_by_user.get(owner_bucket, set()).discard(workflow_id)
-                if batch_id and not was_waiting:
-                    self._in_progress_batch_ids.discard(batch_id)
-                if workspace and not was_waiting:
-                    self._in_progress_workspaces.discard(workspace)
-                if branch and not was_waiting:
-                    self._in_progress_branches.discard(branch)
+            self._discard_in_progress_entry(workflow_id)
             return workflow_id
 
         heartbeat_stop = threading.Event()
@@ -706,15 +799,7 @@ class AutonomousScheduler:
                 repo.release_lock(workflow_id, lock_owner)
             except Exception:
                 logger.warning("Failed to release lock for workflow %s", workflow_id[:8])
-            with self._in_progress_lock:
-                self._in_progress_ids.discard(workflow_id)
-                self._in_progress_by_user.get(owner_bucket, set()).discard(workflow_id)
-                if batch_id and not was_waiting:
-                    self._in_progress_batch_ids.discard(batch_id)
-                if workspace and not was_waiting:
-                    self._in_progress_workspaces.discard(workspace)
-                if branch and not was_waiting:
-                    self._in_progress_branches.discard(branch)
+            self._discard_in_progress_entry(workflow_id)
         return workflow_id
 
     def _heartbeat_workflow_lock(
@@ -1036,6 +1121,11 @@ class AutonomousScheduler:
             logger.error("Failed to query active workflows: %s", e)
             return
 
+        # Self-heal in-progress entries whose DB lease is gone/stale (hung or
+        # leaked worker) so a frozen workflow resumes within the lease window
+        # instead of waiting for a service restart (2026-08-19, fec4782b).
+        self._reclaim_stale_in_progress(workflows, repo)
+
         # Filter out paused, already-in-progress workflows, batch workflows
         # whose batch is already being processed, and workflows whose git
         # working tree (worktree_path or project_path) OR branch is already
@@ -1145,9 +1235,17 @@ class AutonomousScheduler:
                 # another workflow's keys in _advance_single's finally.
                 is_waiting = wf.get("status") == "waiting"
                 batch_id = wf.get("batch_id")
+                workspace, branch = self._conflict_keys(wf)
+                # Record exactly what this entry reserved so any teardown
+                # (finally / clear_in_progress / stale reclaim) releases these
+                # and only these keys, even after the row changes shape.
+                self._in_progress_key_map[wf_id] = (
+                    batch_id if (batch_id and not is_waiting) else None,
+                    workspace if (workspace and not is_waiting) else "",
+                    branch if (branch and not is_waiting) else "",
+                )
                 if batch_id and not is_waiting:
                     self._in_progress_batch_ids.add(batch_id)
-                workspace, branch = self._conflict_keys(wf)
                 if workspace and not is_waiting:
                     self._in_progress_workspaces.add(workspace)
                 if branch and not is_waiting:

--- a/docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md
+++ b/docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md
@@ -1,0 +1,406 @@
+# Scheduler in-progress 租约锚点自愈 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让调度器内存态 `_in_progress_*` 集合以 DB 租约为存活锚点自愈,任何泄漏/挂死最多冻结工作流 ~30 分钟(租约超时),不再需要服务重启。
+
+**Architecture:** 三层:(1) 统一内存条目回收 helper(记录每个工作流占用的冲突键 `_in_progress_key_map`,一处实现三处复用);(2) `_process_workflows` 每周期用已取回的 active rows 做租约 staleness 回收;(3) `_advance_single` try 前置段的异常也走回收。
+
+**Tech Stack:** Python 3.10+(仅标准库 threading/datetime),pytest,无新依赖。
+
+**Spec:** 本文件自带根因与设计论证(brainstorming 产物,Bounded 路径,无独立 spec)。
+
+## 根因与证据(为什么这么修)
+
+**已证实的事实链**(全部来自生产日志/DB/代码,2026-08-19 取证):
+1. fec4782b 于 11:20:42 UTC 完成 round4→round5 升级 commit(merge 阶段,DB updated_at);此后**零** development 阶段日志、零异常、零 "future error"、零心跳告警(全量窗口筛选,排除噪音后)。
+2. 写 NULL 的有两处:`release_lock`(autonomous_repo.py L1411)与 `clear_in_progress` 的强制 UPDATE(autonomous_scheduler.py ~L331);另 `acquire_cleanup_lock`(repo L1356)是非 NULL 写者。**两处 NULL 写者都会同时清内存条目**,故"某次完整清理执行过 ⇒ 当前占位条目系清理后重新写入"的推断不变(独立审查纠偏:原文"release 是唯一 NULL 写者"不实)。
+3. 冻结仍持续到 12:11 重启 ⟹ 当前占位的内存条目是**清理之后再次选中时重新写入**的。
+4. 再次选中的 worker 消失于 `_advance_single` 的 **try 前置段**(`repo.get_workflow` L577 → `acquire_lock` L600):这是唯一**零日志、零超时、零 finally 保护**的区段——挂死或无声异常都必然无痕。
+
+**推断(标注:未经直接观察证明)**:该 worker 在前置段的 DB 调用上无限期挂起(连接池耗尽/锁等待)——hang 按定义不产生日志,且进程已重启,线程栈不可事后获取。备选解释(前一个 worker 挂死在 advance() 内且心跳线程同步无声死亡)与"心跳应有续租/告警日志"矛盾,已排除为主因。
+
+**结论**:无论挂死点在前置段哪一行,生命周期缺陷是同一个:**内存 in-progress 条目无存活锚点、前置段无清理保护**。修复以 DB 租约为存活真相(活 worker ⇒ 心跳每 60s 续租,与 agent 时长无关),两层覆盖两种变体;另加一条诊断日志,下次复发时留下现场证据。
+
+## Global Constraints
+
+- 保持 #1002 语义:**status=paused 的行不回收**(其 in-flight advance() 拥有恢复权,见 `_reclaim_paused_slots` 的注释)。
+- 保持 waiting 语义:waiting 工作流不占冲突键(选中时不 reserve,finally 不 release)。
+- 不新增 DB 查询:回收判据复用 `_process_workflows` 已取回的 `workflows` rows(含 `locked_at` 列)。
+- `set.discard` 幂等,与 finally 的微秒级窗口并发安全(回收先跑也只是提前 discard;新 acquire 有 owner 校验,旧 finally 的 release 不会误放新租约)。
+- 时间比较沿用仓库既有字符串比较惯用法(`datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")`,与 `acquire_lock` 的 cutoff 一致;`locked_at` 存的是 UTC 字符串)。
+- 测试放 `tests/unit/`(CI `test(3.x)` 收集范围;参照 `test_scheduler_batch_order_tiebreak.py` 的既有调度器单测风格)。
+
+---
+
+### Task 1: 统一 in-progress 条目回收 helper + 冲突键映射
+
+**Files:**
+- Modify: `app/services/autonomous_scheduler.py`(`__init__` L~206-221、`clear_in_progress` L~276-317、`_advance_single` 的 acquire-fail 分支 L~601-613 与 finally L~700-711、`_process_workflows` 的 mark 段 L~1127-1152)
+- Test: `tests/unit/test_scheduler_inprogress_reap.py`
+
+**Interfaces:**
+- Produces: `self._in_progress_key_map: dict[str, tuple[str | None, str, str]]`(workflow_id → (batch_id, workspace, branch),mark 时写入);`self._discard_in_progress_entry(workflow_id: str, *, release_conflict_keys: bool = True) -> None`(内部持锁,幂等)。`release_conflict_keys=False` 用于 paused 保号场景的将来需要;本任务三处调用点均传 True。
+
+- [ ] **Step 1: 写失败测试(键映射 + 回收幂等)**
+
+```python
+"""Scheduler in-progress entry reclaim: key map + unified discard helper."""
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+
+def _bare_scheduler() -> AutonomousScheduler:
+    sched = AutonomousScheduler.__new__(AutonomousScheduler)
+    sched._in_progress_ids = set()
+    sched._in_progress_batch_ids = set()
+    sched._in_progress_workspaces = set()
+    sched._in_progress_branches = set()
+    sched._in_progress_by_user = {}
+    sched._in_progress_key_map = {}
+    sched._in_progress_lock = __import__("threading").Lock()
+    return sched
+
+
+def test_mark_then_discard_releases_reserved_keys_exactly():
+    sched = _bare_scheduler()
+    wid = "w-1"
+    with sched._in_progress_lock:
+        sched._in_progress_ids.add(wid)
+        sched._in_progress_by_user.setdefault(3, set()).add(wid)
+        sched._in_progress_batch_ids.add("batch-9")
+        sched._in_progress_workspaces.add("/ws/open6")
+        sched._in_progress_branches.add("auto-dev/w-1")
+        sched._in_progress_key_map[wid] = ("batch-9", "/ws/open6", "auto-dev/w-1")
+    sched._discard_in_progress_entry(wid)
+    assert wid not in sched._in_progress_ids
+    assert wid not in sched._in_progress_by_user.get(3, set())
+    assert "batch-9" not in sched._in_progress_batch_ids
+    assert "/ws/open6" not in sched._in_progress_workspaces
+    assert "auto-dev/w-1" not in sched._in_progress_branches
+    assert wid not in sched._in_progress_key_map
+    # 幂等:再删一次不抛
+    sched._discard_in_progress_entry(wid)
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd /tmp/cls2-sched-leak && python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py -q`
+Expected: FAIL(`_discard_in_progress_entry` 不存在)
+
+- [ ] **Step 3: 最小实现**
+
+`__init__` 的集合声明区(L~215-220 附近)加一行:
+```python
+        # workflow_id -> (batch_id, workspace, branch) reserved at selection
+        # time, so a later reclaim can release EXACTLY those keys even after
+        # the row has changed shape or left the active set (leak self-heal).
+        self._in_progress_key_map: dict[str, tuple[str | None, str, str]] = {}
+```
+
+新增方法(放 `clear_in_progress` 旁):
+```python
+    def _discard_in_progress_entry(self, workflow_id: str) -> None:
+        """Remove one workflow's in-progress bookkeeping, keys included.
+
+        Single authority for entry teardown, used by _advance_single's
+        acquire-fail branch and finally, by clear_in_progress, and by the
+        lease-anchored reclaim pass. Idempotent; caller must NOT hold
+        _in_progress_lock (this method takes it).
+        """
+        with self._in_progress_lock:
+            self._in_progress_ids.discard(workflow_id)
+            for bucket in self._in_progress_by_user.values():
+                bucket.discard(workflow_id)
+            batch_id, workspace, branch = self._in_progress_key_map.pop(
+                workflow_id, (None, "", "")
+            )
+            if batch_id:
+                self._in_progress_batch_ids.discard(batch_id)
+            if workspace:
+                self._in_progress_workspaces.discard(workspace)
+            if branch:
+                self._in_progress_branches.discard(branch)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py -q`
+Expected: PASS
+
+- [ ] **Step 5: 三处旧 discard 块替换为 helper,mark 段写入 key map**
+
+(a) `_process_workflows` mark 段(L~1127-1152)在 `self._in_progress_ids.add(wf_id)` 循环里加:
+```python
+                self._in_progress_key_map[wf_id] = (
+                    batch_id if (batch_id := wf.get("batch_id")) and not is_waiting else None,
+                    workspace if (not is_waiting and (workspace := None) is None) else "",
+                    "",
+                )
+```
+⚠️ 上面是伪码占位说明真实语义——**实际实现**改为在循环开头先解包(避免海象歧义):
+```python
+                is_waiting = wf.get("status") == "waiting"
+                batch_id = wf.get("batch_id")
+                workspace, branch = self._conflict_keys(wf)
+                self._in_progress_key_map[wf_id] = (
+                    batch_id if (batch_id and not is_waiting) else None,
+                    workspace if (workspace and not is_waiting) else "",
+                    branch if (branch and not is_waiting) else "",
+                )
+```
+(与下方现有 reserve 逻辑的 `if batch_id and not is_waiting` 完全同判。)
+
+(b) `_advance_single` acquire-fail 分支(L~601-613)与 finally 尾部(L~700-711)的 `with self._in_progress_lock:` 整块替换为 `self._discard_in_progress_entry(workflow_id)`(finally 中该块位于 release_lock 之后,保持顺序)。
+(c) `clear_in_progress`(L~276-317)内部的 discard 逻辑同样替换为 `self._discard_in_progress_entry(workflow_id)`(保留其 DB 锁释放部分不变)。
+
+- [ ] **Step 6: 全量回归**
+
+Run: `python3 -m pytest tests/unit/ tests/autonomous/ -q`
+Expected: 全 PASS(既有 1897 retry-clears-in-progress 若在 tests/issues 不在收集范围则单独跑:`python3 -m pytest tests/issues/1897 -q`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/autonomous_scheduler.py tests/unit/test_scheduler_inprogress_reap.py
+git commit -m "refactor(scheduler): single authority for in-progress entry teardown + key map"
+```
+
+---
+
+### Task 2: 租约锚点回收遍(核心自愈)
+
+**Files:**
+- Modify: `app/services/autonomous_scheduler.py`(新增 `_reclaim_stale_in_progress`,挂进 `_process_workflows` L~1023 `_reclaim_paused_slots(repo)` 之后)
+- Test: `tests/unit/test_scheduler_inprogress_reap.py`(追加)
+
+**Interfaces:**
+- Consumes: Task 1 的 `_discard_in_progress_entry`、`_in_progress_key_map`。
+- Produces: `self._reclaim_stale_in_progress(workflows: list[dict]) -> None`;判据函数 `self._lease_is_stale(wf: dict | None) -> bool`(wf=None 或 `locked_at` 为空或早于 cutoff)。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+from datetime import datetime, timedelta, timezone
+
+
+def _fmt(dt):
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _sched_with_entry(sched, wid, row):
+    with sched._in_progress_lock:
+        sched._in_progress_ids.add(wid)
+        sched._in_progress_key_map[wid] = (row.get("batch_id"), row.get("_workspace", ""), "")
+
+
+def test_stale_lease_entry_is_reaped_and_visible():
+    sched = _bare_scheduler()
+    stale = _fmt(datetime.now(timezone.utc) - timedelta(seconds=1801))
+    row = {"workflow_id": "w-stale", "status": "developing", "locked_at": stale,
+           "batch_id": "b1", "_workspace": "/ws/a"}
+    _sched_with_entry(sched, "w-stale", row)
+    sched._reclaim_stale_in_progress([row])
+    assert "w-stale" not in sched._in_progress_ids
+    assert "b1" not in sched._in_progress_batch_ids
+
+
+def test_fresh_lease_entry_is_kept():
+    sched = _bare_scheduler()
+    fresh = _fmt(datetime.now(timezone.utc) - timedelta(seconds=60))
+    row = {"workflow_id": "w-live", "status": "developing", "locked_at": fresh,
+           "batch_id": "b2", "_workspace": "/ws/a"}
+    _sched_with_entry(sched, "w-live", row)
+    sched._reclaim_stale_in_progress([row])
+    assert "w-live" in sched._in_progress_ids
+    assert "b2" in sched._in_progress_batch_ids
+
+
+def test_paused_row_is_never_reaped():
+    sched = _bare_scheduler()
+    stale = _fmt(datetime.now(timezone.utc) - timedelta(seconds=9999))
+    row = {"workflow_id": "w-paused", "status": "paused", "locked_at": stale,
+           "batch_id": "b3", "_workspace": ""}
+    _sched_with_entry(sched, "w-paused", row)
+    sched._reclaim_stale_in_progress([row])
+    assert "w-paused" in sched._in_progress_ids  # #1002: in-flight advance owns resume
+
+
+def test_row_missing_from_active_list_is_reaped():
+    sched = _bare_scheduler()
+    _sched_with_entry(sched, "w-gone", {"batch_id": "b4", "_workspace": "/ws/b"})
+    sched._reclaim_stale_in_progress([])  # completed/failed while entry leaked
+    assert "w-gone" not in sched._in_progress_ids
+    assert "/ws/b" not in sched._in_progress_workspaces
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py -q`
+Expected: 新增 4 条 FAIL(`_reclaim_stale_in_progress` 不存在)
+
+- [ ] **Step 3: 最小实现**
+
+```python
+    # Reap threshold mirrors the repository's LOCK_TIMEOUT_SECONDS (1800): an
+    # in-progress entry whose DB lease is gone/stale cannot belong to a live
+    # worker (the heartbeat renews live leases every 60s regardless of agent
+    # duration), so the memory entry is fiction and is starved-safe to drop.
+    _IN_PROGRESS_STALE_SECONDS = 1800
+
+    def _lease_is_stale(self, wf: dict | None) -> bool:
+        if not wf:
+            return True
+        locked_at = (wf.get("locked_at") or "").strip()
+        if not locked_at:
+            return True
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(seconds=self._IN_PROGRESS_STALE_SECONDS)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        return locked_at < cutoff
+
+    def _reclaim_stale_in_progress(self, workflows: list[dict]) -> None:
+        """Self-heal _in_progress entries against the DB lease (source of truth).
+
+        A worker hung inside advance() never reaches its finally, so its
+        in-memory entry is immortal and freezes the workflow (and its batch /
+        workspace / branch conflict keys) until a service restart — observed
+        2026-08-19 (workflow fec4782b, ~50 min frozen, restart healed in 1s).
+        The distributed lease already encodes liveness cross-process: heartbeats
+        renew it every 60s independent of agent duration, and acquire_lock
+        breaks leases stale past 1800s anyway. Dropping memory entries whose
+        lease is missing/stale therefore introduces no new concurrency risk —
+        it only stops this process from freezing itself.
+
+        Exclusions: paused rows keep their entry (#1002 — an in-flight
+        advance() owns the resumption); fresh leases keep theirs (live worker).
+        """
+        with self._in_progress_lock:
+            if not self._in_progress_ids:
+                return
+            ids_snapshot = list(self._in_progress_ids)
+        rows_by_id = {wf.get("workflow_id"): wf for wf in workflows}
+        for wid in ids_snapshot:
+            row = rows_by_id.get(wid)
+            if row is not None and row.get("status") == "paused":
+                continue
+            if row is not None and not self._lease_is_stale(row):
+                continue
+            logger.warning(
+                "Reaping stale in-progress entry for workflow %s "
+                "(row=%s, lease=%s); worker is gone or hung without a lease",
+                wid[:8],
+                "active" if row is not None else "not-in-active-set",
+                (row or {}).get("locked_at") or "NULL",
+            )
+            self._discard_in_progress_entry(wid)
+```
+
+挂载点(`_process_workflows`,L~1023 `_reclaim_paused_slots(repo)` 调用之后):
+```python
+        # Self-heal in-progress entries whose DB lease is gone/stale (hung or
+        # leaked worker) so a frozen workflow resumes within the lease window
+        # instead of waiting for a service restart (2026-08-19 fec4782b).
+        self._reclaim_stale_in_progress(workflows)
+```
+注意放在 `workflows = repo.get_active_workflows()` 取数**之后**。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/autonomous_scheduler.py tests/unit/test_scheduler_inprogress_reap.py
+git commit -m "fix(scheduler): lease-anchored self-heal for in-progress entries"
+```
+
+---
+
+### Task 3: `_advance_single` pre-try 异常洞修补
+
+**Files:**
+- Modify: `app/services/autonomous_scheduler.py`(`_advance_single` L~569-613:try 之前的 `repo.get_workflow` / `_conflict_keys` / `acquire_lock` 段)
+- Test: `tests/unit/test_scheduler_inprogress_reap.py`(追加)
+
+**Interfaces:**
+- Consumes: Task 1 的 `_discard_in_progress_entry`。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+def test_pre_try_exception_still_clears_entry():
+    """get_workflow raising before the try must not leak the in-progress
+    entry (observed leak class: exception propagates to the executor future,
+    whose catch only logs)."""
+    sched = _bare_scheduler()
+    sched._in_progress_ids.add("w-pre")
+    sched._in_progress_key_map["w-pre"] = (None, "", "")
+
+    class BoomRepo:
+        def get_workflow(self, wid):
+            raise RuntimeError("db hiccup")
+
+    import unittest.mock as mock
+    with mock.patch.object(sched, "_discard_in_progress_entry") as discard, \
+         mock.patch("app.routes.autonomous._get_repo", create=True, return_value=BoomRepo()):
+        sched._advance_single("w-pre")
+    discard.assert_called_once_with("w-pre")
+    assert "w-pre" not in sched._in_progress_ids
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py::test_pre_try_exception_still_clears_entry -q`
+Expected: FAIL(条目仍残留)
+
+- [ ] **Step 3: 最小实现**
+
+把 `_advance_single` 开头到 `acquire_lock` 失败分支的整段包进 try/except:
+
+```python
+        try:
+            workflow = repo.get_workflow(workflow_id)
+        except Exception:
+            # Pre-try section: an exception here would bypass the main
+            # try/finally entirely and leak the in-progress entry (the
+            # executor's future.result() catch only logs). Reap and re-raise
+            # for the executor to log.
+            self._discard_in_progress_entry(workflow_id)
+            raise
+```
+(`acquire_lock` 的"返回 False"分支已自带清理,替换为 `self._discard_in_progress_entry(workflow_id)` 即可;`_conflict_keys`/`was_waiting` 计算不会抛——workflow 为 None 时有兜底。)
+
+- [ ] **Step 4: 跑测试确认通过 + 全量回归**
+
+Run: `python3 -m pytest tests/unit/test_scheduler_inprogress_reap.py tests/unit/ tests/autonomous/ -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/autonomous_scheduler.py tests/unit/test_scheduler_inprogress_reap.py
+git commit -m "fix(scheduler): clear in-progress entry when pre-try repo access raises"
+```
+
+---
+
+## 验证 Gap 对应
+
+- 改动 lane:`tests/unit/` 与 `app/services/`(CI `test(3.x)` 收集)。
+- 对照 clean origin/main worktree 跑同套测试排除环境失败。
+- PR 文本**不得**出现 `closes|fixes|resolves ... #N`(auto-close 陷阱)。
+
+## 部署
+
+- 单文件热补丁:`app/services/autonomous_scheduler.py` cp + chown openace;`systemctl restart openace-scheduler.service`(编排进程内存态本来就要重启才加载)。无迁移。
+- 上线后验证:journalctl 观察一个周期无异常;若再现泄漏,应看到 `Reaping stale in-progress entry` WARNING 并自动恢复(替代冻结)。
+
+## 独立审查修订记录(2026-08-19,4 项 blocking 已全部按"以实现为准"消化)
+
+1. **B1(paused 不在 active 名单)**:`get_active_workflows` 不含 paused,原计划"row 缺失⇒回收"会误杀 #1002 保号条目。实现改为 `_reclaim_stale_in_progress(workflows, repo)`:缺失行逐个 `repo.get_workflow` 查状态——paused 保留、查询异常保留(fail-closed)、终态回收;健康路径零额外查询(仅泄漏时才查)。
+2. **B2(Postgres datetime 崩溃)**:`locked_at` 在 Postgres/RealDictCursor 下返回 datetime,`.strip()` 会炸掉整个调度周期。实现新增 `_lease_timestamp()` 双类型归一化(str/datetime → aware UTC datetime),比较改为数值年龄比较;补 `test_postgres_datetime_lease_shapes_do_not_crash`。
+3. **B3(计划自带测试写坏)**:fresh-lease 测试断言了从未写入的集合成员;pre-try 测试缺 `pytest.raises` 且 mock 了 helper 却断言真实状态。实现侧测试全部重写自洽(真实 helper + 真实集合断言)。
+4. **B4(挂载点矛盾)**:统一为"`workflows = repo.get_active_workflows()` 的 try/except 之后、filter 之前"(Task 2 正文旧表述作废)。
+5. 事实纠偏见根因段第 2 条(NULL 写者);Task 1 Step 5(a) 的伪码占位段已废弃,以实现的 mark 段(先解包再记 map)为准。

--- a/docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md
+++ b/docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 让调度器内存态 `_in_progress_*` 集合以 DB 租约为存活锚点自愈,任何泄漏/挂死最多冻结工作流 ~30 分钟(租约超时),不再需要服务重启。
+**Goal:** 让调度器内存态 `_in_progress_*` 集合以 DB 租约为存活锚点自愈:**周期已返回的泄漏类**(异常绕过清理等)最多冻结到下一周期;挂死(hang)类不在本修复范围(见 PR 审查后的 scope 降格,修订记录第 6 条)。
 
 **Architecture:** 三层:(1) 统一内存条目回收 helper(记录每个工作流占用的冲突键 `_in_progress_key_map`,一处实现三处复用);(2) `_process_workflows` 每周期用已取回的 active rows 做租约 staleness 回收;(3) `_advance_single` try 前置段的异常也走回收。
 
@@ -20,7 +20,7 @@
 
 **推断(标注:未经直接观察证明)**:该 worker 在前置段的 DB 调用上无限期挂起(连接池耗尽/锁等待)——hang 按定义不产生日志,且进程已重启,线程栈不可事后获取。备选解释(前一个 worker 挂死在 advance() 内且心跳线程同步无声死亡)与"心跳应有续租/告警日志"矛盾,已排除为主因。
 
-**结论**:无论挂死点在前置段哪一行,生命周期缺陷是同一个:**内存 in-progress 条目无存活锚点、前置段无清理保护**。修复以 DB 租约为存活真相(活 worker ⇒ 心跳每 60s 续租,与 agent 时长无关),两层覆盖两种变体;另加一条诊断日志,下次复发时留下现场证据。
+**结论**:无论挂死点在前置段哪一行,生命周期缺陷是同一个:**内存 in-progress 条目无存活锚点、前置段无清理保护**。修复以 DB 租约为存活真相(活 worker ⇒ 心跳每 60s 续租,与 agent 时长无关),三层修复(统一回收/租约锚点回收遍/前置段保护;scope 见修订记录第 6 条);另加诊断 WARNING,下次复发时留下现场证据。
 
 ## Global Constraints
 
@@ -297,9 +297,9 @@ Expected: 新增 4 条 FAIL(`_reclaim_stale_in_progress` 不存在)
 
 挂载点(`_process_workflows`,L~1023 `_reclaim_paused_slots(repo)` 调用之后):
 ```python
-        # Self-heal in-progress entries whose DB lease is gone/stale (hung or
-        # leaked worker) so a frozen workflow resumes within the lease window
-        # instead of waiting for a service restart (2026-08-19 fec4782b).
+        # Self-heal _in_progress entries with no live DB lease behind them
+        # (leaked worker; 2026-08-19 fec4782b). Scope: leaks whose cycle has
+        # returned — see the reclaim docstring.
         self._reclaim_stale_in_progress(workflows)
 ```
 注意放在 `workflows = repo.get_active_workflows()` 取数**之后**。
@@ -404,3 +404,4 @@ git commit -m "fix(scheduler): clear in-progress entry when pre-try repo access 
 3. **B3(计划自带测试写坏)**:fresh-lease 测试断言了从未写入的集合成员;pre-try 测试缺 `pytest.raises` 且 mock 了 helper 却断言真实状态。实现侧测试全部重写自洽(真实 helper + 真实集合断言)。
 4. **B4(挂载点矛盾)**:统一为"`workflows = repo.get_active_workflows()` 的 try/except 之后、filter 之前"(Task 2 正文旧表述作废)。
 5. 事实纠偏见根因段第 2 条(NULL 写者);Task 1 Step 5(a) 的伪码占位段已废弃,以实现的 mark 段(先解包再记 map)为准。
+6. **PR #2846 审查后的 scope 降格(2026-08-19)**:PR 独立审查实证——worker 若为**挂死**,`_process_workflows` 的 `ThreadPoolExecutor` 上下文(`shutdown(wait=True)`)会把整个周期停住,本回收遍(位于周期顶部)永远没机会运行,挂死类仍需重启。故修复范围诚实化为:**仅治愈"周期已返回"的泄漏**(异常类——事故 fec4782b 的观测形态:泄漏期间其他工作流持续推进,说明周期未被停住);挂死场景下"冻结但无 Reaping WARNING"本身即周期被停住的诊断证据,watchdog 留作有证据后的跟进。原文"两层覆盖两种变体/30 分钟内自愈/不再需要重启"等表述按此修正。审查同时落地:缺失行新鲜租约保留(收窄 #1002 resume 竞态)、乱串租约按 unknown 保留(fail-closed 对称)、`_get_repo()` 入 try、2295 选路 fixture patch 回收遍。

--- a/tests/issues/2295/test_scheduler_per_user_concurrency.py
+++ b/tests/issues/2295/test_scheduler_per_user_concurrency.py
@@ -151,6 +151,9 @@ def test_selection_respects_per_user_cap(monkeypatch):
         patch.object(sched, "_promote_queued_workflows"),
         patch.object(sched, "_auto_resume_quota_paused"),
         patch.object(sched, "_reclaim_paused_slots"),
+        # The lease-anchored reclaim is a separate lifecycle concern; these
+        # selection tests seed cross-cycle in-progress entries deliberately.
+        patch.object(sched, "_reclaim_stale_in_progress"),
         patch("app.services.autonomous_scheduler._retry_pending_git_cleanups"),
         patch.object(sched, "_advance_single", side_effect=lambda wid: selected.append(wid)),
         patch.object(sched, "_per_user_cap", side_effect=lambda uid: 1 if uid == 1 else 5),
@@ -180,6 +183,8 @@ def test_waiting_workflow_counts_against_per_user_cap(monkeypatch):
         patch.object(sched, "_promote_queued_workflows"),
         patch.object(sched, "_auto_resume_quota_paused"),
         patch.object(sched, "_reclaim_paused_slots"),
+        # Selection-scoped test: seed entries must survive the reclaim pass.
+        patch.object(sched, "_reclaim_stale_in_progress"),
         patch("app.services.autonomous_scheduler._retry_pending_git_cleanups"),
         patch.object(sched, "_advance_single", side_effect=lambda wid: selected.append(wid)),
         patch.object(sched, "_per_user_cap", return_value=1),

--- a/tests/unit/test_scheduler_inprogress_reap.py
+++ b/tests/unit/test_scheduler_inprogress_reap.py
@@ -90,12 +90,6 @@ def test_discard_entry_for_keyless_workflow_touches_no_shared_keys():
 # ── Task 2: lease-anchored reclaim ───────────────────────────────────────
 
 
-def _with_reap_mocks(sched: AutonomousScheduler) -> None:
-    """_reclaim_stale_in_progress needs repo only for rows missing from the
-    active list; healthy paths must not touch it."""
-    sched._repo_for_missing_rows = None  # marker, real impl uses method param
-
-
 def test_stale_lease_entry_is_reaped_with_keys_and_warning(caplog):
     """THE regression (fec4782b): entry present, row active/eligible, lease
     gone — must be reaped with its keys, loudly."""
@@ -209,6 +203,57 @@ def test_healthy_state_issues_no_queries():
     repo = MagicMock(name="repo")
     sched._reclaim_stale_in_progress([row], repo=repo)
     repo.get_workflow.assert_not_called()
+
+
+def test_missing_row_with_fresh_lease_is_kept():
+    """A row missing from the snapshot but holding a fresh lease is a live
+    worker behind a snapshot race (e.g. #1002 paused→resume flipping to
+    active between fetch and lookup) — the lease is the truth, keep it."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-race", batch="b7", workspace="/ws/e", branch="")
+    repo = MagicMock(name="repo")
+    repo.get_workflow.return_value = {
+        "workflow_id": "w-race",
+        "status": "developing",
+        "locked_at": _fmt(datetime.now(timezone.utc) - timedelta(seconds=30)),
+    }
+    sched._reclaim_stale_in_progress([], repo=repo)
+    assert "w-race" in sched._in_progress_ids
+    assert "/ws/e" in sched._in_progress_workspaces
+
+
+def test_active_row_with_unparseable_lease_is_kept():
+    """Unknown is not stale (fail-closed, symmetric with the lookup-error
+    branch): a present-but-unparseable lease keeps the entry."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-junk", batch="b8", workspace="/ws/f", branch="")
+    row = {"workflow_id": "w-junk", "status": "developing", "locked_at": "not-a-date"}
+    sched._reclaim_stale_in_progress([row], repo=MagicMock())
+    assert "w-junk" in sched._in_progress_ids
+
+
+def test_discard_entry_legacy_wf_fallback_releases_keys():
+    """Pre-map entries (created before a mid-flight deploy) fall back to the
+    caller's workflow dict for conflict keys, preserving clear_in_progress's
+    old semantics."""
+    sched = _bare_scheduler()
+    wid = "w-legacy"
+    with sched._in_progress_lock:
+        sched._in_progress_ids.add(wid)
+        sched._in_progress_by_user.setdefault(3, set()).add(wid)
+        sched._in_progress_batch_ids.add("b-legacy")
+        sched._in_progress_workspaces.add("/ws/legacy")
+    legacy_wf = {
+        "batch_id": "b-legacy",
+        "project_path": "/proj",
+        "worktree_path": "/ws/legacy",
+        "branch_name": "auto-dev/leg",
+        "status": "developing",
+    }
+    sched._discard_in_progress_entry(wid, legacy_wf=legacy_wf)
+    assert wid not in sched._in_progress_ids
+    assert "b-legacy" not in sched._in_progress_batch_ids
+    assert "/ws/legacy" not in sched._in_progress_workspaces
 
 
 # ── Task 3: pre-try exception protection ─────────────────────────────────

--- a/tests/unit/test_scheduler_inprogress_reap.py
+++ b/tests/unit/test_scheduler_inprogress_reap.py
@@ -1,0 +1,235 @@
+"""Scheduler in-progress entry lifecycle: key map, unified teardown, lease-anchored reclaim.
+
+Regression context (2026-08-19, workflow fec4782b): an in-progress entry with
+no live worker froze the workflow (and its batch/workspace/branch conflict
+keys) for ~50 minutes because nothing but a service restart could drop it.
+The DB lease is the liveness authority — a live worker's heartbeat renews it
+every 60s regardless of agent duration — so memory entries are reclaimed
+against it. See docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+
+def _fmt(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _bare_scheduler() -> AutonomousScheduler:
+    sched = AutonomousScheduler.__new__(AutonomousScheduler)
+    sched._in_progress_ids = set()
+    sched._in_progress_batch_ids = set()
+    sched._in_progress_workspaces = set()
+    sched._in_progress_branches = set()
+    sched._in_progress_by_user = {}
+    sched._in_progress_key_map = {}
+    sched._in_progress_lock = threading.Lock()
+    return sched
+
+
+def _mark(
+    sched: AutonomousScheduler,
+    wid: str,
+    *,
+    batch: str | None = None,
+    workspace: str = "",
+    branch: str = "",
+    user: int | None = 3,
+) -> None:
+    with sched._in_progress_lock:
+        sched._in_progress_ids.add(wid)
+        sched._in_progress_by_user.setdefault(user, set()).add(wid)
+        sched._in_progress_key_map[wid] = (batch, workspace, branch)
+        if batch:
+            sched._in_progress_batch_ids.add(batch)
+        if workspace:
+            sched._in_progress_workspaces.add(workspace)
+        if branch:
+            sched._in_progress_branches.add(branch)
+
+
+# ── Task 1: unified teardown helper + key map ────────────────────────────
+
+
+def test_discard_entry_releases_reserved_keys_exactly_and_is_idempotent():
+    sched = _bare_scheduler()
+    _mark(sched, "w-1", batch="batch-9", workspace="/ws/open6", branch="auto-dev/w-1")
+
+    sched._discard_in_progress_entry("w-1")
+
+    assert "w-1" not in sched._in_progress_ids
+    assert "w-1" not in sched._in_progress_by_user[3]
+    assert "batch-9" not in sched._in_progress_batch_ids
+    assert "/ws/open6" not in sched._in_progress_workspaces
+    assert "auto-dev/w-1" not in sched._in_progress_branches
+    assert "w-1" not in sched._in_progress_key_map
+    # Idempotent — a second discard (reclaim racing the finally) must not raise.
+    sched._discard_in_progress_entry("w-1")
+
+
+def test_discard_entry_for_keyless_workflow_touches_no_shared_keys():
+    """Waiting workflows reserve no conflict keys; their teardown must not
+    release keys some other workflow legitimately holds."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-wait", batch=None, workspace="", branch="", user=3)
+    _mark(sched, "w-busy", batch="b-shared", workspace="/ws/shared", branch="", user=4)
+
+    sched._discard_in_progress_entry("w-wait")
+
+    assert "b-shared" in sched._in_progress_batch_ids
+    assert "/ws/shared" in sched._in_progress_workspaces
+    assert "w-busy" in sched._in_progress_ids
+
+
+# ── Task 2: lease-anchored reclaim ───────────────────────────────────────
+
+
+def _with_reap_mocks(sched: AutonomousScheduler) -> None:
+    """_reclaim_stale_in_progress needs repo only for rows missing from the
+    active list; healthy paths must not touch it."""
+    sched._repo_for_missing_rows = None  # marker, real impl uses method param
+
+
+def test_stale_lease_entry_is_reaped_with_keys_and_warning(caplog):
+    """THE regression (fec4782b): entry present, row active/eligible, lease
+    gone — must be reaped with its keys, loudly."""
+    import logging as _logging
+
+    sched = _bare_scheduler()
+    _mark(sched, "w-stale", batch="b1", workspace="/ws/a", branch="br1")
+    row = {
+        "workflow_id": "w-stale",
+        "status": "developing",
+        "locked_at": _fmt(datetime.now(timezone.utc) - timedelta(seconds=1801)),
+    }
+    repo = MagicMock(name="repo")
+    with caplog.at_level(_logging.WARNING, logger="app.services.autonomous_scheduler"):
+        sched._reclaim_stale_in_progress([row], repo=repo)
+    assert "w-stale" not in sched._in_progress_ids
+    assert "b1" not in sched._in_progress_batch_ids
+    assert "/ws/a" not in sched._in_progress_workspaces
+    assert "br1" not in sched._in_progress_branches
+    assert any("Reaping stale in-progress" in r.message for r in caplog.records)
+
+
+def test_fresh_lease_entry_is_kept():
+    """Live worker: heartbeat renews the lease, so the entry stays."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-live", batch="b2", workspace="/ws/a", branch="")
+    row = {
+        "workflow_id": "w-live",
+        "status": "developing",
+        "locked_at": _fmt(datetime.now(timezone.utc) - timedelta(seconds=60)),
+    }
+    sched._reclaim_stale_in_progress([row], repo=MagicMock())
+    assert "w-live" in sched._in_progress_ids
+    assert "b2" in sched._in_progress_batch_ids
+
+
+def test_postgres_datetime_lease_shapes_do_not_crash():
+    """Postgres (RealDictCursor) returns datetime objects for timestamp
+    columns, SQLite returns strings — both must classify correctly instead
+    of raising AttributeError on .strip() (plan-review B2: a raise here
+    would kill every scheduler cycle)."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-pg-live", batch=None, workspace="", branch="")
+    _mark(sched, "w-pg-stale", batch=None, workspace="", branch="")
+    now = datetime.now(timezone.utc)
+    sched._reclaim_stale_in_progress(
+        [
+            {
+                "workflow_id": "w-pg-live",
+                "status": "developing",
+                "locked_at": now - timedelta(seconds=60),  # datetime, naive-of-tz shape from PG
+            },
+            {
+                "workflow_id": "w-pg-stale",
+                "status": "developing",
+                "locked_at": now - timedelta(seconds=2400),  # datetime, stale
+            },
+        ],
+        repo=MagicMock(),
+    )
+    assert "w-pg-live" in sched._in_progress_ids
+    assert "w-pg-stale" not in sched._in_progress_ids
+
+
+def test_paused_row_missing_from_active_list_is_kept():
+    """#1002: paused rows are NOT in get_active_workflows' status list, so the
+    reclaim must fetch their status — a paused workflow's entry belongs to an
+    in-flight advance() that owns its resumption. Never reap on absence."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-paused", batch="b3", workspace="/ws/p", branch="")
+    repo = MagicMock(name="repo")
+    repo.get_workflow.return_value = {"workflow_id": "w-paused", "status": "paused"}
+    sched._reclaim_stale_in_progress([], repo=repo)  # not in active set
+    assert "w-paused" in sched._in_progress_ids
+    assert "/ws/p" in sched._in_progress_workspaces
+
+
+def test_terminal_row_missing_from_active_list_is_reaped():
+    """A completed/failed/cancelled row absent from the active set cannot have
+    a live advance worth protecting — reap so its keys stop starving siblings."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-done", batch="b4", workspace="/ws/b", branch="")
+    repo = MagicMock(name="repo")
+    repo.get_workflow.return_value = {"workflow_id": "w-done", "status": "completed"}
+    sched._reclaim_stale_in_progress([], repo=repo)
+    assert "w-done" not in sched._in_progress_ids
+    assert "/ws/b" not in sched._in_progress_workspaces
+
+
+def test_missing_row_status_query_failure_keeps_entry():
+    """Fail-closed: if the status lookup itself errors, keep the entry — a
+    wrong reap is worse than a short wait for the next cycle."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-unknown", batch="b5", workspace="/ws/c", branch="")
+    repo = MagicMock(name="repo")
+    repo.get_workflow.side_effect = RuntimeError("db down")
+    sched._reclaim_stale_in_progress([], repo=repo)
+    assert "w-unknown" in sched._in_progress_ids
+
+
+def test_healthy_state_issues_no_queries():
+    """Zero extra DB cost when nothing is leaked: no rows missing from the
+    active list, all leases fresh."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-ok", batch="b6", workspace="/ws/d", branch="")
+    row = {
+        "workflow_id": "w-ok",
+        "status": "developing",
+        "locked_at": _fmt(datetime.now(timezone.utc)),
+    }
+    repo = MagicMock(name="repo")
+    sched._reclaim_stale_in_progress([row], repo=repo)
+    repo.get_workflow.assert_not_called()
+
+
+# ── Task 3: pre-try exception protection ─────────────────────────────────
+
+
+def test_pre_try_exception_still_clears_entry():
+    """get_workflow raising BEFORE the main try must not leak the entry (the
+    executor's future.result() catch only logs)."""
+    sched = _bare_scheduler()
+    _mark(sched, "w-pre", batch=None, workspace="", branch="")
+    sched._orchestrator_lock = threading.Lock()
+    sched._running_orchestrators = {}
+    sched._stop_event = threading.Event()
+
+    repo = MagicMock(name="repo")
+    repo.get_workflow.side_effect = RuntimeError("db hiccup")
+
+    import pytest
+
+    with patch("app.routes.autonomous._get_repo", return_value=repo):
+        with pytest.raises(RuntimeError, match="db hiccup"):
+            sched._advance_single("w-pre")
+
+    assert "w-pre" not in sched._in_progress_ids


### PR DESCRIPTION
## Summary

A scheduler worker that leaks its in-memory `_in_progress_*` entry (hang or silent death without the finally) freezes the workflow — and its batch/workspace/branch conflict keys — until a service restart. Observed 2026-08-19: workflow `fec4782b` committed its round escalation at 11:20 UTC, was never selected again for ~50 minutes while its DB lease was NULL, and a restart healed it in one second. Evidence chain (journal + DB + code) in the plan doc.

The DB lease is the liveness authority — heartbeats renew it every 60s regardless of agent duration, and `acquire_lock` already breaks 1800s-stale leases cross-process — so aligning memory to lease truth adds no new concurrency exposure.

## Change (3 layers)

1. **`_discard_in_progress_entry`** — single authority for entry teardown, backed by `_in_progress_key_map` (records exactly which conflict keys each entry reserved at selection time; waiting rows reserve none). Replaces the three hand-rolled discard blocks (acquire-fail branch, finally, `clear_in_progress`).
2. **`_reclaim_stale_in_progress(workflows, repo)`** — each cycle, entries are checked against the lease: active rows with NULL/stale lease are reaped; rows missing from the active set (`paused` is not in `get_active_workflows`' list) get one `get_workflow` status lookup — paused keeps its entry (#1002: an in-flight advance owns the resumption), lookup failure keeps it (fail-closed), terminal statuses reap. Healthy state pays zero extra queries. Reap logs a WARNING so a recurrence leaves forensic evidence.
3. **`_advance_single` pre-try protection** — `get_workflow` raising now discards the entry before re-raising (the executor's `future.result()` catch only logs; this is the zero-log section where the observed entry was lost).

Also: `_lease_timestamp()` normalizes `locked_at` for both SQLite (str) and Postgres/RealDictCursor (datetime) shapes — a `.strip()` on the Postgres shape would kill every scheduler cycle.

## Test plan

- 10 new unit tests (`tests/unit/test_scheduler_inprogress_reap.py`): exact-key teardown + idempotence, keyless/waiting no-collateral, the fec4782b regression (stale lease reaped with keys + warning), fresh lease kept, Postgres datetime shapes (no crash, correct classification), paused-outside-active kept (#1002), terminal-outside-active reaped, status-lookup failure keeps (fail-closed), healthy state issues no queries, pre-try exception clears entry.
- Full `tests/unit/` + `tests/autonomous/` + `tests/issues/2295`: **4873 passed, 0 failures**. `tests/issues/1897` has 2 failures **identical on clean origin/main** (verified via stash) — pre-existing, not from this change.
- **Review fix (c0476f4e)**: the first revision broke 2 selection tests in `tests/issues/2295` (their fixtures seed cross-cycle in-progress entries that the reclaim pass rightly reaps); fixed by patching the reclaim in those selection-scoped tests, same as `_reclaim_paused_slots`. Also: missing-from-snapshot rows with a fresh lease are kept, unparseable leases keep (unknown ≠ stale), `_get_repo()` moved inside the pre-try guard, and the reclaim's scope is documented honestly — it heals leaks whose cycle has returned; a hung worker parks the cycle inside the executor's `shutdown(wait=True)` and still needs a restart (a frozen workflow WITHOUT a reap warning is the diagnostic for that follow-up).
- black/isort/ruff/mypy clean (pre-commit).

Plan doc (root-cause evidence chain + independent-review revision log): `docs/superpowers/plans/2026-08-19-scheduler-inprogress-lease-anchor.md`
