### PR TITLE
test: close legacy clusters 172/1895/987 (85->73)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -97,38 +97,6 @@
       "summary": "failed on setup with \"file tests/issues/166/test_stream_json_mode.py, line 32"
     },
     {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "172",
-      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_llm_proxy_fail_closed",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 209"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "172",
-      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_quota_check_endpoint",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 91"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "172",
-      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_quota_status_endpoint",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 108"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "172",
-      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_user_daily_stats",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 122"
-    },
-    {
       "category": "test_body_exception",
       "exception_type": "AttributeError",
       "issue_number": "1760",
@@ -199,38 +167,6 @@
       "nodeid": "tests/issues/1831/test_orchestrator_failure_cleanup.py::TestAdvanceTimingDimension::test_transient_error_keeps_worktree",
       "outcome": "failure",
       "summary": "AssertionError: Expected '_mark_failed' to not have been called. Called 1 times."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "RuntimeError",
-      "issue_number": "1895",
-      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordFailClosed::test_development_allows_empty_redis_password_with_warning",
-      "outcome": "failure",
-      "summary": "RuntimeError: REDIS_PASSWORD not set in development mode. The entrypoint should auto-generate and persist this password. If running directly, set REDIS_PASSWORD explicitly."
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "RuntimeError",
-      "issue_number": "1895",
-      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_backtick_handled_correctly",
-      "outcome": "failure",
-      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "RuntimeError",
-      "issue_number": "1895",
-      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_dollar_sign_handled_correctly",
-      "outcome": "failure",
-      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "RuntimeError",
-      "issue_number": "1895",
-      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_exclamation_handled_correctly",
-      "outcome": "failure",
-      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
     },
     {
       "category": "assertion_failure",
@@ -627,38 +563,6 @@
     {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
-      "issue_number": "987",
-      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPostGithubComment::test_long_body_capped_with_notice",
-      "outcome": "failure",
-      "summary": "AssertionError: assert '截断' in 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB…"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "IndexError",
-      "issue_number": "987",
-      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_previous_review_content_not_reinjected_but_instruction_kept",
-      "outcome": "failure",
-      "summary": "IndexError: list index out of range"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "987",
-      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_requirements_not_injected",
-      "outcome": "failure",
-      "summary": "IndexError: list index out of range"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "987",
-      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestSummaryPrompt::test_last_pr_review_kept_last_fix_summary_removed",
-      "outcome": "failure",
-      "summary": "assert 0 >= 2"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
       "issue_number": "993",
       "nodeid": "tests/issues/993/test_tldr.py::TestMilestoneTldrWrite::test_pr_reviewed_milestone_carries_tldr",
       "outcome": "failure",
@@ -683,8 +587,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-19 prune 5 resolved issue-863 ip-whitelist e2e entries: four stacked layers. (a) The file is a manual e2e script whose check functions took plain args pytest misread as fixtures — checks are now script-internal _check_* steps and pytest runs the whole script in a subprocess requiring a full pass (skips without a reachable server). (b) /api/compliance/security-settings moved to /api/security-settings (governance blueprint). (c) Freshly seeded lane servers boot admin with must_change_password=1 which 403-gates authenticated calls — main() clears the seeded flag in the test DB first (165-cluster precedent). (d) Login inputs are id-based and the Security Center default tab is Content Filter — selectors realigned and every UI check switches to the Security Settings tab. Resolution evidence: run 32261407296 resolved list is exactly these 5 nodeids with new/changed/invalid/collection_errors all 0. Negative control: reverting reproduces the 5. Shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32261407296",
+    "prune_note": "2026-08-20 prune 12 resolved entries across three clusters (85->73). 172 quota e2e (4): the file was a manual deployment diagnostic whose check functions took plain args pytest misread as fixtures; moved to manual_e2e_quota_enforcement.py out of discovery, historical path kept as a pointer+guard so the round-robin shard layout is unchanged. 1895 redis auth (4): production evolved to fail-closed - dev empty REDIS_PASSWORD now raises RuntimeError instead of warning, so the fail-open assertion was inverted and special-char passwords lengthened past the validation minimum. 987 prompt truncation (4): fixtures drifted from the phase-migrated autonomous review - agent result must be a REVIEW_RESULT JSON verdict, gh.get_current_branch/_validate_autonomous_change_scope mocked, zh content-language case constructed accordingly.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32373066502",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/172/e2e_quota_enforcement.py
+++ b/tests/issues/172/e2e_quota_enforcement.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+Quota enforcement e2e moved to manual_e2e_quota_enforcement.py (#2457).
+
+The checks historically in this file target a *deployed* environment —
+psql against the production PostgreSQL, greps under /home/openace/, and
+journalctl — none of which exist in a lane/CI checkout. They now live in
+manual_e2e_quota_enforcement.py, outside pytest discovery (see its
+docstring for the manual entrypoint).
+
+This file stays at its historical path so the lane's file-based shard
+layout is unchanged: removing a file from tests/issues/ would shift the
+round-robin shard assignment of every file after it and reshuffle which
+tests share a pytest process (scripts/run_extended_tests.py, apply_split).
+"""
+
+from pathlib import Path
+
+
+def test_manual_diagnostic_script_kept_out_of_discovery():
+    """The quota e2e lives on as a manual diagnostic; guard its presence."""
+    manual = Path(__file__).with_name("manual_e2e_quota_enforcement.py")
+    assert manual.is_file(), f"manual diagnostic script missing: {manual}"
+    text = manual.read_text(encoding="utf-8")
+    assert "MANUAL DIAGNOSTIC SCRIPT" in text
+    assert "NOT COLLECTED BY PYTEST" in text

--- a/tests/issues/172/manual_e2e_quota_enforcement.py
+++ b/tests/issues/172/manual_e2e_quota_enforcement.py
@@ -2,6 +2,16 @@
 """
 Open ACE - Quota Enforcement E2E Test (#172)
 
+⚠️ MANUAL DIAGNOSTIC SCRIPT — NOT COLLECTED BY PYTEST (#2457).
+
+This file targets a *deployed* environment: it queries the production
+PostgreSQL database via psql (hardcoded DSN), greps /home/openace/... and
+reads journalctl service logs — none of which exist in a lane/CI checkout.
+It previously lived at e2e_quota_enforcement.py and was mis-collected by
+pytest (its step functions take plain token args pytest read as missing
+fixtures). It is kept for manual runs against the deployed environment
+only, under a name outside the test_*/e2e_* discovery patterns.
+
 Tests the complete quota enforcement system after fixing:
 - Fix 1: LLM proxy fail-closed
 - Fix 2: QuotaManager uses user_daily_stats
@@ -10,9 +20,9 @@ Tests the complete quota enforcement system after fixing:
 - Fix 5: Independent enforcement scheduler
 - Fix 6: Monthly quota checking
 
-Run:
-  HEADLESS=true  python tests/172/e2e_quota_enforcement.py
-  HEADLESS=false python tests/172/e2e_quota_enforcement.py
+Run (against the deployed environment):
+  HEADLESS=true  python tests/issues/172/manual_e2e_quota_enforcement.py
+  HEADLESS=false python tests/issues/172/manual_e2e_quota_enforcement.py
 """
 
 import os

--- a/tests/issues/1788/test_sso_email_linking_and_audit.py
+++ b/tests/issues/1788/test_sso_email_linking_and_audit.py
@@ -136,7 +136,9 @@ def test_finalize_sso_login_links_by_email_when_admin_opts_in(app_ctx):
     ):
         sso_module._finalize_sso_login("corp-saml", _auth_result(email="match@example.com"), None)
 
-    user_repo.get_user_by_email.assert_called_once_with("match@example.com")
+    # #2755: email linking must exclude soft-deleted users, so the repository
+    # call now passes include_deleted=False explicitly.
+    user_repo.get_user_by_email.assert_called_once_with("match@example.com", include_deleted=False)
     manager.link_identity.assert_called_once()
     assert manager.link_identity.call_args.kwargs["user_id"] == 7
     create_mock.assert_not_called()

--- a/tests/issues/1895/test_redis_authentication.py
+++ b/tests/issues/1895/test_redis_authentication.py
@@ -320,8 +320,10 @@ class TestRedisPasswordFailClosed:
         with pytest.raises(RuntimeError, match="REDIS_PASSWORD must be set"):
             get_redis_password()
 
-    def test_development_allows_empty_redis_password_with_warning(self, monkeypatch):
-        """In development, empty REDIS_PASSWORD should return dev password with warning."""
+    def test_development_missing_redis_password_fails_closed_with_warning(
+        self, monkeypatch, caplog
+    ):
+        """In development, missing REDIS_PASSWORD warns and fails closed (no dev fallback)."""
         from app.utils.security_env import get_redis_password
 
         # Set development environment (default)
@@ -329,9 +331,10 @@ class TestRedisPasswordFailClosed:
         # Unset password
         monkeypatch.delenv("REDIS_PASSWORD", raising=False)
 
-        # Should return dev password without raising
-        password = get_redis_password()
-        assert password == "dev-redis-password"
+        # Fail-closed: the entrypoint (not the library) owns auto-generation
+        with pytest.raises(RuntimeError, match="REDIS_PASSWORD not set in development mode"):
+            get_redis_password()
+        assert "auto-generated and persisted" in caplog.text
 
     def test_development_accepts_strong_redis_password(self, monkeypatch):
         """Strong password should be accepted in development."""
@@ -366,30 +369,30 @@ class TestRedisPasswordSpecialCharacters:
         from app.utils.security_env import get_redis_password
 
         monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
-        monkeypatch.setenv("REDIS_PASSWORD", "pass$word$123")
+        monkeypatch.setenv("REDIS_PASSWORD", "pass$word$1234567890123456789")
 
         password = get_redis_password()
-        assert password == "pass$word$123"
+        assert password == "pass$word$1234567890123456789"
 
     def test_password_with_exclamation_handled_correctly(self, monkeypatch):
         """Password containing ! should be accepted."""
         from app.utils.security_env import get_redis_password
 
         monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
-        monkeypatch.setenv("REDIS_PASSWORD", "pass!word!123")
+        monkeypatch.setenv("REDIS_PASSWORD", "pass!word!1234567890123456789")
 
         password = get_redis_password()
-        assert password == "pass!word!123"
+        assert password == "pass!word!1234567890123456789"
 
     def test_password_with_backtick_handled_correctly(self, monkeypatch):
         """Password containing backtick should be accepted."""
         from app.utils.security_env import get_redis_password
 
         monkeypatch.setenv("OPENACE_SECURITY_MODE", "production")
-        monkeypatch.setenv("REDIS_PASSWORD", "pass`word`123")
+        monkeypatch.setenv("REDIS_PASSWORD", "pass`word`1234567890123456789")
 
         password = get_redis_password()
-        assert password == "pass`word`123"
+        assert password == "pass`word`1234567890123456789"
 
     def test_password_with_special_chars_handled_correctly(self, monkeypatch):
         """Password containing multiple special characters should be accepted."""

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -41,6 +41,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 import pytest
 import requests
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import expect, sync_playwright
 
 # ── Config ──
@@ -350,12 +351,32 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         create_btn = modal.locator(".btn-primary").last
         create_btn.click()
         log("Phase 4", "Clicked Create - mock server will handle connection")
-        time.sleep(3)
-        take_screenshot(page, "p4-02-terminal-created")
 
-        # ── Verify: xterm.js rendered ──
+        # The terminal tab mounts asynchronously (tab switch, React mount,
+        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
+        # regularly exceed any fixed sleep, so wait for xterm to actually
+        # attach and dump browser diagnostics if it never does.
+        console_errors: list[str] = []
+        page.on(
+            "console",
+            lambda msg: (
+                console_errors.append(f"[console.{msg.type}] {msg.text}")
+                if msg.type in ("error", "warning")
+                else None
+            ),
+        )
+        page.on("pageerror", lambda err: console_errors.append(f"[pageerror] {err}"))
+
         xterm_screen = page.locator(".xterm-screen")
-        assert xterm_screen.count() > 0, "xterm.js terminal not rendered (no .xterm-screen)"
+        try:
+            xterm_screen.wait_for(state="visible", timeout=30000)
+        except PlaywrightTimeoutError:
+            take_screenshot(page, "error-no-xterm")
+            log("Phase 4", "body text: " + page.locator("body").inner_text()[:400])
+            if console_errors:
+                log("Phase 4", "browser errors: " + " | ".join(console_errors[-10:]))
+            raise
+        take_screenshot(page, "p4-02-terminal-created")
         log("Phase 4", "xterm.js terminal rendered!")
 
         # ── Verify: dark background (terminal area) ──

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -352,7 +352,7 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         # Terminal creation now requires a selected API model in addition to
         # the machine. Local runs can satisfy this quickly, while CI may still
         # be loading models when the machine click returns.
-        model_select = modal.locator("select.form-select:not(.form-select-sm)")
+        model_select = modal.locator("select.form-select")
         try:
             model_select.wait_for(state="visible", timeout=15000)
             expect(model_select).not_to_have_value("", timeout=15000)

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -153,7 +153,7 @@ def start_mock_terminal_server():
 
     async def run_server():
         async with websockets.serve(
-            handle_connection, "localhost", 0, subprotocols=["binary"]
+            handle_connection, "127.0.0.1", 0, subprotocols=["binary"]
         ) as server:
             port_holder[0] = server.sockets[0].getsockname()[1]
             await asyncio.Future()  # run forever
@@ -283,7 +283,9 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         log("Phase 4", "SKIPPED - websockets package not available")
         return
 
-    mock_ws_url = f"ws://localhost:{mock_ws_port}"
+    # 127.0.0.1 (not localhost): on Linux CI chromium resolves localhost to
+    # ::1 first, and the mock server only listens on IPv4.
+    mock_ws_url = f"ws://127.0.0.1:{mock_ws_port}"
     log("Phase 4", f"Mock terminal server running on port {mock_ws_port}")
 
     # Intercept start_terminal API: return mock server info directly
@@ -355,26 +357,40 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         # The terminal tab mounts asynchronously (tab switch, React mount,
         # then a dynamic import of the @xterm/xterm chunk); slow CI runners
         # regularly exceed any fixed sleep, so wait for xterm to actually
-        # attach and dump browser diagnostics if it never does.
-        console_errors: list[str] = []
-        page.on(
+        # attach. Diagnostics attach at the context level so they survive a
+        # full-page navigation, and capture every console level because the
+        # app logs its progress ([Terminal] ... / [TerminalTab] ...) as info.
+        browser_log: list[str] = []
+        page.context.on(
             "console",
-            lambda msg: (
-                console_errors.append(f"[console.{msg.type}] {msg.text}")
-                if msg.type in ("error", "warning")
-                else None
-            ),
+            lambda msg: browser_log.append(f"[console.{msg.type}] {msg.text[:200]}"),
         )
-        page.on("pageerror", lambda err: console_errors.append(f"[pageerror] {err}"))
+        page.context.on("pageerror", lambda err: browser_log.append(f"[pageerror] {err}"))
+        page.context.on(
+            "requestfailed",
+            lambda req: browser_log.append(f"[requestfailed] {req.method} {req.url} {req.failure}"),
+        )
 
         xterm_screen = page.locator(".xterm-screen")
         try:
             xterm_screen.wait_for(state="visible", timeout=30000)
         except PlaywrightTimeoutError:
             take_screenshot(page, "error-no-xterm")
+            log("Phase 4", f"url: {page.url}")
+            try:
+                nav = page.evaluate(
+                    "performance.getEntriesByType('navigation')"
+                    ".map(e => e.type + ' -> ' + e.name)"
+                )
+                root_len = page.evaluate(
+                    "(document.getElementById('root') || {}).innerHTML?.length ?? -1"
+                )
+                log("Phase 4", f"navigation: {nav}; root innerHTML length: {root_len}")
+            except Exception as exc:  # noqa: BLE001 - diagnostics only
+                log("Phase 4", f"page evaluation failed: {exc}")
             log("Phase 4", "body text: " + page.locator("body").inner_text()[:400])
-            if console_errors:
-                log("Phase 4", "browser errors: " + " | ".join(console_errors[-10:]))
+            if browser_log:
+                log("Phase 4", "browser tail: " + " | ".join(browser_log[-25:]))
             raise
         take_screenshot(page, "p4-02-terminal-created")
         log("Phase 4", "xterm.js terminal rendered!")

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -20,11 +20,18 @@ Tests the terminal tab functionality including:
 Run:
   HEADLESS=true  python tests/394/e2e_terminal_tab.py
   HEADLESS=false python tests/394/e2e_terminal_tab.py
+
+Pytest note (#2457): step functions are named `_check_*` and the script is
+driven by `run_all_checks()`. The only collected test is
+`test_e2e_terminal_tab_script`, which re-runs this file as a subprocess
+against BASE_URL (exported by the lane runner) and asserts on its exit
+code — the same pattern as tests/issues/559/e2e_terminal_ws_handler.py.
 """
 
 import asyncio
 import json
 import os
+import subprocess
 import sys
 import time
 import traceback
@@ -32,6 +39,7 @@ import traceback
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 
+import pytest
 import requests
 from playwright.sync_api import expect, sync_playwright
 
@@ -40,8 +48,8 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-terminal-tab")
 
-TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")
-TEST_PASS = "admin123"
+TEST_USER = os.environ.get("TEST_REAL_USER", "admin")
+TEST_PASS = os.environ.get("TEST_REAL_PASS", "admin123")
 
 
 def log(stage, msg):
@@ -53,6 +61,34 @@ def take_screenshot(page, name):
     path = os.path.join(SCREENSHOT_DIR, f"{name}.png")
     page.screenshot(path=path)
     log("Screenshot", path)
+
+
+def _clear_seeded_password_gate():
+    """Clear must_change_password for the seeded admin (lane/CI only, #2457).
+
+    Freshly initialized databases gate the admin behind a password-change
+    flow that would intercept the UI pages this script exercises. Deployed
+    environments keep their own user list and are unaffected (no-op when
+    the default DB is absent or the gate is already clear).
+    """
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "UPDATE users SET must_change_password = 0 "
+                "WHERE username = ? AND must_change_password = 1",
+                (TEST_USER,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        log("Setup", f"password-gate clear skipped: {exc}")
 
 
 def login_via_api():
@@ -141,14 +177,17 @@ def start_mock_terminal_server():
 # ═══════════════════════════════════════════════════════════
 
 
-def test_terminal_option_in_modal(page):
+def _check_terminal_option_in_modal(page):
     """Verify terminal option exists in the new session modal."""
     log("Phase 1", "Navigating to workspace...")
     page.goto(f"{BASE_URL}/work/workspace", wait_until="networkidle", timeout=30000)
     time.sleep(2)
     take_screenshot(page, "p1-01-workspace")
 
-    new_tab_btn = page.locator(".workspace-new-tab-btn")
+    # Sidebar button on a fresh workspace (no tabs yet); the tab-strip
+    # ".workspace-new-tab-btn" only renders once at least one tab exists —
+    # both open the same NewSessionModal (Workspace.tsx / SessionList.tsx)
+    new_tab_btn = page.locator("[data-testid='new-session-btn'], .workspace-new-tab-btn").first
     new_tab_btn.wait_for(state="visible", timeout=10000)
     new_tab_btn.click()
     time.sleep(1)
@@ -180,7 +219,7 @@ def test_terminal_option_in_modal(page):
 # ═══════════════════════════════════════════════════════════
 
 
-def test_session_sync_api(token):
+def _check_session_sync_api(token):
     """Test session-sync API endpoint accepts data."""
     log("Phase 2", "Testing session-sync endpoint...")
     headers = {"Cookie": f"session_token={token}", "Content-Type": "application/json"}
@@ -231,7 +270,7 @@ def test_session_sync_api(token):
 # ═══════════════════════════════════════════════════════════
 
 
-def test_terminal_connection_and_interaction(page, mock_ws_port):
+def _check_terminal_connection_and_interaction(page, mock_ws_port):
     """
     Test full terminal lifecycle with mock WebSocket server.
 
@@ -272,8 +311,8 @@ def test_terminal_connection_and_interaction(page, mock_ws_port):
         page.goto(f"{BASE_URL}/work/workspace", wait_until="networkidle", timeout=30000)
         time.sleep(2)
 
-        # Open new session modal
-        new_tab_btn = page.locator(".workspace-new-tab-btn")
+        # Open new session modal (see Phase 1 note on the selector)
+        new_tab_btn = page.locator("[data-testid='new-session-btn'], .workspace-new-tab-btn").first
         new_tab_btn.wait_for(state="visible", timeout=10000)
         new_tab_btn.click()
         time.sleep(1)
@@ -413,13 +452,14 @@ def test_terminal_connection_and_interaction(page, mock_ws_port):
 # ═══════════════════════════════════════════════════════════
 
 
-def test_terminal_tab():
-    """Run all terminal tab tests."""
+def run_all_checks():
+    """Run all terminal tab checks (script entrypoint)."""
+    _clear_seeded_password_gate()
     token = login_via_api()
     log("Setup", f"Logged in as {TEST_USER}")
 
     # Phase 2: API-level tests
-    test_session_sync_api(token)
+    _check_session_sync_api(token)
 
     # Start mock terminal server for Phase 4
     mock_ws_port = start_mock_terminal_server()
@@ -433,24 +473,21 @@ def test_terminal_tab():
             viewport={"width": 1280, "height": 900},
             locale="en",
         )
-        context.add_cookies(
-            [
-                {
-                    "name": "session_token",
-                    "value": token,
-                    "domain": "localhost",
-                    "path": "/",
-                }
-            ]
-        )
         page = context.new_page()
 
         try:
+            # UI login establishes the full client-side auth state the SPA
+            # needs (cookie alone is not enough for the workspace route)
+            page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
+            page.fill("#username", TEST_USER)
+            page.fill("#password", TEST_PASS)
+            page.click("button[type='submit']")
+            page.wait_for_load_state("networkidle", timeout=30000)
             # Phase 1: Modal UI verification
-            test_terminal_option_in_modal(page)
+            _check_terminal_option_in_modal(page)
 
             # Phase 4: Full terminal connection & interaction
-            test_terminal_connection_and_interaction(page, mock_ws_port)
+            _check_terminal_connection_and_interaction(page, mock_ws_port)
 
             log("Result", "All Phase 1-4 tests passed!")
         except Exception as e:
@@ -468,4 +505,27 @@ if __name__ == "__main__":
     print(f"  BASE_URL:  {BASE_URL}")
     print(f"  HEADLESS:  {HEADLESS}")
     print("=" * 60)
-    test_terminal_tab()
+    run_all_checks()
+
+
+# ═══════════════════════════════════════════════════════════
+# Pytest entry (single collected test; see module docstring)
+# ═══════════════════════════════════════════════════════════
+
+
+def test_e2e_terminal_tab_script():
+    """Drive this script as a subprocess against BASE_URL (#2457)."""
+    try:
+        resp = requests.get(f"{BASE_URL}/login", timeout=5)
+        resp.raise_for_status()
+    except Exception:
+        pytest.skip(f"test server not reachable at {BASE_URL}")
+
+    proc = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"script failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "All Phase 1-4 tests passed!" in proc.stdout

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -20,18 +20,11 @@ Tests the terminal tab functionality including:
 Run:
   HEADLESS=true  python tests/394/e2e_terminal_tab.py
   HEADLESS=false python tests/394/e2e_terminal_tab.py
-
-Pytest note (#2457): step functions are named `_check_*` and the script is
-driven by `run_all_checks()`. The only collected test is
-`test_e2e_terminal_tab_script`, which re-runs this file as a subprocess
-against BASE_URL (exported by the lane runner) and asserts on its exit
-code — the same pattern as tests/issues/559/e2e_terminal_ws_handler.py.
 """
 
 import asyncio
 import json
 import os
-import subprocess
 import sys
 import time
 import traceback
@@ -39,7 +32,6 @@ import traceback
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 
-import pytest
 import requests
 from playwright.sync_api import expect, sync_playwright
 
@@ -48,8 +40,8 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-terminal-tab")
 
-TEST_USER = os.environ.get("TEST_REAL_USER", "admin")
-TEST_PASS = os.environ.get("TEST_REAL_PASS", "admin123")
+TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")
+TEST_PASS = "admin123"
 
 
 def log(stage, msg):
@@ -61,34 +53,6 @@ def take_screenshot(page, name):
     path = os.path.join(SCREENSHOT_DIR, f"{name}.png")
     page.screenshot(path=path)
     log("Screenshot", path)
-
-
-def _clear_seeded_password_gate():
-    """Clear must_change_password for the seeded admin (lane/CI only, #2457).
-
-    Freshly initialized databases gate the admin behind a password-change
-    flow that would intercept the UI pages this script exercises. Deployed
-    environments keep their own user list and are unaffected (no-op when
-    the default DB is absent or the gate is already clear).
-    """
-    db_path = os.path.expanduser("~/.open-ace/ace.db")
-    if not os.path.exists(db_path):
-        return
-    import sqlite3
-
-    try:
-        conn = sqlite3.connect(db_path)
-        try:
-            conn.execute(
-                "UPDATE users SET must_change_password = 0 "
-                "WHERE username = ? AND must_change_password = 1",
-                (TEST_USER,),
-            )
-            conn.commit()
-        finally:
-            conn.close()
-    except sqlite3.Error as exc:
-        log("Setup", f"password-gate clear skipped: {exc}")
 
 
 def login_via_api():
@@ -177,17 +141,14 @@ def start_mock_terminal_server():
 # ═══════════════════════════════════════════════════════════
 
 
-def _check_terminal_option_in_modal(page):
+def test_terminal_option_in_modal(page):
     """Verify terminal option exists in the new session modal."""
     log("Phase 1", "Navigating to workspace...")
     page.goto(f"{BASE_URL}/work/workspace", wait_until="networkidle", timeout=30000)
     time.sleep(2)
     take_screenshot(page, "p1-01-workspace")
 
-    # Sidebar button on a fresh workspace (no tabs yet); the tab-strip
-    # ".workspace-new-tab-btn" only renders once at least one tab exists —
-    # both open the same NewSessionModal (Workspace.tsx / SessionList.tsx)
-    new_tab_btn = page.locator("[data-testid='new-session-btn'], .workspace-new-tab-btn").first
+    new_tab_btn = page.locator(".workspace-new-tab-btn")
     new_tab_btn.wait_for(state="visible", timeout=10000)
     new_tab_btn.click()
     time.sleep(1)
@@ -219,7 +180,7 @@ def _check_terminal_option_in_modal(page):
 # ═══════════════════════════════════════════════════════════
 
 
-def _check_session_sync_api(token):
+def test_session_sync_api(token):
     """Test session-sync API endpoint accepts data."""
     log("Phase 2", "Testing session-sync endpoint...")
     headers = {"Cookie": f"session_token={token}", "Content-Type": "application/json"}
@@ -270,7 +231,7 @@ def _check_session_sync_api(token):
 # ═══════════════════════════════════════════════════════════
 
 
-def _check_terminal_connection_and_interaction(page, mock_ws_port):
+def test_terminal_connection_and_interaction(page, mock_ws_port):
     """
     Test full terminal lifecycle with mock WebSocket server.
 
@@ -311,8 +272,8 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         page.goto(f"{BASE_URL}/work/workspace", wait_until="networkidle", timeout=30000)
         time.sleep(2)
 
-        # Open new session modal (see Phase 1 note on the selector)
-        new_tab_btn = page.locator("[data-testid='new-session-btn'], .workspace-new-tab-btn").first
+        # Open new session modal
+        new_tab_btn = page.locator(".workspace-new-tab-btn")
         new_tab_btn.wait_for(state="visible", timeout=10000)
         new_tab_btn.click()
         time.sleep(1)
@@ -452,14 +413,13 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
 # ═══════════════════════════════════════════════════════════
 
 
-def run_all_checks():
-    """Run all terminal tab checks (script entrypoint)."""
-    _clear_seeded_password_gate()
+def test_terminal_tab():
+    """Run all terminal tab tests."""
     token = login_via_api()
     log("Setup", f"Logged in as {TEST_USER}")
 
     # Phase 2: API-level tests
-    _check_session_sync_api(token)
+    test_session_sync_api(token)
 
     # Start mock terminal server for Phase 4
     mock_ws_port = start_mock_terminal_server()
@@ -473,21 +433,24 @@ def run_all_checks():
             viewport={"width": 1280, "height": 900},
             locale="en",
         )
+        context.add_cookies(
+            [
+                {
+                    "name": "session_token",
+                    "value": token,
+                    "domain": "localhost",
+                    "path": "/",
+                }
+            ]
+        )
         page = context.new_page()
 
         try:
-            # UI login establishes the full client-side auth state the SPA
-            # needs (cookie alone is not enough for the workspace route)
-            page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
-            page.fill("#username", TEST_USER)
-            page.fill("#password", TEST_PASS)
-            page.click("button[type='submit']")
-            page.wait_for_load_state("networkidle", timeout=30000)
             # Phase 1: Modal UI verification
-            _check_terminal_option_in_modal(page)
+            test_terminal_option_in_modal(page)
 
             # Phase 4: Full terminal connection & interaction
-            _check_terminal_connection_and_interaction(page, mock_ws_port)
+            test_terminal_connection_and_interaction(page, mock_ws_port)
 
             log("Result", "All Phase 1-4 tests passed!")
         except Exception as e:
@@ -505,27 +468,4 @@ if __name__ == "__main__":
     print(f"  BASE_URL:  {BASE_URL}")
     print(f"  HEADLESS:  {HEADLESS}")
     print("=" * 60)
-    run_all_checks()
-
-
-# ═══════════════════════════════════════════════════════════
-# Pytest entry (single collected test; see module docstring)
-# ═══════════════════════════════════════════════════════════
-
-
-def test_e2e_terminal_tab_script():
-    """Drive this script as a subprocess against BASE_URL (#2457)."""
-    try:
-        resp = requests.get(f"{BASE_URL}/login", timeout=5)
-        resp.raise_for_status()
-    except Exception:
-        pytest.skip(f"test server not reachable at {BASE_URL}")
-
-    proc = subprocess.run(
-        [sys.executable, os.path.abspath(__file__)],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    assert proc.returncode == 0, f"script failed:\n{proc.stdout}\n{proc.stderr}"
-    assert "All Phase 1-4 tests passed!" in proc.stdout
+    test_terminal_tab()

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -349,17 +349,23 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         machine_list.first.click()
         time.sleep(0.5)
 
-        # Click Create - this triggers the intercepted start_terminal API
-        create_btn = modal.locator(".btn-primary").last
-        create_btn.click()
-        log("Phase 4", "Clicked Create - mock server will handle connection")
+        # Terminal creation now requires a selected API model in addition to
+        # the machine. Local runs can satisfy this quickly, while CI may still
+        # be loading models when the machine click returns.
+        model_select = modal.locator("select.form-select")
+        try:
+            model_select.wait_for(state="visible", timeout=15000)
+            expect(model_select).not_to_have_value("", timeout=15000)
+            log("Phase 4", f"Selected terminal model: {model_select.input_value()}")
+        except PlaywrightTimeoutError:
+            log("Phase 4", "terminal model selector did not become ready")
+            log("Phase 4", "modal text: " + modal.inner_text()[:500])
+            raise
 
-        # The terminal tab mounts asynchronously (tab switch, React mount,
-        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
-        # regularly exceed any fixed sleep, so wait for xterm to actually
-        # attach. Diagnostics attach at the context level so they survive a
-        # full-page navigation, and capture every console level because the
-        # app logs its progress ([Terminal] ... / [TerminalTab] ...) as info.
+        # Diagnostics attach before Create so they capture failed start
+        # requests as well as terminal mount/connect issues. Use the context
+        # level so logs survive any full-page navigation, and capture every
+        # console level because the app logs its progress as info.
         browser_log: list[str] = []
         page.context.on(
             "console",
@@ -371,6 +377,16 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
             lambda req: browser_log.append(f"[requestfailed] {req.method} {req.url} {req.failure}"),
         )
 
+        # Click Create - this triggers the intercepted start_terminal API
+        create_btn = modal.locator(".btn-primary").last
+        expect(create_btn).to_be_enabled(timeout=15000)
+        create_btn.click()
+        log("Phase 4", "Clicked Create - mock server will handle connection")
+
+        # The terminal tab mounts asynchronously (tab switch, React mount,
+        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
+        # regularly exceed any fixed sleep, so wait for xterm to actually
+        # attach.
         xterm_screen = page.locator(".xterm-screen")
         try:
             xterm_screen.wait_for(state="visible", timeout=30000)

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -41,7 +41,6 @@ sys.path.insert(0, PROJECT_ROOT)
 
 import pytest
 import requests
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import expect, sync_playwright
 
 # ── Config ──
@@ -351,32 +350,12 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         create_btn = modal.locator(".btn-primary").last
         create_btn.click()
         log("Phase 4", "Clicked Create - mock server will handle connection")
-
-        # The terminal tab mounts asynchronously (tab switch, React mount,
-        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
-        # regularly exceed any fixed sleep, so wait for xterm to actually
-        # attach and dump browser diagnostics if it never does.
-        console_errors: list[str] = []
-        page.on(
-            "console",
-            lambda msg: (
-                console_errors.append(f"[console.{msg.type}] {msg.text}")
-                if msg.type in ("error", "warning")
-                else None
-            ),
-        )
-        page.on("pageerror", lambda err: console_errors.append(f"[pageerror] {err}"))
-
-        xterm_screen = page.locator(".xterm-screen")
-        try:
-            xterm_screen.wait_for(state="visible", timeout=30000)
-        except PlaywrightTimeoutError:
-            take_screenshot(page, "error-no-xterm")
-            log("Phase 4", "body text: " + page.locator("body").inner_text()[:400])
-            if console_errors:
-                log("Phase 4", "browser errors: " + " | ".join(console_errors[-10:]))
-            raise
+        time.sleep(3)
         take_screenshot(page, "p4-02-terminal-created")
+
+        # ── Verify: xterm.js rendered ──
+        xterm_screen = page.locator(".xterm-screen")
+        assert xterm_screen.count() > 0, "xterm.js terminal not rendered (no .xterm-screen)"
         log("Phase 4", "xterm.js terminal rendered!")
 
         # ── Verify: dark background (terminal area) ──

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -352,7 +352,7 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         # Terminal creation now requires a selected API model in addition to
         # the machine. Local runs can satisfy this quickly, while CI may still
         # be loading models when the machine click returns.
-        model_select = modal.locator("select.form-select")
+        model_select = modal.locator("select.form-select:not(.form-select-sm)")
         try:
             model_select.wait_for(state="visible", timeout=15000)
             expect(model_select).not_to_have_value("", timeout=15000)

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -349,23 +349,17 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         machine_list.first.click()
         time.sleep(0.5)
 
-        # Terminal creation now requires a selected API model in addition to
-        # the machine. Local runs can satisfy this quickly, while CI may still
-        # be loading models when the machine click returns.
-        model_select = modal.locator("select.form-select")
-        try:
-            model_select.wait_for(state="visible", timeout=15000)
-            expect(model_select).not_to_have_value("", timeout=15000)
-            log("Phase 4", f"Selected terminal model: {model_select.input_value()}")
-        except PlaywrightTimeoutError:
-            log("Phase 4", "terminal model selector did not become ready")
-            log("Phase 4", "modal text: " + modal.inner_text()[:500])
-            raise
+        # Click Create - this triggers the intercepted start_terminal API
+        create_btn = modal.locator(".btn-primary").last
+        create_btn.click()
+        log("Phase 4", "Clicked Create - mock server will handle connection")
 
-        # Diagnostics attach before Create so they capture failed start
-        # requests as well as terminal mount/connect issues. Use the context
-        # level so logs survive any full-page navigation, and capture every
-        # console level because the app logs its progress as info.
+        # The terminal tab mounts asynchronously (tab switch, React mount,
+        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
+        # regularly exceed any fixed sleep, so wait for xterm to actually
+        # attach. Diagnostics attach at the context level so they survive a
+        # full-page navigation, and capture every console level because the
+        # app logs its progress ([Terminal] ... / [TerminalTab] ...) as info.
         browser_log: list[str] = []
         page.context.on(
             "console",
@@ -377,16 +371,6 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
             lambda req: browser_log.append(f"[requestfailed] {req.method} {req.url} {req.failure}"),
         )
 
-        # Click Create - this triggers the intercepted start_terminal API
-        create_btn = modal.locator(".btn-primary").last
-        expect(create_btn).to_be_enabled(timeout=15000)
-        create_btn.click()
-        log("Phase 4", "Clicked Create - mock server will handle connection")
-
-        # The terminal tab mounts asynchronously (tab switch, React mount,
-        # then a dynamic import of the @xterm/xterm chunk); slow CI runners
-        # regularly exceed any fixed sleep, so wait for xterm to actually
-        # attach.
         xterm_screen = page.locator(".xterm-screen")
         try:
             xterm_screen.wait_for(state="visible", timeout=30000)

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -153,7 +153,7 @@ def start_mock_terminal_server():
 
     async def run_server():
         async with websockets.serve(
-            handle_connection, "127.0.0.1", 0, subprotocols=["binary"]
+            handle_connection, "localhost", 0, subprotocols=["binary"]
         ) as server:
             port_holder[0] = server.sockets[0].getsockname()[1]
             await asyncio.Future()  # run forever
@@ -283,9 +283,7 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         log("Phase 4", "SKIPPED - websockets package not available")
         return
 
-    # 127.0.0.1 (not localhost): on Linux CI chromium resolves localhost to
-    # ::1 first, and the mock server only listens on IPv4.
-    mock_ws_url = f"ws://127.0.0.1:{mock_ws_port}"
+    mock_ws_url = f"ws://localhost:{mock_ws_port}"
     log("Phase 4", f"Mock terminal server running on port {mock_ws_port}")
 
     # Intercept start_terminal API: return mock server info directly
@@ -357,40 +355,26 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port):
         # The terminal tab mounts asynchronously (tab switch, React mount,
         # then a dynamic import of the @xterm/xterm chunk); slow CI runners
         # regularly exceed any fixed sleep, so wait for xterm to actually
-        # attach. Diagnostics attach at the context level so they survive a
-        # full-page navigation, and capture every console level because the
-        # app logs its progress ([Terminal] ... / [TerminalTab] ...) as info.
-        browser_log: list[str] = []
-        page.context.on(
+        # attach and dump browser diagnostics if it never does.
+        console_errors: list[str] = []
+        page.on(
             "console",
-            lambda msg: browser_log.append(f"[console.{msg.type}] {msg.text[:200]}"),
+            lambda msg: (
+                console_errors.append(f"[console.{msg.type}] {msg.text}")
+                if msg.type in ("error", "warning")
+                else None
+            ),
         )
-        page.context.on("pageerror", lambda err: browser_log.append(f"[pageerror] {err}"))
-        page.context.on(
-            "requestfailed",
-            lambda req: browser_log.append(f"[requestfailed] {req.method} {req.url} {req.failure}"),
-        )
+        page.on("pageerror", lambda err: console_errors.append(f"[pageerror] {err}"))
 
         xterm_screen = page.locator(".xterm-screen")
         try:
             xterm_screen.wait_for(state="visible", timeout=30000)
         except PlaywrightTimeoutError:
             take_screenshot(page, "error-no-xterm")
-            log("Phase 4", f"url: {page.url}")
-            try:
-                nav = page.evaluate(
-                    "performance.getEntriesByType('navigation')"
-                    ".map(e => e.type + ' -> ' + e.name)"
-                )
-                root_len = page.evaluate(
-                    "(document.getElementById('root') || {}).innerHTML?.length ?? -1"
-                )
-                log("Phase 4", f"navigation: {nav}; root innerHTML length: {root_len}")
-            except Exception as exc:  # noqa: BLE001 - diagnostics only
-                log("Phase 4", f"page evaluation failed: {exc}")
             log("Phase 4", "body text: " + page.locator("body").inner_text()[:400])
-            if browser_log:
-                log("Phase 4", "browser tail: " + " | ".join(browser_log[-25:]))
+            if console_errors:
+                log("Phase 4", "browser errors: " + " | ".join(console_errors[-10:]))
             raise
         take_screenshot(page, "p4-02-terminal-created")
         log("Phase 4", "xterm.js terminal rendered!")

--- a/tests/issues/987/test_prompt_truncation.py
+++ b/tests/issues/987/test_prompt_truncation.py
@@ -46,7 +46,7 @@ def _make_workflow(**overrides):
     return base
 
 
-def _make_agent_result(text="代码审查通过"):
+def _make_agent_result(text='REVIEW_RESULT: {"verdict": "APPROVE", "blocking_findings": []}'):
     return AgentTaskResult(
         session_id="sess-1",
         response_text=text,
@@ -60,6 +60,7 @@ def _make_agent_result(text="代码审查通过"):
 
 def _make_gh():
     gh = MagicMock()
+    gh.get_current_branch.return_value = "feature-x"
     gh.get_diff_stats.return_value = {
         "commits": 1,
         "additions": 5,
@@ -90,6 +91,7 @@ def _make_orchestrator(wf):
         orch.repo = mock_repo
 
     orch.emitter = MagicMock()
+    orch._validate_autonomous_change_scope = MagicMock(return_value="")
     orch._get_gh = MagicMock()
     orch._poll_ci_status = MagicMock(return_value=[])
     orch._smart_truncate_diff = MagicMock(return_value="DIFF_TEXT")
@@ -250,7 +252,7 @@ class TestPostGithubComment:
         gh.add_issue_comment.assert_not_called()
 
     def test_long_body_capped_with_notice(self):
-        orch = _make_orchestrator(_make_workflow())
+        orch = _make_orchestrator(_make_workflow(content_language="zh"))
         gh = MagicMock()
         long_body = "B" * (GITHUB_COMMENT_MAX_CHARS + 5000)
         orch._post_github_comment(gh, 42, long_body, context="report")


### PR DESCRIPTION
# Three-cluster closeout: 172 / 1895 / 987 (baseline 85 -> 73)

Refs #2457

This PR covers the three stable clusters from the combined branch. The
394 terminal-tab cluster is intentionally left in the baseline after repeated
CI-only no-mount results; it should continue separately with the diagnostics
captured from runs 32368673760 / 32370398802 / 32371732259.

## What changed

- **172 quota e2e (4 entries)** - `tests/issues/172/e2e_quota_enforcement.py`
  was a manual deployment diagnostic mis-collected by pytest: its check
  functions took plain args that pytest misread as missing fixtures. The
  script now lives in `manual_e2e_quota_enforcement.py` (explicitly out of
  discovery), and the historical path stays as a pointer+guard test so the
  lane's round-robin file sharding is unchanged.
- **1895 redis auth (4 entries)** - production evolved to fail-closed: an
  empty `REDIS_PASSWORD` in development now raises `RuntimeError` instead of
  warning/auto-generating. The dev-empty-password assertion now matches that
  fail-closed contract, and special-char password cases are long enough for
  the current validation minimum.
- **987 prompt truncation (4 entries)** - fixtures drifted from the
  phase-migrated autonomous review flow: the fake agent result must be a
  `REVIEW_RESULT: {...}` JSON verdict, `gh.get_current_branch` and
  `_validate_autonomous_change_scope` are mocked, and the zh content-language
  case constructs its orchestrator accordingly.

## Main-drift alignment included

- **1788 sso email linking (new failure, not a baseline entry)** - 906a1b0c
  (#2755) made `_finalize_sso_login` call `get_user_by_email(email,
  include_deleted=False)` to exclude soft-deleted users from email linking.
  The test assertion now includes that keyword argument; production behavior
  is unchanged.

## Evidence

- Local lanes: 172 `1 passed`; 1895 `22 passed`; 987 `8 passed`; 1788
  `16 passed`, all via `scripts/run_extended_tests.py --category issues
  --server auto --isolated-home`.
- Run A (pre-prune head, commit `461861d8`): https://github.com/open-ace/open-ace/actions/runs/32373066502 -
  expected exit 1 with 12 baseline removals, and `new/changed/invalid/collection_errors = 0`.
- Prune commit shrinks `ci/legacy-issue-failures.json` 85 -> 73 citing run A.
- Run B (pruned head, commit `1f6c077c`): https://github.com/open-ace/open-ace/actions/runs/32374524757 -
  exit 0, all-zero diff.

## Notes

- 394 remains in baseline for a separate pass; the current CI evidence shows
  the model is selected and Create is clicked, but the terminal tab still does
  not mount in CI.
- Follow-up outside this PR: rotate the pre-existing production DB password
  referenced by the 172 manual diagnostic.
