### PR TITLE
test: backfill 716/1002 fixtures for lease-anchored in-progress reclaim (#2457)

### DIFF
--- a/tests/issues/1002/test_waiting_bypass.py
+++ b/tests/issues/1002/test_waiting_bypass.py
@@ -159,6 +159,10 @@ class TestAdvanceSingleWaitingCleanup:
         sched._in_progress_batch_ids.add("batch-1")
         sched._in_progress_workspaces.add("/proj")
         sched._in_progress_branches.add("shared/branch")
+        # Teardown discards exactly the keys the entry reserved at selection
+        # time (c0ebbf7f key map); a map-less entry is a pre-deploy legacy
+        # shape nobody owns, so register w-dev's keys the way selection does
+        sched._in_progress_key_map["w-dev"] = ("batch-1", "/proj", "shared/branch")
 
         developing_wf = {
             "workflow_id": "w-dev",

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -1,6 +1,7 @@
 """Unit tests for AutonomousScheduler."""
 
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -294,6 +295,12 @@ class TestSchedulerProcessWorkflows:
 
         # Mark wf-1 as already in progress
         scheduler._in_progress_ids.add("wf-1")
+        # ... backed by a fresh locked_at lease: the lease-anchored reclaim
+        # (c0ebbf7f) reaps in-progress memory entries with no live lease
+        # behind them, so the fixture must give wf-1 one.
+        mock_repo.get_active_workflows.return_value[0]["locked_at"] = datetime.now(
+            timezone.utc
+        ).strftime("%Y-%m-%d %H:%M:%S")
 
         with patch(
             "app.routes.autonomous._get_repo",


### PR DESCRIPTION
Refs #2457

## Main stabilization: two deterministic new failures on tonight's main

Today's lease-anchored in-progress self-heal (c0ebbf7f, merged via #2849's main state) reaps in-progress memory entries with no live DB lease behind them, and moved conflict-key teardown to the selection-time `_in_progress_key_map`. Its review pass backfilled the 2295 fixtures but missed two, which now fail deterministically on main content — tonight's extended-tests dispatches (32278265003, 32269376164) show both as `new` failures, which would also redden the nightly baseline gate:

- `tests/issues/716/test_scheduler.py::TestSchedulerProcessWorkflows::test_in_progress_ids_prevent_duplicate` — the fixture marks wf-1 in-progress but its active row carries no `locked_at`; the reclaim correctly treats that as a leaked entry ("active, lease=NULL") and reaps it, so both workflows advance (`assert 2 == 1`). Fix: give wf-1's row a fresh lease so the fixture represents a live worker.
- `tests/issues/1002/test_waiting_bypass.py::TestAdvanceSingleWaitingCleanup::test_developing_does_discard_batch_id` — teardown releases exactly the keys recorded in `_in_progress_key_map`; the fixture seeds the raw conflict-key sets only (a map-less legacy shape nobody owns), so nothing is released (`assert 'batch-1' not in {'batch-1'}`). Fix: register w-dev's keys the way selection does.

No baseline entries are pruned (shrink-only rule untouched); both nodeids were passing before c0ebbf7f and are not in the quarantine baseline.

## Evidence

- Reproduction (negative control = main itself): both nodeids fail deterministically in local lane runs (`--isolated-home`) on current main and in tonight's CI runs; they passed in all pre-c0ebbf7f runs (e.g. 863 final run).
- Fix: local lane on this branch — issue 716: 355 passed; issue 1002: 40 passed.
- Branch verification run: to attach on completion — expected exit_code=0 with new/resolved/changed/invalid/collection_errors all 0.