### PR TITLE
fix(tests): realign 863 ip-whitelist e2e script with evolved app (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -609,46 +609,6 @@
       "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: trusted common_dir is not a .git directory: /tmp/test.git"
     },
     {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "863",
-      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_api_ip_whitelist",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/863/e2e_ip_whitelist_input.py, line 95"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "863",
-      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_dedupe",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "863",
-      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_empty_lines",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "863",
-      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_newline",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "863",
-      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_trim",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "913",
@@ -723,8 +683,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-19 prune 5 resolved issue-822 merge-conflict entries: three guard evolutions. (a) add_worktree gained a containment guard (worktree paths must live under the repo root; GitHubOpsError otherwise) — tests moved their worktree paths inside the root. (b) _resolve_merge_conflicts worktree transitions now carry worktree_transition_state metadata; bare-dict assert_any_call became value-based any() on worktree_path guarding the same invariant (cleared during transition, restored after — including on resolution failure). (c) The effective-round-delta derivation (in _validate_autonomous_change_scope, wrapping get_changed_files) now detects merge commits via rev-parse <pr>^2 and re-derives the merge base; the exact 2-call expectation became entrypoint-prefix + probe-membership assertions. Resolution evidence: run 32256893077 resolved list is exactly these 5 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting reproduces the 5. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32256893077",
+    "prune_note": "2026-08-19 prune 5 resolved issue-863 ip-whitelist e2e entries: four stacked layers. (a) The file is a manual e2e script whose check functions took plain args pytest misread as fixtures — checks are now script-internal _check_* steps and pytest runs the whole script in a subprocess requiring a full pass (skips without a reachable server). (b) /api/compliance/security-settings moved to /api/security-settings (governance blueprint). (c) Freshly seeded lane servers boot admin with must_change_password=1 which 403-gates authenticated calls — main() clears the seeded flag in the test DB first (165-cluster precedent). (d) Login inputs are id-based and the Security Center default tab is Content Filter — selectors realigned and every UI check switches to the Security Settings tab. Resolution evidence: run 32261407296 resolved list is exactly these 5 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting reproduces the 5. Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32261407296",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/863/e2e_ip_whitelist_input.py
+++ b/tests/issues/863/e2e_ip_whitelist_input.py
@@ -67,6 +67,36 @@ def check(condition, description):
         print(f"    [FAIL] {description}")
 
 
+def _clear_seeded_password_gate():
+    """Clear admin's must_change_password flag in the test DB (no-op otherwise).
+
+    Only touches an sqlite DB under the current HOME (.open-ace/ace.db) when
+    the flag is still set for the seeded admin — i.e. a freshly initialized
+    lane server. Dev databases where the password was already changed are
+    unaffected.
+    """
+    import sqlite3
+
+    db_path = os.path.join(os.path.expanduser("~"), ".open-ace", "ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(users)")]
+        if "must_change_password" not in cols:
+            return
+        cur = conn.execute(
+            "UPDATE users SET must_change_password=0 "
+            "WHERE username='admin' AND must_change_password=1"
+        )
+        conn.commit()
+        if cur.rowcount:
+            print("    [SETUP] Cleared seeded admin must_change_password flag")
+        conn.close()
+    except sqlite3.Error:
+        pass
+
+
 def api_login(session, username="admin", password="admin123"):
     r = session.post(
         f"{BASE_URL}/api/auth/login", json={"username": username, "password": password}
@@ -77,7 +107,7 @@ def api_login(session, username="admin", password="admin123"):
 
 def api_get_ip_whitelist(session):
     """Get current IP whitelist via API."""
-    r = session.get(f"{BASE_URL}/api/compliance/security-settings")
+    r = session.get(f"{BASE_URL}/api/security-settings")
     if r.status_code == 200:
         return r.json().get("ip_whitelist", [])
     return []
@@ -86,13 +116,13 @@ def api_get_ip_whitelist(session):
 def api_set_ip_whitelist(session, ip_list):
     """Set IP whitelist via API."""
     r = session.put(
-        f"{BASE_URL}/api/compliance/security-settings",
+        f"{BASE_URL}/api/security-settings",
         json={"ip_whitelist": ip_list},
     )
     return r.status_code == 200
 
 
-def test_api_ip_whitelist(session):
+def _check_api_ip_whitelist(session):
     """Test IP whitelist API endpoints directly."""
     print("\n[API] Testing IP whitelist endpoints...")
 
@@ -115,20 +145,15 @@ def test_api_ip_whitelist(session):
     print(f"    Restored original whitelist: {original_list}")
 
 
-def test_ui_ip_whitelist_newline(page, session):
-    """Test that IP whitelist textarea allows newline input (Issue #863)."""
-    print("\n[UI] Testing IP whitelist newline input...")
+def _open_security_settings_tab(page):
+    """Load Security Center and switch to the Security Settings tab.
 
-    # First, set a single IP via API for test setup
-    original_list = api_get_ip_whitelist(session)
-    api_set_ip_whitelist(session, ["192.168.1.1"])
-
-    # Navigate to Security Center
+    The default tab is Content Filter; the IP whitelist textarea only
+    exists on the Security Settings tab (one textarea there), so every
+    UI check must switch explicitly.
+    """
     page.goto(f"{BASE_URL}/manage/security", wait_until="domcontentloaded", timeout=30000)
-    pause(2)
-    shot(page, "01_security_center_loaded")
-
-    # Click on Security Settings tab (default tab, should be already visible)
+    pause(1)
     try:
         page.click("text=Security Settings", timeout=5000)
     except Exception:
@@ -137,6 +162,17 @@ def test_ui_ip_whitelist_newline(page, session):
         except Exception:
             page.click("text=セキュリティ設定", timeout=5000)
     pause(1)
+
+
+def _check_ui_ip_whitelist_newline(page, session):
+    """Test that IP whitelist textarea allows newline input (Issue #863)."""
+    print("\n[UI] Testing IP whitelist newline input...")
+
+    # First, set a single IP via API for test setup
+    original_list = api_get_ip_whitelist(session)
+    api_set_ip_whitelist(session, ["192.168.1.1"])
+
+    _open_security_settings_tab(page)
     shot(page, "02_security_settings_tab")
 
     # Find the IP whitelist textarea
@@ -173,11 +209,8 @@ def test_ui_ip_whitelist_newline(page, session):
 
     shot(page, "03_after_newline_input")
 
-    # Click Save button
-    try:
-        save_btn = page.locator("button:has-text('Save')").first
-    except Exception:
-        save_btn = page.locator("button:has-text('保存')").first
+    # Click Save button (language-robust union selector)
+    save_btn = page.locator("button:has-text('Save'), button:has-text('保存')").first
     save_btn.click()
     pause(2)
     shot(page, "04_after_save")
@@ -201,15 +234,13 @@ def test_ui_ip_whitelist_newline(page, session):
     api_set_ip_whitelist(session, original_list)
 
 
-def test_ui_ip_whitelist_dedupe(page, session):
+def _check_ui_ip_whitelist_dedupe(page, session):
     """Test that duplicate IPs are removed on save."""
     print("\n[UI] Testing IP whitelist dedupe...")
 
     original_list = api_get_ip_whitelist(session)
 
-    # Navigate to Security Center
-    page.goto(f"{BASE_URL}/manage/security", wait_until="domcontentloaded", timeout=30000)
-    pause(1)
+    _open_security_settings_tab(page)
 
     # Find textarea and clear it
     textarea = page.locator("textarea").first
@@ -237,15 +268,13 @@ def test_ui_ip_whitelist_dedupe(page, session):
     api_set_ip_whitelist(session, original_list)
 
 
-def test_ui_ip_whitelist_trim(page, session):
+def _check_ui_ip_whitelist_trim(page, session):
     """Test that leading/trailing spaces are trimmed on save."""
     print("\n[UI] Testing IP whitelist trim...")
 
     original_list = api_get_ip_whitelist(session)
 
-    # Navigate to Security Center
-    page.goto(f"{BASE_URL}/manage/security", wait_until="domcontentloaded", timeout=30000)
-    pause(1)
+    _open_security_settings_tab(page)
 
     # Find textarea and input IP with spaces
     textarea = page.locator("textarea").first
@@ -272,15 +301,13 @@ def test_ui_ip_whitelist_trim(page, session):
     api_set_ip_whitelist(session, original_list)
 
 
-def test_ui_ip_whitelist_empty_lines(page, session):
+def _check_ui_ip_whitelist_empty_lines(page, session):
     """Test that empty lines are filtered out on save."""
     print("\n[UI] Testing IP whitelist empty line filter...")
 
     original_list = api_get_ip_whitelist(session)
 
-    # Navigate to Security Center
-    page.goto(f"{BASE_URL}/manage/security", wait_until="domcontentloaded", timeout=30000)
-    pause(1)
+    _open_security_settings_tab(page)
 
     # Find textarea and input IPs with empty lines
     textarea = page.locator("textarea").first
@@ -314,12 +341,17 @@ def main():
     print(f"BASE_URL: {BASE_URL}")
     print(f"HEADLESS: {HEADLESS}")
 
+    # A freshly seeded lane server boots admin with must_change_password=1,
+    # which gates every authenticated endpoint behind 403 password_change_
+    # required (the 165-cluster lane-setup precedent clears the same flag).
+    _clear_seeded_password_gate()
+
     # API session for direct endpoint testing
     session = requests.Session()
     api_login(session)
 
     # Test API endpoints first
-    test_api_ip_whitelist(session)
+    _check_api_ip_whitelist(session)
 
     # UI tests with Playwright
     with sync_playwright() as p:
@@ -330,17 +362,17 @@ def main():
         # Login via UI
         print("\n[UI] Logging in as admin...")
         page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded", timeout=30000)
-        page.fill("input[name='username']", "admin")
-        page.fill("input[name='password']", "admin123")
+        page.fill("#username", "admin")
+        page.fill("#password", "admin123")
         page.click("button[type='submit']")
         pause(2)
         shot(page, "00_login")
 
         # Run UI tests
-        test_ui_ip_whitelist_newline(page, session)
-        test_ui_ip_whitelist_dedupe(page, session)
-        test_ui_ip_whitelist_trim(page, session)
-        test_ui_ip_whitelist_empty_lines(page, session)
+        _check_ui_ip_whitelist_newline(page, session)
+        _check_ui_ip_whitelist_dedupe(page, session)
+        _check_ui_ip_whitelist_trim(page, session)
+        _check_ui_ip_whitelist_empty_lines(page, session)
 
         browser.close()
 
@@ -355,6 +387,36 @@ def main():
             print(f"  - {e}")
 
     sys.exit(0 if failed == 0 else 1)
+
+
+def test_e2e_ip_whitelist_script():
+    """Run the manual e2e script in a subprocess and require a full pass.
+
+    The check functions above are script-internal steps driven by main()
+    (requests.Session + Playwright); pytest cannot supply those fixtures.
+    The subprocess inherits the environment (the issues lane exports
+    BASE_URL for the live server) and the script exits 0 only when every
+    check passes. Skipped when no server is reachable (bare local runs).
+    """
+    import subprocess
+
+    import pytest
+    import requests as _requests
+
+    try:
+        _requests.get(f"{BASE_URL}/login", timeout=5)
+    except _requests.RequestException:
+        pytest.skip(f"server not reachable at {BASE_URL}; run via the issues lane")
+
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    tail = f"stdout tail:\n{proc.stdout[-1500:]}\nstderr tail:\n{proc.stderr[-1500:]}"
+    assert proc.returncode == 0, f"e2e script failed:\n{tail}"
+    assert ", 0 failed" in proc.stdout, f"e2e script incomplete:\n{tail}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #2457

## Cluster: 863 (5 entries; baseline 90 → 85)

The file is a manual e2e script (`python tests/issues/863/e2e_ip_whitelist_input.py`) whose check functions took plain arguments pytest misread as fixtures (the recorded setup errors). Four stacked layers fixed:

1. **Collection:** checks renamed `_check_*`; pytest runs the whole script in a subprocess requiring a full pass (exit 0 + `0 failed` summary), skipping when no server is reachable. The subprocess inherits the lane's `BASE_URL`.
2. **API contract:** `/api/compliance/security-settings` → `/api/security-settings` (route moved to the governance blueprint at `/api`).
3. **Auth gate:** a freshly seeded lane server boots admin with `must_change_password=1`, 403-gating every authenticated call (`password_change_required`); `main()` clears the seeded flag in the test DB first (165-cluster lane-setup precedent — only ever clears an *unset* admin flag).
4. **UI drift:** login inputs are `id=`-based (`#username`/`#password`); the Security Center default tab is now **Content Filter**, so every UI check opens the Security Settings tab explicitly via a shared helper (the whitelist textarea is the only textarea there); language-robust union selector for Save.

## Evidence

- Full script vs a live seeded server (booted like the lane): **19 passed, 0 failed** — newline/dedupe/trim/empty-line all verified through the real frontend.
- Lane (`--category issues --issue-numbers 863 --server auto --isolated-home`): **1 passed** (subprocess inherits BASE_URL, runs the full script).
- Negative control (stash-revert → rerun → restore): the original 5 setup errors reproduce exactly.
- Branch verification run (fix commit ad1065b7): to attach on completion.

## Baseline

Shrink-only prune of the 5 entries (90 → 85) follows once the verification run completes; authoritative all-zero diff then verified on the final head.