### PR TITLE
fix(autonomous): recreate workspace for post-merge-cleanup resume rounds

### DIFF
--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -37,6 +37,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Phases that execute agent/git work in the workflow workspace. A workflow
+# resumed AFTER merge cleanup (rejected-acceptance repair round, or new
+# issue-comment requirements) reaches these with worktree_path/branch_name
+# deliberately cleared; running them against project_path (the main
+# checkout) commits repair work straight onto local main (#322/#329/#340).
+_WORKSPACE_CONSUMING_PHASES = ("development", "pr_review")
+
 
 def _GitHubOps(*args, **kwargs):
     """Resolve ``GitHubOps`` through the orchestrator module at call time.
@@ -83,7 +90,11 @@ class GitWorkspaceService:
 
         Returns the canonical worktree path. For non-worktree strategies, or
         when ``worktree_path`` is intentionally empty (merge cleanup / conflict
-        resolution clears it), this is a no-op returning ``project_path``.
+        resolution clears it) in a phase that never touches the workspace
+        (wait/report/acceptance/planning/merge), this is a no-op returning
+        ``project_path``. A workspace-consuming phase (development/pr_review)
+        reached with an empty path after merge cleanup instead recreates the
+        worktree (#322/#329/#340).
         """
         strategy = wf.get("branch_strategy", "new-branch")
         project_path = wf.get("project_path", "")
@@ -107,9 +118,38 @@ class GitWorkspaceService:
                 raise RuntimeError(
                     "worktree transition in progress " f"(state={ts!r}); reconcile before execution"
                 )
-            return worktree_path or project_path  # type: ignore[no-any-return]
-
-        canonical: str = os.path.realpath(worktree_path)
+            # Post-merge-cleanup resume (#322/#329/#340): the merged delivery's
+            # cleanup cleared the fields because the workflow was "done"; a
+            # rejected-acceptance / new-requirements resume brings it back into
+            # a workspace-consuming phase. Recreate the worktree via the same
+            # authoritative-head recovery as the dir-gone path below instead of
+            # returning the main checkout. Phases that never touch the workspace
+            # (wait/report/acceptance/planning/merge) keep the historical no-op
+            # (the merge-retry rationale in the comment above still holds).
+            if (
+                strategy == "worktree"
+                and project_path
+                and not worktree_path
+                and wf.get("current_phase") in _WORKSPACE_CONSUMING_PHASES
+            ):
+                # fall through to the recreation section below. Path: prefer
+                # the same canonical location preparation/CI-repair use —
+                # preferred_worktree_path SURVIVES merge cleanup (cleanup
+                # clears only worktree_path/branch_name), so this recreates
+                # at the exact original spot. Legacy sibling format is a
+                # defensive fallback for the (practically unreachable) case
+                # where no preferred path can be derived; an empty
+                # branch_name there yields a bogus path that `worktree add`
+                # rejects loudly (fail-closed, not silent).
+                canonical: str = self.get_preferred_worktree_path(wf) or os.path.realpath(
+                    os.path.normpath(
+                        f"{project_path}/../{(wf.get('branch_name') or '').strip().replace('/', '-')}"
+                    )
+                )
+            else:
+                return worktree_path or project_path  # type: ignore[no-any-return]
+        else:
+            canonical = os.path.realpath(worktree_path)
         # Resolve system_account up front so the validity check below can use
         # it: os.path.isfile() stats as the service user and raises
         # PermissionError under a user-private parent (700 home, Issue #1395).

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -12560,20 +12560,31 @@ class AutonomousOrchestrator:
         if user_feedback and user_feedback.strip():
             # User provided feedback via cancel — resume from the cancelled phase
             # Find the most recent non-cancelled, non-wait milestone to determine phase
-            cancelled_phase = "development"  # default fallback
-            milestones = self.repo.list_milestones(self._workflow_id)
-            for ms in reversed(milestones):
-                status = ms.get("status", "")
-                mtype = ms.get("milestone_type", "")
-                if status == "completed" and mtype not in (
-                    "wait_started",
-                    "requirement_received",
-                    "branch_created",
-                    "repo_setup",
-                    "issue_created",
-                ):
-                    cancelled_phase = ms.get("phase", "development")
-                    break
+            # A rejected acceptance means the previous delivery ALREADY merged
+            # (acceptance only runs after a successful merge), so milestone
+            # backtracking can only land on merge/acceptance/report-side or infra
+            # milestones — every one a wrong resume target (#322: a stale
+            # worktree_restored(pr_review) skipped the repair round entirely and
+            # the workflow fell straight into the no-changes terminal). The only
+            # meaningful resume is a repair development round; force it.
+            if rejected_acceptance:
+                cancelled_phase = "development"
+            else:
+                cancelled_phase = "development"  # default fallback
+                milestones = self.repo.list_milestones(self._workflow_id)
+                for ms in reversed(milestones):
+                    status = ms.get("status", "")
+                    mtype = ms.get("milestone_type", "")
+                    if status == "completed" and mtype not in (
+                        "wait_started",
+                        "requirement_received",
+                        "branch_created",
+                        "repo_setup",
+                        "issue_created",
+                        "worktree_restored",  # infra bookkeeping, never a resume target
+                    ):
+                        cancelled_phase = ms.get("phase", "development")
+                        break
 
             new_dev_round = wf.get("dev_round", 1) + 1
             # Emit the phase_change event through the host (the commit entrypoint

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -164,6 +164,23 @@ def handle(ctx, deps) -> PhaseResult:
     force_full_rounds = host.must_run_full_review_rounds(wf)
     dev_round = wf.get("dev_round", 1)
     branch_name = wf.get("branch_name", "")
+    if not branch_name.strip():
+        # Empty branch_name is a broken state (every branch_strategy sets it in
+        # preparation; empty only happens after merge cleanup without
+        # recreation). Falling through would run `git rev-parse ''` → exit 128
+        # → the except-swallow leaves has_changes=False and the workflow
+        # terminates as no_changes — masking the breakage (#322/#329/#340).
+        # Fail loudly instead.
+        return PhaseResult.failed(
+            structured_error={
+                "message": (
+                    "pr_review entered with an empty branch_name (workspace "
+                    "cleared by merge cleanup and not recreated); refusing to "
+                    "fall into the no-changes terminal — this is a broken "
+                    "state, not 'no changes'"
+                )
+            }
+        )
     # Capture entry repo state for the push-check recovery (#2302). The worktree
     # may be on main at push time (failure→retry→reentry); recover_worktree_branch
     # needs the feature tip + main HEAD from before any in-phase switch.

--- a/docs/superpowers/plans/2026-08-20-resume-without-workspace.md
+++ b/docs/superpowers/plans/2026-08-20-resume-without-workspace.md
@@ -1,0 +1,286 @@
+# 修复方案（v2）：验收 rejected 修复轮在主仓库裸跑并误终止（Bug 5）
+
+- 日期：2026-08-20
+- v2 修订（独立审查意见）：① 重建路径推导优先 `get_preferred_worktree_path`（merge cleanup 只清 `worktree_path`/`branch_name`，不清 `preferred_worktree_path`，可精确回到原始 worktree 位置，与 preparation/CI-repair 的既有语义一致）；② 测试计划补"worktree 已清、branch 残留"中间态的 attach 用例；③ 删除 2.2 末段冗余表述（recreation 段 L243 的 branch_name 推导保持原样，无需"改为"）。
+- 分支：`fix/resume-without-workspace`（基于 `origin/main`）
+- 生产环境：192.168.31.159（openace-scheduler.service，PostgreSQL `openace` 库）
+- 受害工作流：#322（9be278b1，issue #2755）、#329（4a2d6e76，PR #2902）、#340（04b0b260，PR #2907）
+- 前置：Bug 3 修复（v7，`fix/acceptance-rejected-timing-issue-shortcircuit`，已合并部署）解决了"rejected 重入被 pr_review timing-issue 短路"的误终止；本次 Bug 5 是该修复上线验证时暴露的**更深一层缺陷**：修复轮根本没有拿到隔离工作区。
+- **行号基准声明**：文中行号对应工作区当前 `origin/main` 检出；实施时一律以符号（函数名/常量名/语句）定位为准，行号仅作对照参考。
+
+## 一、Bug 描述
+
+### 1.1 生产证据（三个受害工作流的完整事件链）
+
+共同背景：三个工作流均完成了 round 1 交付（PR 合并进 main，merge 阶段 cleanup 清空了 `worktree_path` 与 `branch_name`），随后 acceptance_verification 判定 **rejected**，人工通过 resume-with-feedback 恢复（16:35:44，milestone `requirement_received`）。此后：
+
+| 工作流 | resume 后路由 | 实际行为 | 结果 |
+|---|---|---|---|
+| #322 | **pr_review**（错误） | `_do_wait` 回溯选中昨日陈旧的 `worktree_restored`(phase=pr_review) 里程碑 → 直接进入 pr_review；branch_name 为空 → `git rev-parse ''` 失败（exit 128，日志 `Failed to check branch status: git rev-parse  failed`）→ `has_changes=False, is_timing_issue=False` → v7 拦截条件（需 `is_timing_issue`）不满足 → 走通用 `no_changes` 终态 | 16:36:01 误终止 completed（resume 后仅 17 秒，开发轮从未运行） |
+| #329 | development（碰巧正确） | `ensure_worktree` 对空 `worktree_path` 是 no-op（返回 `project_path`）→ dev agent **直接在主仓库 `/home/dwu/open-ace-01/open-ace` 上开发**（branch_name 为空，所有分支校验被跳过）→ 编排器自动提交 `auto: development changes (round 2)`（7d279598）**落在本地 main 上** → 测试轮跑完 → pr_review 同样因空分支名走 `no_changes` | 16:51:34 误终止 completed，stray commit 留在主仓库 main |
+| #340 | development（碰巧正确） | 同 #329，主仓库 `/home/qlfan/auto/a1/open-ace` 上 stray commit `c1eb1932` | 16:53:15 误终止 completed |
+
+日志铁证（journalctl，2026-08-21 00:35:58 CST）：
+
+```
+pr_review - WARNING - Failed to check branch status: git rev-parse  failed (exit 128):
+致命错误：有歧义的参数 ''：未知的版本或路径不存在于工作区中。
+```
+
+主仓库污染证据：
+
+```
+# /home/dwu/open-ace-01/open-ace（branch=main）
+7d279598 auto: development changes (round 2)   ← #329 的修复轮产出，未推送、未走 PR
+# /home/qlfan/auto/a1/open-ace（branch=main）
+c1eb1932 auto: development changes (round 2)   ← #340 的修复轮产出
+```
+
+### 1.2 根因（三个叠加缺陷）
+
+**缺陷 A —— `_do_wait` user_feedback 路径的里程碑回溯选中基础设施里程碑**（orchestrator.py，`_do_wait` 内 `if user_feedback and user_feedback.strip():` 块）：
+
+```python
+cancelled_phase = "development"  # default fallback
+milestones = self.repo.list_milestones(self._workflow_id)
+for ms in reversed(milestones):
+    if status == "completed" and mtype not in (
+        "wait_started", "requirement_received", "branch_created",
+        "repo_setup", "issue_created",
+    ):
+        cancelled_phase = ms.get("phase", "development")
+        break
+```
+
+排除表不含 `worktree_restored`。#322 的最新"completed 且不在排除表"里程碑是昨日 pr_review 阶段的 `worktree_restored`（infra 记录）→ resume 目标成了 pr_review，完全跳过开发轮。更根本的问题是：**对 rejected 场景，回溯本身就是错误的决策机制**——rejected 隐含"上一轮交付已合并"（acceptance 只在 merge 成功后运行），此时最近 completed 里程碑必然落在 merge/acceptance/report 侧或 infra 记录上（cleaned_up、merged、worktree_restored、被 cancel 的 report 三件套……），无论命中哪个都不是正确目标。正确目标只有一个：**带着验收失败项重开 development**。#329/#340 碰巧路由到 development 只是因为它们的里程碑形状不同（历史上恰好有未 cancel 的 development 侧 completed 里程碑），属偶然正确。
+
+**缺陷 B —— `ensure_worktree` 对空 `worktree_path` 是 no-op，修复轮拿不到工作区**（git_workspace.py `ensure_worktree`）：
+
+```python
+if strategy != "worktree" or not project_path or not worktree_path:
+    # ... transition-state 守卫 ...
+    return worktree_path or project_path   # ← 空路径：返回主仓库！
+```
+
+该 no-op 的原有理由（注释）：空 `worktree_path` 是 `_do_merge` 最终 cleanup 在 PR 合并后的**有意**清空（"工作流已完成"），把它当"目录丢失"去重建会在重试 merge 时 `git worktree add <主仓库>` 失败。这个假设对**终态**工作流成立，但对**被 resume 拉回活跃阶段**的工作流不成立：merge cleanup 清空了 `worktree_path`/`branch_name` 之后，验收 rejected + 人工 resume 把工作流带回 development/pr_review，`advance()` 每 tick 先调 `_ensure_worktree`（no-op）→ 阶段全部落在 `project_path`（主仓库检出）上执行：
+
+- `_run_development_agent`：`project_path = wf.get("worktree_path") or wf.get("project_path")` → 主仓库；分支校验 `if expected_branch and ...` 因 `expected_branch` 为空**整体跳过**；
+- 编排器自动提交（`git_add_all` + `git_commit("auto: development changes (round N)")`）直接落在主仓库**本地 main** 上；
+- pr_review 的分支检查用空 branch_name 调 `git rev-parse` → 必然失败。
+
+**缺陷 C —— pr_review 对空 branch_name 静默落入 `no_changes` 终态**（pr_review.py `handle`）：
+
+```python
+try:
+    branch_sha = gh._run_git(["rev-parse", branch_name]).stdout.strip()  # branch_name="" → exit 128
+    ...
+except Exception as e:
+    logger.warning("Failed to check branch status: %s", e)
+    pass   # has_changes=False, is_timing_issue=False 保持初值
+```
+
+空分支名是**损坏状态**（所有 branch_strategy 下 preparation 都会设置 branch_name；为空只可能来自 merge cleanup 后未重建），却被当成"无变更"处理 → 误发 issue 评论"Agent did not produce any code changes"、误终止 completed。v7 的 rejected 拦截条件 `is_timing_issue and pr_number and rejected_verification` 因 `is_timing_issue=False` 同样无法兜底。
+
+### 1.3 触发条件（精确）
+
+```
+merge cleanup 已清空 worktree_path（PR 合并后的标准路径）
+∧ verification_status == 'rejected'
+∧ 人工 resume-with-feedback / cancel-with-feedback（_do_wait user_feedback 路径）
+∧ branch_strategy == 'worktree'
+→ 修复轮在主仓库 main 上裸跑（缺陷 B）
+→ 若回溯命中 worktree_restored(pr_review) 则连开发轮都跳过（缺陷 A，#322）
+→ pr_review 空分支名 → no_changes 误终止（缺陷 C，三者共同终点）
+```
+
+注：缺陷 B 的影响面不止 rejected 修复轮——**任何**"已合并交付 → wait → 新需求评论 → planning → development"流程同样以空工作区进入 development（wait 阶段的新需求路径返回 `next_phase="planning"`，不经过 preparation）。本修复在 development 入口统一重建工作区，顺带覆盖该路径。
+
+## 二、修复设计
+
+### 2.1 改动 A（orchestrator.py `_do_wait`：rejected 强制重开 development；回溯排除 infra 里程碑）
+
+在 user_feedback 路径中，`rejected_acceptance`（v7 已计算的局部变量）为真时**跳过回溯**，直接 `cancelled_phase = "development"`；非 rejected 保持现状，但排除表增加 `"worktree_restored"`：
+
+```python
+if user_feedback and user_feedback.strip():
+    # A rejected acceptance means the previous delivery ALREADY merged
+    # (acceptance only runs after a successful merge), so milestone
+    # backtracking can only land on merge/acceptance/report-side or infra
+    # milestones — every one a wrong resume target (#322: a stale
+    # worktree_restored(pr_review) skipped the repair round entirely and
+    # the workflow fell straight into the no-changes terminal). The only
+    # meaningful resume is a repair development round; force it.
+    if rejected_acceptance:
+        cancelled_phase = "development"
+    else:
+        cancelled_phase = "development"  # default fallback
+        milestones = self.repo.list_milestones(self._workflow_id)
+        for ms in reversed(milestones):
+            status = ms.get("status", "")
+            mtype = ms.get("milestone_type", "")
+            if status == "completed" and mtype not in (
+                "wait_started",
+                "requirement_received",
+                "branch_created",
+                "repo_setup",
+                "issue_created",
+                "worktree_restored",  # infra bookkeeping, never a resume target
+            ):
+                cancelled_phase = ms.get("phase", "development")
+                break
+    ...  # 其余（dev_round+1、emit、PhaseResult.completed）不变
+```
+
+设计说明：
+- `rejected_acceptance` 为真时工作流必然带验收反馈注入（v7 主路径）或人工反馈，dev prompt 有修复目标；`dev_round+1` 与 v7 语义一致。
+- v6 一次性防护不受影响：其守卫（`fresh_human_resume`）只控制**反馈注入**；本改动只控制**阶段路由**。修复轮第二个 wait tick 上 `user_feedback` 已被消费清空 → 不进 user_feedback 路径 → 无重入循环。
+- 人工反复 resume 的 dev 轮数无自动上限（与 v7 现状一致，人在环内，`MAX_ACCEPTANCE_DEV_ROUNDS` 只约束 pr_review 拦截路径的自动重开）。
+
+### 2.2 改动 B（git_workspace.py `ensure_worktree`：cleanup 后进入工作区消费阶段时重建）
+
+空路径 no-op 分支增加重建条件：`branch_strategy == 'worktree'` 且 `worktree_path` 为空且 `current_phase ∈ {development, pr_review}` 时，落入既有的"worktree 丢失重建"逻辑（复用 Issue #814/#2042/#1999 的全部安全机制），而不是返回主仓库：
+
+```python
+# module-level constant
+# Phases that execute agent/git work in the workflow workspace. A workflow
+# resumed AFTER merge cleanup (rejected-acceptance repair round, or new
+# issue-comment requirements) reaches these with worktree_path/branch_name
+# deliberately cleared; running them against project_path (the main
+# checkout) commits repair work straight onto local main (#322/#329/#340).
+_WORKSPACE_CONSUMING_PHASES = ("development", "pr_review")
+
+# in ensure_worktree, replacing the early-return guard:
+if strategy != "worktree" or not project_path or not worktree_path:
+    ts = wf.get("worktree_transition_state")
+    if ts and ts != "recovery_failed":
+        raise RuntimeError(
+            "worktree transition in progress " f"(state={ts!r}); reconcile before execution"
+        )
+    # Post-merge-cleanup resume (#322/#329/#340): the merged delivery's
+    # cleanup cleared the fields because the workflow was "done"; a
+    # rejected-acceptance / new-requirements resume brings it back into a
+    # workspace-consuming phase. Recreate the worktree via the same
+    # authoritative-head recovery as the dir-gone path below instead of
+    # returning the main checkout. Phases that never touch the workspace
+    # (wait/report/acceptance/planning/merge) keep the historical no-op
+    # (the merge-retry rationale in the comment above still holds).
+    if (
+        strategy == "worktree"
+        and project_path
+        and not worktree_path
+        and wf.get("current_phase") in _WORKSPACE_CONSUMING_PHASES
+    ):
+        # fall through to the recreation section below. Path: prefer the
+        # same canonical location preparation/CI-repair use —
+        # preferred_worktree_path SURVIVES merge cleanup (cleanup clears
+        # only worktree_path/branch_name), so this recreates at the exact
+        # original spot. Legacy sibling format is a defensive fallback for
+        # the (practically unreachable) case where no preferred path can
+        # be derived; an empty branch_name there yields a bogus path that
+        # `worktree add` rejects loudly (fail-closed, not silent).
+        canonical = self.get_preferred_worktree_path(wf) or os.path.realpath(
+            os.path.normpath(
+                f"{project_path}/../{(wf.get('branch_name') or '').strip().replace('/', '-')}"
+            )
+        )
+    else:
+        return worktree_path or project_path
+else:
+    canonical = os.path.realpath(worktree_path)
+    # ... 既有 valid-worktree / branch-mismatch 逻辑不变（命中时 return canonical）...
+
+# ... 既有 recreation 段（fetch origin main → resolve_recovery_head →
+#     branch 存活则 attach，否则 worktree add -b → _update_workflow →
+#     worktree_restored 里程碑）不变 ...
+```
+
+结构上具体实现为：把现行 `if strategy != "worktree" or not project_path or not worktree_path:` 早退块改为上述形状，让"cleanup 后进入工作区消费阶段"的空路径与"目录丢失"共用下方的重建段（重建段现成的 `branch_name = wf.get("branch_name") or f"auto-dev/{...}"` 推导、分支存活探测、fail-closed 守卫、`_refresh_trusted_git_context`、`_update_workflow`、`worktree_restored` 里程碑全部原样复用，branch_name 推导无需任何改动）。
+
+设计说明：
+- **重建基点**：`resolve_recovery_head` 四态决策树（PR head → expected_head_sha → base_commit_sha → fail-closed）。三个受害工作流 `github_pr_number` 仍在（cleanup 不清 PR 号）→ `resolve_verified_pr_head`：merged PR 的 headRefOid 经 `fetch origin main` 后本地 `cat-file -e` 可验证（合并提交的第二父链）→ CONFIRMED → 在旧 PR head 上重建分支。修复轮的新提交使分支不再是 main 祖先 → pr_review 正常走 diff 检查 → 新 PR → merge。
+- **重建路径**：`get_preferred_worktree_path` 优先返回 `preferred_worktree_path`（merge cleanup 只清 `worktree_path`/`branch_name`，该字段留存）→ 精确回到原始 worktree 位置（`.worktrees/{workflow_id}` 格式）；无留存字段时推导同款 `.worktrees` 路径——与 preparation 的 pre-generated 优先序（`orchestrator.py` preparation：pre-generated `.worktrees` 路径优先，legacy sibling 格式仅向后兼容 fallback）和 CI-repair 的 `_get_preferred_worktree_path` 用法保持同一语义。空 `branch_name` 不影响 preferred 路径推导（路径只含 workflow_id）。
+- **gate 不要求 branch_name 为空**：覆盖 cleanup 部分失败（worktree 已删、branch 残留）的中间态——重建段的"分支存活则 attach"分支恰好处理它（attach 到存活分支，且 #1999 守卫校验分支头与 verified head 一致）。
+- **gate 不含 merge**：保留原 no-op 注释针对的"重试 merge"场景（PR 已合并的 merge 重试不应重建工作区）。
+- **gate 不含 planning**：planning 是只读分析阶段，维持现状（新需求流程 wait→planning 期间不重建，到 development 入口才重建）。
+- **squash-merge 仓库的边界**：PR head 不可达 main 时 `resolve_verified_pr_head` 返回 indeterminate → fail-closed → 工作流 failed（带清晰错误），操作员介入。与 #2042 哲学一致，本仓库（open-ace）使用 merge-commit 风格不受影响。
+- **重建后 advance() 已有 `wf = self.workflow` 重读**（ensure_worktree 之后），下游阶段看到的是重建后的 `worktree_path`/`branch_name`；`_run_development_agent` 的分支校验随之生效。
+
+### 2.3 改动 C（pr_review.py `handle`：空 branch_name 大声失败）
+
+在 `handle` 读取 `branch_name` 之后、进入分支检查之前：
+
+```python
+branch_name = wf.get("branch_name", "")
+if not branch_name.strip():
+    # Empty branch_name is a broken state (every branch_strategy sets it in
+    # preparation; empty only happens after merge cleanup without
+    # recreation). Falling through would run `git rev-parse ''` → exit 128
+    # → the except-swallow leaves has_changes=False and the workflow
+    # terminates as no_changes — masking the breakage (#322/#329/#340).
+    # Fail loudly instead.
+    return PhaseResult.failed(
+        structured_error={
+            "message": (
+                "pr_review entered with an empty branch_name (workspace "
+                "cleared by merge cleanup and not recreated); refusing to "
+                "fall into the no-changes terminal — this is a broken "
+                "state, not 'no changes'"
+            )
+        }
+    )
+```
+
+防御纵深：改动 A+B 生效后该路径不可达（development/pr_review 入口已重建工作区）；保留它是为了非 worktree 策略或任何未预见的路由把空分支送进 pr_review 时**可见地失败**而非静默误终止。
+
+### 2.4 修复后的完整闭环（验证用）
+
+```
+rejected → 人工 resume-with-feedback → _do_wait：
+  user_feedback 非空 ∧ verification_status='rejected'
+  → 注入验收失败项（v7 主路径，已有）
+  → 强制 next_phase=development（改动 A）
+→ 下一 tick advance(phase=development)：
+  ensure_worktree 发现 worktree_path 空 ∧ phase∈工作区消费集 → 重建
+  worktree+branch@旧 PR head（改动 B）
+→ dev agent 在隔离 worktree 修复 → auto-commit 落在 auto-dev 分支
+→ pr_review：分支有新提交 → 正常建 PR
+→ merge → acceptance_verification 重验（verification_merge_sha 已清空）
+```
+
+## 三、测试计划
+
+新增/修改测试（沿用 v7 的测试文件与 fake 模式）：
+
+1. `tests/autonomous/test_orchestrator_characterization.py`（`_do_wait` 测试区）：
+   - `test_wait_rejected_resume_forces_development`：`verification_status='rejected'` + user_feedback，里程碑列表以 `worktree_restored`(pr_review, completed) 结尾 → 断言 `next_phase == "development"`（修复前为 pr_review）。
+   - `test_wait_non_rejected_backtracking_skips_worktree_restored`：非 rejected + user_feedback，里程碑 `[dev_completed(development, completed), worktree_restored(pr_review, completed)]` → 断言 `next_phase == "development"`（修复前 pr_review）。
+   - 回归：v7 已有的注入类用例全部保持通过。
+2. `tests/autonomous/` 下 ensure_worktree 的既有测试文件（实施时定位，应为 git_workspace/orchestrator 的 worktree 恢复测试）：
+   - `test_ensure_worktree_recreates_cleared_workspace_for_development`：strategy=worktree、worktree_path=""/branch_name=""、current_phase=development → 断言执行了 `worktree add -b`、`_update_workflow` 写回 worktree_path+branch_name、创建 `worktree_restored` 里程碑、返回 canonical 路径（= `get_preferred_worktree_path` 的推导值）。
+   - `test_ensure_worktree_recreates_cleared_workspace_for_pr_review`：同上，phase=pr_review。
+   - `test_ensure_worktree_attaches_surviving_branch_when_worktree_cleared`：strategy=worktree、worktree_path=""、branch_name 非空且 `show-ref` 存活、current_phase=development → 断言走 `worktree add <path> <branch>`（attach 存活分支）而非 `worktree add -b`，写回 worktree_path+branch_name——锁定"gate 不要求 branch_name 为空"声明的分支残留中间态行为。
+   - `test_ensure_worktree_noop_for_wait_and_merge_when_cleared`：phase=wait / merge、空路径 → 返回 project_path、无 git 重建调用（保留历史行为）。
+   - `test_ensure_worktree_noop_when_not_worktree_strategy`：strategy=new-branch、空路径 → project_path。
+   - 回归：既有 "dir gone 重建"、branch-mismatch、transition-state 守卫用例保持通过。
+3. `tests/autonomous/phases/test_pr_review.py`：
+   - `test_empty_branch_name_fails_loudly`：workflow 无 branch_name → 断言 `PhaseResult` 为 failed（含 structured_error message），且**不是** completed/no_changes 终态。
+4. 全量回归：`HOME=/tmp/fakehome python -m pytest tests/autonomous -x -q`（隔离本机 `~/.open-ace/agent-launcher.conf` 对 MAX_CONCURRENT_WORKFLOWS 的覆盖）。
+
+## 四、部署与受害工作流恢复（运维步骤）
+
+1. 合并 PR 后部署：`ssh root@192.168.31.159 "cd /home/openace && git pull && systemctl restart openace-scheduler.service"`。
+2. 清理主仓库 stray commit（丢弃误提交，修复轮将重做）：
+   - `/home/dwu/open-ace-01/open-ace`：确认无未提交内容后 `git reset --hard origin/main`（丢弃 7d279598）；
+   - `/home/qlfan/auto/a1/open-ace`：同样 `git reset --hard origin/main`（丢弃 c1eb1932）。
+   - 说明：两个 stray commit 是误在 main 上的修复轮产出，内容将由恢复后的工作流在隔离 worktree 中重做并走正常 PR 流程；不 cherry-pick 以免绕过评审。
+3. 恢复三个误终止工作流（#322/#329/#340，当前 status=completed 不在可 resume 状态；resume API 仅接受 waiting/paused）：将其复位为 waiting 并提供修复目标反馈——`UPDATE autonomous_workflows SET status='waiting', current_phase='wait', user_feedback='Resume: fix the rejected acceptance items.', error_message='' WHERE id IN (...)`。
+   - 说明：这是修复系统误终止后的状态复位（把工作流交还给调度器重跑），不是代替工作流做事；修复后的 `_do_wait` 会在 user_feedback 路径上自动注入验收失败项并强制 development（改动 A），ensure_worktree 会重建隔离工作区（改动 B），修复轮完整闭环。
+   - #322 的 user_feedback 字段仍残留 v7 注入文本，复位时统一覆盖为简短人工指令，避免注入文本重复拼接。
+4. 验证：观察三个工作流进入 development 且 `worktree_path`/`branch_name` 非空、`worktree_restored` 里程碑出现、agent 在 worktree 内工作、后续 PR 正常创建合并、acceptance 重验。
+
+## 五、风险与回滚
+
+- **改动 B 的行为面**：唯一语义变化是"worktree 策略 + 空路径 + development/pr_review 阶段"从 no-op 变为重建。该状态此前必然产生错误行为（主仓库裸跑或 no_changes 误终止），不存在依赖旧行为的正确路径；wait/report/acceptance/planning/merge 及非 worktree 策略完全不变。回滚 = revert 单个 PR。
+- **重建失败**（fail-closed，如 squash-merge 后 PR head 不可达）：工作流 failed 并带清晰 error_message，操作员可介入；不劣于现状（现状是静默误终止）。
+- **既有测试破坏风险**：任何"worktree 策略 + 空路径 + development/pr_review"形状的既有用例会从 no-op 变为重建路径；实施时跑全量 autonomous 测试套件，对这类用例逐个确认是"断言旧的错误行为"（更新断言）还是真实回归（重新设计）。
+- **里程碑排除表加 `worktree_restored`**：只影响非 rejected 的 cancel-with-feedback 回溯；`worktree_restored` 是纯 infra 记录，排除后回溯落到真实工作里程碑上，方向必然更正确。

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -214,6 +214,31 @@ def test_timing_issue_marks_completed_with_timing_milestone():
     ), result.milestone_events
 
 
+def test_empty_branch_name_fails_loudly():
+    """An empty branch_name is a broken state (merge cleanup cleared it and
+    nothing recreated the workspace), NOT "no changes": the handler must
+    fail with a structured error instead of falling into the no-changes
+    completed terminal (which masked the breakage in #322/#329/#340)."""
+    gh = _gh()
+    host = _host()
+    deps = _deps(host, gh)
+
+    result = pr_review_phase.handle(_ctx(_workflow(branch_name="")), deps)
+
+    assert isinstance(result, PhaseResult)
+    assert result.outcome == "failed"
+    assert result.next_phase is None
+    msg = (result.structured_error or {}).get("message", "")
+    assert "empty branch_name" in msg, msg
+    # NOT the no-changes terminal.
+    assert result.next_phase != "completed"
+    assert not any(
+        ms.get("milestone_type") == "no_changes" for ms in result.milestone_events
+    ), result.milestone_events
+    host.emit_phase_change.assert_not_called()
+    host.post_github_comment.assert_not_called()
+
+
 # ── acceptance-rejected re-entry: reopen development, not completed ───────
 
 

--- a/tests/autonomous/test_orchestrator_characterization.py
+++ b/tests/autonomous/test_orchestrator_characterization.py
@@ -1143,6 +1143,72 @@ def test_wait_no_injection_when_latest_completed_is_wait_started(monkeypatch):
     assert not result.workflow_patch.get("user_feedback")
 
 
+def test_wait_rejected_resume_forces_development(monkeypatch):
+    """#322: a rejected-acceptance resume must force a repair development
+    round — milestone backtracking is the wrong decision mechanism here
+    (acceptance only runs after merge, so the latest completed milestone is
+    merge/acceptance/report-side or infra bookkeeping; #322's stale
+    worktree_restored(pr_review) skipped the repair round entirely and the
+    workflow fell straight into the no-changes terminal)."""
+    result = _run_wait_resume(
+        monkeypatch,
+        milestones=[
+            {
+                "phase": "development",
+                "milestone_type": "dev_completed",
+                "status": "completed",
+            },
+            {
+                "phase": "pr_review",
+                "milestone_type": "worktree_restored",
+                "status": "completed",
+            },
+            {
+                "phase": "merge",
+                "milestone_type": "cleaned_up",
+                "status": "completed",
+            },
+        ],
+        verification_status="rejected",
+        verification_report=_REJECTED_REPORT,
+        github_pr_number=2902,
+        user_feedback="Resume: fix the rejected acceptance items.",
+    )
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "development"
+    assert result.next_status == "developing"
+    assert result.workflow_patch.get("dev_round") == 2
+
+
+def test_wait_non_rejected_backtracking_skips_worktree_restored(monkeypatch):
+    """Non-rejected resume keeps the milestone backtracking, but infra
+    bookkeeping (worktree_restored) is never a resume target: backtracking
+    past it lands on the real work milestone (development) instead of the
+    stale pr_review phase it was recorded under."""
+    result = _run_wait_resume(
+        monkeypatch,
+        milestones=[
+            {
+                "phase": "development",
+                "milestone_type": "dev_completed",
+                "status": "completed",
+            },
+            {
+                "phase": "pr_review",
+                "milestone_type": "worktree_restored",
+                "status": "completed",
+            },
+        ],
+        verification_status="confirmed",
+        user_feedback="please continue",
+    )
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "development"  # not pr_review
+    assert result.next_status == "developing"
+
+
 @pytest.mark.parametrize(
     "comments,pr_number,expected",
     [

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -122,7 +122,12 @@ def _make_workflow(**overrides):
         "cli_tool": "claude-code",
         "model": "claude-sonnet-4-6",
         "permission_mode": "auto-edit",
-        "branch_name": "",
+        # Same name preparation derives for workflow_id "test-wf-uuid" —
+        # pr_review-phase tests enter past preparation, and the handler now
+        # fails loudly on an empty branch_name (post-merge-cleanup broken
+        # state, #322/#329/#340), so the fixture must model the invariant
+        # (branch_name is always set before pr_review).
+        "branch_name": "auto-dev/test-wf-uuid",
         "branch_strategy": "new-branch",
         "workspace_type": "local",
         "remote_machine_id": "",

--- a/tests/unit/test_worktree_recovery_2042.py
+++ b/tests/unit/test_worktree_recovery_2042.py
@@ -327,3 +327,206 @@ def test_ensure_worktree_never_uses_origin_main_for_missing_branch():
     create_call = [c for c in add_calls if "-b" in c][0]
     assert create_call[-1] == "base-sha-verified"
     assert "origin/main" not in create_call
+
+
+# ── post-merge-cleanup resume recreates the workspace (#322/#329/#340) ──────
+
+
+def _cleared_wf(**overrides) -> dict:
+    """A worktree-strategy workflow resumed AFTER merge cleanup: the merged
+    delivery's cleanup cleared worktree_path/branch_name (the workflow was
+    "done"), and a rejected-acceptance / new-requirements resume brought it
+    back into a workspace-consuming phase."""
+    wf = {
+        "workflow_id": "wf-2042",
+        "branch_strategy": "worktree",
+        "project_path": "/private/tmp/repo",
+        "worktree_path": "",
+        "branch_name": "",
+        "current_phase": "development",
+        "github_pr_number": 42,
+        "user_id": None,
+        "preferred_worktree_path": "/private/tmp/repo/.worktrees/wf-2042",
+    }
+    wf.update(overrides)
+    return wf
+
+
+@pytest.mark.parametrize("phase", ["development", "pr_review"])
+def test_ensure_worktree_recreates_cleared_workspace(phase):
+    """Empty worktree_path in a workspace-consuming phase recreates the
+    worktree (NOT a no-op returning the main checkout): `worktree add -b` at
+    the preferred path from the verified PR head, fields written back, and a
+    worktree_restored milestone recorded."""
+    orch = _make_orch()
+    _set_evidence(
+        orch,
+        MagicMock(
+            resolve_verified_pr_head=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "pr-head-sha")
+            ),
+            verify_commit_available=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "pr-head-sha")
+            ),
+        ),
+    )
+    wf = _cleared_wf(current_phase=phase)
+    canonical = "/private/tmp/repo/.worktrees/wf-2042"
+    main_gh = MagicMock()
+    main_gh.path_exists_as_user.return_value = False
+    not_found = MagicMock(returncode=1)  # branch gone locally + remotely
+    main_gh._run_git.side_effect = [
+        MagicMock(),  # fetch origin main
+        not_found,  # local branch missing
+        not_found,  # remote branch missing
+        MagicMock(),  # worktree add -b <branch> <path> <head>
+    ]
+    fake_gh_cls = MagicMock(side_effect=lambda _p, **_kw: main_gh)
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", fake_gh_cls),
+        patch("os.path.realpath", side_effect=lambda p: p),
+    ):
+        result = orch._ensure_worktree(wf)
+
+    assert result == canonical
+    add_calls = [
+        c.args[0]
+        for c in main_gh._run_git.call_args_list
+        if c.args and c.args[0] and c.args[0][0:2] == ["worktree", "add"]
+    ]
+    assert add_calls, "expected a worktree add call"
+    create_call = [c for c in add_calls if "-b" in c][0]
+    # branch_name was cleared by cleanup → re-derived from workflow_id
+    assert create_call == ["worktree", "add", "-b", "auto-dev/wf-2042", canonical, "pr-head-sha"]
+    orch._update_workflow.assert_called_once_with(
+        {"worktree_path": canonical, "branch_name": "auto-dev/wf-2042"}
+    )
+    ms_kwargs = orch._create_milestone.call_args.kwargs
+    assert ms_kwargs["milestone_type"] == "worktree_restored"
+    assert ms_kwargs["status"] == "completed"
+
+
+def test_ensure_worktree_recreates_cleared_workspace_derives_path_without_preferred():
+    """No surviving preferred_worktree_path → the preferred-path helper still
+    derives the conventional {project_path}/.worktrees/{workflow_id} spot."""
+    orch = _make_orch()
+    _set_evidence(
+        orch,
+        MagicMock(
+            resolve_verified_pr_head=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "pr-head-sha")
+            ),
+            verify_commit_available=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "pr-head-sha")
+            ),
+        ),
+    )
+    wf = _cleared_wf(preferred_worktree_path="")
+    canonical = "/private/tmp/repo/.worktrees/wf-2042"
+    main_gh = MagicMock()
+    main_gh.path_exists_as_user.return_value = False
+    not_found = MagicMock(returncode=1)
+    main_gh._run_git.side_effect = [
+        MagicMock(),  # fetch origin main
+        not_found,  # local branch missing
+        not_found,  # remote branch missing
+        MagicMock(),  # worktree add -b
+    ]
+    fake_gh_cls = MagicMock(side_effect=lambda _p, **_kw: main_gh)
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", fake_gh_cls),
+        patch("os.path.realpath", side_effect=lambda p: p),
+    ):
+        result = orch._ensure_worktree(wf)
+
+    assert result == canonical
+    orch._update_workflow.assert_called_once_with(
+        {"worktree_path": canonical, "branch_name": "auto-dev/wf-2042"}
+    )
+
+
+def test_ensure_worktree_attaches_surviving_branch_when_worktree_cleared():
+    """Cleanup partial failure (worktree cleared, branch survives) → attach
+    the surviving branch (`worktree add <path> <branch>`, NOT -b); the #1999
+    guard verifies the attached HEAD matches the verified head."""
+    orch = _make_orch()
+    _set_evidence(
+        orch,
+        MagicMock(
+            resolve_verified_pr_head=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "verified-head-abc")
+            ),
+            verify_commit_available=MagicMock(
+                return_value=_make_evidence(Verdict.CONFIRMED, "verified-head-abc")
+            ),
+        ),
+    )
+    wf = _cleared_wf(branch_name="auto-dev/survivor")
+    canonical = "/private/tmp/repo/.worktrees/wf-2042"
+    main_gh = MagicMock()
+    main_gh.path_exists_as_user.return_value = False
+    found = MagicMock(returncode=0)  # branch survives
+    main_gh._run_git.side_effect = [
+        MagicMock(),  # fetch origin main
+        found,  # local branch exists
+        found,  # remote branch exists
+        MagicMock(),  # worktree add <canonical> <branch> (attach)
+    ]
+    wt_gh = MagicMock()
+    wt_gh.get_current_commit.return_value = "verified-head-abc"  # guard passes
+
+    def fake_gh_ctor(path, **kw):
+        return wt_gh if path.endswith("wf-2042") else main_gh
+
+    fake_gh_cls = MagicMock(side_effect=fake_gh_ctor)
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", fake_gh_cls),
+        patch("os.path.realpath", side_effect=lambda p: p),
+    ):
+        result = orch._ensure_worktree(wf)
+
+    assert result == canonical
+    add_calls = [
+        c.args[0]
+        for c in main_gh._run_git.call_args_list
+        if c.args and c.args[0] and c.args[0][0:2] == ["worktree", "add"]
+    ]
+    assert add_calls == [["worktree", "add", canonical, "auto-dev/survivor"]]
+    orch._update_workflow.assert_called_once_with(
+        {"worktree_path": canonical, "branch_name": "auto-dev/survivor"}
+    )
+
+
+@pytest.mark.parametrize(
+    "phase",
+    ["wait", "merge", "planning", "report", "acceptance_verification", "preparation"],
+)
+def test_ensure_worktree_noop_for_non_workspace_phases_when_cleared(phase):
+    """Phases that never touch the workspace keep the historical no-op when
+    worktree_path is cleared after merge cleanup (e.g. a retried merge must
+    NOT rebuild the worktree): returns project_path, no git calls at all."""
+    orch = _make_orch()
+    wf = _cleared_wf(current_phase=phase)
+    main_gh = MagicMock()
+    fake_gh_cls = MagicMock(side_effect=lambda _p, **_kw: main_gh)
+    with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", fake_gh_cls):
+        result = orch._ensure_worktree(wf)
+
+    assert result == "/private/tmp/repo"
+    main_gh._run_git.assert_not_called()
+    orch._update_workflow.assert_not_called()
+    orch._create_milestone.assert_not_called()
+
+
+def test_ensure_worktree_noop_when_not_worktree_strategy():
+    """Non-worktree strategies never recreate: empty path in development
+    still returns project_path (branch-strategy workflows work in place)."""
+    orch = _make_orch()
+    wf = _cleared_wf(branch_strategy="new-branch")
+    main_gh = MagicMock()
+    fake_gh_cls = MagicMock(side_effect=lambda _p, **_kw: main_gh)
+    with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", fake_gh_cls):
+        result = orch._ensure_worktree(wf)
+
+    assert result == "/private/tmp/repo"
+    main_gh._run_git.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes Bug 5 (found while validating the Bug 3 fix, PR #2913): a rejected-acceptance repair round resumed after merge cleanup ran **bare on the main checkout** and/or was falsely terminated as completed (#322/#329/#340).

Merge cleanup clears `worktree_path`/`branch_name` because the workflow is "done". A rejected-acceptance human resume brings the workflow back into active phases with those fields still empty, and three stacked defects let the repair round proceed anyway:

| Workflow | Symptom |
|---|---|
| #322 | `_do_wait` backtracking picked a stale `worktree_restored`(pr_review) infra milestone → skipped the repair round entirely → no-changes terminal 17s after resume |
| #329 | dev agent ran on the main checkout `/home/dwu/open-ace-01/open-ace`, stray commit `7d279598` on local main → no-changes terminal |
| #340 | same on `/home/qlfan/auto/a1/open-ace`, stray commit `c1eb1932` |

## Changes

1. **`_do_wait` (orchestrator.py)**: rejected acceptance forces a repair development round (backtracking can only land on merge/acceptance/report-side or infra milestones — every one a wrong target, since acceptance only runs after a successful merge); non-rejected backtracking now excludes `worktree_restored` (infra bookkeeping is never a resume target).
2. **`ensure_worktree` (git_workspace.py)**: a workspace-consuming phase (development/pr_review) reached with an empty `worktree_path` after merge cleanup recreates the worktree via the existing authoritative-head recovery (PR head → expected_head_sha → base_commit_sha, fail-closed), at the preferred path (`preferred_worktree_path` survives cleanup → exact original spot). wait/report/acceptance/planning/merge keep the historical no-op (a retried merge must not rebuild the workspace). Also covers the new-requirements path (wait → planning → development).
3. **`pr_review` (pr_review.py)**: empty `branch_name` fails loudly with a structured error instead of swallowing the `git rev-parse ''` failure into a no-changes completed terminal.

## Tests

- wait routing: rejected resume forces development (was pr_review via stale infra milestone); non-rejected backtracking skips `worktree_restored`
- `ensure_worktree` cleared-state matrix: recreate for development/pr_review (verified `worktree add -b` from PR head at preferred path, field write-back, `worktree_restored` milestone), attach surviving branch (no `-b`), no-op for wait/merge/planning/report/acceptance/preparation and non-worktree strategies, path derivation without preferred
- `pr_review` empty branch_name → `PhaseResult.failed`, not the no-changes terminal
- `tests/issues/716` fixture now models the branch_name-before-pr_review invariant (same name preparation derives)

Full local run: `tests/autonomous` 191 passed, `tests/unit` + issues suites pass except 13 pre-existing failures verified identical on base.

Fixes the production incident on 192.168.31.159 (victim workflows #322/#329/#340 to be reset to waiting after deploy).

Design doc: `docs/superpowers/plans/2026-08-20-resume-without-workspace.md` (independently reviewed to zero opinions, v2).