### PR TITLE
fix: merged-PR reuse in pr_review (#331) + scheduler starvation from blocking advances

### DIFF
--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -312,6 +312,40 @@ def handle(ctx, deps) -> PhaseResult:
     # stale. The handler keeps a local pr_number after creation so downstream
     # reads in the same cycle do not depend on the persisted write.
     existing_pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+    # Liveness check on the recorded PR: a re-entry into pr_review (e.g. after
+    # an acceptance-verification rejection with resume-with-feedback, which
+    # resets current_round to 0) keeps the OLD github_pr_number on the row.
+    # If that PR was already merged, every later round — and the merge phase —
+    # operates on the merged PR's headRefOid and the merge resolution computes
+    # no new commit ("Merge resolution made no commit; refusing unchanged
+    # push", workflow #331). A non-OPEN recorded PR is therefore treated as
+    # absent on the round-1 creation window so a fresh PR is created; the
+    # "already exists" recovery below still guards against duplicates when the
+    # state probe failed while an OPEN PR exists. On later rounds the number is
+    # kept (downstream reads expect a non-None pr_number) and only a warning is
+    # logged — the main reachable path there is a human merging the PR
+    # mid-review.
+    if existing_pr_number:
+        try:
+            recorded_pr = gh.get_pr(existing_pr_number)
+            pr_state = (recorded_pr.get("state") or "").upper()
+        except Exception:
+            pr_state = ""
+        if pr_state != "OPEN":
+            if round_num == 1:
+                logger.warning(
+                    "Recorded PR #%s state=%r is not OPEN; creating a fresh PR",
+                    existing_pr_number,
+                    pr_state or "unknown",
+                )
+                existing_pr_number = None
+            else:
+                logger.warning(
+                    "Recorded PR #%s state=%r is not OPEN at round %d; keeping PR id",
+                    existing_pr_number,
+                    pr_state or "unknown",
+                    round_num,
+                )
     pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
     if round_num == 1 and not existing_pr_number:
         try:

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -318,20 +318,34 @@ def handle(ctx, deps) -> PhaseResult:
     # If that PR was already merged, every later round — and the merge phase —
     # operates on the merged PR's headRefOid and the merge resolution computes
     # no new commit ("Merge resolution made no commit; refusing unchanged
-    # push", workflow #331). A non-OPEN recorded PR is therefore treated as
-    # absent on the round-1 creation window so a fresh PR is created; the
-    # "already exists" recovery below still guards against duplicates when the
-    # state probe failed while an OPEN PR exists. On later rounds the number is
-    # kept (downstream reads expect a non-None pr_number) and only a warning is
-    # logged — the main reachable path there is a human merging the PR
-    # mid-review.
+    # push", workflow #331). A confirmed non-OPEN recorded PR is therefore
+    # treated as absent on the round-1 creation window so a fresh PR is
+    # created; the "already exists" recovery below still guards against
+    # duplicates when the state probe failed while an OPEN PR exists. On later
+    # rounds the number is kept (downstream reads expect a non-None
+    # pr_number) and only a warning is logged — the main reachable path there
+    # is a human merging the PR mid-review.
     if existing_pr_number:
+        probe_error: Exception | None = None
+        pr_state = ""
         try:
             recorded_pr = gh.get_pr(existing_pr_number)
             pr_state = (recorded_pr.get("state") or "").upper()
-        except Exception:
-            pr_state = ""
-        if pr_state != "OPEN":
+        except Exception as e:
+            probe_error = e
+        if probe_error is not None:
+            # A FAILED probe (transient gh/API error) is not evidence the PR
+            # is non-OPEN: nulling the number here would attempt a doomed
+            # create_pr through the same flaky gh and could fail the workflow
+            # outright where keeping the recorded PR proceeds normally. Keep
+            # the id on every round and let the "already exists" recovery
+            # handle the rare case where a fresh PR genuinely exists.
+            logger.warning(
+                "Recorded PR #%s state probe failed (%s); keeping PR id",
+                existing_pr_number,
+                probe_error,
+            )
+        elif pr_state != "OPEN":
             if round_num == 1:
                 logger.warning(
                     "Recorded PR #%s state=%r is not OPEN; creating a fresh PR",

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -312,6 +312,13 @@ class AutonomousScheduler:
         self._reap_completed_futures()
         if self._bg_executor is not None:
             self._bg_executor.shutdown(wait=False)
+            # Reset so a later start() on this singleton rebuilds a live
+            # executor. _get_bg_executor only rebuilds on None/cap-change, so
+            # without this reset a stop()→start() cycle would submit to the
+            # dead executor forever (RuntimeError swallowed by _run_loop's
+            # except → the loop spins advancing nothing, a silent outage).
+            self._bg_executor = None
+            self._bg_executor_cap = 0
         logger.info(
             "Autonomous scheduler stopped (%d active attempts interrupted)", len(orchestrators)
         )
@@ -1206,8 +1213,11 @@ class AutonomousScheduler:
         returns immediately; completed futures are reaped later via
         ``_reap_completed_futures``. Slot accounting is identical on both
         paths: selected workflows are registered in ``_in_progress_ids``
-        before submission, so the background executor never holds more work
-        than the concurrency cap. NOTE: the ``wait=False`` path currently has
+        before submission, so the background executor holds no more work than
+        the concurrency cap — except when the stale-lease reclaim
+        (``_reclaim_stale_in_progress``) drops a memory entry whose future is
+        still executing, which intentionally supersedes the memory cap when
+        the DB lease breaks. NOTE: the ``wait=False`` path currently has
         a single caller (``_run_loop``); a second concurrent caller would need
         the selection+registration lock blocks merged into one critical
         section to keep the "read-then-register" window race-free.
@@ -1397,7 +1407,21 @@ class AutonomousScheduler:
             executor = self._get_bg_executor()
             for wf in to_process:
                 wf_id = wf.get("workflow_id", "")
-                future = executor.submit(self._advance_single, wf_id)
+                try:
+                    future = executor.submit(self._advance_single, wf_id)
+                except RuntimeError:
+                    # stop() shut the executor down between selection and this
+                    # submit (the 20s join can time out while the loop is
+                    # still mid-tick). Release the registration made for this
+                    # workflow — otherwise its slot/conflict keys linger until
+                    # the stale-lease reclaim (~30 min) heals them.
+                    logger.warning(
+                        "Background submit for workflow %s failed (executor shut down); "
+                        "releasing slot",
+                        wf_id[:8],
+                    )
+                    self._discard_in_progress_entry(wf_id, legacy_wf=wf)
+                    continue
                 with self._futures_lock:
                     self._in_flight_futures[future] = wf_id
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -15,7 +15,7 @@ import signal
 import socket
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -244,6 +244,22 @@ class AutonomousScheduler:
         # _reclaim_stale_in_progress).
         self._in_progress_key_map: dict[str, tuple[str | None, str, str]] = {}
         self._in_progress_lock = threading.Lock()
+        # Non-blocking advance path (#331 follow-up, scheduler starvation): a
+        # single _advance_single call can run tens of minutes (agent runs +
+        # CI polling). Waiting for it inside _process_workflows parked the
+        # whole _run_loop — promotion/auto-resume/reclaim/cleanup all stalled
+        # and new batches starved for the duration (observed 49-min gap,
+        # 2026-08-20 18:19→19:08). _run_loop therefore submits via a
+        # persistent background executor and returns immediately; completed
+        # futures are reaped (and their errors logged) on later ticks.
+        self._bg_executor: ThreadPoolExecutor | None = None
+        self._bg_executor_cap: int = 0
+        self._in_flight_futures: dict[Future, str] = {}  # future -> workflow_id
+        # Guards _in_flight_futures: normally only the _run_loop thread
+        # touches it, but stop() may call _reap_completed_futures() from
+        # another thread even when the loop join timed out and the loop is
+        # still running — the lock keeps that concurrent access safe.
+        self._futures_lock = threading.Lock()
         self._running_orchestrators: dict[str, AutonomousOrchestrator] = {}
         self._orchestrator_lock = threading.Lock()
         # #2022 P6: RemoteSessionManager shared with the periodic reaper so a
@@ -289,9 +305,70 @@ class AutonomousScheduler:
             self._thread.join(timeout=20)
             if self._thread.is_alive():
                 logger.warning("Autonomous scheduler did not drain before shutdown timeout")
+        # Reap errors from already-finished background advances, then release
+        # the executor without waiting: in-flight advances were already asked
+        # to shut down via prepare_for_shutdown above (same semantics as the
+        # join-timeout path above).
+        self._reap_completed_futures()
+        if self._bg_executor is not None:
+            self._bg_executor.shutdown(wait=False)
         logger.info(
             "Autonomous scheduler stopped (%d active attempts interrupted)", len(orchestrators)
         )
+
+    def _get_bg_executor(self) -> ThreadPoolExecutor:
+        """Return the persistent advance executor, rebuilding it if the
+        concurrency cap changed since it was created.
+
+        ``get_max_concurrent_workflows()`` re-parses the config on every call,
+        so an operator can raise/lower the cap at runtime. The rebuild is safe
+        without draining: the system-wide concurrency ceiling is enforced by
+        the ``_in_progress_ids`` accounting (every submission — running or
+        queued, on the old or the new executor — is registered there before
+        its slot is counted as taken), not by any single executor's
+        max_workers. A lowered cap simply yields ``max(0, ...)`` free slots
+        until the excess advances drain.
+        """
+        cap = get_max_concurrent_workflows()
+        if self._bg_executor is None or self._bg_executor_cap != cap:
+            old = self._bg_executor
+            old_cap = self._bg_executor_cap
+            self._bg_executor = ThreadPoolExecutor(
+                max_workers=max(1, cap),
+                thread_name_prefix="auto-wf-bg",
+            )
+            self._bg_executor_cap = cap
+            if old is not None:
+                # In-flight workers finish their current task and exit; queued
+                # work items (there should be none — see the slot accounting
+                # above) are not cancelled.
+                old.shutdown(wait=False)
+                logger.info(
+                    "Rebuilt advance executor for new concurrency cap %d (was %d)",
+                    cap,
+                    old_cap,
+                )
+        return self._bg_executor
+
+    def _reap_completed_futures(self) -> None:
+        """Log errors from completed background advances and drop them.
+
+        Mirrors the error-logging duty of the legacy ``as_completed`` loop:
+        without this, an exception escaping ``_advance_single`` on the
+        background path would vanish silently. Iterates over a lock-held
+        snapshot so a concurrent ``stop()``-thread reap can't hit
+        ``dictionary changed size during iteration``; ``f.result()`` on a
+        ``done()`` future never blocks, so the call is safe outside the lock.
+        """
+        with self._futures_lock:
+            completed = [(f, wf_id) for f, wf_id in self._in_flight_futures.items() if f.done()]
+            for f, _wf_id in completed:
+                del self._in_flight_futures[f]
+        for future, wf_id in completed:
+            try:
+                future.result()
+            except Exception as e:
+                logger.error("Workflow %s future error: %s", wf_id[:8], e)
 
     def get_running_orchestrator(self, workflow_id: str):
         """Get the currently running orchestrator for a workflow, if any."""
@@ -620,7 +697,13 @@ class AutonomousScheduler:
         last_reap_monotonic = time.monotonic()
         while not self._stop_event.is_set():
             try:
-                self._process_workflows()
+                # Non-blocking submit: one advance() can run tens of minutes
+                # (agent runs + CI polling); waiting for it here would park
+                # promotion/auto-resume/reclaim/cleanup and starve new batches
+                # for the whole duration (observed 49-min gap on 2026-08-20).
+                # Completed futures are reaped on the next tick.
+                self._process_workflows(wait=False)
+                self._reap_completed_futures()
                 # #2022 P6: periodically reap stuck 'running' sandbox rows the
                 # scheduler is not driving. Bounded by _SANDBOX_REAP_INTERVAL
                 # so the hot 10s poll loop does not hit the DB each cycle.
@@ -1110,12 +1193,24 @@ class AutonomousScheduler:
             logger.warning("per-user cap lookup failed for user %s: %s", user_id, exc)
         return DEFAULT_MAX_SESSIONS
 
-    def _process_workflows(self):
+    def _process_workflows(self, *, wait: bool = True):
         """Find and process active workflows using thread pool for concurrency.
 
         For batch workflows, ensures only one workflow per batch is processed at a time.
         Additionally, ensures only one workflow per project_path is processed at a time
         to prevent git conflicts when multiple workflows share the same project directory.
+
+        ``wait=True`` (default) blocks until every submitted advance finishes —
+        the legacy semantics the unit tests rely on. ``wait=False`` (used by
+        ``_run_loop``) submits to the persistent background executor and
+        returns immediately; completed futures are reaped later via
+        ``_reap_completed_futures``. Slot accounting is identical on both
+        paths: selected workflows are registered in ``_in_progress_ids``
+        before submission, so the background executor never holds more work
+        than the concurrency cap. NOTE: the ``wait=False`` path currently has
+        a single caller (``_run_loop``); a second concurrent caller would need
+        the selection+registration lock blocks merged into one critical
+        section to keep the "read-then-register" window race-free.
         """
         from app.routes.autonomous import _get_repo
 
@@ -1274,24 +1369,37 @@ class AutonomousScheduler:
                 if branch and not is_waiting:
                     self._in_progress_branches.add(branch)
 
-        with ThreadPoolExecutor(
-            max_workers=min(get_max_concurrent_workflows(), len(to_process)),
-            thread_name_prefix="auto-wf",
-        ) as executor:
-            futures = {
-                executor.submit(self._advance_single, wf.get("workflow_id", "")): wf
-                for wf in to_process
-            }
-            for future in as_completed(futures):
-                try:
-                    future.result()
-                except Exception as e:
-                    wf = futures[future]
-                    logger.error(
-                        "Workflow %s future error: %s",
-                        wf.get("workflow_id", "")[:8],
-                        e,
-                    )
+        if wait:
+            with ThreadPoolExecutor(
+                max_workers=min(get_max_concurrent_workflows(), len(to_process)),
+                thread_name_prefix="auto-wf",
+            ) as executor:
+                futures = {
+                    executor.submit(self._advance_single, wf.get("workflow_id", "")): wf
+                    for wf in to_process
+                }
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception as e:
+                        wf = futures[future]
+                        logger.error(
+                            "Workflow %s future error: %s",
+                            wf.get("workflow_id", "")[:8],
+                            e,
+                        )
+        else:
+            # Fire-and-forget: submit to the persistent executor and return.
+            # _in_progress_ids was populated above under _in_progress_lock, so
+            # the next selection pass already sees these slots as taken; the
+            # error logging for these futures happens in
+            # _reap_completed_futures on a later tick (or at stop()).
+            executor = self._get_bg_executor()
+            for wf in to_process:
+                wf_id = wf.get("workflow_id", "")
+                future = executor.submit(self._advance_single, wf_id)
+                with self._futures_lock:
+                    self._in_flight_futures[future] = wf_id
 
 
 def _cleanup_orphan_processes():

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -1414,13 +1414,17 @@ class AutonomousScheduler:
                     # submit (the 20s join can time out while the loop is
                     # still mid-tick). Release the registration made for this
                     # workflow — otherwise its slot/conflict keys linger until
-                    # the stale-lease reclaim (~30 min) heals them.
+                    # the stale-lease reclaim (~30 min) heals them. No
+                    # legacy_wf: the key map entry was unconditionally written
+                    # moments earlier in this same invocation, and the legacy
+                    # fallback would recompute a WAITING workflow's row keys
+                    # and release a running sibling's reservation.
                     logger.warning(
                         "Background submit for workflow %s failed (executor shut down); "
                         "releasing slot",
                         wf_id[:8],
                     )
-                    self._discard_in_progress_entry(wf_id, legacy_wf=wf)
+                    self._discard_in_progress_entry(wf_id)
                     continue
                 with self._futures_lock:
                     self._in_flight_futures[future] = wf_id

--- a/docs/superpowers/plans/2026-08-20-merged-pr-reuse-and-scheduler-starvation.md
+++ b/docs/superpowers/plans/2026-08-20-merged-pr-reuse-and-scheduler-starvation.md
@@ -1,0 +1,225 @@
+# 修复方案：已合并 PR 复用导致 merge 空提交 + 调度器同步阻塞饥饿
+
+- 日期：2026-08-20
+- 分支：`fix/merged-pr-reuse-and-scheduler-starvation`（基于 `origin/main` @ 57a88aef）
+- 生产环境：192.168.31.159（openace-scheduler.service，PostgreSQL `openace` 库）
+- 涉及工作流：#331（merge 失败，bug 1 受害者）；批次 280f009c #340-349 / 批次 3fc727cb #350-355（bug 2 受害者，调度延迟 46 分钟）
+
+## 一、Bug 1：pr_review 阶段复用已合并（MERGED）的 PR
+
+### 1.1 生产证据（#331 事件时间线，autonomous_workflows + workflow_events）
+
+| 时间 (UTC) | 事件 |
+|---|---|
+| 14:59 | PR #2851 创建（pr_review round 1） |
+| 14:59–16:02 | review rounds 1–6（pr_reviewed / pr_updated 交替） |
+| 16:38–16:54 | merge 阶段：冲突解决 → push → CI 失败 → CI repair attempt 1 |
+| 17:14 | **PR #2851 merged**（milestone `PR #2851 merged`） |
+| 17:19 | acceptance_verification 判定 **rejected**（verification_merge_sha=b7219a7a） |
+| 18:22 | 重新进入 pr_review（`current_round` 重置为 0，`github_pr_number=2851` 保留） |
+| 19:50–20:27 | 第二轮 review rounds 1–6：**无任何 `pr_created` milestone** —— 复用已合并的 #2851 |
+| 20:29 | 进入 merge（auto_merge=true） |
+| 20:48 | merge 失败：`Merge resolution made no commit; refusing unchanged push`（workflow status=failed） |
+
+### 1.2 根因（代码级）
+
+[pr_review.py](../../../app/modules/workspace/autonomous/phases/pr_review.py#L313-L316)：
+
+```python
+existing_pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+if round_num == 1 and not existing_pr_number:
+    # 仅在此分支创建 PR
+```
+
+PR 创建仅在 `round_num == 1 and not existing_pr_number` 时发生。验收 rejected 后重新进入 pr_review 时 round 重置为 1，但 `github_pr_number` 仍指向上一轮**已合并**的 PR（#2851）。后续所有轮次、以及 merge 阶段，全部围绕这个已合并 PR 的 headRefOid 操作：merge 阶段 `resolve_merge_conflicts` 计算出的"解决结果"与原 PR head 相同（main 已包含这些提交），触发 [git_workspace.py](../../../app/modules/workspace/autonomous/git_workspace.py) 的防呆检查 `Merge resolution made no commit; refusing unchanged push`，工作流终态 failed。
+
+### 1.3 修复设计
+
+在计算 `existing_pr_number` 之后、进入创建/复用分支之前，增加 PR 状态活性检查：
+
+以下为初始草案（**已被 1.4 节"修正后的插入位置"取代，实现以 1.4 为准**——本草案的活性检查缺少 round 1 守卫，会对 round>1 错误清空 `pr_number`；保留仅为说明设计意图）：
+
+```python
+existing_pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+# 新增：已记录的 PR 可能已 MERGED/CLOSED（验收 rejected 后 resume-with-
+# feedback / cancel-with-feedback 重入等路径）。复用已合并 PR 的 headRefOid
+# 会让 merge 阶段计算出空提交并失败（#331，"Merge resolution made no
+# commit"）。非 OPEN 状态的已记录 PR 视为不存在，强制走新 PR 创建路径。
+if existing_pr_number:
+    try:
+        recorded_pr = gh.get_pr(existing_pr_number)
+        pr_state = (recorded_pr.get("state") or "").upper()
+    except Exception:
+        pr_state = ""  # 状态查询失败 → 同样强制新建（见下方论证）
+    if pr_state != "OPEN":
+        logger.warning(
+            "Recorded PR #%s state=%r is not OPEN; creating a fresh PR for this cycle",
+            existing_pr_number, pr_state or "unknown",
+        )
+        existing_pr_number = None
+pr_number = existing_pr_number
+```
+
+要点论证：
+
+1. **状态查询失败时也强制新建（fail-closed to create）是安全的**：若该分支实际仍有 OPEN PR，`gh.create_pr` 会抛 "already exists"，现有恢复逻辑（[pr_review.py L342-L394](../../../app/modules/workspace/autonomous/phases/pr_review.py#L342-L394)）通过 `_extract_pr_number_from_error` / `find_existing_pr` 找到并复用那个 OPEN PR —— 与旧行为等价。不会产生重复 PR。若编号是脏数据（分支上无任何 PR），`create_pr` 直接成功，恰好完成自愈。
+2. **MERGED 后同分支新建 PR 语义正确**：branch_name 由 workflow UUID 派生（如 `auto-dev/21a26fe8-...`），重新进入的修复提交已 push 到同一分支；main 已包含旧提交，新 PR 的 diff 只含本轮修复增量（GitHub 以 merge-base 计算），正是期望行为。若合并时分支被远端删除，`_ensure_branch_and_push`（L287 调用、L102 定义）的 force push 会重建分支。
+3. **不选择在 acceptance_verification rejected 转换点清空 `github_pr_number`**：入口防御（point-of-use）覆盖所有保留旧 PR 编号重入 pr_review 的路径——验收 rejected 后 resume-with-feedback / cancel-with-feedback（orchestrator 重置 `current_round=0` 后重新走 pr_review round 1，是 #331 的实际路径），以及未来新增的任何重入路径；单一埋点、无状态泄漏。转换点清理需要枚举所有路径，易漏。（merge 阶段的 transient retry 停留在 merge phase，不重入 pr_review，不在枚举内。）
+4. **`pr_number` 局部变量**：保持现有 L314-L315 原值读取，活性检查仅影响 `existing_pr_number`（详见 1.4 的精确插入位置）——round>1 时 `pr_number` 永不为 None。
+5. **失败里程碑语义**：新建路径的异常处理完全复用现有 except 分支（"already exists" 恢复、非瞬时错误 raise），不新增失败路径。
+6. **`workflow_patch["github_pr_number"]` 持久化**：新 PR 编号会覆盖旧值（L340/L384 现有逻辑），merge 阶段读取的是新 PR —— 链路闭环。
+
+### 1.4 影响范围
+
+- 仅 `app/modules/workspace/autonomous/phases/pr_review.py` 单文件、单函数。
+- 正常路径（OPEN PR 复用）行为不变：多一次 `gh pr view` 调用（**任何 round 且有已记录 PR 时**——活性检查对所有 round 执行，round>1 的查询结果仅用于决定是否记 warning，见 1.4 代码块；每轮 review 一次秒级调用，round>1+非 OPEN 场景 warning 每轮重复一条属可接受噪音）。
+
+补充说明 round>1 路径：round>1 时现有代码本就不创建 PR（`round_num == 1` 条件），复用 `pr_number`。若 round>1 时已记录 PR 已 MERGED——主要可达路径是 review 轮进行中（round≥2）人工直接在 GitHub 合并了 PR——`pr_number` 置 None 会导致下游拿不到编号。因此**活性检查只在 `round_num == 1` 时执行清空，round>1 保持原值并记 warning 日志**（该场景属人工干预后的深层异常态，交由现有 merge/CI 失败路径暴露，不在本次扩大战线；warning 即排查线索）。
+
+修正后的插入位置（精确，**实现以此为准**）：
+
+```python
+existing_pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+if existing_pr_number:
+    try:
+        recorded_pr = gh.get_pr(existing_pr_number)
+        pr_state = (recorded_pr.get("state") or "").upper()
+    except Exception:
+        pr_state = ""
+    if pr_state != "OPEN":
+        if round_num == 1:
+            # 仅 round 1 创建窗口清空 → 走下方 create_pr；
+            # "already exists" 恢复逻辑兜底防重复
+            logger.warning(
+                "Recorded PR #%s state=%r is not OPEN; creating a fresh PR",
+                existing_pr_number, pr_state or "unknown",
+            )
+            existing_pr_number = None
+        else:
+            # round>1 不动编号（下游依赖非 None）；warning 即排查线索
+            logger.warning(
+                "Recorded PR #%s state=%r is not OPEN at round %d; keeping PR id",
+                existing_pr_number, pr_state or "unknown", round_num,
+            )
+pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
+if round_num == 1 and not existing_pr_number:
+    ...创建...（现有 L316 起的逻辑不变）
+```
+
+### 1.5 测试计划
+
+新增单测（挂在现有 pr_review 测试文件或 `tests/issues/` 新建目录）：
+
+1. `test_round1_reuses_open_pr`：`github_pr_number=100`，`gh.get_pr` 返回 `state=OPEN` → 断言 `create_pr` 未被调用、`pr_number==100`（回归保护）。
+2. `test_round1_creates_new_pr_when_recorded_pr_merged`：`github_pr_number=100`，`get_pr` 返回 `state=MERGED` → 断言 `create_pr` 被调用一次、`workflow_patch["github_pr_number"]` 为新编号。
+3. `test_round1_state_check_failure_falls_back_to_create`：`get_pr` 抛 `GitHubOpsError` → 断言 `create_pr` 被调用（依赖 "already exists" 恢复兜底）。
+4. `test_round_gt1_keeps_recorded_pr_even_if_merged`：round=6、`state=MERGED` → 断言 `create_pr` 未被调用、`pr_number` 保持 100、有 warning 日志。
+
+## 二、Bug 2：`_process_workflows` 同步等待导致调度循环饥饿
+
+### 2.1 生产证据
+
+journalctl（openace-scheduler.service，2026-08-20 CST）中 `Advancing workflow` 事件间隔：
+
+```
+17:48:51 preparation     ← 批次推进
+17:49:06 planning
+17:56:24 planning
+18:06:49 development
+18:19:39 pr_review       ← #329 进入 pr_review
+（49 分钟空窗：#329 单次 advance 内含 agent 运行 + CI 轮询）
+19:08:01 pr_review       ← #329 下一次 advance
+19:08:01 preparation     ← #340（批次 280f009c，18:22 创建，等待 46 分钟）
+19:08:01 preparation     ← #350（批次 3fc727cb）
+```
+
+批次 280f009c 创建于 18:22，#340 直到 19:08 才首次被推进（延迟 46 分钟）；期间 `_promote_queued_workflows`、`_auto_resume_quota_paused`、`_reclaim_paused_slots`、`_retry_pending_git_cleanups`、sandbox reap 全部停摆。
+
+### 2.2 根因（代码级）
+
+[autonomous_scheduler.py L615-L638](../../../app/services/autonomous_scheduler.py#L615-L638)：`_run_loop` 每 10 秒调用 `_process_workflows()` 并**同步等待其返回**。
+
+[autonomous_scheduler.py L1277-L1294](../../../app/services/autonomous_scheduler.py#L1277-L1294)：
+
+```python
+with ThreadPoolExecutor(
+    max_workers=min(get_max_concurrent_workflows(), len(to_process)),
+    thread_name_prefix="auto-wf",
+) as executor:
+    futures = {executor.submit(self._advance_single, wf_id): wf for wf in to_process}
+    for future in as_completed(futures):
+        ...
+```
+
+`with` 块退出时 `shutdown(wait=True)`，且 `as_completed` 循环等待**所有** future 完成。`_advance_single` 的一次执行包含 agent 运行（10-40 分钟）与 CI 轮询（30s×N），因此 `_process_workflows` 单次调用可阻塞主循环近一小时。代码注释（L320-327）已自认此问题："A worker HUNG mid-cycle parks the whole cycle inside the executor's shutdown(wait=True) and this pass cannot run; a restart remains the remedy there."
+
+### 2.3 修复设计
+
+保持 `_process_workflows` 的默认同步语义（13 处现有测试直接调用并断言同步完成：tests/issues/716 ×9、tests/issues/2295 ×3、tests/unit/test_scheduler_batch_order_tiebreak.py ×1；生产代码唯一调用方是 `_run_loop`），仅让 `_run_loop` 走非阻塞路径：
+
+1. **签名扩展**：`def _process_workflows(self, *, wait: bool = True)`。
+   - `wait=True`（默认）：现有 `with ThreadPoolExecutor + as_completed` 行为逐字保留 —— 所有现有测试不变。
+   - `wait=False`：向**持久化 executor** 提交后立即返回，不等待。
+2. **持久化 executor**：
+   - `__init__` 增加 `self._bg_executor: ThreadPoolExecutor | None = None`、`self._in_flight_futures: dict[Future, str] = {}`（future → workflow_id）、`self._futures_lock = threading.Lock()`。
+   - 懒初始化：`_get_bg_executor()` 首次调用时创建 `ThreadPoolExecutor(max_workers=get_max_concurrent_workflows(), thread_name_prefix="auto-wf-bg")`。
+   - **cap 运行时变化处理**：`get_max_concurrent_workflows()` 每次从配置解析、可变。`_get_bg_executor()` 检测当前 cap 与创建时不一致则重建 executor（旧的 `shutdown(wait=False)`，在途 worker 自然跑完当前任务后退出）。重建安全性：系统级并发上界由 `_in_progress_ids` 记账约束（旧 executor 在途 R 项均在集合内，新提交数 ≤ 新 cap − R），不依赖单个 executor 的 max_workers，因此无超发。
+   - 提交量上界论证：选择逻辑在 `_in_progress_lock` 内计算 `slots_available = cap - len(self._in_progress_ids)`（L1201-L1240），随后在第二个锁块内将选中项写入 `_in_progress_ids`（L1246-L1275）。两块之间存在无锁窗口，但 `_process_workflows` 的 `wait=False` 路径只有 `_run_loop` 单线程调用（含现状与改造后），窗口内无其它选择者，"读到即登记"时序成立；**前提声明**：未来若出现第二个调用线程，须将两个锁块合并为单一锁区间，否则本上界论证失效。
+3. **future 回收与错误日志**：新增 `_reap_completed_futures()`，在 `_run_loop` 每 tick 调用：在 `_futures_lock` 内取 `_in_flight_futures` 快照并 `pop` 已完成项，锁外对已完成 future 调 `f.result()` 捕获异常记 error 日志（等价于原 `as_completed` 循环的日志职责，不丢错误可见性；`f.done()` 为真后 `result()` 不阻塞）。
+4. **`_run_loop` 改造**：
+
+```python
+while not self._stop_event.is_set():
+    try:
+        self._process_workflows(wait=False)   # 立即返回，主循环恢复 10s 心跳
+        self._reap_completed_futures()         # 回收已完成 future + 错误日志
+        ...sandbox reap 不变...
+    except Exception as e:
+        logger.error("Scheduler error: %s", e, exc_info=True)
+    self._stop_event.wait(10)
+```
+
+5. **`stop()` 收尾**：在现有逻辑后增加 —— 若 `self._bg_executor` 存在，先 `_reap_completed_futures()` 记录已完成项的错误，再 `shutdown(wait=False)`（不等待在途 advance：与现有 stop 语义一致 —— 现有 stop 也只 join 主线程 20s 超时后放弃，在途 advance 由 `prepare_for_shutdown` 中断）。
+6. **线程安全论证**：`_in_flight_futures` 的所有读写（提交、回收）都持有 `self._futures_lock`。正常路径下仅主循环线程触碰（`wait=False` 提交与 reap 都在 `_run_loop`），但 `stop()` 可能从其它线程调用 `_reap_completed_futures()`——即使 `_run_loop` 的 join 超时后主循环仍在跑（现有代码 L290-291 允许该路径，仅 warning），锁保证 stop 线程与主循环线程对 dict 的并发访问安全；reap 的迭代基于锁内快照，杜绝 `dictionary changed size during iteration`。`wait=True` 路径不触碰 `_in_flight_futures`（独立局部 executor），两条路径互不干扰。
+7. **hang worker 行为变化论证（改善而非风险）**：worker 挂死场景下，现状是整个调度 pass 停摆（L320-327 注释自认，需重启）；修复后主循环恢复 10s 心跳。若挂死 worker 仍能续约 lease（heartbeat 60s，即"挂"在可被信号唤醒的等待上），`_reclaim_stale_in_progress` 判定 keep → slot 仍被占用、不会重复 advance 同一工作流，仅维护操作（promotion/auto-resume/cleanup/reap）恢复正常运转；若挂死到 heartbeat 也停止，lease 过期后（`_IN_PROGRESS_STALE_SECONDS`）该条目被 reap、工作流将被重新 advance——由 DB `acquire_lock` 的 break-stale-lease 兜底防并发写，与现状"重启后恢复"路径等价。两种子情形均不劣于现状；挂死 worker 的彻底恢复仍依赖重启或 lease 过期，但不再连带饿死其它批次。
+8. **不选用的替代方案及理由**：
+   - *每 tick 起新线程跑完整 `_process_workflows`*：会并发执行 `_promote_queued_workflows` 等维护操作，语义改变超出本次修复范围。
+   - *gevent GreenletPool*：`_advance_single` 链路含原生阻塞子进程调用（agent、gh CLI），monkey-patch 兼容性风险大。
+   - *as_completed 加 timeout*：治标不治本，超时后仍需处理未完成 future 的生命周期，复杂度更高。
+
+### 2.4 影响范围
+
+- 仅 `app/services/autonomous_scheduler.py`：`__init__`、`_run_loop`、`_process_workflows`（签名+尾部提交块）、`stop()`、新增 `_get_bg_executor` / `_reap_completed_futures`。
+- 默认行为（`wait=True`）对所有现有调用方（13 处测试）完全兼容。
+
+### 2.5 测试计划
+
+1. 现有测试回归：`tests/issues/716/test_scheduler.py`、`tests/issues/1002/`、`tests/issues/2295/`、`tests/unit/test_scheduler_batch_order_tiebreak.py` 全部不改即通过（默认 `wait=True`）。
+2. 新增 `test_run_loop_does_not_block_on_slow_advance`（tests/issues/716/ 或新目录）：
+   - mock `_advance_single` 为 sleep(2)，并沿用 716 现有 fixture：patch `app.routes.autonomous._get_repo` 返回 MagicMock repo、`get_active_workflows` 返回 ≥1 条 active workflow（仅 mock `_advance_single` 不足以走到提交步骤；quota stub 因 `_advance_single` 被整体替换而不需要）；
+   - **退出手法（注意：不可预设 `_stop_event` —— `start()` 会 `clear()`，且 `while not is_set()` 下循环体零次执行）**：测试线程内直接同步调用 `scheduler._run_loop()`，配合 `threading.Timer(0.5, scheduler._stop_event.set)`（在调用前 start 该 Timer）。循环体执行一轮（`_process_workflows(wait=False)` 立即返回），随后 `self._stop_event.wait(10)` 被 Timer 置位唤醒，循环退出；
+   - 断言 `_run_loop()` 在 <1s 内返回（慢 advance 的 2s sleep 不阻塞主循环）；
+   - `time.sleep(2.5)` 等待 advance 完成后，**显式调用** `scheduler._reap_completed_futures()`（循环退出后无人自动 reap——循环内那次 reap 发生在 future 完成前），断言 `_in_flight_futures` 为空且 `_advance_single` 确实被调用过（future 已执行）；
+   - 测试收尾：`scheduler._stop_event.set()` + 若创建了 bg executor 则 `shutdown(wait=False)`，避免线程泄漏影响其它测试。
+3. 新增 `test_reap_logs_future_exception`：提交一个抛异常的 `_advance_single`，等待完成后调用 `_reap_completed_futures`，断言 error 日志包含 workflow id 且 `_in_flight_futures` 清空。
+4. 新增 `test_wait_false_submits_without_blocking`：`wait=False` 调用即时返回，`_in_flight_futures` 含 1 项，`_in_progress_ids` 已登记。
+
+## 三、实施步骤
+
+1. Bug 1 修复 + 单测（1.5）→ 全量跑 pr_review 相关测试。
+2. Bug 2 修复 + 单测（2.5）→ 全量跑 scheduler 相关测试。
+3. `python -m pytest tests/issues/716 tests/issues/1002 tests/issues/2295 tests/unit/test_scheduler_batch_order_tiebreak.py` + pr_review 相关测试目录全绿。（附注：若本机存在 `~/.open-ace/agent-launcher.conf`，`test_max_concurrency`、`test_pending_workflows_are_prioritized_ahead_of_waiting` 可能因 cap 被环境覆盖为 3 而假红——属环境性失败，以 HOME 隔离或 CI 结果为准。）
+4. 提交 PR（描述含两个 bug 的生产证据时间线）→ 独立 agent 审查 PR，意见发表到 PR，迭代至零意见 → 合并 → 部署 192.168.31.159 → 重启 openace-scheduler.service。
+5. 复盘验证：重置 #331 使其走完 pr_review（新 PR 创建）→ merge；观察新批次在长 advance 期间是否保持 10s 级调度心跳。
+
+## 四、风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| PR 状态查询增加 gh 调用（任何 round 且有已记录 PR 时，每轮 review 一次） | 单次 `gh pr view` 秒级；失败路径已论证安全 |
+| 持久化 executor 泄漏（stop 未 shutdown） | stop() 显式 shutdown；进程退出亦回收（daemon 线程模型不变） |
+| `_in_flight_futures` 跨线程访问 | 正常路径仅主循环线程触碰；stop() 线程的回收路径由 `_futures_lock` 保护（快照迭代） |
+| 新 PR 语义偏差（同分支多 PR） | GitHub merge-base diff 语义保证只含增量；"already exists" 恢复兜底防重复 |
+
+回滚：两个修复相互独立，均可单独 revert；不影响数据库 schema，无迁移。

--- a/docs/superpowers/plans/2026-08-20-merged-pr-reuse-and-scheduler-starvation.md
+++ b/docs/superpowers/plans/2026-08-20-merged-pr-reuse-and-scheduler-starvation.md
@@ -63,7 +63,7 @@ pr_number = existing_pr_number
 
 要点论证：
 
-1. **状态查询失败时也强制新建（fail-closed to create）是安全的**：若该分支实际仍有 OPEN PR，`gh.create_pr` 会抛 "already exists"，现有恢复逻辑（[pr_review.py L342-L394](../../../app/modules/workspace/autonomous/phases/pr_review.py#L342-L394)）通过 `_extract_pr_number_from_error` / `find_existing_pr` 找到并复用那个 OPEN PR —— 与旧行为等价。不会产生重复 PR。若编号是脏数据（分支上无任何 PR），`create_pr` 直接成功，恰好完成自愈。
+1. **状态查询失败时保留已记录编号（review 修正）**：初始草案将探测异常与"确认非 OPEN"同等对待（fail-closed to create）。独立审查（PR #2906 review round 1, opinion 3）推翻了该论证：探测失败通常意味着 gh/API 瞬时故障，此时强制 `create_pr` 会经同一故障通道必然失败——"already exists" 恢复逻辑同样依赖 gh（`find_existing_pr`），也可能同时失败，导致工作流在"保留编号即可正常推进"的场景下终态 failed。因此**仅当 `get_pr` 成功返回且状态非 OPEN 时才清空编号**；探测异常时每轮保留编号并记 warning（"already exists" 恢复兜底极罕见的"新 PR 已存在"场景）。
 2. **MERGED 后同分支新建 PR 语义正确**：branch_name 由 workflow UUID 派生（如 `auto-dev/21a26fe8-...`），重新进入的修复提交已 push 到同一分支；main 已包含旧提交，新 PR 的 diff 只含本轮修复增量（GitHub 以 merge-base 计算），正是期望行为。若合并时分支被远端删除，`_ensure_branch_and_push`（L287 调用、L102 定义）的 force push 会重建分支。
 3. **不选择在 acceptance_verification rejected 转换点清空 `github_pr_number`**：入口防御（point-of-use）覆盖所有保留旧 PR 编号重入 pr_review 的路径——验收 rejected 后 resume-with-feedback / cancel-with-feedback（orchestrator 重置 `current_round=0` 后重新走 pr_review round 1，是 #331 的实际路径），以及未来新增的任何重入路径；单一埋点、无状态泄漏。转换点清理需要枚举所有路径，易漏。（merge 阶段的 transient retry 停留在 merge phase，不重入 pr_review，不在枚举内。）
 4. **`pr_number` 局部变量**：保持现有 L314-L315 原值读取，活性检查仅影响 `existing_pr_number`（详见 1.4 的精确插入位置）——round>1 时 `pr_number` 永不为 None。
@@ -82,12 +82,21 @@ pr_number = existing_pr_number
 ```python
 existing_pr_number = wf.get("github_pr_number") or host.get_workflow_field("github_pr_number")
 if existing_pr_number:
+    probe_error = None
+    pr_state = ""
     try:
         recorded_pr = gh.get_pr(existing_pr_number)
         pr_state = (recorded_pr.get("state") or "").upper()
-    except Exception:
-        pr_state = ""
-    if pr_state != "OPEN":
+    except Exception as e:
+        probe_error = e
+    if probe_error is not None:
+        # 探测失败 ≠ 确认非 OPEN（review 修正）：保留编号，
+        # 不经同一故障通道强行 create_pr
+        logger.warning(
+            "Recorded PR #%s state probe failed (%s); keeping PR id",
+            existing_pr_number, probe_error,
+        )
+    elif pr_state != "OPEN":
         if round_num == 1:
             # 仅 round 1 创建窗口清空 → 走下方 create_pr；
             # "already exists" 恢复逻辑兜底防重复
@@ -113,7 +122,7 @@ if round_num == 1 and not existing_pr_number:
 
 1. `test_round1_reuses_open_pr`：`github_pr_number=100`，`gh.get_pr` 返回 `state=OPEN` → 断言 `create_pr` 未被调用、`pr_number==100`（回归保护）。
 2. `test_round1_creates_new_pr_when_recorded_pr_merged`：`github_pr_number=100`，`get_pr` 返回 `state=MERGED` → 断言 `create_pr` 被调用一次、`workflow_patch["github_pr_number"]` 为新编号。
-3. `test_round1_state_check_failure_falls_back_to_create`：`get_pr` 抛 `GitHubOpsError` → 断言 `create_pr` 被调用（依赖 "already exists" 恢复兜底）。
+3. `test_probe_failure_keeps_recorded_pr_id`（review 修正后语义）：`get_pr` 抛 `GitHubOpsError` → 断言 `create_pr` 未被调用、编号保留（探测失败 ≠ 确认非 OPEN，见 1.3 要点论证 #1）。
 4. `test_round_gt1_keeps_recorded_pr_even_if_merged`：round=6、`state=MERGED` → 断言 `create_pr` 未被调用、`pr_number` 保持 100、有 warning 日志。
 
 ## 二、Bug 2：`_process_workflows` 同步等待导致调度循环饥饿

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -67,6 +67,11 @@ def _gh(*, commits: int = 1, branch: str = "feature-x") -> MagicMock:
         "files": 1,
     }
     gh.git_push.return_value = None
+    # The default workflow fixture records PR #1234; the pr_review liveness
+    # check probes the recorded PR's state, so the default probe must be OPEN
+    # to keep the reuse semantics the older tests were written against.
+    gh.get_pr.return_value = {"number": 1234, "state": "OPEN"}
+    gh.create_pr.return_value = {"number": 5001, "url": "https://x/pull/5001"}
     return gh
 
 
@@ -525,3 +530,57 @@ def test_ensure_branch_and_push_skips_commit_when_worktree_clean():
     gh.git_add_all.assert_not_called()
     gh.git_commit.assert_not_called()
     gh.git_push.assert_called_once()
+
+
+# ── merged-PR reuse regression (#331) ─────────────────────────────────────
+
+
+@pytest.mark.regression
+@pytest.mark.issue(331)
+def test_round1_creates_new_pr_when_recorded_pr_merged():
+    """An acceptance-verification rejection resets current_round to 0 but keeps
+    the OLD github_pr_number on the row. If that PR is already MERGED, reusing
+    it makes the second review pass — and the merge phase — operate on the
+    merged PR's head, so the merge resolution computes no new commit and fails
+    ("Merge resolution made no commit; refusing unchanged push", #331). A
+    non-OPEN recorded PR on the round-1 creation window must therefore be
+    treated as absent: a fresh PR is created and the new number/url land in
+    workflow_patch."""
+    gh = _gh()
+    gh.get_pr.return_value = {"number": 1234, "state": "MERGED"}
+    host = _host(review_is_approved=True)
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps)
+
+    # A fresh PR replaced the merged one...
+    gh.create_pr.assert_called_once()
+    assert result.workflow_patch.get("github_pr_number") == 5001
+    assert result.workflow_patch.get("github_pr_url") == "https://x/pull/5001"
+    # ...and the pr_created milestone records the FRESH number.
+    pr_created = [
+        c
+        for c in host.create_milestone_idempotent.call_args_list
+        if c.kwargs.get("milestone_type") == "pr_created"
+    ]
+    assert pr_created, host.create_milestone_idempotent.call_args_list
+    assert pr_created[0].kwargs.get("github_pr_number") == 5001
+
+
+@pytest.mark.regression
+@pytest.mark.issue(331)
+def test_later_round_keeps_recorded_pr_id_when_not_open():
+    """On rounds > 1 downstream code expects a non-None pr_number, so a
+    non-OPEN recorded PR is kept (warning logged) instead of forcing a fresh
+    creation mid-review — the reachable path is a human merging the PR
+    mid-review. No new PR is created and the recorded number survives."""
+    gh = _gh()
+    gh.get_pr.return_value = {"number": 1234, "state": "MERGED"}
+    host = _host(review_is_approved=True)
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=2, max_pr_review_rounds=3)), deps)
+
+    gh.create_pr.assert_not_called()
+    # The recorded PR number is not rewritten to a fresh PR.
+    assert "github_pr_number" not in result.workflow_patch

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -584,3 +584,22 @@ def test_later_round_keeps_recorded_pr_id_when_not_open():
     gh.create_pr.assert_not_called()
     # The recorded PR number is not rewritten to a fresh PR.
     assert "github_pr_number" not in result.workflow_patch
+
+
+@pytest.mark.regression
+@pytest.mark.issue(331)
+def test_probe_failure_keeps_recorded_pr_id():
+    """A FAILED state probe (transient gh/API error) is not evidence that the
+    recorded PR is non-OPEN: nulling the number would attempt a doomed
+    create_pr through the same flaky gh and could fail the workflow outright.
+    The recorded number is kept on every round and no PR is created."""
+    gh = _gh()
+    gh.get_pr.side_effect = Exception("gh: rate limit exceeded")
+    host = _host(review_is_approved=True)
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow(current_round=0, max_pr_review_rounds=1)), deps)
+
+    gh.create_pr.assert_not_called()
+    # The recorded PR number is not rewritten to a fresh PR.
+    assert "github_pr_number" not in result.workflow_patch

--- a/tests/issues/1857/test_pr_review_duplicate_create.py
+++ b/tests/issues/1857/test_pr_review_duplicate_create.py
@@ -109,7 +109,14 @@ def _make_gh_with_changes():
     gh.get_diff.return_value = "diff --git a/app/x.py b/app/x.py\n+new line"
     gh.get_pr_checks.return_value = []  # no CI fails for simplicity
     gh.get_pr_head_sha.return_value = "head-sha-123"
-    gh.get_pr.return_value = {"number": 1877, "url": "https://x/pull/1877"}
+    gh.get_pr.return_value = {
+        "number": 1877,
+        "url": "https://x/pull/1877",
+        # The pr_review liveness check (merged-PR reuse fix) probes the
+        # recorded PR's state; a mock without it reads as non-OPEN and would
+        # wrongly force a fresh PR creation.
+        "state": "OPEN",
+    }
     return gh
 
 

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -456,7 +456,8 @@ class TestNonBlockingAdvancePath:
             assert "wf-slow" not in scheduler._in_progress_ids
         finally:
             # Drain the executor so the test leaves no worker threads behind.
-            scheduler._bg_executor.shutdown(wait=True) if scheduler._bg_executor else None
+            if scheduler._bg_executor:
+                scheduler._bg_executor.shutdown(wait=True)
 
     def test_reap_completed_futures_logs_errors(self, caplog):
         """An exception escaping _advance_single on the background path must
@@ -495,21 +496,46 @@ class TestNonBlockingAdvancePath:
             # Reaped: a second reap is a no-op.
             assert scheduler._in_flight_futures == {}
         finally:
-            scheduler._bg_executor.shutdown(wait=True) if scheduler._bg_executor else None
+            if scheduler._bg_executor:
+                scheduler._bg_executor.shutdown(wait=True)
 
-    def test_stop_reaps_and_shuts_down_background_executor(self):
+    def test_stop_reaps_and_shuts_down_background_executor(self, caplog):
         """stop() must reap completed background advances (so their errors are
         logged) and release the executor without waiting for in-flight work
         (in-flight advances were already told to shut down via
-        prepare_for_shutdown)."""
+        prepare_for_shutdown). It must also RESET the executor reference so a
+        later start() on the same singleton rebuilds a live executor instead
+        of submitting to the dead one forever (silent-outage restart bug)."""
         scheduler = AutonomousScheduler()
         scheduler._get_bg_executor()
         executor = scheduler._bg_executor
-        scheduler._stop_event.set()
-        scheduler.stop()
 
+        # Seed one completed-but-unreaped failing future, as a tick that was
+        # interrupted between completion and reaping would leave behind.
+        def boom(workflow_id):
+            raise RuntimeError(f"boom {workflow_id}")
+
+        future = executor.submit(boom, "wf-boom")
+        with scheduler._futures_lock:
+            scheduler._in_flight_futures[future] = "wf-boom"
+        # Wait for completion; result() re-raises the boom — that's expected.
+        with pytest.raises(RuntimeError, match="boom wf-boom"):
+            future.result(timeout=5)
+
+        scheduler._stop_event.set()
+        with caplog.at_level(logging.ERROR, logger="app.services.autonomous_scheduler"):
+            scheduler.stop()
+
+        # The completed future's error surfaced and the tracking dict drained.
+        assert any(
+            "wf-boom" in r.message and "boom" in r.message for r in caplog.records
+        ), caplog.messages
+        assert scheduler._in_flight_futures == {}
+        # The old executor is dead...
         with pytest.raises(RuntimeError):
             executor.submit(lambda: None)
+        # ...and the reference was reset so start() rebuilds a live one.
+        assert scheduler._bg_executor is None
 
     def test_wait_true_still_blocks_until_advances_finish(self):
         """The legacy wait=True semantics (used by direct callers and relied on

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -537,6 +537,66 @@ class TestNonBlockingAdvancePath:
         # ...and the reference was reset so start() rebuilds a live one.
         assert scheduler._bg_executor is None
 
+    def test_submit_failure_releases_slot_without_touching_sibling_keys(self, caplog):
+        """A RuntimeError from executor.submit mid-tick (stop() raced the loop)
+        must release the workflow's own registration — and, for a WAITING
+        workflow (which deliberately registers an EMPTY key map), must NOT fall
+        back to the row's conflict keys: that legacy fallback would discard a
+        running batch sibling's reservation from the shared sets."""
+        scheduler = AutonomousScheduler()
+        scheduler._get_bg_executor()
+        dead = scheduler._bg_executor
+        dead.shutdown(wait=False)
+
+        # A running sibling already holds the batch-1 reservation.
+        scheduler._in_progress_ids.add("wf-sibling")
+        scheduler._in_progress_batch_ids.add("batch-1")
+        scheduler._in_progress_key_map["wf-sibling"] = ("batch-1", "/wt/1", "auto/1")
+
+        mock_repo = MagicMock()
+        mock_repo.get_queued_workflows.return_value = []
+        mock_repo.get_active_workflows.return_value = [
+            # The sibling backs its in-progress entry with a fresh lease so
+            # _reclaim_stale_in_progress leaves it alone; it's already in
+            # _in_progress_ids so selection skips it.
+            {
+                "workflow_id": "wf-sibling",
+                "status": "planning",
+                "batch_id": "batch-1",
+                "worktree_path": "/wt/1",
+                "branch_name": "auto/1",
+                "locked_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            },
+            {
+                "workflow_id": "wf-wait",
+                "status": "waiting",
+                "batch_id": "batch-1",
+                "worktree_path": "/wt/1",
+                "branch_name": "auto/1",
+            },
+        ]
+
+        with (
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+            patch.object(scheduler, "_get_bg_executor", return_value=dead),
+            patch.object(scheduler, "_advance_single") as advance,
+        ):
+            with caplog.at_level(logging.WARNING, logger="app.services.autonomous_scheduler"):
+                scheduler._process_workflows(wait=False)
+
+        # Submit failed → the advance never ran...
+        advance.assert_not_called()
+        # ...the waiting workflow's own registration was released...
+        assert "wf-wait" not in scheduler._in_progress_ids
+        assert "wf-wait" not in scheduler._in_progress_key_map
+        # ...with a warning explaining why...
+        assert any(
+            "wf-wait" in r.message and "releasing slot" in r.message for r in caplog.records
+        ), caplog.messages
+        # ...but the running sibling's batch reservation survived (the empty
+        # key map recorded at selection means no legacy-key fallback fired).
+        assert "batch-1" in scheduler._in_progress_batch_ids
+
     def test_wait_true_still_blocks_until_advances_finish(self):
         """The legacy wait=True semantics (used by direct callers and relied on
         by the older unit tests) are unchanged: the call returns only after

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -1,6 +1,8 @@
 """Unit tests for AutonomousScheduler."""
 
+import logging
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -377,3 +379,160 @@ class TestSchedulerProcessWorkflows:
 
                 called_ids = [call.args[0] for call in mock_orch_cls.call_args_list]
                 assert called_ids == ["wf-pending"]
+
+
+class TestNonBlockingAdvancePath:
+    """Tests for the non-blocking advance submission path
+    (_process_workflows(wait=False) + _reap_completed_futures).
+
+    Regression guard for the 2026-08-20 starvation incident: _run_loop waited
+    for a tens-of-minutes advance inside _process_workflows, parking
+    promotion/auto-resume/reclaim/cleanup and delaying newly created batches
+    by ~49 minutes (batches 280f009c / 3fc727cb). The loop now submits to a
+    persistent background executor and returns; completed futures are reaped
+    on later ticks."""
+
+    def setup_method(self):
+        AutonomousScheduler._instance = None
+
+    @pytest.fixture(autouse=True)
+    def _allow_quota(self):
+        """Same quota stub as TestSchedulerProcessWorkflows: _advance_single
+        is patched wholesale in these tests, but keep the guard so a future
+        edit routing these tests through the real advance stays green."""
+        mock = MagicMock()
+        mock.return_value.check_quota.return_value = {"allowed": True, "reason": None}
+        with patch("app.modules.governance.quota_manager.QuotaManager", mock):
+            yield
+
+    def test_wait_false_returns_before_slow_advance_finishes(self):
+        """wait=False must submit the advance and return immediately — a slow
+        advance (agent runs + CI polling can run tens of minutes) must not
+        park the scheduler tick. The slot is registered before submission and
+        the future is tracked for later reaping."""
+        scheduler = AutonomousScheduler()
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_advance(workflow_id):
+            started.set()
+            release.wait(timeout=10)
+            # Mirror the real _advance_single's finally-block cleanup so the
+            # slot accounting is exercised end-to-end.
+            scheduler._in_progress_ids.discard(workflow_id)
+            return workflow_id
+
+        mock_repo = MagicMock()
+        mock_repo.get_queued_workflows.return_value = []
+        mock_repo.get_active_workflows.return_value = [
+            {"workflow_id": "wf-slow", "status": "pending"}
+        ]
+
+        try:
+            with (
+                patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+                patch.object(scheduler, "_advance_single", side_effect=slow_advance),
+            ):
+                t0 = time.monotonic()
+                scheduler._process_workflows(wait=False)
+                submit_elapsed = time.monotonic() - t0
+
+                # The submit path returned without waiting for the advance...
+                assert started.wait(timeout=5), "advance never started"
+                assert not release.is_set(), "submit path blocked until advance finished"
+                assert submit_elapsed < 4.5, f"submit blocked for {submit_elapsed:.2f}s"
+                # ...but the slot is reserved and the future is tracked.
+                assert "wf-slow" in scheduler._in_progress_ids
+                assert len(scheduler._in_flight_futures) == 1
+
+            release.set()
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not all(
+                f.done() for f in scheduler._in_flight_futures
+            ):
+                time.sleep(0.01)
+            scheduler._reap_completed_futures()
+            assert scheduler._in_flight_futures == {}
+            assert "wf-slow" not in scheduler._in_progress_ids
+        finally:
+            # Drain the executor so the test leaves no worker threads behind.
+            scheduler._bg_executor.shutdown(wait=True) if scheduler._bg_executor else None
+
+    def test_reap_completed_futures_logs_errors(self, caplog):
+        """An exception escaping _advance_single on the background path must
+        surface in the log via _reap_completed_futures — without it the error
+        would vanish silently (the legacy as_completed loop logged it)."""
+        scheduler = AutonomousScheduler()
+
+        def boom(workflow_id):
+            raise RuntimeError(f"boom {workflow_id}")
+
+        mock_repo = MagicMock()
+        mock_repo.get_queued_workflows.return_value = []
+        mock_repo.get_active_workflows.return_value = [
+            {"workflow_id": "wf-boom", "status": "pending"}
+        ]
+
+        try:
+            with (
+                patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+                patch.object(scheduler, "_advance_single", side_effect=boom),
+            ):
+                scheduler._process_workflows(wait=False)
+
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not all(
+                f.done() for f in scheduler._in_flight_futures
+            ):
+                time.sleep(0.01)
+
+            with caplog.at_level(logging.ERROR, logger="app.services.autonomous_scheduler"):
+                scheduler._reap_completed_futures()
+
+            assert any(
+                "wf-boom" in r.message and "boom" in r.message for r in caplog.records
+            ), caplog.messages
+            # Reaped: a second reap is a no-op.
+            assert scheduler._in_flight_futures == {}
+        finally:
+            scheduler._bg_executor.shutdown(wait=True) if scheduler._bg_executor else None
+
+    def test_stop_reaps_and_shuts_down_background_executor(self):
+        """stop() must reap completed background advances (so their errors are
+        logged) and release the executor without waiting for in-flight work
+        (in-flight advances were already told to shut down via
+        prepare_for_shutdown)."""
+        scheduler = AutonomousScheduler()
+        scheduler._get_bg_executor()
+        executor = scheduler._bg_executor
+        scheduler._stop_event.set()
+        scheduler.stop()
+
+        with pytest.raises(RuntimeError):
+            executor.submit(lambda: None)
+
+    def test_wait_true_still_blocks_until_advances_finish(self):
+        """The legacy wait=True semantics (used by direct callers and relied on
+        by the older unit tests) are unchanged: the call returns only after
+        every submitted advance finished."""
+        scheduler = AutonomousScheduler()
+        finished = threading.Event()
+
+        def quick_advance(workflow_id):
+            scheduler._in_progress_ids.discard(workflow_id)
+            finished.set()
+            return workflow_id
+
+        mock_repo = MagicMock()
+        mock_repo.get_queued_workflows.return_value = []
+        mock_repo.get_active_workflows.return_value = [
+            {"workflow_id": "wf-quick", "status": "pending"}
+        ]
+
+        with (
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+            patch.object(scheduler, "_advance_single", side_effect=quick_advance),
+        ):
+            scheduler._process_workflows(wait=True)
+
+        assert finished.is_set()


### PR DESCRIPTION
## Summary

Two production incidents from the 2026-08-20 monitoring session, both in the workflow system's own code:

### Bug 1 — pr_review reuses an already-MERGED PR (#331)

After an acceptance-verification **rejection**, resume-with-feedback resets `current_round` to 0 but keeps the OLD `github_pr_number` on the row. The second review pass then reuses the already-merged PR, and the merge phase resolves against the merged PR's `headRefOid` — merge resolution computes no new commit and the workflow fails with:

> `Merge resolution made no commit; refusing unchanged push`

Timeline (workflow #331): PR #2851 created 14:59 → merged 17:14 → acceptance rejected 17:19 → re-entered pr_review 18:22 (no new `pr_created` milestone — merged PR reused) → merge failed 20:48.

**Fix** ([pr_review.py](app/modules/workspace/autonomous/phases/pr_review.py)): probe the recorded PR's state before the creation window —
- non-OPEN on **round 1** → treated as absent, a fresh PR is created (the existing "already exists" recovery still guards duplicates when the state probe fails while an OPEN PR exists);
- **round > 1** → number kept (downstream reads expect non-None; reachable path is a human merging mid-review), warning logged.

### Bug 2 — scheduler starvation from blocking advances

`_run_loop` called `_process_workflows()`, which blocked until every submitted advance finished. A single advance runs tens of minutes (agent runs + CI polling), parking promotion/auto-resume/reclaim/cleanup for the whole duration. New batches 280f009c (#340–349) and 3fc727cb (#350–355) were delayed ~49 minutes (18:19 → 19:08).

**Fix** ([autonomous_scheduler.py](app/services/autonomous_scheduler.py)):
- `_process_workflows(wait=)` — `wait=True` keeps the legacy blocking semantics for direct callers and the existing unit tests; `wait=False` (used by `_run_loop`) submits to a persistent background executor and returns immediately;
- completed futures are reaped on later ticks (`_reap_completed_futures`), mirroring the legacy `as_completed` error-logging duty so background exceptions don't vanish silently;
- `stop()` reaps and releases the executor without waiting;
- slot accounting via `_in_progress_ids` is identical on both paths, so the system-wide concurrency ceiling still holds; the executor rebuilds when the configured cap changes.

## Tests

- `test_round1_creates_new_pr_when_recorded_pr_merged` / `test_later_round_keeps_recorded_pr_id_when_not_open` — #331 regression pair
- `TestNonBlockingAdvancePath` — non-blocking submit, error reaping, stop() shutdown, unchanged `wait=True` semantics
- `_gh()` fixture in the phase tests now returns an OPEN state probe (existing tests keep their reuse semantics); 1857 test mock gains `"state": "OPEN"`

Full plan: `docs/superpowers/plans/2026-08-20-merged-pr-reuse-and-scheduler-starvation.md`

## Test results

- `tests/autonomous` — 173 passed
- `tests/issues/716` + scheduler-related suites — 782 passed, 2 skipped
- 3 pre-existing failures on the base commit (1897 ×2, 1831 ×1) reproduced with the fix stashed — unrelated to this change