### PR TITLE
fix(scheduler): deprecate unsafe advisory leader-election lock (eval §6.2 P2-1)

### DIFF
--- a/app/services/distributed_scheduler.py
+++ b/app/services/distributed_scheduler.py
@@ -32,7 +32,7 @@ class DistributedScheduler:
     Example:
         class MyScheduler(DistributedScheduler):
             def __init__(self, db: Database):
-                super().__init__("my_scheduler", db, strategy="advisory")
+                super().__init__("my_scheduler", db, strategy="heartbeat")
 
             def run(self):
                 self.run_with_lock(self._run_job)
@@ -134,9 +134,14 @@ class DistributedScheduler:
             # Record execution
             client.record_run(status, duration_ms, error_message)
 
-            # Release leadership (for heartbeat strategy)
-            if self.strategy == "heartbeat":
-                client.release_leadership()
+            # Release leadership. The client always holds the lease via the
+            # heartbeat strategy after acquisition (the deprecated "advisory"
+            # strategy falls back to heartbeat), so the leader row + heartbeat
+            # thread must be released regardless of the requested strategy.
+            # Gating on self.strategy == "heartbeat" would leak both for an
+            # "advisory"/"auto" scheduler; release_leadership() is a safe no-op
+            # when this client is not the leader.
+            client.release_leadership()
 
         return True
 

--- a/app/services/leader_election.py
+++ b/app/services/leader_election.py
@@ -1,25 +1,27 @@
 """
 Open ACE - Distributed Leader Election
 
-Provides leader election mechanisms for distributed scheduler coordination.
-Supports two strategies:
+Provides leader election for distributed scheduler coordination via the
+Heartbeat strategy: a ``scheduler_leaders`` row with periodic heartbeat
+updates, supporting leader expiration and failover. This is the mechanism
+every caller uses and the only one here that provides mutual exclusion
+spanning a caller's critical section.
 
-Strategy A (Advisory Lock): For short tasks (< 5 minutes)
-- Uses PostgreSQL session-level advisory locks
-- Lock held within transaction scope
-- Automatically released on commit/rollback/connection close
-
-Strategy B (Heartbeat): For long tasks (> 5 minutes)
-- Uses scheduler_leaders table with periodic heartbeat updates
-- Supports leader expiration and failover
-- Requires manual release or expiration timeout
+Deprecated -- Advisory Lock strategy (``strategy="advisory"``):
+    This strategy is unsafe and no longer used. It relied on
+    ``pg_try_advisory_xact_lock``, a transaction-scoped lock that the
+    connection pool releases (via rollback) as soon as the acquiring
+    ``SELECT`` returns -- i.e. before the caller runs its critical section --
+    so it never actually excluded a second leader. Selecting it now logs a
+    warning and transparently falls back to the Heartbeat strategy.
+    (For a correct session-level advisory lock held on a dedicated
+    connection, see ``app.services.scheduler_guard.SchedulerExecutionGuard``.)
 
 Issue #2187
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import socket
@@ -73,21 +75,15 @@ def get_owner_info() -> str:
     return f"{socket.gethostname()}:{os.getpid()}"
 
 
-def job_name_to_lock_key(job_name: str) -> int:
-    """Convert job_name to advisory lock key (64-bit integer).
-
-    Uses SHA-256 hash and takes first 8 bytes to ensure consistent mapping.
-    """
-    hash_bytes = hashlib.sha256(job_name.encode()).digest()[:8]
-    return int.from_bytes(hash_bytes, byteorder="big", signed=True)
-
-
 class LeaderElectionClient:
     """Client for distributed leader election.
 
-    Supports two strategies:
-    - Advisory Lock (strategy="advisory"): For short tasks, lock held in transaction
-    - Heartbeat (strategy="heartbeat"): For long tasks, periodic heartbeat updates
+    Strategy:
+    - Heartbeat (strategy="heartbeat", also what "auto" resolves to):
+      periodic heartbeat updates on the scheduler_leaders table, with leader
+      expiration and failover. Provides real mutual exclusion.
+    - Advisory (strategy="advisory"): deprecated and unsafe; transparently
+      falls back to Heartbeat at acquire time (see module docstring).
     """
 
     def __init__(
@@ -114,10 +110,13 @@ class LeaderElectionClient:
         self.leader_id = generate_leader_id()
         self.owner_info = get_owner_info()
 
-        # Determine strategy
+        # Determine strategy. "auto" always resolves to heartbeat: it is the
+        # only mechanism here that provides real mutual exclusion (the advisory
+        # strategy is deprecated -- see module docstring). An explicit
+        # strategy="advisory" is still accepted for backward compatibility and
+        # falls back to heartbeat at acquire time.
         if strategy == "auto":
-            # Auto-select based on lock timeout
-            self.strategy = "heartbeat" if lock_timeout > 300 else "advisory"
+            self.strategy = "heartbeat"
         else:
             self.strategy = strategy
 
@@ -127,7 +126,6 @@ class LeaderElectionClient:
 
         # State tracking
         self._is_leader = False
-        self._lock_key = job_name_to_lock_key(job_name)
         self._heartbeat_thread: threading.Thread | None = None
         self._stop_heartbeat = threading.Event()
         self._lock = threading.Lock()
@@ -154,44 +152,31 @@ class LeaderElectionClient:
         timeout = timeout or self.lock_timeout
 
         if self.strategy == "advisory":
-            return self._try_acquire_advisory_lock()
+            return self._try_acquire_advisory_lock(timeout)
         else:
             return self._try_acquire_heartbeat_lock(timeout)
 
-    def _try_acquire_advisory_lock(self) -> bool:
-        """Try to acquire advisory lock (Strategy A).
+    def _try_acquire_advisory_lock(self, timeout: int) -> bool:
+        """Deprecated advisory-lock path; falls back to the heartbeat strategy.
 
-        Uses PostgreSQL session-level advisory lock.
-        Lock is held for the duration of the transaction.
+        The previous implementation used ``pg_try_advisory_xact_lock``, whose
+        lock is released the moment the acquiring statement's transaction ends
+        (the connection pool rolls back before returning the connection). That
+        happened before the caller ran its critical section, so it provided no
+        mutual exclusion at all. Selecting the advisory strategy now logs a
+        warning and switches to the heartbeat strategy, which is correct.
+
+        For a correct session-level advisory lock held on a dedicated
+        connection, use ``app.services.scheduler_guard.SchedulerExecutionGuard``.
+        See the module docstring and Issue #2187.
         """
-        if not self.db.is_postgresql:
-            # SQLite doesn't support advisory locks, fall back to heartbeat
-            logger.warning(
-                f"Advisory lock not supported on SQLite, using heartbeat for {self.job_name}"
-            )
-            self.strategy = "heartbeat"
-            return self._try_acquire_heartbeat_lock(self.lock_timeout)
-
-        try:
-            # Check if lock is available
-            result = self.db.fetch_one(
-                "SELECT pg_try_advisory_xact_lock(?) AS acquired",
-                (self._lock_key,),
-            )
-
-            if result and result.get("acquired"):
-                self._is_leader = True
-                logger.info(f"Advisory lock acquired: job={self.job_name}, key={self._lock_key}")
-                return True
-            else:
-                self._skip_count += 1
-                logger.debug(f"Advisory lock not acquired (held by another): job={self.job_name}")
-                return False
-
-        except Exception as e:
-            logger.error(f"Failed to acquire advisory lock: {e}")
-            self._fail_count += 1
-            return False
+        logger.warning(
+            "LeaderElectionClient: strategy='advisory' is deprecated and unsafe; "
+            "falling back to heartbeat for job=%s",
+            self.job_name,
+        )
+        self.strategy = "heartbeat"
+        return self._try_acquire_heartbeat_lock(timeout)
 
     def _try_acquire_heartbeat_lock(self, timeout: int) -> bool:
         """Try to acquire leadership via heartbeat mechanism (Strategy B).
@@ -300,20 +285,17 @@ class LeaderElectionClient:
 
             self._stop_heartbeat_thread()
 
-            if self.strategy == "heartbeat":
-                try:
-                    self.db.execute(
-                        "DELETE FROM scheduler_leaders WHERE job_name = ? AND leader_id = ?",
-                        (self.job_name, self.leader_id),
-                    )
-                    logger.info(f"Leadership released: job={self.job_name}")
-                except Exception as e:
-                    logger.error(f"Failed to release leadership: {e}")
-            else:
-                # Advisory lock is released automatically on transaction commit
-                logger.info(
-                    f"Advisory lock will be released on transaction commit: job={self.job_name}"
+            # Leadership is always held via the heartbeat strategy (the
+            # deprecated advisory strategy falls back to it), so releasing
+            # deletes this leader's scheduler_leaders row.
+            try:
+                self.db.execute(
+                    "DELETE FROM scheduler_leaders WHERE job_name = ? AND leader_id = ?",
+                    (self.job_name, self.leader_id),
                 )
+                logger.info(f"Leadership released: job={self.job_name}")
+            except Exception as e:
+                logger.error(f"Failed to release leadership: {e}")
 
             self._is_leader = False
 

--- a/app/services/leader_election.py
+++ b/app/services/leader_election.py
@@ -100,7 +100,8 @@ class LeaderElectionClient:
         Args:
             job_name: Unique name for this job
             db: Database instance
-            strategy: "advisory", "heartbeat", or "auto" (chooses based on timeout)
+            strategy: "heartbeat" (also what "auto" resolves to). "advisory" is
+                deprecated and unsafe; it falls back to heartbeat at acquire time.
             heartbeat_interval: Seconds between heartbeat updates
             heartbeat_timeout: Seconds before heartbeat considered stale
             lock_timeout: Seconds before lock expires (fallback)

--- a/app/services/pending_revoke_cleanup.py
+++ b/app/services/pending_revoke_cleanup.py
@@ -37,7 +37,9 @@ class PendingRevokeCleanupScheduler(DistributedScheduler):
         super().__init__(
             job_name="pending_revoke_token_cleanup",
             db=db,
-            strategy="advisory",  # Short task, use advisory lock
+            # Heartbeat is the supported strategy; "advisory" is deprecated and
+            # unsafe (it fell back to heartbeat anyway -- see leader_election).
+            strategy="heartbeat",
             lock_timeout=300,  # 5 minutes max execution time
         )
         self.db = db

--- a/tests/unit/test_distributed_scheduler.py
+++ b/tests/unit/test_distributed_scheduler.py
@@ -1,0 +1,130 @@
+"""Tests for DistributedScheduler.run_with_lock (Issue #2187).
+
+Regression coverage for the advisory-lock deprecation: run_with_lock must
+release the lease (delete the leader row and stop the heartbeat thread) after
+each run, even when the scheduler was constructed with the deprecated
+``strategy="advisory"`` (which now falls back to heartbeat). Gating the release
+on ``self.strategy == "heartbeat"`` would leak a perpetual heartbeat thread and
+never-deleted leader row for advisory/auto schedulers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.repositories.database import Database
+from app.services.distributed_scheduler import DistributedScheduler
+
+
+@pytest.fixture
+def db():
+    """Database instance with the scheduler tables created (SQLite-safe)."""
+    database = Database()
+
+    conn = database.get_connection()
+    cursor = conn.cursor()
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS scheduler_leaders (
+            job_name TEXT PRIMARY KEY,
+            leader_id TEXT NOT NULL,
+            owner_info TEXT,
+            acquired_at TIMESTAMP NOT NULL,
+            expires_at TIMESTAMP NOT NULL,
+            heartbeat_at TIMESTAMP NOT NULL,
+            last_run_at TIMESTAMP,
+            run_count INTEGER DEFAULT 0,
+            skip_count INTEGER DEFAULT 0,
+            fail_count INTEGER DEFAULT 0
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS scheduler_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_name TEXT NOT NULL,
+            leader_id TEXT NOT NULL,
+            started_at TIMESTAMP NOT NULL,
+            ended_at TIMESTAMP,
+            status TEXT NOT NULL,
+            duration_ms INTEGER,
+            error_message TEXT,
+            metrics TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    yield database
+
+    try:
+        conn = database.get_connection()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM scheduler_runs")
+        cursor.execute("DELETE FROM scheduler_leaders")
+        conn.commit()
+        conn.close()
+    except Exception:  # allow-swallow: sqlite fixture cleanup (best-effort teardown)
+        pass
+
+
+def _assert_released(scheduler: DistributedScheduler, db: Database, job_name: str) -> None:
+    """The lease is fully released: not leader, no row, no heartbeat thread."""
+    assert scheduler.is_leader() is False
+    client = scheduler._leader_client
+    assert client is not None
+    assert client._is_leader is False
+    assert client._heartbeat_thread is None
+    row = db.fetch_one(
+        "SELECT leader_id FROM scheduler_leaders WHERE job_name = ?",
+        (job_name,),
+    )
+    assert row is None
+
+
+@pytest.mark.parametrize("strategy", ["heartbeat", "advisory", "auto"])
+def test_run_with_lock_releases_leadership(db, strategy):
+    """run_with_lock runs the job and releases the lease for every strategy.
+
+    Regression: with the pre-fix ``if self.strategy == "heartbeat"`` release
+    gate, an "advisory"/"auto" scheduler ran the job but never released,
+    leaking the heartbeat thread and leader row.
+    """
+    job_name = f"drwl_{strategy}"
+    scheduler = DistributedScheduler(job_name, db, strategy=strategy, lock_timeout=60)
+
+    ran: list[int] = []
+    result = scheduler.run_with_lock(lambda: ran.append(1))
+
+    assert result is True
+    assert ran == [1]
+    _assert_released(scheduler, db, job_name)
+
+
+def test_run_with_lock_releases_after_job_failure(db):
+    """A failing job still releases the lease (release is in the finally block)."""
+    job_name = "drwl_failing"
+    scheduler = DistributedScheduler(job_name, db, strategy="advisory", lock_timeout=60)
+
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    # run_with_lock swallows the job exception and returns True (it acquired).
+    result = scheduler.run_with_lock(boom)
+
+    assert result is True
+    assert scheduler._metrics["fail_count"] == 1
+    _assert_released(scheduler, db, job_name)
+
+
+def test_run_with_lock_second_cycle_reacquires(db):
+    """The cached client can re-acquire on a later cycle after release.
+
+    Mirrors the pending_revoke_cleanup loop (run_with_lock every 60s): a leaked
+    lease from cycle 1 would not by itself break cycle 2, but a leaked heartbeat
+    thread would accumulate. After the fix each cycle acquires and releases.
+    """
+    job_name = "drwl_cycles"
+    scheduler = DistributedScheduler(job_name, db, strategy="advisory", lock_timeout=60)
+
+    for _ in range(2):
+        assert scheduler.run_with_lock(lambda: None) is True
+        _assert_released(scheduler, db, job_name)

--- a/tests/unit/test_leader_election.py
+++ b/tests/unit/test_leader_election.py
@@ -19,7 +19,6 @@ from app.services.leader_election import (
     check_scheduler_tables_exist,
     generate_leader_id,
     get_owner_info,
-    job_name_to_lock_key,
 )
 
 
@@ -112,21 +111,6 @@ class TestLeaderElectionHelpers:
         owner = get_owner_info()
         assert ":" in owner
         assert len(owner) > 0
-
-    def test_job_name_to_lock_key_consistent(self):
-        """Test lock key is consistent for same job name."""
-        key1 = job_name_to_lock_key("test_job")
-        key2 = job_name_to_lock_key("test_job")
-
-        assert key1 == key2
-        assert isinstance(key1, int)
-
-    def test_job_name_to_lock_key_different(self):
-        """Test lock keys are different for different job names."""
-        key1 = job_name_to_lock_key("job1")
-        key2 = job_name_to_lock_key("job2")
-
-        assert key1 != key2
 
 
 class TestSchedulerTablesExist:
@@ -262,13 +246,11 @@ class TestLeaderElectionClient:
 
         client.release_leadership()
 
-    def test_auto_strategy_selection(self, db):
-        """Test auto strategy selection based on timeout."""
-        # Short timeout -> advisory
+    def test_auto_strategy_always_selects_heartbeat(self, db):
+        """auto resolves to heartbeat regardless of timeout (advisory is deprecated)."""
         client_short = LeaderElectionClient("short_job", db, strategy="auto", lock_timeout=60)
-        assert client_short.strategy == "advisory"
+        assert client_short.strategy == "heartbeat"
 
-        # Long timeout -> heartbeat
         client_long = LeaderElectionClient("long_job", db, strategy="auto", lock_timeout=3600)
         assert client_long.strategy == "heartbeat"
 
@@ -306,36 +288,42 @@ class TestLeaderElectionConcurrency:
         # (This test is probabilistic, but in practice only one should succeed at a time)
 
 
-# Skip advisory lock tests on SQLite (not supported)
-@pytest.mark.skipif(
-    not pytest.importorskip("app.repositories.database").Database().is_postgresql,
-    reason="Advisory locks require PostgreSQL",
-)
-class TestAdvisoryLock:
-    """Tests for PostgreSQL advisory locks."""
+class TestAdvisoryDeprecation:
+    """The deprecated advisory strategy transparently uses heartbeat.
 
-    def test_advisory_lock_basic(self, db):
-        """Test basic advisory lock functionality."""
-        client = LeaderElectionClient("test_advisory", db, strategy="advisory")
+    Advisory locks used to be a PostgreSQL-only path; the heartbeat fallback
+    runs on every backend, so these tests are no longer skipped on SQLite.
+    """
+
+    def test_advisory_falls_back_to_heartbeat(self, db):
+        """strategy='advisory' acquires via heartbeat and flips its strategy."""
+        client = LeaderElectionClient("test_advisory_fallback", db, strategy="advisory")
 
         acquired = client.try_acquire_leadership()
-        assert acquired is True
+        try:
+            assert acquired is True
+            assert client.is_leader()
+            # The advisory request is redirected to the correct heartbeat path.
+            assert client.strategy == "heartbeat"
+        finally:
+            client.release_leadership()
 
-        # Advisory lock is released on transaction commit
-        # No explicit release needed
+    def test_advisory_provides_real_mutual_exclusion(self, db):
+        """Two 'advisory' clients: exactly one wins (real exclusion via heartbeat).
 
-    def test_advisory_lock_conflict(self, db):
-        """Test that advisory locks prevent concurrent execution."""
-        job_name = "test_advisory_conflict"
+        Regression for the advisory-lock lifetime bug: the old path released its
+        transaction-scoped lock before the critical section, so both clients
+        could "acquire". The heartbeat fallback gives genuine mutual exclusion.
+        """
+        job_name = "test_advisory_exclusion"
+        client1 = LeaderElectionClient(job_name, db, strategy="advisory", lock_timeout=60)
+        client2 = LeaderElectionClient(job_name, db, strategy="advisory", lock_timeout=60)
 
-        client1 = LeaderElectionClient(job_name, db, strategy="advisory")
-        client2 = LeaderElectionClient(job_name, db, strategy="advisory")
-
-        # First client acquires
         acquired1 = client1.try_acquire_leadership()
-
-        # Second client should fail (within same transaction)
         acquired2 = client2.try_acquire_leadership()
-
-        # Only one should succeed
-        assert acquired1 != acquired2 or not acquired1
+        try:
+            assert acquired1 is True
+            assert acquired2 is False
+        finally:
+            client1.release_leadership()
+            client2.release_leadership()


### PR DESCRIPTION
## The bug

`LeaderElectionClient`'s **advisory** strategy provided **no mutual exclusion**.

`_try_acquire_advisory_lock` acquired `pg_try_advisory_xact_lock` via `db.fetch_one(...)`. That lock is **transaction-scoped**, but `fetch_one` was called with `commit=False`, and `Database.connection()`'s `finally` block **rolls back** any non-idle transaction before returning the connection to the pool ([database.py](app/repositories/database.py)). So the lock was released *the instant the `SELECT` returned* — before `try_acquire_leadership()` even returned `True`, and long before the caller ran its critical section. Two nodes could both "acquire" and run concurrently.

Compounding issues:
- **Contradictory docstrings**: the module docstring called it "session-level advisory locks" while the class docstring (and the code, `pg_try_advisory_xact_lock`) said transaction-scoped.
- **A weak test masked it**: `assert acquired1 != acquired2 or not acquired1` passes vacuously.

## Why deprecate rather than reimplement

- **No production caller uses the advisory path.** All five callers use `strategy="heartbeat", lock_timeout=1800`; `strategy="auto"` also resolved to heartbeat at that timeout. The advisory path was latent-but-broken.
- **A correct implementation already exists**: `app.services.scheduler_guard.SchedulerExecutionGuard` uses session-level `pg_try_advisory_lock` held on a **dedicated connection** via a context manager (with fencing tokens + lease validation). Reimplementing that here would duplicate it.

Maintainer decision: **deprecate the advisory strategy and route it to the correct heartbeat mechanism.**

## Changes

`app/services/leader_election.py`
- `strategy="advisory"` now logs a deprecation warning and **falls back to heartbeat at acquire time** (generalizes the pre-existing SQLite fallback that already lived in this method). The public API is unchanged — existing/explicit callers keep working, correctly.
- `strategy="auto"` **always** resolves to `heartbeat` (never the deprecated path).
- Rewrote the contradictory module/class docstrings; cross-referenced `SchedulerExecutionGuard`.
- Removed now-dead advisory plumbing: `job_name_to_lock_key`, `self._lock_key`, the `hashlib` import, and the unreachable `release_leadership` advisory branch. (`scheduler_guard.py` keeps its own independent `job_name_to_lock_key` — untouched.)

`tests/unit/test_leader_election.py`
- Replaced the weak `test_advisory_lock_conflict` with regression tests that assert (a) `strategy="advisory"` redirects to heartbeat, and (b) **real mutual exclusion** — two "advisory" clients, exactly one wins. These no longer skip on SQLite (the heartbeat fallback runs on every backend).
- Updated the auto-strategy test (auto → heartbeat regardless of timeout); removed the two `job_name_to_lock_key` unit tests along with the function.

## Verification

- `tests/unit/test_leader_election.py`: **15 passed** on SQLite (the required-lane backend).
- Related suites green: `test_scheduler_guard.py`, `test_data_fetch_scheduler.py`, `test_quota_enforcement_scheduler.py` (**105 passed**).
- `import app` clean; pre-commit (black/isort/ruff/mypy/bandit) all pass.

Scope: only `leader_election.py` + its test. `scheduler_guard.py` (the correct successor) is intentionally untouched.

Issue #2187