### PR TITLE
fix(analytics): restore forecast API contract

### DIFF
--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -66,6 +66,7 @@ def api_usage_report():
     return jsonify(report.to_dict())
 
 
+@analytics_bp.route("/analytics/forecast", methods=["GET"])
 @analytics_bp.route("/analysis/forecast", methods=["GET"])
 @admin_required
 def api_usage_forecast():

--- a/docs/cn/API.md
+++ b/docs/cn/API.md
@@ -838,6 +838,8 @@ GET /api/analytics/forecast
 
 获取用量预测。
 
+为保持向后兼容，`GET /api/analysis/forecast` 仍作为已弃用别名提供。新接入应使用上方的规范端点。
+
 **查询参数：**
 - `days` - 预测天数（默认：7）
 

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -838,6 +838,9 @@ GET /api/analytics/forecast
 
 Get usage forecast.
 
+For backward compatibility, `GET /api/analysis/forecast` remains available as a
+deprecated alias. New integrations should use the canonical endpoint above.
+
 **Query Parameters:**
 - `days` - Forecast days (default: 7)
 

--- a/frontend/src/api/analysis.ts
+++ b/frontend/src/api/analysis.ts
@@ -336,7 +336,7 @@ export const analysisApi = {
       if (validatedDays > 90) validatedDays = 90;
     }
 
-    return apiClient.get<ForecastResponse>('/api/analysis/forecast', {
+    return apiClient.get<ForecastResponse>('/api/analytics/forecast', {
       days: String(validatedDays),
     });
   },

--- a/tests/unit/test_analytics_forecast_route_2826.py
+++ b/tests/unit/test_analytics_forecast_route_2826.py
@@ -1,0 +1,50 @@
+"""Forecast API route contract regression tests for Issue #2826."""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from app.routes.analytics import analytics_bp
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2826)]
+
+CANONICAL_PATH = "/api/analytics/forecast"
+LEGACY_PATH = "/api/analysis/forecast"
+
+
+def _create_route_app() -> Flask:
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="issue-2826-route-contract")
+    app.register_blueprint(analytics_bp, url_prefix="/api")
+    return app
+
+
+def test_forecast_paths_share_the_authenticated_handler():
+    """The canonical path and compatibility alias must not drift."""
+    app = _create_route_app()
+    forecast_rules = {
+        rule.rule: rule
+        for rule in app.url_map.iter_rules()
+        if rule.rule in {CANONICAL_PATH, LEGACY_PATH}
+    }
+
+    assert set(forecast_rules) == {CANONICAL_PATH, LEGACY_PATH}
+    assert all("GET" in rule.methods for rule in forecast_rules.values())
+
+    endpoints = {rule.endpoint for rule in forecast_rules.values()}
+    views = {app.view_functions[rule.endpoint] for rule in forecast_rules.values()}
+    assert endpoints == {"analytics.api_usage_forecast"}
+    assert len(views) == 1
+
+
+def test_forecast_paths_apply_the_same_authentication_gate():
+    """Both registered paths must reject an unauthenticated request identically."""
+    client = _create_route_app().test_client()
+
+    canonical_response = client.get(f"{CANONICAL_PATH}?days=7")
+    legacy_response = client.get(f"{LEGACY_PATH}?days=7")
+
+    assert canonical_response.status_code == 401
+    assert legacy_response.status_code == 401
+    assert canonical_response.get_json() == legacy_response.get_json()


### PR DESCRIPTION
## Root cause

PR #2799 renamed the documented forecast route from `/api/analytics/forecast` to `/api/analysis/forecast` without a migration alias. The new frontend followed the renamed route, while the bilingual API docs and comprehensive Analytics smoke contract continued to use the public `/api/analytics/*` namespace.

## Solution

- Restore `/api/analytics/forecast` as the canonical route.
- Keep `/api/analysis/forecast` as a deprecated compatibility alias on the same authenticated handler.
- Move the frontend forecast request to the canonical route.
- Document the compatibility alias in English and Chinese API docs.
- Add an in-process route contract regression test for both paths and their shared auth gate.

## Verification

- `python -m pytest tests/unit/test_analytics_forecast_route_2826.py -q` — 2 passed (Linux and Windows)
- `python -m pytest tests/unit/test_usage_analytics.py -q` — 13 passed (Linux)
- `python -m ruff check app/routes/analytics.py tests/unit/test_analytics_forecast_route_2826.py` — passed
- `npm run typecheck` — passed (Linux and Windows)
- `npx eslint src/api/analysis.ts` — passed (Linux and Windows)
- `npx prettier --check src/api/analysis.ts` — passed (Linux and Windows)
- `git diff --check origin/main...HEAD` — passed
- Authenticated route probe with mocked forecast data: canonical 200, legacy 200, identical payloads

## Risk and rollback

Risk is low: both URL rules share one existing handler and one `admin_required` wrapper; no algorithm, schema, dependency, or authorization-policy change is included. The frontend can temporarily return to the compatibility alias independently. The restored canonical route should not be rolled back because that would reintroduce #2826.

Fixes #2826
