### PR TITLE
feat: 共享项目权限变更审计日志 (#2745)

### DIFF
--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -166,6 +166,10 @@ class AuditAction(Enum):
     TOOL_ACCOUNT_MAPPING_DELETE = "tool_account_mapping_delete"
     TOOL_ACCOUNT_MAPPING_BATCH = "tool_account_mapping_batch"
 
+    # Shared project permission actions (Issue #2745)
+    SHARED_PROJECT_PERMISSION_SETUP_START = "shared_project_permission_setup_start"
+    SHARED_PROJECT_PERMISSION_SETUP_COMPLETE = "shared_project_permission_setup_complete"
+
 
 class AuditSeverity(Enum):
     """Severity levels for audit events."""
@@ -880,6 +884,16 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
                     "value": "permission_revoke",
                     "label": "Permission Revoke",
                     "i18n_key": "actionPermissionRevoke",
+                },
+                {
+                    "value": "shared_project_permission_setup_start",
+                    "label": "Shared Project Permission Setup Start",
+                    "i18n_key": "actionSharedProjectPermissionSetupStart",
+                },
+                {
+                    "value": "shared_project_permission_setup_complete",
+                    "label": "Shared Project Permission Setup Complete",
+                    "i18n_key": "actionSharedProjectPermissionSetupComplete",
                 },
             ],
         },

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -287,6 +287,8 @@ def api_create_project():
                     path,
                     depth_limit=None,  # No depth limit for small projects
                     timeout=60,
+                    user_id=user_id,  # Issue #2745: Pass user_id for audit log
+                    project_id=project_id,  # Issue #2745: Pass project_id for audit log
                 )
                 if not success:
                     logger.error(f"Failed to setup shared permissions: {error_msg}")
@@ -397,6 +399,8 @@ def api_update_project(project_id):
                     project.path,
                     depth_limit=None,
                     timeout=60,
+                    user_id=user_id,  # Issue #2745: Pass user_id for audit log
+                    project_id=project_id,  # Issue #2745: Pass project_id for audit log
                 )
                 if not success:
                     logger.error(f"Failed to setup shared permissions: {error_msg}")
@@ -643,6 +647,8 @@ def api_fix_project_permissions(project_id):
             project.path,
             depth_limit=depth_limit,
             timeout=60,
+            user_id=user_id,  # Issue #2745: Pass user_id for audit log
+            project_id=project_id,  # Issue #2745: Pass project_id for audit log
         )
 
         if success:

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -789,7 +789,7 @@ def _log_permission_audit(
             details["error_message"] = error_message
 
         audit_logger.log_action(
-            action=AuditAction.SHARED_PROJECT_PERMISSION_SETUP_COMPLETE.value,
+            action=AuditAction.SHARED_PROJECT_PERMISSION_SETUP_COMPLETE,
             user_id=user_id,
             resource_type="project",
             resource_id=str(project_id) if project_id else None,

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -13,6 +13,7 @@ import os
 import platform
 import re
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -498,6 +499,8 @@ def setup_permissions_with_depth_limit(
     depth_limit: int | None = None,
     timeout: int = 60,
     progress_callback=None,
+    user_id: int | None = None,
+    project_id: int | None = None,
 ) -> tuple[bool, str, int]:
     """Set permissions with optional recursion depth limit.
 
@@ -506,21 +509,29 @@ def setup_permissions_with_depth_limit(
     2. Limits recursion depth when specified
     3. Provides progress feedback via callback
     4. Has better timeout handling
+    5. Records audit log for permission setup (Issue #2745)
 
     Args:
         path: Absolute path to the project directory.
         depth_limit: Maximum recursion depth (None = no limit).
         timeout: Timeout in seconds for entire operation.
         progress_callback: Optional callback function(percent, processed, total).
+        user_id: User ID who initiated the operation (for audit log).
+        project_id: Project ID for audit log resource_id.
 
     Returns:
         Tuple of (success, error_message, files_processed).
     """
+    import time
+
     if not _is_docker_multi_user_mode():
         return (True, "", 0)
 
     if not path or not os.path.isabs(path) or not os.path.exists(path):
         return (False, "Invalid path", 0)
+
+    operation_start_time = time.time()
+    operation_start_datetime = datetime.now().isoformat()
 
     try:
         # Ensure shared group
@@ -600,14 +611,64 @@ def setup_permissions_with_depth_limit(
                 progress_callback(100, files_processed, files_processed)
 
         logger.info(f"Set permissions for {files_processed} items in {path}")
+
+        # Record audit log for successful permission setup (Issue #2745)
+        _log_permission_audit(
+            user_id=user_id,
+            project_id=project_id,
+            path=path,
+            success=True,
+            files_processed=files_processed,
+            operation_start_time=operation_start_time,
+            operation_start_datetime=operation_start_datetime,
+            depth_limit=depth_limit,
+        )
+
         return (True, "", files_processed)
 
-    except subprocess.TimeoutExpired:
-        return (False, f"Operation timed out after {timeout}s", 0)
+    except subprocess.TimeoutExpired as e:
+        error_msg = f"Operation timed out after {timeout}s"
+        # Record audit log for failed permission setup (Issue #2745)
+        _log_permission_audit(
+            user_id=user_id,
+            project_id=project_id,
+            path=path,
+            success=False,
+            files_processed=0,
+            operation_start_time=operation_start_time,
+            operation_start_datetime=operation_start_datetime,
+            error_message=error_msg,
+            depth_limit=depth_limit,
+        )
+        return (False, error_msg, 0)
     except subprocess.CalledProcessError as e:
-        return (False, f"Command failed: {e.stderr}", 0)
+        error_msg = f"Command failed: {e.stderr}"
+        _log_permission_audit(
+            user_id=user_id,
+            project_id=project_id,
+            path=path,
+            success=False,
+            files_processed=0,
+            operation_start_time=operation_start_time,
+            operation_start_datetime=operation_start_datetime,
+            error_message=error_msg,
+            depth_limit=depth_limit,
+        )
+        return (False, error_msg, 0)
     except Exception as e:
-        return (False, f"Unexpected error: {e}", 0)
+        error_msg = f"Unexpected error: {e}"
+        _log_permission_audit(
+            user_id=user_id,
+            project_id=project_id,
+            path=path,
+            success=False,
+            files_processed=0,
+            operation_start_time=operation_start_time,
+            operation_start_datetime=operation_start_datetime,
+            error_message=error_msg,
+            depth_limit=depth_limit,
+        )
+        return (False, error_msg, 0)
 
 
 def verify_setgid_support(path: str) -> tuple[bool, str]:
@@ -668,3 +729,80 @@ def verify_setgid_support(path: str) -> tuple[bool, str]:
             import shutil
 
             shutil.rmtree(test_dir, ignore_errors=True)
+
+
+# ============================================================================
+# Audit Log Helper Functions (Issue #2745)
+# ============================================================================
+
+
+def _log_permission_audit(
+    user_id: int | None,
+    project_id: int | None,
+    path: str,
+    success: bool,
+    files_processed: int,
+    operation_start_time: float,
+    operation_start_datetime: str,
+    error_message: str | None = None,
+    depth_limit: int | None = None,
+) -> None:
+    """Record audit log for shared project permission setup.
+
+    Uses a separate database connection to avoid transaction rollback issues.
+    Failures are logged but never raise exceptions.
+
+    Args:
+        user_id: User ID who initiated the operation.
+        project_id: Project ID for resource_id.
+        path: Project path.
+        success: Whether the operation succeeded.
+        files_processed: Number of files processed.
+        operation_start_time: Unix timestamp when operation started.
+        operation_start_datetime: ISO format datetime when operation started.
+        error_message: Error message if operation failed.
+        depth_limit: Recursion depth limit used.
+    """
+    import time
+
+    try:
+        from app.modules.governance.audit_logger import AuditAction, AuditLogger
+
+        audit_logger = AuditLogger()
+
+        operation_end_time = time.time()
+        duration_seconds = operation_end_time - operation_start_time
+
+        details = {
+            "path": path,
+            "files_processed": files_processed,
+            "operation_start_time": operation_start_datetime,
+            "operation_end_time": datetime.now().isoformat(),
+            "duration_seconds": round(duration_seconds, 2),
+            "success": success,
+        }
+
+        if depth_limit is not None:
+            details["depth_limit"] = depth_limit
+
+        if error_message:
+            details["error_message"] = error_message
+
+        audit_logger.log_action(
+            action=AuditAction.SHARED_PROJECT_PERMISSION_SETUP_COMPLETE.value,
+            user_id=user_id,
+            resource_type="project",
+            resource_id=str(project_id) if project_id else None,
+            details=details,
+            success=success,
+            error_message=error_message,
+        )
+
+        logger.debug(
+            f"Recorded permission audit log: user_id={user_id}, project_id={project_id}, "
+            f"path={path}, success={success}, files_processed={files_processed}"
+        )
+
+    except Exception as e:
+        # Audit log failure should not affect main operation
+        logger.error(f"Failed to record permission audit log: {e}")

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -626,7 +626,7 @@ def setup_permissions_with_depth_limit(
 
         return (True, "", files_processed)
 
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         error_msg = f"Operation timed out after {timeout}s"
         # Record audit log for failed permission setup (Issue #2745)
         _log_permission_audit(

--- a/tests/test_audit_actions_sync.py
+++ b/tests/test_audit_actions_sync.py
@@ -32,7 +32,7 @@ class TestAuditActionsSynchronization:
         expected_categories = {
             "Authentication": 4,  # LOGIN, LOGOUT, LOGIN_FAILED, SESSION_EXPIRED
             "User Management": 8,  # USER_CREATE, UPDATE, DELETE, RESTORE, PASSWORD_CHANGE, PASSWORD_CHANGE_FAILED, ROLE_CHANGE, STATUS_CHANGE
-            "Permission": 2,  # PERMISSION_GRANT, REVOKE
+            "Permission": 4,  # PERMISSION_GRANT, REVOKE, SHARED_PROJECT_PERMISSION_SETUP_START, SHARED_PROJECT_PERMISSION_SETUP_COMPLETE (Issue #2745)
             "Quota": 3,  # QUOTA_UPDATE, ALERT, EXCEEDED
             "Data Access": 4,  # DATA_VIEW, EXPORT, IMPORT, DELETE
             "System": 3,  # SYSTEM_CONFIG_CHANGE, START, STOP

--- a/tests/unit/test_audit_logger.py
+++ b/tests/unit/test_audit_logger.py
@@ -541,7 +541,8 @@ class TestGetActionCategories:
         total_actions = sum(len(cat["actions"]) for cat in categories.values())
         # Issue #2759: Added 4 tool_account_mapping actions (57 -> 61)
         # Issue #2755: Added user_restore action (61 -> 62)
-        assert total_actions == 62, f"Expected 62 actions, got {total_actions}"
+        # Issue #2745: Added 2 shared_project_permission actions (62 -> 64)
+        assert total_actions == 64, f"Expected 64 actions, got {total_actions}"
 
     def test_get_action_categories_matches_enum_values(self):
         """Test that all action values match AuditAction enum values."""


### PR DESCRIPTION
Closes #2745

## 修复内容

为共享项目权限设置操作添加审计日志记录，便于追踪：
- 何时设置了共享权限
- 由谁触发（API 调用者）
- 涉及哪些目录

## 主要变更

- `app/modules/governance/audit_logger.py`: 新增 AuditAction 枚举值和类别定义
- `app/utils/workspace.py`: 添加审计日志记录逻辑
- `app/routes/projects.py`: 传递 user_id、project_id 参数
- `tests/unit/test_audit_logger.py`: 更新动作总数断言

## 审计日志内容

- 触发者 user_id
- 项目路径 path
- 操作结果 success
- 处理文件数 files_processed
- 操作时间线（开始时间、结束时间、持续时间）

## 修复方案

详见 Issue #2745 评论中的方案协作过程。

## 测试

- 单元测试：42 个审计日志测试全部通过
- 单元测试：29 个共享项目权限测试全部通过

## 注意事项

当前仅实现同步场景审计日志，异步任务审计日志将在任务执行器实现时添加。