### PR TITLE
fix: 验收 verifier JSON 解析容忍字符串内未转义双引号 (#2867)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2289,8 +2289,67 @@ def _extract_verifier_json(text: str) -> dict | None:
             try:
                 parsed = _json.loads(cleaned)
             except Exception:
-                return None
+                # Last resort (#2867): glm reproduces the Chinese acceptance
+                # criteria verbatim, so a checklist item that quotes a UI label
+                # lands with UNESCAPED inner ASCII double quotes (…进入"租户管理"。).
+                # Escape structurally-inner quotes, then re-strip trailing commas
+                # and parse strictly. Still fail-closed: an unrecoverable blob
+                # raises and returns None (never a fabricated verdict).
+                requoted = _strip_trailing_commas(_escape_inner_string_quotes(candidate))
+                try:
+                    parsed = _json.loads(requoted)
+                except Exception:
+                    return None
         return parsed if isinstance(parsed, dict) else None
+
+    def _escape_inner_string_quotes(s: str) -> str:
+        # Repair a JSON candidate whose string VALUES contain unescaped ASCII
+        # double quotes (#2867). A string token's real closing quote is the one
+        # followed — past whitespace — by a structural delimiter (``:`` ``,``
+        # ``}`` ``]``) or end-of-input; any other in-string ``"`` is an inner
+        # quote the model forgot to escape, so we backslash-escape it. This is a
+        # heuristic: a value that itself ends a quoted run right before a real
+        # delimiter (…said "yes", ok) can still be misread, but that produces
+        # invalid JSON downstream (→ None, fail-closed), never a wrong verdict.
+        out: list[str] = []
+        in_str = False
+        escaped = False
+        n = len(s)
+        i = 0
+        while i < n:
+            ch = s[i]
+            if not in_str:
+                out.append(ch)
+                if ch == '"':
+                    in_str = True
+                i += 1
+                continue
+            # inside a string
+            if escaped:
+                out.append(ch)
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                out.append(ch)
+                escaped = True
+                i += 1
+                continue
+            if ch == '"':
+                j = i + 1
+                while j < n and s[j] in " \t\r\n":
+                    j += 1
+                nxt = s[j] if j < n else ""
+                if nxt in ("", ":", ",", "}", "]"):
+                    out.append(ch)  # real closing quote
+                    in_str = False
+                else:
+                    out.append('\\"')  # unescaped inner quote → escape it
+                i += 1
+                continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
 
     def _strip_trailing_commas(s: str) -> str:
         out: list[str] = []
@@ -9113,6 +9172,11 @@ class AutonomousOrchestrator:
                 "verdicts": [],
                 "snapshot": None,
                 "infra_error": "verification agent output was not valid JSON",
+                # Deterministic failure (#2867): the agent emitted output that
+                # cannot be parsed. Re-running it usually reproduces the same
+                # unparseable form, so the phase caps consecutive repeats of this
+                # kind below the transient-retry budget instead of burning it.
+                "infra_error_kind": "unparseable_output",
             }
         if not isinstance(parsed, dict):
             return {

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -799,10 +799,12 @@ def handle(ctx, deps) -> PhaseResult:
     infra_error_kind = None
     if agent_out.get("infra_error"):
         infra_retry_count = _prior_infra_retry_count(wf, merge_sha, snap_hash) + 1
-        # The parse-failure kind is set by _parse_verifier_output and never
-        # overwritten downstream (every later stage that sets infra_error guards
-        # on `not agent_out.get("infra_error")`), so it reliably describes THIS
-        # attempt's infra_error.
+        # infra_error_kind is set only by _parse_verifier_output's parse-failure
+        # path, which also returns verdicts=[] and snapshot=None. So whenever a
+        # kind is present the per-verdict loop above is empty (its verdict-level
+        # infra_error assignments never fire) and the snapshot/probe sites are
+        # skipped (None snapshot) or guarded by `not infra_error` — the kind can
+        # never go stale relative to THIS attempt's final infra_error.
         infra_error_kind = agent_out.get("infra_error_kind")
     report = {
         "merge_sha": merge_sha,

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -43,6 +43,12 @@ from app.utils.config import is_acceptance_verification_enabled
 
 VERIFIED_BY = "acceptance-verifier-v1"
 MAX_VERIFIER_INFRA_RETRIES = 3
+# A deterministic parse failure (agent output that cannot be parsed) that
+# repeats identically is not a transient hiccup — re-running just reproduces the
+# same unparseable form. Cap consecutive repeats of that kind here so the
+# workflow reaches human review after 2 attempts instead of burning the full
+# transient-retry budget on a certain-to-fail retry (#2867).
+DETERMINISTIC_PARSE_MAX_RETRIES = 2
 
 logger = logging.getLogger(__name__)
 
@@ -519,6 +525,29 @@ def _prior_infra_retry_count(wf: dict, merge_sha: str, snap_hash: str) -> int:
         return 0
 
 
+def _prior_infra_error_kind(wf: dict, merge_sha: str, snap_hash: str) -> str | None:
+    """Return the prior attempt's ``infra_error_kind`` for the current pair.
+
+    Used to detect a deterministic parse failure repeating identically across
+    consecutive attempts (#2867). Returns ``None`` when the prior report is for
+    a different merge/snapshot pair, was not an infra failure, or carried no
+    kind (older reports predating the field).
+    """
+    raw = wf.get("verification_report")
+    if not raw:
+        return None
+    try:
+        report = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    except Exception:
+        return None
+    if not isinstance(report, dict) or not report.get("infra_error"):
+        return None
+    if report.get("merge_sha") != merge_sha or report.get("issue_acceptance_hash") != snap_hash:
+        return None
+    kind = report.get("infra_error_kind")
+    return kind if isinstance(kind, str) and kind else None
+
+
 def _acceptance_milestone(*, workflow_id, dev_round, attempt, status, report) -> dict:
     """Build the acceptance-verification milestone row.
 
@@ -767,8 +796,14 @@ def handle(ctx, deps) -> PhaseResult:
     # (S5); fall back to the static runner tag otherwise.
     verified_by = agent_out.get("verified_by") or VERIFIED_BY
     infra_retry_count = 0
+    infra_error_kind = None
     if agent_out.get("infra_error"):
         infra_retry_count = _prior_infra_retry_count(wf, merge_sha, snap_hash) + 1
+        # The parse-failure kind is set by _parse_verifier_output and never
+        # overwritten downstream (every later stage that sets infra_error guards
+        # on `not agent_out.get("infra_error")`), so it reliably describes THIS
+        # attempt's infra_error.
+        infra_error_kind = agent_out.get("infra_error_kind")
     report = {
         "merge_sha": merge_sha,
         "issue_acceptance_hash": snap_hash,
@@ -797,6 +832,7 @@ def handle(ctx, deps) -> PhaseResult:
         ],
         "status": status,
         "infra_error": agent_out.get("infra_error") or None,
+        "infra_error_kind": infra_error_kind,
         "infra_retry_count": infra_retry_count,
         "verified_at": _now_iso(),
     }
@@ -821,7 +857,18 @@ def handle(ctx, deps) -> PhaseResult:
         status=status,
         report=report,
     )
-    if agent_out.get("infra_error") and infra_retry_count < MAX_VERIFIER_INFRA_RETRIES:
+    # A deterministic parse failure that repeats identically across consecutive
+    # attempts is certain to keep failing, so cap it below the transient budget
+    # (#2867). The first occurrence still gets one retry (a genuine one-off is
+    # possible); the second consecutive same-kind failure stops early.
+    effective_max = MAX_VERIFIER_INFRA_RETRIES
+    deterministic_repeat = (
+        infra_error_kind == "unparseable_output"
+        and _prior_infra_error_kind(wf, merge_sha, snap_hash) == "unparseable_output"
+    )
+    if deterministic_repeat:
+        effective_max = DETERMINISTIC_PARSE_MAX_RETRIES
+    if agent_out.get("infra_error") and infra_retry_count < effective_max:
         # Infrastructure failures are not acceptance evidence and must not
         # create a terminal milestone. Keep the workflow in its current phase
         # so the scheduler can retry automatically; the attempt report remains
@@ -833,12 +880,16 @@ def handle(ctx, deps) -> PhaseResult:
             }
         )
     if agent_out.get("infra_error"):
+        exhausted_msg = (
+            "Acceptance verifier produced unparseable output "
+            f"{infra_retry_count}x; awaiting review"
+            if deterministic_repeat
+            else "Acceptance verifier infrastructure retries exhausted; awaiting review"
+        )
         return PhaseResult.pause(
             workflow_patch={
                 **common_patch,
-                "error_message": (
-                    "Acceptance verifier infrastructure retries exhausted; awaiting review"
-                ),
+                "error_message": exhausted_msg,
             },
             milestone_events=[milestone],
             structured_error={"message": "verifier-infrastructure-exhausted", "report": report},

--- a/tests/unit/test_acceptance_verifier_infra_cap_2867.py
+++ b/tests/unit/test_acceptance_verifier_infra_cap_2867.py
@@ -1,0 +1,146 @@
+"""Regression (#2867): a deterministic verifier parse failure must not burn the
+full transient-retry budget.
+
+When the verifier emits output that cannot be parsed, re-running it usually
+reproduces the same unparseable form. The old code treated every infra failure
+as transient and retried up to ``MAX_VERIFIER_INFRA_RETRIES`` (3), so a
+certain-to-fail parse failure wasted the whole budget before pausing. The phase
+now tags parse failures (``infra_error_kind == "unparseable_output"``) and caps
+CONSECUTIVE repeats at ``DETERMINISTIC_PARSE_MAX_RETRIES`` (2), while genuinely
+transient infra errors keep the full budget.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2867)]
+
+UNPARSEABLE = {
+    "verdicts": [],
+    "snapshot": None,
+    "infra_error": "verification agent output was not valid JSON",
+    "infra_error_kind": "unparseable_output",
+}
+TRANSIENT = {
+    "verdicts": [],
+    "snapshot": None,
+    "infra_error": "verification agent returned empty output",
+}
+
+
+def _ctx(wf):
+    return WorkflowContext(
+        workflow=wf,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings=MagicMock(),
+        cancellation=MagicMock(),
+    )
+
+
+def _base_wf():
+    # Empty snapshot -> source "missing" -> requires extraction -> the idempotent
+    # "already verified" reuse is skipped, so each call re-runs the verifier.
+    snap = {
+        "required_paths": [],
+        "checklist": [],
+        "non_scope": [],
+        "closure_constraints": False,
+        "source": "missing",
+        "confidence": "low",
+    }
+    return {
+        "id": 1,
+        "workflow_id": "wf-2867",
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_snapshot": json.dumps(snap),
+        "verification_status": None,
+        "dev_round": 1,
+    }
+
+
+def _deps(agent_out):
+    d = MagicMock()
+    d.gh = MagicMock()
+    d.host.run_verification_agent.return_value = agent_out
+    d.host.issue_is_open.return_value = True
+    return d
+
+
+def _run(wf, agent_out):
+    # Isolate the infra-retry decision from the mechanical gates.
+    with (
+        patch.object(av, "is_acceptance_verification_enabled", return_value=True),
+        patch.object(av, "run_scope_gate", return_value=[]),
+        patch.object(av, "run_mechanical_gates", return_value=[]),
+    ):
+        return av.handle(_ctx(wf), _deps(agent_out))
+
+
+def test_first_unparseable_failure_retries_and_tags_kind():
+    result = _run(_base_wf(), UNPARSEABLE)
+    assert result.outcome == "retry"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert report["infra_error_kind"] == "unparseable_output"
+    assert report["infra_retry_count"] == 1
+
+
+def test_second_consecutive_unparseable_failure_pauses_early():
+    r1 = _run(_base_wf(), UNPARSEABLE)
+    assert r1.outcome == "retry"
+
+    wf2 = _base_wf()
+    wf2["verification_report"] = r1.workflow_patch["verification_report"]
+    r2 = _run(wf2, UNPARSEABLE)
+
+    # Capped at 2 (deterministic), not the transient budget of 3.
+    assert r2.outcome == "pause"
+    assert "unparseable" in r2.workflow_patch["error_message"].lower()
+    report2 = json.loads(r2.workflow_patch["verification_report"])
+    assert report2["infra_retry_count"] == 2
+    assert report2["infra_error_kind"] == "unparseable_output"
+
+
+def test_transient_infra_error_keeps_full_budget_at_same_count():
+    # Contrast: a non-parse infra error at the SAME count (2) still retries,
+    # proving the early cap is specific to deterministic parse failures.
+    r1 = _run(_base_wf(), TRANSIENT)
+    assert r1.outcome == "retry"
+    report1 = json.loads(r1.workflow_patch["verification_report"])
+    assert report1["infra_error_kind"] is None
+
+    wf2 = _base_wf()
+    wf2["verification_report"] = r1.workflow_patch["verification_report"]
+    r2 = _run(wf2, TRANSIENT)
+    assert r2.outcome == "retry"  # budget is 3; count 2 still retries
+    report2 = json.loads(r2.workflow_patch["verification_report"])
+    assert report2["infra_retry_count"] == 2
+
+
+def test_prior_infra_error_kind_helper_matches_pair():
+    snap_hash = "h1"
+    prior = json.dumps(
+        {
+            "merge_sha": "merge",
+            "issue_acceptance_hash": snap_hash,
+            "infra_error": "verification agent output was not valid JSON",
+            "infra_error_kind": "unparseable_output",
+            "infra_retry_count": 1,
+        }
+    )
+    wf = {"verification_report": prior}
+    assert av._prior_infra_error_kind(wf, "merge", snap_hash) == "unparseable_output"
+    # Different merge/hash pair -> not consecutive, no kind carried over.
+    assert av._prior_infra_error_kind(wf, "other", snap_hash) is None
+    assert av._prior_infra_error_kind(wf, "merge", "other") is None
+    # Older report predating the field -> None.
+    wf_old = {"verification_report": json.dumps({"merge_sha": "merge", "infra_error": "x"})}
+    assert av._prior_infra_error_kind(wf_old, "merge", snap_hash) is None

--- a/tests/unit/test_verifier_json_parse.py
+++ b/tests/unit/test_verifier_json_parse.py
@@ -138,3 +138,94 @@ def test_truncated_object_with_no_complete_element_returns_none():
     # Cut off before ANY complete verdict — nothing safe to recover.
     text = '```json\n{"verdicts": [{"item": "a", "verdict": "conf'
     assert _extract(text) is None
+
+
+# --- Unescaped inner ASCII double quotes (#2867). glm reproduces the Chinese
+# acceptance criteria verbatim; when a checklist item quotes a UI label the
+# inner 「"..."」 quotes land unescaped, so strict json.loads raises and the
+# whole (actually-passing) verdict batch was misjudged as an infra failure.
+# The parser must escape structurally-inner quotes and recover the verdicts,
+# while still returning None (fail-closed) when nothing valid can be recovered.
+
+
+def test_unescaped_inner_quotes_in_string_value_recovered():
+    # An item value that quotes a UI label: the inner quotes are unescaped.
+    text = (
+        "```json\n"
+        '{"verdicts": [{"item": "`platform_admin` 可以看到并进入"租户管理"。", '
+        '"verdict": "confirmed"}], "snapshot": null}\n'
+        "```"
+    )
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"][0]["verdict"] == "confirmed"
+    # The inner label is preserved intact in the recovered value.
+    assert '"租户管理"' in result["verdicts"][0]["item"]
+    assert result["snapshot"] is None
+
+
+def test_2756_style_full_batch_recovers_all_confirmed():
+    # Mirrors the #2756 raw output: 5/5 confirmed, several items quoting labels
+    # with unescaped inner quotes, terse evidence refs, prose preface + fence.
+    items = [
+        '{"item": "`platform_admin` 可以看到并进入"租户管理"。", "verdict": "confirmed", '
+        '"evidence": [{"ref": "app/routes/tenant.py:42", "note": "route guarded"}], '
+        '"rationale": "读到 admin 分支"}',
+        '{"item": "普通用户访问"租户管理"返回 403。", "verdict": "confirmed", '
+        '"evidence": [{"ref": "app/routes/tenant.py:55", "note": "403 path"}], '
+        '"rationale": "deny 分支"}',
+        '{"item": "列表按 "tenant_id" 过滤。", "verdict": "confirmed", '
+        '"evidence": [{"ref": "app/repositories/tenant.py:8", "note": "where tenant_id"}], '
+        '"rationale": "SQL where"}',
+        '{"item": "创建时写入 "tenant_id"。", "verdict": "confirmed", '
+        '"evidence": [{"ref": "app/repositories/tenant.py:20", "note": "insert col"}], '
+        '"rationale": "insert"}',
+        '{"item": "前端菜单显示"租户管理"入口。", "verdict": "confirmed", '
+        '"evidence": [{"ref": "web/src/Nav.tsx:12", "note": "menu item"}], '
+        '"rationale": "nav"}',
+    ]
+    text = (
+        "I verified the merged changes against the acceptance snapshot.\n"
+        "```json\n"
+        '{"verdicts": [' + ", ".join(items) + '], "snapshot": null}\n'
+        "```"
+    )
+    result = _extract(text)
+    assert result is not None
+    verdicts = result["verdicts"]
+    assert len(verdicts) == 5
+    assert all(v["verdict"] == "confirmed" for v in verdicts)
+
+
+def test_unescaped_inner_quotes_combined_with_trailing_comma():
+    # fence + prose preface + trailing comma + unescaped inner quotes together.
+    text = (
+        "Result below:\n"
+        "```json\n"
+        '{"verdicts": [{"item": "进入"设置"页", "verdict": "confirmed",},], "snapshot": null,}\n'
+        "```"
+    )
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"][0]["verdict"] == "confirmed"
+    assert '"设置"' in result["verdicts"][0]["item"]
+    assert result["snapshot"] is None
+
+
+def test_unescaped_inner_quotes_unfenced_prose_wrapped():
+    # Same defect but unfenced, wrapped in prose on both sides.
+    text = (
+        "Here is my assessment: "
+        '{"verdicts": [{"item": "点击"保存"按钮生效", "verdict": "confirmed"}], "snapshot": null}'
+        " Done."
+    )
+    result = _extract(text)
+    assert result is not None
+    assert '"保存"' in result["verdicts"][0]["item"]
+
+
+def test_unrecoverable_garbage_still_returns_none():
+    # A brace-y blob that is not recoverable JSON must still fail closed — the
+    # heuristic must never fabricate a verdict out of noise.
+    text = '```json\n{this is "not: json at "all }{ }"\n```'
+    assert _extract(text) is None

--- a/tests/unit/test_verifier_json_parse.py
+++ b/tests/unit/test_verifier_json_parse.py
@@ -229,3 +229,31 @@ def test_unrecoverable_garbage_still_returns_none():
     # heuristic must never fabricate a verdict out of noise.
     text = '```json\n{this is "not: json at "all }{ }"\n```'
     assert _extract(text) is None
+
+
+def test_parse_verifier_output_tags_unparseable_kind():
+    # Producer side of the #2867 deterministic-retry contract: when extraction
+    # fails, _parse_verifier_output must return infra_error_kind ==
+    # "unparseable_output" — the exact string acceptance_verification's early
+    # cap keys on. Anchors the cross-file literal so a rename on one side is
+    # caught by a test rather than by a stuck prod workflow.
+    from unittest.mock import MagicMock
+
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._artifact_text = MagicMock(return_value="prose only, no json object at all")
+    out = orch._parse_verifier_output(MagicMock())
+    assert out["infra_error"] == "verification agent output was not valid JSON"
+    assert out["infra_error_kind"] == "unparseable_output"
+    assert out["verdicts"] == []
+
+    # And the success path stays clean: a recoverable batch parses with no
+    # infra_error / kind, so the cap logic never engages on a real verdict.
+    orch._artifact_text = MagicMock(
+        return_value='{"verdicts": [{"item": "进入"设置"页", "verdict": "confirmed"}], "snapshot": null}'
+    )
+    good = orch._parse_verifier_output(MagicMock())
+    assert good.get("infra_error") is None
+    assert good.get("infra_error_kind") is None
+    assert good["verdicts"][0]["verdict"] == "confirmed"


### PR DESCRIPTION
## 问题

工作流 5d43842c（issue #2756，PR #2848）验收阶段：verifier 三轮输出**都是判定正确的完整验收 JSON（5/5 confirmed）**，却全部被判 `infra_error: "verification agent output was not valid JSON"`，重试 3 次同形失败烧完额度 → paused 等人工。实际验收已通过，工作流卡死在字符串解析上。

**根因**：`_extract_verifier_json` 已对 fence/prose/尾逗号/串内大括号/截断做容错，但**不处理字符串值内未转义的 ASCII 双引号**。glm 复述中文验收标准时天然含引号（`…可以看到并进入"租户管理"。`），内层引号未转义 → `json.loads` 必炸。且确定性解析失败被当瞬时故障重试，3 次全部无效。

## 改动

`app/modules/workspace/autonomous/orchestrator.py`
- 新增 `_escape_inner_string_quotes`：结构感知重引号。字符串 token 的**真实闭合引号**是其后（跳空白）紧跟结构分隔符 `:` `,` `}` `]` 或 EOF 的那个；其余在串内的 `"` 视为模型漏转义的内引号并 `\"` 转义。
- 作为 `_try_parse` 的**最后回退**接入：仅在「严格解析」+「去尾逗号后解析」都失败后才触发，之后仍走严格 `json.loads`。因此与现有各路径（fenced / prose-wrapped / 尾逗号 / 截断恢复）自动叠加，且对正常输入零影响（正常输入首次严格解析即成功，永不进入重引号分支）。
- **fail-closed**：无法恢复的噪声仍返回 `None` 交给 infra-retry，绝不编造 verdict。启发式的已知边界（值内恰以引号收尾且紧跟真实分隔符，如 `…said "yes", ok`）会解析失败 → `None`，而非产生错误 verdict，已在注释中说明。

`app/modules/workspace/autonomous/phases/acceptance_verification.py`（加分项：区分确定性 vs 瞬时失败）
- 解析失败标记 `infra_error_kind="unparseable_output"`（由 `_parse_verifier_output` 设置，后续阶段设 `infra_error` 均 guard 在 `not infra_error`，故不会覆盖，kind 与该次 infra_error 始终一致）。
- 新增 `_prior_infra_error_kind` + `DETERMINISTIC_PARSE_MAX_RETRIES=2`：**连续**同类解析失败在第 2 次即提前转人工（首次仍给 1 次重试以容忍一次性抖动），不再烧满瞬时预算 3；瞬时错误（如 empty output）仍用满预算。pause 文案区分可判读。
- report 落库新增 `infra_error_kind` 字段（向后兼容：旧 report 无此字段 → 视为无 kind → 正常预算）。

## 验收标准对照

- [x] 解析器恢复串内未转义双引号，对 #2756 式原文解析出 5/5 confirmed
- [x] fail-closed：无法恢复返回 None，绝不编造/静默丢弃
- [x] 单测覆盖 fence + prose 前缀 + 尾逗号 + 内嵌引号组合，及现有容错回归
- [x] 加分：区分确定性/瞬时失败，连续 2 次解析失败即停重试并给可判读信息
- [x] 成功路径不变：verdicts 正确落库、confirmed→completed 状态机不受影响（现有 159 项相关测试全绿）

## 测试

```
pytest tests/unit/test_verifier_json_parse.py \
       tests/unit/test_acceptance_verifier_infra_cap_2867.py \
       tests/unit/test_acceptance_verification_milestone.py \
       tests/unit/test_acceptance_item_fuzzy_coverage.py \
       tests/unit/test_orchestrator_verification_agent.py \
       tests/issues/2335/
# 159 passed
```

Closes #2867

🤖 Generated with [Claude Code](https://claude.com/claude-code)