### PR TITLE
ci(coverage): measure app/routes + app/services in the coverage gate (eval §6.2 P1-3)

### DIFF
--- a/ci/suites.json
+++ b/ci/suites.json
@@ -59,7 +59,7 @@
       "description": "Required deterministic Python suite on the production runtime",
       "timeout_seconds": 420,
       "commands": [
-        ["{python}", "-m", "pytest", "tests/", "-q", "--maxfail=1", "--cov=scripts/shared", "--cov=app/auth", "--cov=app/remote_ws_handler", "--cov=app/modules/sso", "--cov-fail-under=30", "--cov-report=xml", "-m", "not postgres and not performance"],
+        ["{python}", "-m", "pytest", "tests/", "-q", "--maxfail=1", "--cov=scripts/shared", "--cov=app/auth", "--cov=app/remote_ws_handler", "--cov=app/modules/sso", "--cov=app/routes", "--cov=app/services", "--cov-fail-under=38", "--cov-report=term", "--cov-report=xml", "-m", "not postgres and not performance"],
         ["{python}", "scripts/scan_test_false_positives.py", "tests", "--exclude-dirs", "tests/issues", "--baseline", ".false-positive-baseline.json"]
       ]
     },

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -59,7 +59,7 @@
       "description": "Required deterministic Python suite on the production runtime",
       "timeout_seconds": 420,
       "commands": [
-        ["{python}", "-m", "pytest", "tests/", "-q", "--maxfail=1", "--cov=scripts/shared", "--cov=app/auth", "--cov=app/remote_ws_handler", "--cov=app/modules/sso", "--cov=app/routes", "--cov=app/services", "--cov-fail-under=38", "--cov-report=term", "--cov-report=xml", "-m", "not postgres and not performance"],
+        ["{python}", "-m", "pytest", "tests/", "-q", "--maxfail=1", "--cov=scripts/shared", "--cov=app/auth", "--cov=app/remote_ws_handler", "--cov=app/modules/sso", "--cov=app/routes", "--cov=app/services", "--cov-fail-under=47", "--cov-report=term", "--cov-report=xml", "-m", "not postgres and not performance"],
         ["{python}", "scripts/scan_test_false_positives.py", "tests", "--exclude-dirs", "tests/issues", "--baseline", ".false-positive-baseline.json"]
       ]
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,11 @@ filterwarnings = [
 # Coverage Configuration
 # =============================================================================
 [tool.coverage.run]
-# Phase 1: Include P0 security modules (Issue #1856)
+# Phase 1: P0 security modules (Issue #1856).
+# Phase 2 (eval §6.2 P1-3): expand to app/routes + app/services so the coverage
+# gate measures the HTTP + business-logic surface, not just the security core.
+# The CI gate is driven by the --cov flags in ci/suites.json (python-core
+# suite); keep this source list in sync with them.
 # Gradually expand: P0 → P1 → P2
 source = [
     "scripts/shared",
@@ -255,6 +259,8 @@ source = [
     "app/auth",
     "app/remote_ws_handler",
     "app/modules/sso",
+    "app/routes",
+    "app/services",
 ]
 omit = [
     "tests/*",


### PR DESCRIPTION
## What & why

The `python-core` coverage gate only measured the P0 security core — `scripts/shared`, `app/auth`, `app/remote_ws_handler`, `app/modules/sso`. The HTTP surface (`app/routes`, ~25.7k lines) and business logic (`app/services`, ~17.3k lines) were **not measured at all**, so the `--cov-fail-under` gate gave false confidence (eval §6.2 **P1-3**).

## Change

- `ci/suites.json` (`python-core`): add `--cov=app/routes --cov=app/services`; add `--cov-report=term` so the measured % is visible in the job log; raise `--cov-fail-under` from **30 → 47** (ratcheted baseline, see below).
- `pyproject.toml` `[tool.coverage.run] source`: mirror the additions (kept in sync with the CI `--cov` flags, which drive the gate).

No production code changes — CI configuration + coverage scope only.

## Ratchet baseline (empirically measured)

I set the floor from the **actual CI number**, not a guess:
- A first push at a conservative `--cov-fail-under=38` let the gate pass and print the real figure.
- Only the `test(3.11)` lane runs `python-core` (the coverage suite); `test(3.10)`/`test(3.12)`/`test(3.14)` run `compatibility-smoke`, which has no `--cov`. So the coverage gate lives on a single lane (pre-existing matrix design — see `.github/workflows/ci.yml`). That `python-core` run (full suite, `-m "not postgres and not performance"`) reported **49.25%** over 22,701 statements — "Required test coverage of 38% reached. Total coverage: 49.25%", 6029 passed.
- Floor set to **47** — a ~2-point buffer below 49.25% so it guards against real regression without flaking. A flaky *required* coverage gate would block every PR, so the buffer is deliberate; ratchet it up over time as coverage rises.

## Notes

- The gate is driven by the `--cov` flags in `ci/suites.json`; the 22,701-statement count (identical local and CI) confirms the flags define the scope (`server.py`/`cli.py` from `pyproject`'s `source` are not in the gate). `pyproject`'s `source` is kept aligned for anyone running `coverage` directly.
- Commit history: (1) add scope + conservative floor to measure; (2) ratchet floor to the measured 47.
