### PR TITLE
fix(frontend): retain lazy chunks across releases

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "description": "Open ACE Frontend - Modern React/TypeScript/Vite based frontend",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && node scripts/retain-release-assets.mjs --dist ../static/js/dist",
     "build:watch": "vite build --watch",
     "preview": "vite preview",
     "lint": "eslint src",
@@ -14,6 +14,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json}\"",
     "typecheck": "tsc --noEmit",
+    "pretest": "node --test scripts/retain-release-assets.test.mjs",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",

--- a/frontend/scripts/retain-release-assets.mjs
+++ b/frontend/scripts/retain-release-assets.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const SCHEMA_VERSION = 1;
+export const STATE_FILENAME = '.openace-release-assets.json';
+export const VITE_MANIFEST = '.vite/manifest.json';
+export const MAX_ASSETS = 10_000;
+export const MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024;
+
+const HASHED_ASSET_RE = /(?:^|\/)[^/]+\.[A-Za-z0-9_-]{8}\.[^/]+$/;
+
+function fail(message) {
+  throw new Error(`frontend asset retention: ${message}`);
+}
+
+export function normalizeAssetPath(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    fail('asset path must be a non-empty string');
+  }
+  if (value.includes('\\') || isAbsolute(value)) fail(`unsafe asset path: ${value}`);
+  const normalized = posix.normalize(value);
+  if (normalized !== value || normalized === '..' || normalized.startsWith('../')) {
+    fail(`unsafe asset path: ${value}`);
+  }
+  return normalized;
+}
+
+export function isStrictHashedAsset(value) {
+  return HASHED_ASSET_RE.test(value);
+}
+
+function assetAbsolutePath(distDir, asset) {
+  const distRoot = realpathSync(resolve(distDir));
+  const absolute = resolve(distRoot, ...normalizeAssetPath(asset).split('/'));
+  if (absolute !== distRoot && !absolute.startsWith(`${distRoot}${sep}`)) {
+    fail(`asset escapes dist directory: ${asset}`);
+  }
+  let parent;
+  try {
+    parent = realpathSync(dirname(absolute));
+  } catch {
+    fail(`missing asset parent: ${asset}`);
+  }
+  if (parent !== distRoot && !parent.startsWith(`${distRoot}${sep}`)) {
+    fail(`asset escapes dist directory through a symlink: ${asset}`);
+  }
+  return absolute;
+}
+
+function validateRegularAssets(distDir, assets) {
+  if (!Array.isArray(assets) || assets.length > MAX_ASSETS) fail('asset count exceeds limit');
+  let totalBytes = 0;
+  for (const asset of assets) {
+    if (!isStrictHashedAsset(normalizeAssetPath(asset))) fail(`not a hashed release asset: ${asset}`);
+    const absolute = assetAbsolutePath(distDir, asset);
+    if (!existsSync(absolute)) fail(`missing asset: ${asset}`);
+    const info = lstatSync(absolute);
+    if (info.isSymbolicLink() || !info.isFile()) fail(`asset is not a regular file: ${asset}`);
+    totalBytes += info.size;
+    if (totalBytes > MAX_TOTAL_BYTES) fail('asset bytes exceed limit');
+  }
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+export function deriveCurrentRelease(distDir) {
+  const manifestPath = join(resolve(distDir), VITE_MANIFEST);
+  if (!existsSync(manifestPath)) fail(`missing Vite manifest: ${VITE_MANIFEST}`);
+  const raw = readFileSync(manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(raw.toString('utf8'));
+  } catch {
+    fail('invalid Vite manifest JSON');
+  }
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    fail('invalid Vite manifest schema');
+  }
+
+  const keys = new Set(Object.keys(manifest));
+  const assets = [];
+  for (const [key, entry] of Object.entries(manifest)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) fail(`invalid manifest entry: ${key}`);
+    for (const dependencyField of ['imports', 'dynamicImports']) {
+      const dependencies = entry[dependencyField] ?? [];
+      if (!Array.isArray(dependencies)) fail(`invalid ${dependencyField} for ${key}`);
+      for (const dependency of dependencies) {
+        if (typeof dependency !== 'string' || !keys.has(dependency)) {
+          fail(`dangling ${dependencyField} key for ${key}: ${String(dependency)}`);
+        }
+      }
+    }
+    if (typeof entry.file !== 'string') fail(`missing file for manifest entry: ${key}`);
+    assets.push(normalizeAssetPath(entry.file));
+    for (const assetField of ['css', 'assets']) {
+      const values = entry[assetField] ?? [];
+      if (!Array.isArray(values)) fail(`invalid ${assetField} for ${key}`);
+      for (const value of values) assets.push(normalizeAssetPath(value));
+    }
+  }
+
+  const currentAssets = uniqueSorted(assets);
+  validateRegularAssets(distDir, currentAssets);
+  return {
+    build_id: createHash('sha256').update(raw).digest('hex'),
+    assets: currentAssets,
+  };
+}
+
+function validateGeneration(distDir, value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`invalid ${label} generation`);
+  if (typeof value.build_id !== 'string' || !/^[a-f0-9]{64}$/.test(value.build_id)) {
+    fail(`invalid ${label} build id`);
+  }
+  if (!Array.isArray(value.assets) || value.assets.some((asset) => typeof asset !== 'string')) {
+    fail(`invalid ${label} assets`);
+  }
+  const assets = uniqueSorted(value.assets);
+  if (assets.length !== value.assets.length || assets.some((asset, index) => asset !== value.assets[index])) {
+    fail(`duplicate or unsorted ${label} assets`);
+  }
+  validateRegularAssets(distDir, assets);
+  return { build_id: value.build_id, assets };
+}
+
+export function readState(distDir) {
+  const statePath = join(resolve(distDir), STATE_FILENAME);
+  if (!existsSync(statePath)) return null;
+  let state;
+  try {
+    state = JSON.parse(readFileSync(statePath, 'utf8'));
+  } catch {
+    fail('invalid release state JSON');
+  }
+  if (!state || state.schema_version !== SCHEMA_VERSION) fail('unsupported release state schema');
+  return {
+    schema_version: SCHEMA_VERSION,
+    current: validateGeneration(distDir, state.current, 'current'),
+    previous: state.previous == null ? null : validateGeneration(distDir, state.previous, 'previous'),
+  };
+}
+
+function walkHashedAssets(distDir, directory = resolve(distDir)) {
+  const found = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = join(directory, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      found.push(...walkHashedAssets(distDir, absolute));
+    } else if (entry.isFile()) {
+      const asset = relative(resolve(distDir), absolute).split(sep).join('/');
+      if (isStrictHashedAsset(asset)) found.push(asset);
+    }
+  }
+  return uniqueSorted(found);
+}
+
+function legacyPrevious(distDir, current) {
+  const assets = walkHashedAssets(distDir).filter((asset) => !current.assets.includes(asset));
+  if (assets.length === 0) return null;
+  validateRegularAssets(distDir, assets);
+  return {
+    build_id: createHash('sha256').update(assets.join('\n')).digest('hex'),
+    assets,
+  };
+}
+
+function atomicWriteState(distDir, state) {
+  const statePath = join(resolve(distDir), STATE_FILENAME);
+  const tempPath = `${statePath}.tmp-${process.pid}`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(tempPath, statePath);
+}
+
+export function retainReleaseAssets(distDir) {
+  const current = deriveCurrentRelease(distDir);
+  const oldState = readState(distDir);
+  const repeatedCurrent =
+    oldState?.current.build_id === current.build_id &&
+    oldState.current.assets.length === current.assets.length &&
+    oldState.current.assets.every((asset, index) => asset === current.assets[index]);
+  const previousCandidate = repeatedCurrent
+    ? oldState.previous
+    : (oldState?.current ?? legacyPrevious(distDir, current));
+  const previousAssets = (previousCandidate?.assets ?? []).filter(
+    (asset) => !current.assets.includes(asset)
+  );
+  const previous =
+    previousCandidate && previousAssets.length > 0
+      ? { build_id: previousCandidate.build_id, assets: previousAssets }
+      : null;
+  const keep = new Set([...current.assets, ...(previous?.assets ?? [])]);
+
+  for (const asset of walkHashedAssets(distDir)) {
+    if (!keep.has(asset)) rmSync(assetAbsolutePath(distDir, asset));
+  }
+
+  const state = { schema_version: SCHEMA_VERSION, current, previous };
+  atomicWriteState(distDir, state);
+  return state;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const distIndex = args.indexOf('--dist');
+  if (distIndex < 0 || !args[distIndex + 1]) fail('usage: retain-release-assets.mjs --dist <path>');
+  retainReleaseAssets(args[distIndex + 1]);
+}
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/frontend/scripts/retain-release-assets.test.mjs
+++ b/frontend/scripts/retain-release-assets.test.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { STATE_FILENAME, readState, retainReleaseAssets } from './retain-release-assets.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'openace-assets-node-'));
+  mkdirSync(join(root, '.vite'), { recursive: true });
+  return root;
+}
+
+function writeRelease(root, name, hash, extra = {}) {
+  const file = `${name}.${hash}.js`;
+  writeFileSync(join(root, file), `// ${file}`);
+  const manifest = { [`src/${name}.tsx`]: { file, isEntry: true, ...extra } };
+  writeFileSync(join(root, '.vite', 'manifest.json'), JSON.stringify(manifest));
+  return file;
+}
+
+test('retains current and one previous release across A -> B -> C', () => {
+  const root = fixture();
+  try {
+    const a = writeRelease(root, 'AutonomousDev', 'aaaaaaaa');
+    retainReleaseAssets(root);
+    const b = writeRelease(root, 'AutonomousDev', 'bbbbbbbb');
+    retainReleaseAssets(root);
+    assert.equal(readFileSync(join(root, a), 'utf8'), `// ${a}`);
+    const c = writeRelease(root, 'AutonomousDev', 'cccccccc');
+    const state = retainReleaseAssets(root);
+    assert.throws(() => readFileSync(join(root, a)), /ENOENT/);
+    assert.equal(readFileSync(join(root, b), 'utf8'), `// ${b}`);
+    assert.equal(readFileSync(join(root, c), 'utf8'), `// ${c}`);
+    assert.deepEqual(state.current.assets, [c]);
+    assert.deepEqual(state.previous.assets, [b]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('deduplicates content hashes shared by consecutive releases', () => {
+  const root = fixture();
+  try {
+    const shared = 'react-vendor.11111111.js';
+    const a = 'AutonomousDev.aaaaaaaa.js';
+    const b = 'AutonomousDev.bbbbbbbb.js';
+    for (const asset of [shared, a]) writeFileSync(join(root, asset), asset);
+    writeFileSync(
+      join(root, '.vite', 'manifest.json'),
+      JSON.stringify({ 'src/main.tsx': { file: shared, assets: [a], isEntry: true } })
+    );
+    retainReleaseAssets(root);
+
+    writeFileSync(join(root, b), b);
+    writeFileSync(
+      join(root, '.vite', 'manifest.json'),
+      JSON.stringify({ 'src/main.tsx': { file: shared, assets: [b], isEntry: true } })
+    );
+    const state = retainReleaseAssets(root);
+
+    assert.deepEqual(state.current.assets, [b, shared]);
+    assert.deepEqual(state.previous.assets, [a]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('does not rotate away the previous release when the current build repeats', () => {
+  const root = fixture();
+  try {
+    const a = writeRelease(root, 'AutonomousDev', 'aaaaaaaa');
+    retainReleaseAssets(root);
+    const b = writeRelease(root, 'AutonomousDev', 'bbbbbbbb');
+    retainReleaseAssets(root);
+
+    const state = retainReleaseAssets(root);
+
+    assert.deepEqual(state.current.assets, [b]);
+    assert.deepEqual(state.previous.assets, [a]);
+    assert.equal(readFileSync(join(root, a), 'utf8'), `// ${a}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('keeps public files and never follows or removes symlinks', (t) => {
+  const root = fixture();
+  try {
+    writeFileSync(join(root, 'manifest.json'), '{"public":true}');
+    const current = writeRelease(root, 'index', 'dddddddd');
+    const outside = join(root, '..', `outside-${process.pid}.eeeeeeee.js`);
+    writeFileSync(outside, 'outside');
+    try {
+      symlinkSync(outside, join(root, 'linked.ffffffff.js'));
+    } catch (error) {
+      if (error?.code !== 'EPERM') throw error;
+      rmSync(outside, { force: true });
+      t.skip('symlinks are unavailable on this platform');
+      return;
+    }
+    retainReleaseAssets(root);
+    assert.equal(readFileSync(join(root, 'manifest.json'), 'utf8'), '{"public":true}');
+    assert.equal(readFileSync(join(root, current), 'utf8'), `// ${current}`);
+    assert.equal(readFileSync(outside, 'utf8'), 'outside');
+    rmSync(outside, { force: true });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('fails closed for dangling manifest imports and missing assets', () => {
+  const root = fixture();
+  try {
+    writeFileSync(
+      join(root, '.vite', 'manifest.json'),
+      JSON.stringify({ 'src/main.tsx': { file: 'index.12345678.js', dynamicImports: ['missing'] } })
+    );
+    assert.throws(() => retainReleaseAssets(root), /dangling dynamicImports/);
+    assert.equal(readFileSync(join(root, '.vite', 'manifest.json'), 'utf8').length > 0, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects manifest assets that traverse a symlinked directory', (t) => {
+  const root = fixture();
+  const outside = mkdtempSync(join(tmpdir(), 'openace-assets-outside-'));
+  try {
+    writeFileSync(join(outside, 'escaped.12345678.js'), 'outside');
+    try {
+      symlinkSync(outside, join(root, 'linked'), 'dir');
+    } catch (error) {
+      if (error?.code !== 'EPERM') throw error;
+      t.skip('directory symlinks are unavailable on this platform');
+      return;
+    }
+    writeFileSync(
+      join(root, '.vite', 'manifest.json'),
+      JSON.stringify({ 'src/main.tsx': { file: 'linked/escaped.12345678.js', isEntry: true } })
+    );
+    assert.throws(() => retainReleaseAssets(root), /escapes dist directory through a symlink/);
+    assert.equal(readFileSync(join(outside, 'escaped.12345678.js'), 'utf8'), 'outside');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('writes a versioned state atomically after validation', () => {
+  const root = fixture();
+  try {
+    const current = writeRelease(root, 'index', '12345678');
+    retainReleaseAssets(root);
+    const state = JSON.parse(readFileSync(join(root, STATE_FILENAME), 'utf8'));
+    assert.equal(state.schema_version, 1);
+    assert.deepEqual(state.current.assets, [current]);
+    assert.equal(state.previous, null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('accepts the shared cross-runtime state fixture', () => {
+  const root = fixture();
+  try {
+    const fixturePath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'tests',
+      'fixtures',
+      'frontend_asset_state_v1.json'
+    );
+    const state = JSON.parse(readFileSync(fixturePath, 'utf8'));
+    for (const generation of [state.current, state.previous]) {
+      for (const asset of generation.assets) writeFileSync(join(root, asset), asset);
+    }
+    writeFileSync(join(root, STATE_FILENAME), JSON.stringify(state));
+    assert.deepEqual(readState(root), state);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/frontend/src/components/common/ChunkLoadErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ChunkLoadErrorBoundary.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChunkLoadErrorBoundary, isChunkLoadError } from './ChunkLoadErrorBoundary';
+
+const consoleError = console.error;
+const preventWindowError = (event: Event): void => event.preventDefault();
+
+function Broken({ error }: { error: Error }): never {
+  throw error;
+}
+
+describe('ChunkLoadErrorBoundary', () => {
+  beforeEach(() => {
+    console.error = vi.fn();
+    window.addEventListener('error', preventWindowError);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('error', preventWindowError);
+    console.error = consoleError;
+  });
+
+  it('conservatively recognizes browser chunk loading errors', () => {
+    expect(
+      isChunkLoadError(Object.assign(new Error('Loading chunk 42 failed'), { name: 'Error' }))
+    ).toBe(true);
+    expect(isChunkLoadError(new TypeError('Failed to fetch dynamically imported module'))).toBe(
+      true
+    );
+    expect(isChunkLoadError(new TypeError('Failed to fetch'))).toBe(false);
+    expect(isChunkLoadError(new Error('API request failed'))).toBe(false);
+  });
+
+  it('shows a recoverable version message instead of a blank root', () => {
+    render(
+      <ChunkLoadErrorBoundary>
+        <Broken error={new TypeError('Failed to fetch dynamically imported module')} />
+      </ChunkLoadErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('A new version of Open ACE is available');
+    expect(screen.getByRole('button', { name: 'Reload page' })).toBeVisible();
+  });
+
+  it('does not reload automatically and reloads only after an explicit click', () => {
+    const reloadPage = vi.fn();
+    render(
+      <ChunkLoadErrorBoundary reloadPage={reloadPage}>
+        <Broken
+          error={Object.assign(new Error('Loading chunk autonomous failed'), {
+            name: 'ChunkLoadError',
+          })}
+        />
+      </ChunkLoadErrorBoundary>
+    );
+
+    expect(reloadPage).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Reload page' }));
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a generic recovery message for unrelated render failures', () => {
+    render(
+      <ChunkLoadErrorBoundary reloadPage={vi.fn()}>
+        <Broken error={new Error('private implementation detail')} />
+      </ChunkLoadErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Open ACE could not render');
+    expect(screen.getByRole('alert')).not.toHaveTextContent('private implementation detail');
+  });
+});

--- a/frontend/src/components/common/ChunkLoadErrorBoundary.tsx
+++ b/frontend/src/components/common/ChunkLoadErrorBoundary.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+interface ChunkLoadErrorBoundaryProps {
+  children: React.ReactNode;
+  reloadPage?: () => void;
+}
+
+interface ChunkLoadErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Return true only for browser errors that specifically identify a failed
+ * JavaScript chunk or dynamic import. Generic network errors must not turn
+ * ordinary API failures into full-page reload prompts.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'ChunkLoadError') return true;
+  return [
+    /Loading (?:CSS )?chunk [^ ]+ failed/i,
+    /Failed to fetch dynamically imported module/i,
+    /Importing a module script failed/i,
+    /error loading dynamically imported module/i,
+  ].some((pattern) => pattern.test(error.message));
+}
+
+/**
+ * React.lazy rejects when a content-hashed chunk disappears during a release.
+ * Suspense does not handle rejected imports, so this boundary keeps the app
+ * recoverable instead of allowing React to unmount the entire root.
+ */
+export class ChunkLoadErrorBoundary extends React.Component<
+  ChunkLoadErrorBoundaryProps,
+  ChunkLoadErrorBoundaryState
+> {
+  public override state: ChunkLoadErrorBoundaryState = { error: null };
+
+  public static getDerivedStateFromError(error: Error): ChunkLoadErrorBoundaryState {
+    return { error };
+  }
+
+  private readonly reloadPage = (): void => {
+    if (this.props.reloadPage) {
+      this.props.reloadPage();
+      return;
+    }
+    window.location.reload();
+  };
+
+  public override render(): React.ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const chunkFailure = isChunkLoadError(error);
+    return (
+      <main
+        className="min-vh-100 d-flex align-items-center justify-content-center bg-light p-4"
+        data-testid="application-error-boundary"
+      >
+        <section className="card shadow-sm border-0 text-center p-4" role="alert">
+          <i className="bi bi-exclamation-triangle-fill text-warning fs-1 mb-3" />
+          <h1 className="h4">
+            {chunkFailure ? 'A new version of Open ACE is available' : 'Open ACE could not render'}
+          </h1>
+          <p className="text-muted mb-4">
+            {chunkFailure
+              ? 'This page is still using files from an older version. Reload to continue safely.'
+              : 'An unexpected display error occurred. Reload the page to try again.'}
+          </p>
+          <button className="btn btn-primary" type="button" onClick={this.reloadPage}>
+            Reload page
+          </button>
+        </section>
+      </main>
+    );
+  }
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -12,6 +12,7 @@ export { SearchableSelect } from './SearchableSelect';
 export { Pagination } from './Pagination';
 export { FeatureRouteGuard } from './FeatureRouteGuard';
 export { PlatformAdminGuard } from './PlatformAdminGuard';
+export { ChunkLoadErrorBoundary, isChunkLoadError } from './ChunkLoadErrorBoundary';
 
 // New Phase 5 components
 export { Modal, ConfirmModal } from './Modal';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
+import { ChunkLoadErrorBoundary } from './components/common/ChunkLoadErrorBoundary';
 
 // Import Bootstrap and Bootstrap Icons locally (no external CDN)
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -24,9 +25,11 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ChunkLoadErrorBoundary>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ChunkLoadErrorBoundary>
     </React.StrictMode>
   );
 } else {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,7 +39,11 @@ export default defineConfig(({ command }) => ({
   build: {
     // 输出目录 - 构建到父目录的 static/js/dist 目录
     outDir: '../static/js/dist',
-    emptyOutDir: true,
+    // Keep the previous release's content-hashed assets until the post-build
+    // retention step has written the new release state. This prevents an
+    // already-open SPA from losing lazy chunks during a deployment.
+    emptyOutDir: false,
+    manifest: true,
 
     // 仅本地开发服务器生成 source map；生产构建关闭以避免源码泄露
     sourcemap: command === 'serve',

--- a/scripts/frontend_asset_retention.py
+++ b/scripts/frontend_asset_retention.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Safely preserve one deployed frontend release across package upgrades.
+
+The frontend Node post-build step and this installer helper share the state
+schema in ``.openace-release-assets.json``.  All paths in that file are treated
+as untrusted input and must resolve to regular files below the dist directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCHEMA_VERSION = 1
+STATE_FILENAME = ".openace-release-assets.json"
+SNAPSHOT_FILENAME = "snapshot-state.json"
+VITE_MANIFEST = Path(".vite/manifest.json")
+MAX_ASSETS = 10_000
+MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
+HASHED_ASSET_RE = re.compile(r"(?:^|/)[^/]+\.[A-Za-z0-9_-]{8}\.[^/]+$")
+
+
+class RetentionError(RuntimeError):
+    """Raised when release metadata or an asset violates the safety contract."""
+
+
+def _normalize_asset(value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
+        raise RetentionError("asset path must be a safe non-empty string")
+    path = PurePosixPath(value)
+    if path.is_absolute() or value != path.as_posix() or ".." in path.parts:
+        raise RetentionError(f"unsafe asset path: {value}")
+    return value
+
+
+def _asset_path(dist: Path, asset: str) -> Path:
+    dist_real = dist.resolve(strict=True)
+    candidate = dist_real.joinpath(*PurePosixPath(_normalize_asset(asset)).parts)
+    try:
+        candidate.parent.resolve(strict=True).relative_to(dist_real)
+    except (FileNotFoundError, ValueError) as exc:
+        raise RetentionError(f"asset escapes dist directory: {asset}") from exc
+    return candidate
+
+
+def _safe_destination(dist: Path, asset: str) -> Path:
+    """Create destination parents without traversing symlinks."""
+    dist_real = dist.resolve(strict=True)
+    parts = PurePosixPath(_normalize_asset(asset)).parts
+    parent = dist_real
+    for part in parts[:-1]:
+        candidate = parent / part
+        try:
+            info = candidate.lstat()
+        except FileNotFoundError:
+            candidate.mkdir(mode=0o755)
+            info = candidate.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise RetentionError(f"unsafe destination parent: {asset}")
+        try:
+            candidate.resolve(strict=True).relative_to(dist_real)
+        except ValueError as exc:
+            raise RetentionError(f"destination escapes dist directory: {asset}") from exc
+        parent = candidate
+    destination = parent / parts[-1]
+    if destination.exists() or destination.is_symlink():
+        info = destination.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise RetentionError(f"unsafe destination asset: {asset}")
+    return destination
+
+
+def _validate_regular_assets(dist: Path, assets: list[str]) -> list[str]:
+    if len(assets) > MAX_ASSETS:
+        raise RetentionError("asset count exceeds limit")
+    if assets != sorted(set(assets)):
+        raise RetentionError("assets must be sorted and unique")
+    total_bytes = 0
+    for asset in assets:
+        if not HASHED_ASSET_RE.search(_normalize_asset(asset)):
+            raise RetentionError(f"not a hashed release asset: {asset}")
+        path = _asset_path(dist, asset)
+        try:
+            info = path.lstat()
+        except FileNotFoundError as exc:
+            raise RetentionError(f"missing asset: {asset}") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise RetentionError(f"asset is not a regular file: {asset}")
+        total_bytes += info.st_size
+        if total_bytes > MAX_TOTAL_BYTES:
+            raise RetentionError("asset bytes exceed limit")
+    return assets
+
+
+def _load_json(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RetentionError(f"invalid {label} JSON") from exc
+    if not isinstance(value, dict):
+        raise RetentionError(f"invalid {label} schema")
+    return value, raw
+
+
+def derive_current_release(dist: Path) -> dict[str, Any]:
+    manifest, raw = _load_json(dist / VITE_MANIFEST, "Vite manifest")
+    keys = set(manifest)
+    assets: set[str] = set()
+    for key, entry in manifest.items():
+        if not isinstance(entry, dict):
+            raise RetentionError(f"invalid manifest entry: {key}")
+        for dependency_field in ("imports", "dynamicImports"):
+            dependencies = entry.get(dependency_field, [])
+            if not isinstance(dependencies, list):
+                raise RetentionError(f"invalid {dependency_field} for {key}")
+            for dependency in dependencies:
+                if not isinstance(dependency, str) or dependency not in keys:
+                    raise RetentionError(f"dangling {dependency_field} key for {key}: {dependency}")
+        file_name = entry.get("file")
+        if not isinstance(file_name, str):
+            raise RetentionError(f"missing file for manifest entry: {key}")
+        assets.add(_normalize_asset(file_name))
+        for asset_field in ("css", "assets"):
+            values = entry.get(asset_field, [])
+            if not isinstance(values, list):
+                raise RetentionError(f"invalid {asset_field} for {key}")
+            for value in values:
+                assets.add(_normalize_asset(value))
+    current_assets = _validate_regular_assets(dist, sorted(assets))
+    return {
+        "build_id": hashlib.sha256(raw).hexdigest(),
+        "assets": current_assets,
+    }
+
+
+def _validate_generation(dist: Path, value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RetentionError(f"invalid {label} generation")
+    build_id = value.get("build_id")
+    assets = value.get("assets")
+    if not isinstance(build_id, str) or re.fullmatch(r"[a-f0-9]{64}", build_id) is None:
+        raise RetentionError(f"invalid {label} build id")
+    if not isinstance(assets, list) or not all(isinstance(item, str) for item in assets):
+        raise RetentionError(f"invalid {label} assets")
+    return {
+        "build_id": build_id,
+        "assets": _validate_regular_assets(dist, assets),
+    }
+
+
+def load_state(dist: Path) -> dict[str, Any] | None:
+    state_path = dist / STATE_FILENAME
+    if not state_path.exists():
+        return None
+    state, _ = _load_json(state_path, "release state")
+    if state.get("schema_version") != SCHEMA_VERSION:
+        raise RetentionError("unsupported release state schema")
+    previous = state.get("previous")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "current": _validate_generation(dist, state.get("current"), "current"),
+        "previous": None if previous is None else _validate_generation(dist, previous, "previous"),
+    }
+
+
+def validate_source(dist: Path) -> dict[str, Any]:
+    state = load_state(dist)
+    if state is None:
+        raise RetentionError(f"missing source release state: {STATE_FILENAME}")
+    manifest_current = derive_current_release(dist)
+    if state["current"] != manifest_current:
+        raise RetentionError("source state current does not match Vite manifest")
+    return state
+
+
+def _legacy_assets(dist: Path) -> list[str]:
+    assets: list[str] = []
+    for root, directories, files in os.walk(dist, followlinks=False):
+        root_path = Path(root)
+        directories[:] = [name for name in directories if not (root_path / name).is_symlink()]
+        for name in files:
+            path = root_path / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            asset = path.relative_to(dist).as_posix()
+            if HASHED_ASSET_RE.search(asset):
+                assets.append(asset)
+    return _validate_regular_assets(dist, sorted(set(assets)))
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def snapshot_deployment(dist: Path, output: Path) -> dict[str, Any]:
+    if output.exists() and any(output.iterdir()):
+        raise RetentionError("snapshot output must be empty")
+    output.mkdir(parents=True, mode=0o700, exist_ok=True)
+    state = load_state(dist)
+    if state is None:
+        assets = _legacy_assets(dist)
+        current = {
+            "build_id": hashlib.sha256("\n".join(assets).encode()).hexdigest(),
+            "assets": assets,
+        }
+    else:
+        current = state["current"]
+
+    snapshot_assets = output / "assets"
+    for asset in current["assets"]:
+        source = _asset_path(dist, asset)
+        destination = snapshot_assets.joinpath(*PurePosixPath(asset).parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination, follow_symlinks=False)
+    snapshot = {"schema_version": SCHEMA_VERSION, "current": current, "previous": None}
+    _atomic_write(output / SNAPSHOT_FILENAME, snapshot)
+    return snapshot
+
+
+def _load_snapshot(snapshot_dir: Path) -> dict[str, Any]:
+    state, _ = _load_json(snapshot_dir / SNAPSHOT_FILENAME, "snapshot state")
+    if state.get("schema_version") != SCHEMA_VERSION or state.get("previous") is not None:
+        raise RetentionError("invalid snapshot schema")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "current": _validate_generation(snapshot_dir / "assets", state.get("current"), "snapshot"),
+        "previous": None,
+    }
+
+
+def reconcile_install(target_dist: Path, snapshot_dir: Path | None = None) -> dict[str, Any]:
+    package_state = validate_source(target_dist)
+    current_assets = set(package_state["current"]["assets"])
+
+    # Discard only the package/build-machine previous generation. Unknown and
+    # public files are deliberately left alone.
+    package_previous = package_state["previous"]
+    for asset in [] if package_previous is None else package_previous["assets"]:
+        if asset not in current_assets:
+            _asset_path(target_dist, asset).unlink(missing_ok=True)
+
+    snapshot = None if snapshot_dir is None else _load_snapshot(snapshot_dir)
+    previous_assets = (
+        []
+        if snapshot is None
+        else [asset for asset in snapshot["current"]["assets"] if asset not in current_assets]
+    )
+    for asset in previous_assets:
+        assert snapshot is not None and snapshot_dir is not None
+        source = _asset_path(snapshot_dir / "assets", asset)
+        destination = _safe_destination(target_dist, asset)
+        if destination.exists():
+            if (
+                hashlib.sha256(destination.read_bytes()).digest()
+                != hashlib.sha256(source.read_bytes()).digest()
+            ):
+                raise RetentionError(f"conflicting content-hashed asset: {asset}")
+        else:
+            shutil.copy2(source, destination, follow_symlinks=False)
+
+    previous = (
+        None
+        if snapshot is None
+        else {
+            "build_id": snapshot["current"]["build_id"],
+            "assets": previous_assets,
+        }
+    )
+    deployed_state = {
+        "schema_version": SCHEMA_VERSION,
+        "current": package_state["current"],
+        "previous": previous,
+    }
+    _atomic_write(target_dist / STATE_FILENAME, deployed_state)
+    return deployed_state
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser("validate-source")
+    validate_parser.add_argument("--dist", required=True, type=Path)
+    snapshot_parser = subparsers.add_parser("snapshot")
+    snapshot_parser.add_argument("--dist", required=True, type=Path)
+    snapshot_parser.add_argument("--output", required=True, type=Path)
+    reconcile_parser = subparsers.add_parser("reconcile")
+    reconcile_parser.add_argument("--target-dist", required=True, type=Path)
+    reconcile_parser.add_argument("--snapshot", type=Path)
+    args = parser.parse_args()
+    if args.command == "validate-source":
+        validate_source(args.dist)
+    elif args.command == "snapshot":
+        snapshot_deployment(args.dist, args.output)
+    else:
+        reconcile_install(args.target_dist, args.snapshot)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RetentionError as exc:
+        raise SystemExit(f"frontend asset retention: {exc}") from exc

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -5156,10 +5156,35 @@ do_upgrade() {
             cp "$target_path/usage.db" "$backup_dir/"
         fi
 
-        # Backup frontend build artifacts if source doesn't have them (Issue #1943)
-        # static/js/dist is not tracked in git, so upgrading from git repo would lose it
+        # Validate the new frontend and snapshot the deployment's current
+        # release before any target files are removed (Issues #1943, #2875).
+        # A package build may contain its build machine's previous release;
+        # reconcile_install replaces that with the deployment's previous
+        # release after the new package has been copied.
+        local frontend_retention_helper="$SOURCE_DIR/scripts/frontend_asset_retention.py"
+        local source_frontend_dist="$SOURCE_DIR/static/js/dist"
         local preserve_frontend=false
-        if [ -d "$target_path/static/js/dist" ] && [ ! -d "$SOURCE_DIR/static/js/dist" ]; then
+        local reconcile_frontend=false
+        local retain_previous_frontend=false
+        local frontend_snapshot_dir=""
+        if [ -d "$source_frontend_dist" ]; then
+            reconcile_frontend=true
+            print_info "Validating frontend release metadata before upgrade..."
+            python3 "$frontend_retention_helper" validate-source \
+                --dist "$source_frontend_dist"
+
+            if [ -d "$target_path/static/js/dist" ]; then
+                frontend_snapshot_dir=$(mktemp -d /tmp/open-ace-frontend-assets.XXXXXX)
+                chmod 700 "$frontend_snapshot_dir"
+                print_info "Snapshotting the currently deployed frontend release..."
+                python3 "$frontend_retention_helper" snapshot \
+                    --dist "$target_path/static/js/dist" \
+                    --output "$frontend_snapshot_dir"
+                retain_previous_frontend=true
+            fi
+        elif [ -d "$target_path/static/js/dist" ]; then
+            # static/js/dist is not tracked in git, so upgrading from a source
+            # checkout without build artifacts must preserve the complete dist.
             print_info "Backing up frontend build artifacts (static/js/dist)..."
             mkdir -p "$backup_dir/static/js"
             cp -r "$target_path/static/js/dist" "$backup_dir/static/js/"
@@ -5232,6 +5257,25 @@ do_upgrade() {
             print_warning "Preserved existing frontend build artifacts"
             print_warning "To rebuild frontend with latest code, run:"
             print_warning "  cd $target_path/frontend && npm install && npm run build"
+        elif [ "$reconcile_frontend" = true ]; then
+            print_info "Finalizing frontend release retention..."
+            if [ "$retain_previous_frontend" = true ]; then
+                python3 "$target_path/scripts/frontend_asset_retention.py" reconcile \
+                    --target-dist "$target_path/static/js/dist" \
+                    --snapshot "$frontend_snapshot_dir"
+                case "$frontend_snapshot_dir" in
+                    /tmp/open-ace-frontend-assets.*)
+                        rm -rf -- "$frontend_snapshot_dir"
+                        ;;
+                    *)
+                        print_error "Refusing to remove unexpected frontend snapshot path"
+                        exit 1
+                        ;;
+                esac
+            else
+                python3 "$target_path/scripts/frontend_asset_retention.py" reconcile \
+                    --target-dist "$target_path/static/js/dist"
+            fi
         fi
     fi
 

--- a/tests/fixtures/frontend_asset_state_v1.json
+++ b/tests/fixtures/frontend_asset_state_v1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "current": {
+    "build_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "assets": [
+      "AutonomousDev.aaaaaaaa.js",
+      "index.bbbbbbbb.js"
+    ]
+  },
+  "previous": {
+    "build_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "assets": [
+      "AutonomousDev.dddddddd.js"
+    ]
+  }
+}

--- a/tests/integration/filesystem/test_frontend_asset_retention.py
+++ b/tests/integration/filesystem/test_frontend_asset_retention.py
@@ -1,0 +1,170 @@
+"""Filesystem integration coverage for frontend release asset retention."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER_PATH = REPO_ROOT / "scripts" / "frontend_asset_retention.py"
+SPEC = importlib.util.spec_from_file_location("frontend_asset_retention", HELPER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+retention = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(retention)
+
+pytestmark = [pytest.mark.issue(2875), pytest.mark.regression]
+
+
+def _write_release(
+    dist: Path,
+    name: str,
+    digest: str,
+    *,
+    previous: dict[str, object] | None = None,
+) -> dict[str, object]:
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / ".vite").mkdir(exist_ok=True)
+    asset = f"{name}.{digest}.js"
+    (dist / asset).write_text(asset, encoding="utf-8")
+    manifest = {f"src/{name}.tsx": {"file": asset, "isEntry": True}}
+    raw = json.dumps(manifest, separators=(",", ":")).encode()
+    (dist / ".vite" / "manifest.json").write_bytes(raw)
+    current = {"build_id": hashlib.sha256(raw).hexdigest(), "assets": [asset]}
+    state = {"schema_version": 1, "current": current, "previous": previous}
+    (dist / retention.STATE_FILENAME).write_text(json.dumps(state), encoding="utf-8")
+    return state
+
+
+def test_shared_state_fixture_has_identical_python_contract(tmp_path: Path) -> None:
+    fixture = json.loads(
+        (REPO_ROOT / "tests" / "fixtures" / "frontend_asset_state_v1.json").read_text()
+    )
+    for generation in (fixture["current"], fixture["previous"]):
+        for asset in generation["assets"]:
+            (tmp_path / asset).write_text(asset, encoding="utf-8")
+    (tmp_path / retention.STATE_FILENAME).write_text(json.dumps(fixture))
+
+    assert retention.load_state(tmp_path) == fixture
+
+
+def test_reconcile_keeps_deployment_previous_not_package_previous(tmp_path: Path) -> None:
+    deployed = tmp_path / "deployed"
+    deployed_state = _write_release(deployed, "AutonomousDev", "dddddddd")
+    snapshot = tmp_path / "snapshot"
+    retention.snapshot_deployment(deployed, snapshot)
+
+    package = tmp_path / "package"
+    package_previous_asset = "AutonomousDev.pppppppp.js"
+    package_previous = {
+        "build_id": "f" * 64,
+        "assets": [package_previous_asset],
+    }
+    package_state = _write_release(package, "AutonomousDev", "bbbbbbbb", previous=package_previous)
+    (package / package_previous_asset).write_text("package-only", encoding="utf-8")
+
+    result = retention.reconcile_install(package, snapshot)
+
+    deployed_asset = deployed_state["current"]["assets"][0]
+    package_asset = package_state["current"]["assets"][0]
+    assert (package / deployed_asset).is_file()
+    assert (package / package_asset).is_file()
+    assert not (package / package_previous_asset).exists()
+    assert result["current"] == package_state["current"]
+    assert result["previous"] == deployed_state["current"]
+
+
+def test_reconcile_without_deployment_discards_package_previous(tmp_path: Path) -> None:
+    package_previous_asset = "AutonomousDev.pppppppp.js"
+    package_previous = {"build_id": "f" * 64, "assets": [package_previous_asset]}
+    package_state = _write_release(tmp_path, "AutonomousDev", "bbbbbbbb", previous=package_previous)
+    (tmp_path / package_previous_asset).write_text("package-only", encoding="utf-8")
+
+    result = retention.reconcile_install(tmp_path)
+
+    assert result["current"] == package_state["current"]
+    assert result["previous"] is None
+    assert not (tmp_path / package_previous_asset).exists()
+
+
+def test_reconcile_rejects_symlinked_destination_parent(tmp_path: Path) -> None:
+    deployed = tmp_path / "deployed"
+    nested = deployed / "nested"
+    nested.mkdir(parents=True)
+    old_asset = "nested/AutonomousDev.dddddddd.js"
+    (deployed / old_asset).write_text("deployed", encoding="utf-8")
+    deployed_state = {
+        "schema_version": 1,
+        "current": {"build_id": "d" * 64, "assets": [old_asset]},
+        "previous": None,
+    }
+    (deployed / retention.STATE_FILENAME).write_text(json.dumps(deployed_state))
+    snapshot = tmp_path / "snapshot"
+    retention.snapshot_deployment(deployed, snapshot)
+
+    package = tmp_path / "package"
+    _write_release(package, "AutonomousDev", "bbbbbbbb")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (package / "nested").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable on this platform")
+
+    with pytest.raises(retention.RetentionError, match="unsafe destination parent"):
+        retention.reconcile_install(package, snapshot)
+    assert not (outside / "AutonomousDev.dddddddd.js").exists()
+
+
+def test_legacy_snapshot_ignores_unknown_files_and_symlinks(tmp_path: Path) -> None:
+    dist = tmp_path / "legacy"
+    dist.mkdir()
+    hashed = dist / "AutonomousDev.aaaaaaaa.js"
+    hashed.write_text("old release", encoding="utf-8")
+    (dist / "runtime-config.js").write_text("public", encoding="utf-8")
+    outside = tmp_path / "outside.bbbbbbbb.js"
+    outside.write_text("outside", encoding="utf-8")
+    link = dist / "linked.cccccccc.js"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    snapshot = tmp_path / "snapshot"
+    state = retention.snapshot_deployment(dist, snapshot)
+
+    assert state["current"]["assets"] == [hashed.name]
+    assert not (snapshot / "assets" / "runtime-config.js").exists()
+    assert not (snapshot / "assets" / link.name).exists()
+    assert outside.read_text(encoding="utf-8") == "outside"
+
+
+def test_source_state_must_exactly_match_manifest(tmp_path: Path) -> None:
+    state = _write_release(tmp_path, "index", "12345678")
+    state["current"]["assets"].append("extra.87654321.js")
+    state["current"]["assets"].sort()
+    (tmp_path / "extra.87654321.js").write_text("extra", encoding="utf-8")
+    (tmp_path / retention.STATE_FILENAME).write_text(json.dumps(state))
+
+    with pytest.raises(retention.RetentionError, match="does not match Vite manifest"):
+        retention.validate_source(tmp_path)
+
+
+def test_installer_validates_and_snapshots_before_destructive_cleanup() -> None:
+    installer = (
+        REPO_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
+    ).read_text(encoding="utf-8")
+    validate = installer.index("validate-source")
+    snapshot = installer.index('frontend_retention_helper" snapshot')
+    destructive_cleanup = installer.index('find "$target_path" -mindepth 1', snapshot)
+    destructive_cleanup = installer.index("-exec rm -rf", destructive_cleanup)
+    package_copy = installer.index('cp -r "$SOURCE_DIR"/* "$target_path/"', destructive_cleanup)
+    reconcile = installer.index('frontend_asset_retention.py" reconcile', package_copy)
+
+    assert validate < destructive_cleanup
+    assert snapshot < destructive_cleanup
+    assert destructive_cleanup < package_copy < reconcile
+    assert "source directory lacks static/js/dist" in installer


### PR DESCRIPTION
## Summary

- retain the current and one previous Vite manifest generation so already-open tabs can still fetch lazy chunks after a deployment
- validate and snapshot deployed frontend assets before package-upgrade cleanup, then reconcile deployment history instead of build-machine history
- add a global React error boundary that replaces lazy-import white screens with an explicit, non-looping reload action
- fail closed on malformed manifests, unsafe paths, symlinks, non-regular files, and oversized asset metadata

## Root cause

A deployment replaced the content-hashed frontend distribution and immediately removed the previous hashes. An already-open SPA later visited a route whose `React.lazy` chunk had not been loaded before deployment. The dynamic import returned 404, and because the application had no error boundary, React removed the root UI.

The same deletion risk existed in both package upgrades and direct Vite builds because the build output was emptied before writing the new release.

## Design

The build emits a Vite manifest and a versioned, atomically written `current/previous` asset state. Only manifest/state-controlled or strictly matched legacy hashed regular files may be removed. Repeated builds do not rotate away the real previous generation, and hashes shared by consecutive releases are deduplicated.

The installer validates the package state against its manifest and snapshots the deployed current generation before destructive cleanup. Reconciliation removes package/build-machine history and restores only deployment history. Invalid metadata fails before deletion; a post-cleanup failure leaves the recoverable snapshot in place.

The runtime boundary never auto-reloads, never uses storage guards, and never exposes internal error details.

## Validation

- Node retention tests: 8 passed
- Python filesystem integration: 7 passed
- full frontend Vitest suite: 60 files / 918 tests passed
- TypeScript, ESLint, Black, Ruff, mypy, pre-commit, shell syntax, and diff checks passed
- real Vite production build passed; manifest-derived state contained all 55 hashed resources
- Node 20 Alpine frontend-builder passed and emitted the same valid state
- independent black-box review verified A→B→B retention, no-snapshot package-history removal, and symlink-destination blocking

## Remaining Draft acceptance

- browser matrix with service worker enabled/disabled and a forced lazy-chunk 404
- confirm the recovery UI stays visible and reload occurs only after the explicit button action

Closes #2875