### PR TITLE
fix: 访问不存在的会话时返回明确提示 (#2892)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1033,63 +1033,89 @@ export const Workspace: React.FC = () => {
     let initialActiveTabId = '';
 
     if (restoreSessionId) {
-      // Case 1: URL restore params - create a single tab with the restore session
-      // Build settings from URL params
-      const urlSettings:
-        { model?: string; useWebUI?: boolean; permissionMode?: string } | undefined =
-        urlModel || urlUseWebUI !== null || urlPermissionMode
-          ? {
-              model: urlModel ?? undefined,
-              useWebUI: urlUseWebUI === 'true' ? true : urlUseWebUI === 'false' ? false : undefined,
-              permissionMode: urlPermissionMode ?? undefined,
+      // Issue #2892: Validate session exists before restoring
+      // This prevents showing empty page when user visits a non-existent session URL
+      const validateAndRestoreSession = async () => {
+        // Only validate non-terminal sessions (terminal uses terminalId)
+        if (urlWorkspaceType !== 'terminal') {
+          try {
+            const response = await sessionsApi.getSession(restoreSessionId, false);
+            if (!response.success || response.error) {
+              console.warn('[Workspace] Session validation failed:', response.error);
+              setError(t('sessionNotFound', language) || 'Session not found or has been deleted');
+              setTabsInitialized(true);
+              return;
             }
-          : undefined;
+          } catch (err) {
+            console.error('[Workspace] Failed to verify session:', err);
+            setError(t('sessionNotFound', language) || 'Session not found or has been deleted');
+            setTabsInitialized(true);
+            return;
+          }
+        }
 
-      // Build remote params from URL (only for local/remote, not terminal)
-      const remoteParams:
-        | { workspaceType?: 'local' | 'remote'; machineId?: string; machineName?: string }
-        | undefined =
-        urlWorkspaceType && urlWorkspaceType !== 'terminal'
-          ? {
-              workspaceType: urlWorkspaceType,
-              machineId: urlMachineId ?? undefined,
-              machineName: urlMachineName ?? undefined,
-            }
-          : undefined;
+        // Session is valid, proceed to create tab
+        // Case 1: URL restore params - create a single tab with the restore session
+        // Build settings from URL params
+        const urlSettings:
+          { model?: string; useWebUI?: boolean; permissionMode?: string } | undefined =
+          urlModel || urlUseWebUI !== null || urlPermissionMode
+            ? {
+                model: urlModel ?? undefined,
+                useWebUI: urlUseWebUI === 'true' ? true : urlUseWebUI === 'false' ? false : undefined,
+                permissionMode: urlPermissionMode ?? undefined,
+              }
+            : undefined;
 
-      // Handle terminal session restoration separately
-      if (urlWorkspaceType === 'terminal' && urlTerminalId && urlMachineId) {
-        // Create terminal tab
-        const tab: WorkspaceTab = {
-          id: generateTabId(),
-          title: t('restoredSession', language),
-          url: '', // Terminal tabs don't use iframe URL
-          token: '',
-          sessionId: restoreSessionId,
-          tabType: 'terminal',
-          terminalId: urlTerminalId,
-          machineId: urlMachineId,
-          machineName: urlMachineName ?? undefined,
-          createdAt: Date.now(),
-          waitingForUser: false,
-          waitingType: null,
-        };
-        initialTabs = [tab];
-        initialActiveTabId = tab.id;
+        // Build remote params from URL (only for local/remote, not terminal)
+        const remoteParams:
+          | { workspaceType?: 'local' | 'remote'; machineId?: string; machineName?: string }
+          | undefined =
+          urlWorkspaceType && urlWorkspaceType !== 'terminal'
+            ? {
+                workspaceType: urlWorkspaceType,
+                machineId: urlMachineId ?? undefined,
+                machineName: urlMachineName ?? undefined,
+              }
+            : undefined;
 
-        // Save to store
-        addStoredTab({
-          id: tab.id,
-          title: tab.title,
-          tabType: 'terminal',
-          terminalId: urlTerminalId,
-          machineId: urlMachineId,
-          machineName: urlMachineName ?? undefined,
-          createdAt: tab.createdAt,
-          waitingForUser: false,
-          waitingType: null,
-        });
-      } else {
+        // Handle terminal session restoration separately
+        if (urlWorkspaceType === 'terminal' && urlTerminalId && urlMachineId) {
+          // Create terminal tab
+          const tab: WorkspaceTab = {
+            id: generateTabId(),
+            title: t('restoredSession', language),
+            url: '', // Terminal tabs don't use iframe URL
+            token: '',
+            sessionId: restoreSessionId,
+            tabType: 'terminal',
+            terminalId: urlTerminalId,
+            machineId: urlMachineId,
+            machineName: urlMachineName ?? undefined,
+            createdAt: Date.now(),
+            waitingForUser: false,
+            waitingType: null,
+          };
+          setTabs([tab]);
+          setActiveTabId(tab.id);
+          setStoredActiveTabId(tab.id);
+
+          // Save to store
+          addStoredTab({
+            id: tab.id,
+            title: tab.title,
+            tabType: 'terminal',
+            terminalId: urlTerminalId,
+            machineId: urlMachineId,
+            machineName: urlMachineName ?? undefined,
+            createdAt: tab.createdAt,
+            waitingForUser: false,
+            waitingType: null,
+          });
+          setTabsInitialized(true);
+          return;
+        }
+
         // Regular session (local or remote)
         const effectiveUrl = getEffectiveUrl(
           restoreSessionId,
@@ -1117,10 +1143,11 @@ export const Workspace: React.FC = () => {
             waitingForUser: false,
             waitingType: null,
           };
-          initialTabs = [tab];
-          initialActiveTabId = tab.id;
+          setTabs([tab]);
+          setActiveTabId(tab.id);
+          setStoredActiveTabId(tab.id);
 
-          // Save to store (this replaces any previous stored tabs)
+          // Save to store
           addStoredTab({
             id: tab.id,
             title: tab.title,
@@ -1135,20 +1162,24 @@ export const Workspace: React.FC = () => {
             waitingForUser: tab.waitingForUser,
             waitingType: tab.waitingType,
           });
+          setTabsInitialized(true);
         }
-      }
 
-      // Clear the restore parameters after using it
-      searchParams.delete('sessionId');
-      searchParams.delete('restoreSession');
-      searchParams.delete('encodedProjectName');
-      searchParams.delete('toolName');
-      searchParams.delete('workspaceType');
-      searchParams.delete('machineId');
-      searchParams.delete('machineName');
-      searchParams.delete('terminalId');
-      searchParams.delete('resumeHint');
-      setSearchParams(searchParams, { replace: true });
+        // Clear the restore parameters after using it
+        searchParams.delete('sessionId');
+        searchParams.delete('restoreSession');
+        searchParams.delete('encodedProjectName');
+        searchParams.delete('toolName');
+        searchParams.delete('workspaceType');
+        searchParams.delete('machineId');
+        searchParams.delete('machineName');
+        searchParams.delete('terminalId');
+        searchParams.delete('resumeHint');
+        setSearchParams(searchParams, { replace: true });
+      };
+
+      validateAndRestoreSession();
+      return;
     } else if (storedTabs.length > 0) {
       // Case 2: Restore from store - regenerate URLs for each tab
       initialTabs = storedTabs.map((storedTab) => {

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1062,7 +1062,8 @@ export const Workspace: React.FC = () => {
           urlModel || urlUseWebUI !== null || urlPermissionMode
             ? {
                 model: urlModel ?? undefined,
-                useWebUI: urlUseWebUI === 'true' ? true : urlUseWebUI === 'false' ? false : undefined,
+                useWebUI:
+                  urlUseWebUI === 'true' ? true : urlUseWebUI === 'false' ? false : undefined,
                 permissionMode: urlPermissionMode ?? undefined,
               }
             : undefined;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -200,6 +200,8 @@ export const translations: Record<Language, Translations> = {
     workspaceNotConfiguredHelp: 'Please contact administrator to configure workspace URL',
     workspaceUnavailable: 'Workspace unavailable',
     workspaceUnavailableHelp: 'Please log in to access your workspace',
+    sessionNotFound: 'Session not found or has been deleted',
+    projectPathNotFound: 'Project path not found in history',
     security: 'Security',
 
     // Mode - Dual-track system
@@ -2286,6 +2288,8 @@ export const translations: Record<Language, Translations> = {
     workspaceNotConfiguredHelp: '请联系管理员配置工作区 URL',
     workspaceUnavailable: '工作区不可用',
     workspaceUnavailableHelp: '请登录后访问您的工作区',
+    sessionNotFound: '会话不存在或已被删除',
+    projectPathNotFound: '项目路径不在历史记录中',
     security: '安全',
 
     // Mode - Dual-track system


### PR DESCRIPTION
## 修复内容

**问题**：用户访问不存在的会话 URL 或项目路径时，系统未返回明确的"未找到"提示，用户无法快速定位问题。

**根因**：
- 前端从 URL 获取 sessionId 参数后直接创建标签页，未验证会话是否存在
- 后端虽正确返回 404，但前端缺少验证和错误处理

**解决方案**：
1. 在恢复会话前添加会话验证逻辑
2. 验证失败时显示明确的错误提示："会话不存在或已被删除"
3. 添加中英文国际化支持

## 代码变更

**主要文件**：
- `frontend/src/components/features/Workspace.tsx`：在恢复会话逻辑中添加验证
- `frontend/src/i18n/index.ts`：添加 sessionNotFound、projectPathNotFound 翻译键

## 测试场景

1. **正常场景**：
   - 访问存在的会话 ID → 正常恢复会话
   - 终端会话恢复 → 使用 terminalId 验证（不阻断）

2. **异常场景**：
   - 访问不存在的会话 ID → 显示"会话不存在"错误

## 修复方案

详细方案见 Issue #2892 中的评论：https://github.com/open-ace/open-ace/issues/2892#issuecomment-5364205461

Closes #2892