### PR TITLE
ci: auto-heal schema sync snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-  # Re-triggered by the Lint Heal workflow (.github/workflows/lint-heal.yml)
+  # Re-triggered by heal workflows (for example lint-heal.yml and
+  # schema-sync-heal.yml)
   # when approving the parked runs for a healed head was not possible
   # (GITHUB_TOKEN pushes fire no CI events; dispatch does). healed_sha marks a
   # dispatch as heal-originated: PR Gate stamps only for PR runs or dispatches
@@ -17,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       healed_sha:
-        description: 'Head SHA of a Lint Heal push (set automatically; manual dispatches must leave it empty)'
+        description: 'Head SHA of an automated heal push (set automatically; manual dispatches must leave it empty)'
         required: false
         type: string
 

--- a/.github/workflows/schema-sync-heal.yml
+++ b/.github/workflows/schema-sync-heal.yml
@@ -1,0 +1,247 @@
+name: Schema Sync Heal
+
+# Auto-heal Schema Sync snapshot drift: when Schema Sync fails on a same-repo
+# PR after producing its authoritative regenerated-schema artifact, apply that
+# artifact back to the exact failed head and push a normal follow-up commit.
+#
+# This workflow intentionally does not rebuild snapshots itself. The failed
+# Schema Sync run already ran the CI-pinned rebuild on its PostgreSQL service;
+# this job only applies that run's artifact after strict path validation.
+
+on:
+  workflow_run:
+    workflows: [Schema Sync]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: schema-sync-heal-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  heal:
+    name: Apply regenerated schema snapshots
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Guard - schema-sync failed, head is still the PR tip
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if ! schema_state="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "schema-sync") | .conclusion')"; then
+            echo "::warning::Could not read jobs for Schema Sync run ${RUN_ID}; skipping heal."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$schema_state" ]; then
+            echo "::warning::No job named 'schema-sync' in run ${RUN_ID}; workflow coupling has drifted."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$schema_state" != "failure" ]; then
+            echo "Schema Sync job did not fail (schema-sync=${schema_state}); nothing to heal."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          prs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+            --jq "[.[] | select(.state == \"open\")]" || true)"
+          pr="$(printf '%s' "$prs" | jq --arg sha "$HEAD_SHA" \
+            'map(select(.head.sha == $sha))[0] // .[0] // empty')"
+          pr_number="$(printf '%s' "$pr" | jq -r '.number // empty')"
+          if [ -z "$pr_number" ]; then
+            echo "No open PR is associated with head ${HEAD_SHA:0:8}; nothing to heal."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$(printf '%s' "$pr" | jq -r '.head.repo.full_name')" != "$GITHUB_REPOSITORY" ]; then
+            echo "PR #${pr_number} head lives in a fork; only same-repo branches are healed."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          tip="$(printf '%s' "$pr" | jq -r '.head.sha')"
+          if [ "$tip" != "$HEAD_SHA" ]; then
+            echo "Branch moved (${tip:0:8} is the tip); the newer push's own Schema Sync run takes over."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "branch=$(printf '%s' "$pr" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        if: steps.guard.outputs.skip != 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          submodules: false
+
+      - name: Loop guard - do not heal twice in a row
+        id: loopguard
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          if [[ "$(git log -1 --pretty=%s)" == "chore(schema): apply regenerated schema snapshots"* ]]; then
+            echo "Head commit is already a schema snapshot heal; the remaining Schema Sync failure is not artifact-fixable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download regenerated schema artifact
+        id: download
+        if: steps.guard.outputs.skip != 'true' && steps.loopguard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          rm -rf regenerated-schema
+          mkdir -p regenerated-schema
+          if ! gh run download "$RUN_ID" --name regenerated-schema --dir regenerated-schema; then
+            echo "::warning::Schema Sync run ${RUN_ID} did not expose a regenerated-schema artifact; nothing to apply."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and apply schema artifact
+        id: validate
+        if: >-
+          steps.guard.outputs.skip != 'true' &&
+          steps.loopguard.outputs.skip != 'true' &&
+          steps.download.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+
+          unexpected_node="$(find regenerated-schema ! -type d ! -type f -print -quit)"
+          if [ -n "$unexpected_node" ]; then
+            echo "::error::unexpected regenerated-schema artifact payload: ${unexpected_node}"
+            exit 1
+          fi
+
+          artifact_expected="$(mktemp)"
+          diff_allowed="$(mktemp)"
+          actual="$(mktemp)"
+          printf '%s\n' \
+            schema-postgres.sql \
+            schema-sqlite.sql \
+            > "$artifact_expected"
+          printf '%s\n' \
+            schema/schema-postgres.sql \
+            schema/schema-sqlite.sql \
+            > "$diff_allowed"
+          find regenerated-schema -type f -print \
+            | sed 's#^regenerated-schema/##' \
+            | sort > "$actual"
+          if ! cmp -s "$artifact_expected" "$actual"; then
+            echo "::error::unexpected regenerated-schema artifact payload"
+            echo "Expected:"
+            cat "$artifact_expected"
+            echo "Actual:"
+            cat "$actual"
+            exit 1
+          fi
+
+          cp regenerated-schema/schema-postgres.sql schema/schema-postgres.sql
+          cp regenerated-schema/schema-sqlite.sql schema/schema-sqlite.sql
+
+          changed="$(git diff --name-only | sort)"
+          unexpected_changed="$(printf '%s\n' "$changed" | grep -vxF -f "$diff_allowed" || true)"
+          if [ -n "$unexpected_changed" ]; then
+            echo "::error::unexpected files changed by schema artifact"
+            printf '%s\n' "$unexpected_changed"
+            exit 1
+          fi
+
+          if git diff --quiet -- schema/schema-postgres.sql schema/schema-sqlite.sql; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Do not execute PR-controlled validation scripts under this write-token
+          # workflow. The re-triggered Schema Sync run remains the authoritative
+          # schema validator.
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push regenerated schema snapshots and re-trigger checks
+        if: >-
+          steps.guard.outputs.skip != 'true' &&
+          steps.loopguard.outputs.skip != 'true' &&
+          steps.download.outputs.skip != 'true' &&
+          steps.validate.outputs.changed == 'true'
+        env:
+          BRANCH: ${{ steps.guard.outputs.branch }}
+          PR_NUMBER: ${{ steps.guard.outputs.pr_number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- schema/schema-postgres.sql schema/schema-sqlite.sql
+          git commit -m "chore(schema): apply regenerated schema snapshots for #${PR_NUMBER}"
+          if ! git push origin "HEAD:$BRANCH"; then
+            echo "::warning::Branch $BRANCH moved during the heal; skipping re-trigger."
+            exit 0
+          fi
+
+          NEW_SHA="$(git rev-parse HEAD)"
+          # A GITHUB_TOKEN push may park pull_request runs for the new head in
+          # action_required. Approving them replays the normal PR pipeline and
+          # Schema Sync. If no parked runs appear, dispatch both workflows.
+          approved=0
+          RUN_IDS=""
+          for attempt in 1 2; do
+            sleep 5
+            RUN_IDS="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${NEW_SHA}&status=action_required" \
+              --jq '.workflow_runs[].id' 2>/dev/null || true)"
+            if [ -n "$RUN_IDS" ]; then break; fi
+            echo "waiting for parked runs at ${NEW_SHA:0:8} (attempt $attempt)"
+          done
+          for run_id in $RUN_IDS; do
+            if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/approve" --method POST >/dev/null 2>&1; then
+              approved=$((approved + 1))
+              echo "Approved parked run $run_id"
+            else
+              echo "::warning::Could not approve parked run $run_id"
+            fi
+          done
+          if [ "$approved" -eq 0 ]; then
+            for run_id in $RUN_IDS; do
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" --method POST >/dev/null 2>&1 || true
+            done
+            echo "No parked runs approved; cancelling leftovers and dispatching CI with healed_sha and Schema Sync with pull_request_number."
+            jq -n --arg ref "$BRANCH" --arg sha "$NEW_SHA" \
+              '{ref: $ref, inputs: {healed_sha: $sha}}' \
+              | gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/dispatches" \
+                --method POST --input -
+            jq -n --arg ref "$BRANCH" --arg sha "$NEW_SHA" --arg pr "$PR_NUMBER" \
+              '{ref: $ref, inputs: {pull_request_number: $pr}}' \
+              | gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/schema-sync.yml/dispatches" \
+                --method POST --input -
+            echo "Re-triggered CI on $BRANCH via workflow_dispatch (healed_sha=$NEW_SHA)"
+            echo "Re-triggered Schema Sync on $BRANCH via workflow_dispatch (pull_request_number=$PR_NUMBER)"
+          fi
+
+      - name: Nothing to apply
+        if: >-
+          steps.guard.outputs.skip != 'true' &&
+          steps.loopguard.outputs.skip != 'true' &&
+          (
+            steps.download.outputs.skip == 'true' ||
+            steps.validate.outputs.changed == 'false'
+          )
+        run: echo "No regenerated schema snapshot changes to push."

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -33,6 +33,12 @@ on:
       - 'scripts/generate_schema.py'
       - 'scripts/validate_schema.py'
       - 'scripts/shared/schema_sync.py'
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'PR number whose merge ref should be verified after an automated heal'
+        required: false
+        type: string
 
 jobs:
   schema-sync:
@@ -62,6 +68,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.pull_request_number && format('refs/pull/{0}/merge', inputs.pull_request_number) || github.sha }}
           submodules: false
 
       - name: Set up Python

--- a/tests/unit/test_schema_sync_heal_workflow.py
+++ b/tests/unit/test_schema_sync_heal_workflow.py
@@ -1,0 +1,157 @@
+"""Contract tests for the Schema Sync Heal workflow.
+
+The workflow applies the authoritative ``regenerated-schema`` artifact emitted
+by the failed Schema Sync run. These tests pin the safety boundaries that make
+that write-token workflow acceptable: same-repo PRs only, exact failed head,
+the schema artifact only, and a two-file diff before push.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "schema-sync-heal.yml"
+
+pytestmark = []
+
+
+def _workflow() -> dict:
+    return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, *, name: str | None = None, step_id: str | None = None) -> dict:
+    steps = workflow["jobs"]["heal"]["steps"]
+    for step in steps:
+        if name is not None and step.get("name") == name:
+            return step
+        if step_id is not None and step.get("id") == step_id:
+            return step
+    wanted = name if name is not None else step_id
+    raise AssertionError(f"workflow step not found: {wanted}")
+
+
+def test_schema_sync_heal_is_triggered_by_schema_sync_completion_only():
+    workflow = _workflow()
+
+    assert workflow["name"] == "Schema Sync Heal"
+    assert workflow["on"]["workflow_run"]["workflows"] == ["Schema Sync"]
+    assert workflow["on"]["workflow_run"]["types"] == ["completed"]
+    assert workflow["permissions"] == {"contents": "write", "actions": "write"}
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+
+    job = workflow["jobs"]["heal"]
+    assert "github.event.workflow_run.conclusion == 'failure'" in job["if"]
+    assert "github.event.workflow_run.event == 'pull_request'" in job["if"]
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in job["if"]
+
+
+def test_guard_requires_failed_schema_sync_job_and_exact_pr_tip():
+    workflow = _workflow()
+    guard = _step(workflow, step_id="guard")
+    run = guard["run"]
+
+    assert 'select(.name == "schema-sync") | .conclusion' in run
+    assert 'if [ "$schema_state" != "failure" ]; then' in run
+    assert "commits/${HEAD_SHA}/pulls" in run
+    assert "select(.head.sha == $sha)" in run
+    assert ".head.repo.full_name" in run
+    assert 'if [ "$tip" != "$HEAD_SHA" ]; then' in run
+    assert "branch moved" in run.lower()
+
+
+def test_loop_guard_skips_existing_schema_heal_commit():
+    workflow = _workflow()
+    loopguard = _step(workflow, step_id="loopguard")
+    run = loopguard["run"]
+
+    assert "chore(schema): apply regenerated schema snapshots" in run
+    assert "skip=true" in run
+    download = _step(workflow, step_id="download")
+    assert "steps.loopguard.outputs.skip != 'true'" in download["if"]
+
+
+def test_artifact_download_and_validation_are_fail_closed_to_schema_files():
+    workflow = _workflow()
+    download = _step(workflow, step_id="download")
+    validate = _step(workflow, step_id="validate")
+
+    assert 'gh run download "$RUN_ID" --name regenerated-schema' in download["run"]
+
+    run = validate["run"]
+    assert "schema-postgres.sql" in run
+    assert "schema-sqlite.sql" in run
+    assert "regenerated-schema/schema-postgres.sql" in run
+    assert "regenerated-schema/schema-sqlite.sql" in run
+    assert "regenerated-schema/schema/schema-postgres.sql" not in run
+    assert "regenerated-schema/schema/schema-sqlite.sql" not in run
+    assert "schema/schema-postgres.sql" in run
+    assert "schema/schema-sqlite.sql" in run
+    assert "unexpected regenerated-schema artifact payload" in run
+    assert "git diff --name-only" in run
+    assert "unexpected files changed by schema artifact" in run
+    assert "scripts/validate_schema.py" not in run
+    assert "PR-controlled validation scripts" in run
+    assert "git diff --check" not in run
+
+
+def test_diff_guard_allows_schema_file_subset_changes_only():
+    workflow = _workflow()
+    validate = _step(workflow, step_id="validate")
+    run = validate["run"]
+
+    assert 'grep -vxF -f "$diff_allowed"' in run
+    assert '[ "$changed" != "$(cat "$expected")" ]' not in run
+
+
+def test_push_is_plain_non_force_and_retriggers_ci():
+    workflow = _workflow()
+    push = _step(workflow, name="Push regenerated schema snapshots and re-trigger checks")
+    run = push["run"]
+
+    assert (
+        'git commit -m "chore(schema): apply regenerated schema snapshots for #${PR_NUMBER}"' in run
+    )
+    assert 'git push origin "HEAD:$BRANCH"' in run
+    assert "--force" not in run
+    assert "actions/runs/${run_id}/approve" in run
+    assert "actions/runs?head_sha=${NEW_SHA}&status=action_required" in run
+    assert (
+        "actions/workflows/schema-sync.yml/runs?head_sha=${NEW_SHA}&status=action_required"
+        not in run
+    )
+    assert "actions/workflows/ci.yml/dispatches" in run
+    assert "actions/workflows/schema-sync.yml/dispatches" in run
+    assert "sleep 5" in run
+    assert "1 2" in run
+
+
+def test_schema_sync_dispatch_checks_out_pr_merge_ref():
+    workflow = yaml.load(
+        (REPO_ROOT / ".github" / "workflows" / "schema-sync.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    checkout = next(
+        step
+        for step in workflow["jobs"]["schema-sync"]["steps"]
+        if step.get("uses") == "actions/checkout@v6"
+    )
+
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert "healed_sha" not in inputs
+    assert inputs["pull_request_number"]
+    assert checkout["with"]["ref"] == (
+        "${{ inputs.pull_request_number && "
+        "format('refs/pull/{0}/merge', inputs.pull_request_number) || github.sha }}"
+    )
+
+
+def test_fallback_dispatch_uses_healed_sha_only_for_ci_marker():
+    workflow = _workflow()
+    push = _step(workflow, name="Push regenerated schema snapshots and re-trigger checks")
+    run = push["run"]
+
+    assert "{ref: $ref, inputs: {healed_sha: $sha}}" in run
+    assert '--arg pr "$PR_NUMBER"' in run
+    assert "inputs: {pull_request_number: $pr}" in run
+    assert "inputs: {healed_sha: $sha, pull_request_number: $pr}" not in run


### PR DESCRIPTION
## Summary
- add a Schema Sync Heal workflow that applies the failed run's regenerated-schema artifact to same-repo PRs
- validate the artifact payload and resulting diff so only schema snapshots can be committed
- add workflow contract tests and workflow_dispatch support for Schema Sync re-runs

## Verification
- python3 -m pytest tests/unit/test_schema_sync_heal_workflow.py tests/unit/test_lint_heal_workflow.py
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/schema-sync.yml .github/workflows/schema-sync-heal.yml