### PR TITLE
fix(models): parse 'Z'-suffixed timestamps in Session/User from_dict (py3.10 — fixes red main)

### DIFF
--- a/app/models/session.py
+++ b/app/models/session.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from app.models.user import User
-from app.utils.datetime_utils import ensure_utc_suffix
+from app.utils.datetime_utils import ensure_utc_suffix, parse_utc
 
 
 @dataclass
@@ -47,12 +47,8 @@ class Session:
             email=data.get("email"),
             role=data.get("role", "user"),
             token=data.get("token", ""),
-            created_at=(
-                datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None
-            ),
-            expires_at=(
-                datetime.fromisoformat(data["expires_at"]) if data.get("expires_at") else None
-            ),
+            created_at=parse_utc(data.get("created_at")),
+            expires_at=parse_utc(data.get("expires_at")),
         )
 
     def is_expired(self) -> bool:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
-from app.utils.datetime_utils import ensure_utc_suffix
+from app.utils.datetime_utils import ensure_utc_suffix, parse_utc
 
 
 class UserRole(Enum):
@@ -92,12 +92,8 @@ class User:
             password_hash=data.get("password_hash", ""),
             role=data.get("role", "user"),
             is_active=data.get("is_active", True),
-            created_at=(
-                datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None
-            ),
-            last_login=(
-                datetime.fromisoformat(data["last_login"]) if data.get("last_login") else None
-            ),
+            created_at=parse_utc(data.get("created_at")),
+            last_login=parse_utc(data.get("last_login")),
             tenant_id=data.get("tenant_id"),
             daily_token_quota=data.get("daily_token_quota"),
             monthly_token_quota=data.get("monthly_token_quota"),

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -63,3 +63,43 @@ def ensure_utc_suffix(timestamp: str | datetime | None) -> str | None:
     if timestamp.endswith("Z") or _TZ_PATTERN.search(timestamp):
         return timestamp
     return timestamp + "Z"
+
+
+def parse_utc(value: str | datetime | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp (accepting a trailing ``Z``) into a datetime.
+
+    Read-path companion to :func:`ensure_utc_suffix`. Python 3.10's
+    ``datetime.fromisoformat`` rejects the trailing ``Z`` that
+    ``ensure_utc_suffix`` emits (Python 3.11+ accepts it), so serializing a
+    timestamp with ``ensure_utc_suffix`` and reading it back with a bare
+    ``fromisoformat`` breaks the round-trip on 3.10. Normalizing ``Z`` to
+    ``+00:00`` keeps parsing consistent across supported Python versions.
+
+    This is the tight companion to :func:`ensure_utc_suffix` for model
+    (de)serialization, where inputs are ISO strings from ``datetime.isoformat()``.
+    For raw database text (space-separated timestamps, variable fractional-second
+    widths) use :func:`app.utils.helpers.parse_db_datetime` instead.
+
+    Args:
+        value: A ``datetime`` (returned unchanged), an ISO-8601 string, or
+            ``None``.
+
+    Returns:
+        A ``datetime`` (timezone-aware when the string carried ``Z`` or an
+        offset), or ``None`` for ``None``/blank input.
+
+    Examples:
+        >>> parse_utc(None) is None
+        True
+        >>> parse_utc('2026-08-06T09:54:57Z').tzinfo is not None
+        True
+        >>> parse_utc('2026-08-06T09:54:57').tzinfo is None
+        True
+    """
+    if value is None or isinstance(value, datetime):
+        return value
+    if not value.strip():
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/tests/unit/test_datetime_utils.py
+++ b/tests/unit/test_datetime_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from app.utils.datetime_utils import ensure_utc_suffix
+from app.utils.datetime_utils import ensure_utc_suffix, parse_utc
 
 
 class TestEnsureUtcSuffix:
@@ -76,3 +76,52 @@ class TestEnsureUtcSuffix:
         # This is already covered by test_none_input, but we add it for completeness
         # to show that the function handles both str | datetime | None types
         assert ensure_utc_suffix(None) is None
+
+
+class TestParseUtc:
+    """Test cases for parse_utc (read-path companion to ensure_utc_suffix)."""
+
+    def test_none_returns_none(self):
+        """None input returns None."""
+        assert parse_utc(None) is None
+
+    def test_blank_returns_none(self):
+        """Blank/whitespace input returns None."""
+        assert parse_utc("   ") is None
+
+    def test_datetime_passthrough(self):
+        """A datetime is returned unchanged (defensive against pre-parsed input)."""
+        dt = datetime(2025, 12, 1, 8, 30, 0)
+        assert parse_utc(dt) is dt
+
+    def test_z_suffix_parses_to_aware_utc(self):
+        """Regression: Python 3.10's fromisoformat rejects the 'Z' that
+        ensure_utc_suffix emits; parse_utc must accept it on every version."""
+        assert parse_utc("2025-12-01T08:30:00Z") == datetime(
+            2025, 12, 1, 8, 30, 0, tzinfo=timezone.utc
+        )
+
+    def test_z_suffix_with_microseconds(self):
+        """The exact shape isoformat() emits for non-zero microseconds -- the
+        form that broke main's 3.10 lane."""
+        assert parse_utc("2026-08-06T09:54:57.981635Z") == datetime(
+            2026, 8, 6, 9, 54, 57, 981635, tzinfo=timezone.utc
+        )
+
+    def test_naive_string_parses_naive(self):
+        """A string with no offset parses to a naive datetime."""
+        result = parse_utc("2025-12-01T08:30:00")
+        assert result == datetime(2025, 12, 1, 8, 30, 0)
+        assert result.tzinfo is None
+
+    def test_offset_string_preserved(self):
+        """An explicit offset is preserved (not coerced to UTC)."""
+        assert parse_utc("2025-12-01T08:30:00-08:00") == datetime(
+            2025, 12, 1, 8, 30, 0, tzinfo=timezone(timedelta(hours=-8))
+        )
+
+    def test_roundtrip_with_ensure_utc_suffix(self):
+        """The exact serialize -> deserialize path the models use."""
+        serialized = ensure_utc_suffix(datetime(2025, 12, 1, 8, 30, 0))
+        assert serialized == "2025-12-01T08:30:00Z"
+        assert parse_utc(serialized) == datetime(2025, 12, 1, 8, 30, 0, tzinfo=timezone.utc)

--- a/tests/unit/test_models_user.py
+++ b/tests/unit/test_models_user.py
@@ -1,0 +1,56 @@
+"""Unit tests for the User model's dict (de)serialization.
+
+Regression coverage for the Python 3.10 round-trip bug: User.to_dict emits UTC
+'Z'-suffixed timestamps via ensure_utc_suffix, and User.from_dict must parse
+them back on every supported Python version (3.10's datetime.fromisoformat
+rejects a bare 'Z').
+"""
+
+from datetime import datetime
+
+from app.models.user import User
+
+
+class TestUserFromDictTimestamps:
+    def test_from_dict_parses_z_suffixed_timestamps(self):
+        """A 'Z'-suffixed timestamp from to_dict parses without raising."""
+        data = {
+            "id": 1,
+            "username": "u",
+            "email": "u@test.com",
+            "role": "user",
+            "created_at": "2025-12-01T08:30:00Z",
+            "last_login": "2025-12-02T08:30:00Z",
+        }
+        user = User.from_dict(data)
+        assert user.created_at is not None
+        assert (user.created_at.year, user.created_at.month, user.created_at.day) == (
+            2025,
+            12,
+            1,
+        )
+        assert user.last_login is not None
+
+    def test_roundtrip_to_dict_from_dict(self):
+        """to_dict -> from_dict survives the ensure_utc_suffix/parse_utc pair."""
+        original = User(
+            id=100,
+            username="roundtrip",
+            email="rt@test.com",
+            role="user",
+            created_at=datetime(2025, 12, 1, 8, 30, 0),
+            last_login=datetime(2025, 12, 2, 8, 30, 0),
+        )
+        restored = User.from_dict(original.to_dict())
+        assert restored.id == original.id
+        assert restored.username == original.username
+        assert restored.email == original.email
+        assert restored.role == original.role
+        assert restored.created_at is not None
+        assert restored.last_login is not None
+
+    def test_from_dict_none_timestamps(self):
+        """Missing/None timestamps stay None."""
+        user = User.from_dict({"username": "u", "created_at": None, "last_login": None})
+        assert user.created_at is None
+        assert user.last_login is None


### PR DESCRIPTION
## What & why

**`main` is currently red** on the Python 3.10 compatibility lane — `test_models_session.py::test_roundtrip_to_dict_from_dict` fails with `ValueError: Invalid isoformat string: '2025-12-01T08:30:00Z'`. Small, focused fix (surfaced while working the eval §6.2 follow-ups — the Docker PR #2839's CI is blocked by this via the PR merge ref).

## Root cause

`Session.to_dict` / `User.to_dict` emit UTC `Z`-suffixed timestamps via `ensure_utc_suffix`, but their `from_dict` still called bare `datetime.fromisoformat()`, which **rejects a trailing `Z` on Python 3.10** (3.11+ accepts it). So the serialize→deserialize round-trip breaks only on 3.10. `app/models/message.py` already avoids this by normalizing `Z` on read; this generalizes the pattern.

## Fix

- Add `parse_utc()` to [`app/utils/datetime_utils.py`](app/utils/datetime_utils.py) — a read-path companion to `ensure_utc_suffix` that normalizes a trailing `Z` to `+00:00` before `fromisoformat` (consistent across 3.10–3.14).
- Use it in `Session.from_dict` (created_at, expires_at) and `User.from_dict` (created_at, last_login).

Behavior on 3.11+ is unchanged — `parse_utc('…Z')` yields the same timezone-aware datetime `fromisoformat` already produced there; only 3.10 is fixed.

## Scope

Fixes the two models whose `to_dict` emits `Z` while `from_dict` didn't handle it (**Session, User**). `tenant.py` / `tool_account_mapping_rule.py` don't emit `Z` from `to_dict`, so they aren't affected; `message.py` already handles it.

## Verification

- `parse_utc` parses `'…Z'` on **real Python 3.10** (direct module load, bypassing the app package).
- New `parse_utc` unit tests, the previously-failing Session roundtrip, and a **new `tests/unit/test_models_user.py`** roundtrip all pass (37 tests) under local Python; pre-commit clean.
- CI's 3.10 compatibility lane is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
