### PR TITLE
fix(tenant): preserve empty allowed tools settings (#2819)

### DIFF
--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -708,7 +708,9 @@ class TenantRepository:
 
                     settings = TenantSettings(
                         allowed_tools=(
-                            allowed_tools if allowed_tools else TenantSettings().allowed_tools
+                            allowed_tools
+                            if allowed_tools is not None
+                            else TenantSettings().allowed_tools
                         ),
                         content_filter_enabled=bool(settings_row.get("content_filter_enabled", 1)),
                         audit_log_enabled=bool(settings_row.get("audit_log_enabled", 1)),

--- a/tests/integration/test_tenant_allowed_tools_persistence.py
+++ b/tests/integration/test_tenant_allowed_tools_persistence.py
@@ -1,0 +1,63 @@
+"""Regression tests for tenant ``allowed_tools`` persistence (Issue #2819)."""
+
+from app.models.tenant import Tenant, TenantSettings
+from app.repositories.database import Database
+from app.repositories.tenant_repo import TenantRepository
+from app.services.tenant_service import TenantService
+
+
+def _create_tenant(db: Database, slug: str) -> int:
+    tenant_id = TenantRepository(db=db).create(
+        Tenant(
+            name="Allowed Tools Regression",
+            slug=slug,
+            contact_email="admin@example.com",
+            settings=TenantSettings(),
+        )
+    )
+    assert tenant_id is not None
+    return tenant_id
+
+
+def _reopened_service(db_url: str) -> TenantService:
+    return TenantService(tenant_repo=TenantRepository(db=Database(db_url=db_url)))
+
+
+def test_allowed_tools_removal_survives_repository_reopen(tmp_db, monkeypatch):
+    """Removing one tool remains visible after reopening the database."""
+    import app.repositories.tenant_repo as tenant_repo_module
+
+    monkeypatch.setattr(tenant_repo_module, "is_postgresql", lambda: False)
+    tenant_id = _create_tenant(tmp_db, "issue-2819-remove-one")
+    service = TenantService(tenant_repo=TenantRepository(db=tmp_db))
+    requested_tools = ["claude", "qwen", "openclaw", "codex"]
+
+    result = service.update_settings(
+        tenant_id,
+        {"allowed_tools": requested_tools},
+    )
+
+    assert result.success is True
+    reopened = _reopened_service(tmp_db.db_url).get_tenant(tenant_id)
+    assert reopened is not None
+    assert reopened.settings.allowed_tools == requested_tools
+
+
+def test_empty_allowed_tools_with_nondefault_setting_survives_reopen(tmp_db, monkeypatch):
+    """An empty list is a persisted value, even beside non-default settings."""
+    import app.repositories.tenant_repo as tenant_repo_module
+
+    monkeypatch.setattr(tenant_repo_module, "is_postgresql", lambda: False)
+    tenant_id = _create_tenant(tmp_db, "issue-2819-empty-list")
+    service = TenantService(tenant_repo=TenantRepository(db=tmp_db))
+
+    result = service.update_settings(
+        tenant_id,
+        {"allowed_tools": [], "custom_branding": True},
+    )
+
+    assert result.success is True
+    reopened = _reopened_service(tmp_db.db_url).get_tenant(tenant_id)
+    assert reopened is not None
+    assert reopened.settings.allowed_tools == []
+    assert reopened.settings.custom_branding is True

--- a/tests/unit/test_tenant_repo.py
+++ b/tests/unit/test_tenant_repo.py
@@ -229,6 +229,44 @@ class TestTenantRepository:
         assert result.settings.sso_provider == "okta"
         assert result.settings.content_filter_enabled is False
 
+    @pytest.mark.parametrize(
+        ("postgresql", "stored_allowed_tools"),
+        [(False, "[]"), (True, [])],
+        ids=["sqlite-text", "postgresql-jsonb"],
+    )
+    def test_row_to_tenant_preserves_empty_allowed_tools(self, postgresql, stored_allowed_tools):
+        """An explicit empty tool list must not be treated as a missing value."""
+        row = self._tenant_row()
+        self.db.fetch_one.side_effect = [
+            None,
+            {
+                "allowed_tools": stored_allowed_tools,
+                "custom_branding": 1,
+            },
+        ]
+
+        with patch("app.repositories.tenant_repo.is_postgresql", return_value=postgresql):
+            result = self.repo._row_to_tenant(row)
+
+        assert result.settings.allowed_tools == []
+        assert result.settings.custom_branding is True
+
+    def test_row_to_tenant_defaults_allowed_tools_when_column_is_null(self):
+        """Legacy NULL values retain the documented default tool list."""
+        row = self._tenant_row()
+        self.db.fetch_one.side_effect = [
+            None,
+            {
+                "allowed_tools": None,
+                "custom_branding": 1,
+            },
+        ]
+
+        result = self.repo._row_to_tenant(row)
+
+        assert result.settings.allowed_tools == TenantSettings().allowed_tools
+        assert result.settings.custom_branding is True
+
     def test_row_to_tenant_fallback_to_json(self):
         """When dedicated tables return None, fall back to JSON in tenant row."""
         custom_quota = QuotaConfig(max_users=200, daily_token_limit=2000000)


### PR DESCRIPTION
## 根因

PR #2855 已修复普通的 `allowed_tools` 单项移除持久化，但读取规范化 `tenant_settings` 时仍使用真值判断。显式保存的空列表 `[]` 会被当成字段缺失并恢复为默认五工具；当其他设置为非默认值时，整对象 JSON fallback 不会执行，因此 GET 返回错误值。

## 方案

- 用 `allowed_tools is not None` 区分合法空列表和 SQL `NULL`。
- 保持历史 `NULL` 回退默认五工具的兼容行为。
- 不重复新增 PR #2855 已提供的列、迁移或映射。

## 主要变更

- 修正 TenantRepository 的读取语义。
- 增加 SQLite TEXT `"[]"`、PostgreSQL JSONB `[]` 和 `NULL` 兼容单测。
- 增加真实临时 SQLite 数据库往返测试，覆盖：
  - 从五项移除一项；
  - 重新实例化 Service/Repository；
  - `allowed_tools=[]` 与 `custom_branding=true` 组合。

## 测试

- Windows / Python 3.13：`157 passed`
- Linux 测试环境 / Python 3.12：`157 passed`
- `python -m ruff check ...`：通过
- `git diff --check`：通过

## 风险

- 未连接 PostgreSQL 实库；使用 PostgreSQL 驱动的 JSONB 返回形态做了单元覆盖。
- 双存储事务化、异常吞噬和混合未知字段校验属于关联风险，不在本 PR 范围。

## 回滚

Revert 本 PR 即可；不涉及 schema 或数据回滚。

Closes #2819