### PR TITLE
fix: preserve GH_TOKEN in gh repo create under multi-user sudo (#2909)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1009,7 +1009,11 @@ class GitHubOps:
 
         # `gh repo create` rejects -R (unlike issue/pr subcommands), so disable
         # repo-scoped binding; it creates a new repo and needs no existing one.
-        result = self._run_gh(args, repo_scoped=False)
+        # api_only=True: repo creation is a pure GitHub API call that needs no
+        # local repo access, so when a bot token is configured and the command
+        # would otherwise sudo (cross-user), run gh as the service user to keep
+        # GH_TOKEN from being stripped by sudo env_reset (Issue #2909).
+        result = self._run_gh(args, repo_scoped=False, api_only=True)
         # gh repo create doesn't support --json; parse URL from stdout
         output = result.stdout.strip()
         repo_url = output.split("\n")[-1].strip()

--- a/tests/issues/2909/test_create_repo_sudo_token.py
+++ b/tests/issues/2909/test_create_repo_sudo_token.py
@@ -1,0 +1,203 @@
+"""Regression tests for Issue #2909: GH_TOKEN stripped by sudo env_reset in
+multi-user ``gh repo create``.
+
+These tests verify that ``create_repo()`` uses ``api_only=True`` so the
+configured AI GitHub token (``GH_TOKEN``) is not stripped by sudo's
+``env_reset`` policy when the service user differs from the system account.
+They also cover the fallback (no token → sudo), same-user compatibility,
+token-leak prevention, ``-R`` absence, and Git ops isolation.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+
+
+def _completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+_FAKE_ENV = {
+    "GH_TOKEN": "ghp_faketoken_2909",
+    "GIT_AUTHOR_NAME": "Bot",
+    "GIT_AUTHOR_EMAIL": "bot@example.com",
+    "GIT_COMMITTER_NAME": "Bot",
+    "GIT_COMMITTER_EMAIL": "bot@example.com",
+}
+
+
+class TestCreateRepoSudoTokenPreservation:
+    """Issue #2909: create_repo must not strip GH_TOKEN under sudo."""
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_with_token_skips_sudo(self, mock_run, _needs, _env):
+        """Condition 1-3: _needs_sudo True, GH_TOKEN present, create_repo
+        does NOT go through the sudo path that would strip the token."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        cmd = mock_run.call_args.args[0]
+        assert "sudo" not in cmd
+        assert cmd[0] == "gh"
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_with_token_preserves_gh_token_in_env(self, mock_run, _needs, _env):
+        """Condition 5: GH_TOKEN is correctly passed into the gh subprocess env."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert env.get("GH_TOKEN") == "ghp_faketoken_2909"
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_with_token_no_dash_r(self, mock_run, _needs, _env):
+        """Condition 6: gh repo create must not carry -R (it rejects it)."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        cmd = mock_run.call_args.args[0]
+        assert "-R" not in cmd
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_with_token_drops_cwd(self, mock_run, _needs, _env):
+        """The api_as_service path must drop cwd (service user may lack access
+        to the owner's workspace directory)."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        assert "cwd" not in mock_run.call_args.kwargs
+
+
+class TestCreateRepoNoTokenFallback:
+    """Condition 8: without a bot token, create_repo falls back to sudo."""
+
+    @patch.object(GitHubOps, "_get_env", return_value=None)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_no_token_uses_sudo(self, mock_run, _needs, _env):
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == ["sudo", "-u", "alice"]
+        assert cmd[3] == "gh"
+
+    @patch.object(GitHubOps, "_get_env", return_value=None)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_cross_user_no_token_no_gh_token_in_env(self, mock_run, _needs, _env):
+        """No token configured → env should not contain GH_TOKEN."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        env = mock_run.call_args.kwargs.get("env", {})
+        assert "GH_TOKEN" not in env or env.get("GH_TOKEN") is None
+
+
+class TestCreateRepoSameUserCompatibility:
+    """Condition 7: same-user deployment must remain unchanged."""
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=False)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_same_user_with_token_no_sudo_keeps_cwd(self, mock_run, _needs, _env):
+        """Same-user + token: gh runs directly, cwd preserved (gh infers repo
+        from working directory)."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        cmd = mock_run.call_args.args[0]
+        assert "sudo" not in cmd
+        assert cmd[0] == "gh"
+        assert mock_run.call_args.kwargs.get("cwd") == "/workspace/alice/project"
+
+    @patch.object(GitHubOps, "_get_env", return_value=None)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=False)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_same_user_no_token_no_sudo(self, mock_run, _needs, _env):
+        """Same-user + no token: gh runs directly, no sudo."""
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        cmd = mock_run.call_args.args[0]
+        assert "sudo" not in cmd
+        assert cmd[0] == "gh"
+
+
+class TestCreateRepoTokenNoLeak:
+    """Condition 4 (log hygiene): error messages must not contain the real token."""
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_error_message_excludes_token(self, mock_run, _needs, _env):
+        """GitHubOpsError from a failed gh repo create must not embed GH_TOKEN."""
+        mock_run.return_value = _completed(
+            stdout="", returncode=4, stderr="gh auth login required"
+        )
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        try:
+            gh.create_repo("new-repo", private=True)
+            assert False, "Should have raised GitHubOpsError"
+        except GitHubOpsError as exc:
+            assert "ghp_faketoken_2909" not in str(exc)
+
+
+class TestGitOpsStillSudoUnderCrossUser:
+    """Condition 9: Git operations that need local repo access must still use
+    sudo (api_only on create_repo must not bleed into _run_git)."""
+
+    @patch.object(GitHubOps, "_get_env", return_value=_FAKE_ENV)
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_run_git_still_uses_sudo(self, mock_run, _needs, _env):
+        """_run_git must still use sudo -u under cross-user, unlike the
+        api_only gh path."""
+        mock_run.return_value = _completed(stdout="")
+        gh = GitHubOps("/workspace/alice/project", system_account="alice")
+
+        gh._run_git(["status", "--porcelain"])
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == ["sudo", "-u", "alice"]

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -210,13 +210,39 @@ class TestRunGhSudo:
 class TestRunGhRepoScoped:
     """repo create/view reject -R; repo_scoped=False omits it (review feedback)."""
 
+    @patch.object(GitHubOps, "_get_env", return_value={"GH_TOKEN": "ghp_test"})
     @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
     @patch.object(GitHubOps, "_needs_sudo", return_value=True)
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_create_repo_no_dash_r(self, mock_run, _needs, _resolve):
-        # `gh repo create` does not accept -R; even when a remote resolves, the
-        # command must run plain gh under sudo (previously the unconditional -R
-        # would regress to "unknown shorthand flag: 'R'").
+    def test_create_repo_no_dash_r_with_token(self, mock_run, _needs, _resolve, _env):
+        # `gh repo create` does not accept -R. With api_only=True (Issue #2909),
+        # when a bot token is configured, create_repo runs gh as the service
+        # user (no sudo) so GH_TOKEN survives; -R is still omitted.
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert gh_cmd[0] == "gh"  # no sudo prefix
+        assert "sudo" not in gh_cmd
+        assert "-R" not in gh_cmd
+        assert "repo" in gh_cmd and "create" in gh_cmd
+        # GH_TOKEN must be present in the subprocess environment.
+        assert mock_run.call_args.kwargs.get("env", {}).get("GH_TOKEN") == "ghp_test"
+        # cwd is dropped on the api_as_service path (service user may lack
+        # access to the owner's repo directory).
+        assert "cwd" not in mock_run.call_args.kwargs
+
+    @patch.object(GitHubOps, "_get_env", return_value=None)
+    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_repo_no_dash_r_no_token_fallback_sudo(self, mock_run, _needs, _resolve, _env):
+        # Without a bot token, api_as_service is False, so create_repo falls
+        # back to the sudo path (preserving pre-#2909 behavior).
         mock_run.return_value = _completed(
             stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
         )

--- a/tests/unit/test_create_repo_sudo_token_2909.py
+++ b/tests/unit/test_create_repo_sudo_token_2909.py
@@ -172,9 +172,7 @@ class TestCreateRepoTokenNoLeak:
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     def test_error_message_excludes_token(self, mock_run, _needs, _env):
         """GitHubOpsError from a failed gh repo create must not embed GH_TOKEN."""
-        mock_run.return_value = _completed(
-            stdout="", returncode=4, stderr="gh auth login required"
-        )
+        mock_run.return_value = _completed(stdout="", returncode=4, stderr="gh auth login required")
         gh = GitHubOps("/workspace/alice/project", system_account="alice")
 
         try:

--- a/tests/unit/test_create_repo_sudo_token_2909.py
+++ b/tests/unit/test_create_repo_sudo_token_2909.py
@@ -177,7 +177,7 @@ class TestCreateRepoTokenNoLeak:
 
         try:
             gh.create_repo("new-repo", private=True)
-            assert False, "Should have raised GitHubOpsError"
+            raise AssertionError("Should have raised GitHubOpsError")
         except GitHubOpsError as exc:
             assert "ghp_faketoken_2909" not in str(exc)
 


### PR DESCRIPTION
Closes #2909

## 修复内容

在多用户 Docker Compose 部署中，`create_repo()` 调用 `_run_gh()` 时未设置 `api_only=True`，导致 `gh repo create` 走 `sudo -u <account>` 路径，sudo 的 `env_reset` 策略清除了 `GH_TOKEN`，GitHub CLI 在未认证状态下运行并返回退出码 4。

`gh repo create` 是纯 GitHub API 操作，不需要访问本地用户仓库目录。设置 `api_only=True` 后，当配置了 AI GitHub Token 且需要跨用户执行时，命令以服务用户身份直接运行 `gh`，`GH_TOKEN` 保留在环境变量中。

## 修复方案

- `app/modules/workspace/autonomous/github_ops.py`：`create_repo()` 的 `_run_gh()` 调用添加 `api_only=True`
- `tests/issues/716/test_github_ops_sudo.py`：更新现有测试 `test_create_repo_no_dash_r`，拆分为有 token（跳过 sudo）和无 token（降级 sudo）两个场景
- `tests/issues/2909/test_create_repo_sudo_token.py`：新建回归测试，覆盖 9 个条件

## 风险评估

- 无 bot token 时 `api_as_service=False`，自动降级为原有 sudo 行为
- `gh repo create` 不接受 `-R`，`repo_scoped=False` 保持不变
- 同用户部署场景不受影响（`_needs_sudo()` 返回 `False`）