### PR TITLE
fix: 补充 Issue #2766 遗漏的时间字段序列化修复 (#2872)

### DIFF
--- a/app/modules/sso/provider.py
+++ b/app/modules/sso/provider.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, cast
 
+from app.utils.datetime_utils import ensure_utc_suffix
+
 
 class ProviderType(Enum):
     """SSO provider types."""
@@ -133,7 +135,7 @@ class SSOToken:
             "refresh_token": "***" if self.refresh_token else None,
             "id_token": "***" if self.id_token else None,
             "scope": self.scope,
-            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "expires_at": ensure_utc_suffix(self.expires_at),
         }
 
     def is_expired(self) -> bool:

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -11,6 +11,8 @@ import sqlite3
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+
+from app.utils.datetime_utils import ensure_utc_suffix
 from enum import Enum
 from typing import Any
 
@@ -72,8 +74,8 @@ class PromptTemplate:
             "is_public": self.is_public,
             "is_featured": self.is_featured,
             "use_count": self.use_count,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "created_at": ensure_utc_suffix(self.created_at),
+            "updated_at": ensure_utc_suffix(self.updated_at),
         }
 
     @classmethod

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -11,8 +11,6 @@ import sqlite3
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-
-from app.utils.datetime_utils import ensure_utc_suffix
 from enum import Enum
 from typing import Any
 
@@ -24,6 +22,7 @@ from app.repositories.database import (
     get_database_url,
     is_postgresql,
 )
+from app.utils.datetime_utils import ensure_utc_suffix
 
 logger = logging.getLogger(__name__)
 

--- a/app/modules/workspace/state_sync.py
+++ b/app/modules/workspace/state_sync.py
@@ -18,8 +18,8 @@ from enum import Enum
 from typing import Any
 
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
-from app.utils.helpers import parse_db_datetime
 from app.utils.datetime_utils import ensure_utc_suffix
+from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
 

--- a/app/modules/workspace/state_sync.py
+++ b/app/modules/workspace/state_sync.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
 from app.utils.helpers import parse_db_datetime
+from app.utils.datetime_utils import ensure_utc_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class SyncEvent:
         return {
             "event_id": self.event_id,
             "event_type": self.event_type,
-            "timestamp": self.timestamp.isoformat(),
+            "timestamp": ensure_utc_suffix(self.timestamp),
             "source": self.source,
             "session_id": self.session_id,
             "user_id": self.user_id,
@@ -112,8 +113,8 @@ class SyncState:
         """Convert to dictionary."""
         return {
             "client_id": self.client_id,
-            "connected_at": self.connected_at.isoformat(),
-            "last_activity": self.last_activity.isoformat(),
+            "connected_at": ensure_utc_suffix(self.connected_at),
+            "last_activity": ensure_utc_suffix(self.last_activity),
             "subscriptions": list(self.subscriptions),
             "user_id": self.user_id,
             "session_id": self.session_id,


### PR DESCRIPTION
Closes #2872

## 修复内容

补充 PR #2847 遗漏的时间字段序列化修复，确保所有返回前端的时间字段都使用 `ensure_utc_suffix` 函数。

## 修改文件

- `app/modules/sso/provider.py`: 修复 `SSOToken.expires_at` 字段
- `app/modules/workspace/prompt_library.py`: 修复 `PromptTemplate.created_at` 和 `updated_at` 字段
- `app/modules/workspace/state_sync.py`: 修复 `SyncEvent.timestamp`、`SyncState.connected_at` 和 `last_activity` 字段

## 修复方案

详细修复方案见 Issue #2872 评论：[修复方案1](https://github.com/open-ace/open-ace/issues/2872#issuecomment-5351023542)

## 验证

- 遵循 PR #2847 的修复模式
- 数据库操作字段保持原有方式（不修改）
- 前端序列化字段统一使用 `ensure_utc_suffix`