### PR TITLE
ci: surface a visible "lane not needed" note + un-mask advisory E2E (eval §6.2 P1-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,23 @@ jobs:
           - python-version: '3.14'
             suite: compatibility-smoke
     steps:
+      # eval P1-1: each lane is a REQUIRED check, so it must always report (green)
+      # to satisfy the branch ruleset. When the suite was not selected for this
+      # change set the real steps below are skipped, which historically left the
+      # lane green with no visible reason -- a "was this actually tested?" gap that
+      # was only discoverable in the raw step logs. Make that honest and visible:
+      # emit a run-summary annotation and a job-summary line naming the skipped
+      # lane. (A truly SKIPPED badge instead of green would require de-matrixing
+      # into per-version jobs; that is deliberately out of scope for this change.)
       - name: Explain skipped lane
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core != 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke != 'true')
-        run: echo "${{ matrix.suite }} is not needed for this change set"
+        run: |
+          MSG="Lane not needed: ${{ matrix.suite }} was not selected for this change set (no matching paths changed)."
+          echo "::notice title=Lane not needed::${MSG}"
+          echo "**${{ matrix.suite }} lane skipped** — ${MSG}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${MSG}"
 
       - uses: actions/checkout@v6
         if: >-
@@ -270,18 +282,28 @@ jobs:
         run: python scripts/ci.py run postgres
 
   critical-e2e:
-    name: Critical E2E (advisory)
+    # Advisory, and honestly so (eval P1-1). This job is deliberately NOT in the
+    # PR Gate's `needs`, so its result never blocks a PR merge -- E2E gates
+    # releases, not PRs. It intentionally does NOT set `continue-on-error`: a
+    # failure now surfaces as an honest red check (informational) rather than a
+    # masked green one. The previous `continue-on-error: true` + absence from the
+    # gate double-neutered it into a hidden fail-open.
+    name: Critical E2E (advisory, non-blocking)
     needs: changes
     if: >-
       needs.changes.outputs.critical_e2e == 'true' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-extended-tests')
-    continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       # Keep the installed browser outside the isolated HOME used by the tests.
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
+      - name: Advisory notice
+        run: >-
+          echo "::notice title=Critical E2E is advisory::This suite does NOT gate
+          PR merge (it gates releases). A red result here is informational, not a
+          merge blocker."
       - uses: actions/checkout@v6
         with:
           submodules: false


### PR DESCRIPTION
## What & why (eval §6.2 P1-1: CI gating honesty)

Two honesty gaps in `ci.yml`, fixed with the **minimum** change and **zero** risk to the required-check contexts.

### 1. `critical-e2e` — remove the hidden fail-open
It had `continue-on-error: true` **and** was absent from the PR Gate's `needs`, so a genuine E2E failure reported a **masked green** and blocked nothing.

- Drop `continue-on-error: true` → a real failure now shows an **honest red** (informational) check.
- Keep it **non-blocking** (still not in the gate's `needs`) and add an advisory `::notice::` saying it gates releases, not PRs.

### 2. `test` lanes — make "green but not tested" honest and visible
Each `test (3.x)` is a **required** check, so it must always report to satisfy the branch ruleset. When a suite isn't selected for a change set, the real steps are skipped and the lane went green with the reason buried in raw logs.

- Keep the proven **step-level** selection guards (the lane stays a reported required check).
- Upgrade the `Explain skipped lane` step to emit a run-summary `::notice::` annotation **and** a `$GITHUB_STEP_SUMMARY` line naming the un-selected suite — visible on the run/job pages without opening logs.

### Deliberately out of scope
A truly **skipped/gray** badge for an un-selected lane would require de-matrixing `test` into per-version jobs. An earlier revision of this PR attempted the honest-skip via a **job-level `if` that referenced `matrix`** — which is **not a valid context** at job level and made the whole workflow `startup_failure` (0 checks, unmergeable; would have locked merges repo-wide if forced). That approach was reverted. Per-lane gray badges can be revisited as a separate, larger change if desired.

### `pr-gate`
Unchanged from `main`: with step-level guards the `test` job always reports success, so the earlier selection-aware gate rewrite was a no-op and was dropped to keep the diff minimal.

## Validation
- `actionlint` passes clean (exit 0) on `ci.yml` — the invalid-context error is gone (no job-level `if` references `matrix` anymore).
- Diff vs `main` is exactly the two changes above; `pr-gate` and the step-guards are byte-identical to base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
