### PR TITLE
fix: 浏览器前进及刷新后无法恢复原会话页面 (#2899)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -657,6 +657,8 @@ export const Workspace: React.FC = () => {
             // Switch to the target tab
             setActiveTabId(targetTab.id);
             useAppStore.getState().setWorkspaceActiveTabId(targetTab.id);
+            // Sync URL with active tab (Issue #2899)
+            updateUrlWithActiveTab(targetTab);
 
             // Send focus message to iframe after tab switch
             setTimeout(() => {
@@ -1139,15 +1141,15 @@ export const Workspace: React.FC = () => {
       }
 
       // Clear the restore parameters after using it
-      searchParams.delete('sessionId');
+      // Issue #2899: Keep sessionId in URL for browser back/forward and refresh
+      // Only clear one-time parameters (restoreSession, resumeHint)
       searchParams.delete('restoreSession');
-      searchParams.delete('encodedProjectName');
-      searchParams.delete('toolName');
+      searchParams.delete('resumeHint');
+      // Clear other params that should not persist after navigation
       searchParams.delete('workspaceType');
       searchParams.delete('machineId');
       searchParams.delete('machineName');
       searchParams.delete('terminalId');
-      searchParams.delete('resumeHint');
       setSearchParams(searchParams, { replace: true });
     } else if (storedTabs.length > 0) {
       // Case 2: Restore from store - regenerate URLs for each tab
@@ -1270,6 +1272,28 @@ export const Workspace: React.FC = () => {
     setStoredActiveTabId,
   ]);
 
+  // Listen for browser back/forward (Issue #2899)
+  useEffect(() => {
+    if (!tabsInitialized || tabs.length === 0) return;
+
+    const handlePopState = () => {
+      const url = new URL(window.location.href);
+      const sessionId = url.searchParams.get('sessionId');
+
+      if (sessionId) {
+        // Find the corresponding tab and switch to it
+        const tab = tabs.find((t) => t.sessionId === sessionId);
+        if (tab && tab.id !== activeTabId) {
+          setActiveTabId(tab.id);
+          setStoredActiveTabId(tab.id);
+        }
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [tabs, activeTabId, tabsInitialized, setActiveTabId, setStoredActiveTabId]);
+
   // Handle URL parameter for creating new tab
   useEffect(() => {
     const newTab = searchParams.get('newTab');
@@ -1364,6 +1388,9 @@ export const Workspace: React.FC = () => {
               }
               setActiveTabId(tabId);
               setStoredActiveTabId(tabId);
+              // Sync URL with terminal tab (Issue #2899)
+              // Terminal tab has no sessionId, so URL will have sessionId cleared
+              updateUrlWithActiveTab(newTab);
 
               // Poll for terminal status until WebSocket proxy is ready
               pollTerminalProxy(tabId, terminalId, machineId);
@@ -1646,6 +1673,8 @@ export const Workspace: React.FC = () => {
       setStoredActiveTabId(newTab.id);
       // Issue #1470: Update tabsOrder in store
       setStoredTabsOrder((prev) => [...prev, newTab.id]);
+      // Sync URL with new tab (Issue #2899)
+      updateUrlWithActiveTab(newTab);
 
       // Mark as loading
       setLoadingTabs((prev) => new Set(prev).add(newTab.id));
@@ -1658,6 +1687,7 @@ export const Workspace: React.FC = () => {
       setStoredActiveTabId,
       clearTabNotification,
       setStoredTabsOrder,
+      updateUrlWithActiveTab,
     ]
   );
 
@@ -1684,7 +1714,11 @@ export const Workspace: React.FC = () => {
         if (activeTabId === tabId && newTabs.length > 0) {
           const closedIndex = prev.findIndex((tab) => tab.id === tabId);
           const newActiveIndex = Math.min(closedIndex, newTabs.length - 1);
-          setActiveTabId(newTabs[newActiveIndex].id);
+          const newActiveTab = newTabs[newActiveIndex];
+          setActiveTabId(newActiveTab.id);
+          setStoredActiveTabId(newActiveTab.id);
+          // Sync URL with active tab (Issue #2899)
+          updateUrlWithActiveTab(newActiveTab);
         }
         return newTabs;
       });
@@ -1695,7 +1729,7 @@ export const Workspace: React.FC = () => {
         createNewTab();
       }
     },
-    [tabs.length, activeTabId, removeStoredTab, createNewTab]
+    [tabs.length, activeTabId, removeStoredTab, createNewTab, setStoredActiveTabId, updateUrlWithActiveTab]
   );
 
   // Close a tab
@@ -1765,13 +1799,40 @@ export const Workspace: React.FC = () => {
     setRemoteCloseTabId(null);
   }, []);
 
+  // Update URL when active tab changes (Issue #2899)
+  const updateUrlWithActiveTab = useCallback(
+    (tab: WorkspaceTab | null) => {
+      const url = new URL(window.location.href);
+
+      if (tab?.sessionId) {
+        url.searchParams.set('sessionId', tab.sessionId);
+        if (tab.encodedProjectName) {
+          url.searchParams.set('encodedProjectName', tab.encodedProjectName);
+        }
+        if (tab.toolName) {
+          url.searchParams.set('toolName', tab.toolName);
+        }
+      } else {
+        url.searchParams.delete('sessionId');
+        url.searchParams.delete('encodedProjectName');
+        url.searchParams.delete('toolName');
+      }
+
+      window.history.replaceState({}, '', url.toString());
+    },
+    []
+  );
+
   // Switch to a tab
   const switchTab = useCallback(
     (tabId: string) => {
       const previousTabId = activeTabId;
+      const tab = tabs.find((t) => t.id === tabId);
       setActiveTabId(tabId);
       // Update store (Issue #65)
       setStoredActiveTabId(tabId);
+      // Sync URL with active tab (Issue #2899)
+      updateUrlWithActiveTab(tab ?? null);
 
       // Clear notification state for the tab we're leaving
       if (previousTabId && previousTabId !== tabId) {
@@ -1810,7 +1871,7 @@ export const Workspace: React.FC = () => {
         }
       }, 100);
     },
-    [activeTabId, setStoredActiveTabId, clearTabNotification, userWebUI]
+    [activeTabId, tabs, setStoredActiveTabId, clearTabNotification, userWebUI, updateUrlWithActiveTab]
   );
 
   // Rename a tab
@@ -2876,6 +2937,9 @@ export const Workspace: React.FC = () => {
               };
               addStoredTab(storeTab);
               setStoredActiveTabId(tabId);
+              // Sync URL with terminal tab (Issue #2899)
+              // Terminal tab has no sessionId, so URL will have sessionId cleared
+              updateUrlWithActiveTab(newTab);
 
               // Poll for terminal status until WebSocket proxy is ready
               pollTerminalProxy(tabId, terminalId, params.machineId);

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1595,6 +1595,27 @@ export const Workspace: React.FC = () => {
     }
   }, [tabs, tabsInitialized, config, setTabs, updateStoredTab]);
 
+  // Update URL when active tab changes (Issue #2899)
+  const updateUrlWithActiveTab = useCallback((tab: WorkspaceTab | null) => {
+    const url = new URL(window.location.href);
+
+    if (tab?.sessionId) {
+      url.searchParams.set('sessionId', tab.sessionId);
+      if (tab.encodedProjectName) {
+        url.searchParams.set('encodedProjectName', tab.encodedProjectName);
+      }
+      if (tab.toolName) {
+        url.searchParams.set('toolName', tab.toolName);
+      }
+    } else {
+      url.searchParams.delete('sessionId');
+      url.searchParams.delete('encodedProjectName');
+      url.searchParams.delete('toolName');
+    }
+
+    window.history.replaceState({}, '', url.toString());
+  }, []);
+
   // Create a new tab
   const createNewTab = useCallback(
     (
@@ -1729,7 +1750,14 @@ export const Workspace: React.FC = () => {
         createNewTab();
       }
     },
-    [tabs.length, activeTabId, removeStoredTab, createNewTab, setStoredActiveTabId, updateUrlWithActiveTab]
+    [
+      tabs.length,
+      activeTabId,
+      removeStoredTab,
+      createNewTab,
+      setStoredActiveTabId,
+      updateUrlWithActiveTab,
+    ]
   );
 
   // Close a tab
@@ -1799,30 +1827,6 @@ export const Workspace: React.FC = () => {
     setRemoteCloseTabId(null);
   }, []);
 
-  // Update URL when active tab changes (Issue #2899)
-  const updateUrlWithActiveTab = useCallback(
-    (tab: WorkspaceTab | null) => {
-      const url = new URL(window.location.href);
-
-      if (tab?.sessionId) {
-        url.searchParams.set('sessionId', tab.sessionId);
-        if (tab.encodedProjectName) {
-          url.searchParams.set('encodedProjectName', tab.encodedProjectName);
-        }
-        if (tab.toolName) {
-          url.searchParams.set('toolName', tab.toolName);
-        }
-      } else {
-        url.searchParams.delete('sessionId');
-        url.searchParams.delete('encodedProjectName');
-        url.searchParams.delete('toolName');
-      }
-
-      window.history.replaceState({}, '', url.toString());
-    },
-    []
-  );
-
   // Switch to a tab
   const switchTab = useCallback(
     (tabId: string) => {
@@ -1871,7 +1875,14 @@ export const Workspace: React.FC = () => {
         }
       }, 100);
     },
-    [activeTabId, tabs, setStoredActiveTabId, clearTabNotification, userWebUI, updateUrlWithActiveTab]
+    [
+      activeTabId,
+      tabs,
+      setStoredActiveTabId,
+      clearTabNotification,
+      userWebUI,
+      updateUrlWithActiveTab,
+    ]
   );
 
   // Rename a tab


### PR DESCRIPTION
## 问题描述

在会话页面中发送消息并等待 AI 回复期间，使用浏览器后退、前进以及刷新操作时，页面状态无法正确保持。

### 具体表现：
- 点击浏览器"后退"按钮后，可以正常返回上一个页面
- 再点击"前进"按钮后，无法恢复原来的会话内容，而是显示无对话页面
- 在会话页面连续刷新 3-5 次后，页面没有白屏或崩溃，但每次刷新都会返回首页，无法保持当前会话页面

## 问题根因

Workspace 组件在初始化后会**清除 URL 中的会话参数**，导致：
- 用户在会话页面时，URL 始终是 `/work`，不包含任何会话信息
- 浏览器历史记录不记录会话状态变化
- 用户后退/前进时，URL 不变，组件不会重新初始化

## 修复方案

在 Workspace 组件中添加**活动 Tab → URL 同步机制**：

1. **新增 `updateUrlWithActiveTab` 函数**：将活动 tab 的 sessionId 同步到 URL
2. **修改切换逻辑**：在 `switchTab`/`createNewTab`/`doCloseTab` 等函数中同步 URL
3. **保留 sessionId 参数**：初始化时不再清除 URL 中的 sessionId，让浏览器历史记录可以恢复
4. **添加 popstate 监听**：处理浏览器后退/前进事件，从 URL 恢复会话

## 代码变更

**文件**: `frontend/src/components/features/Workspace.tsx`

- 新增函数: `updateUrlWithActiveTab`
- 修改函数: `switchTab`, `createNewTab`, `doCloseTab`
- 新增监听: `popstate` 事件

## 测试计划

1. **后退/前进测试**：进入会话页面，点击后退再前进，验证会话正确恢复
2. **刷新测试**：进入会话页面，连续刷新 5 次，验证停留在当前会话页面
3. **多 Tab 测试**：创建多个会话 tab，切换 tab 验证 URL 参数同步，后退/前进验证正确切换

Fixes #2899