### PR TITLE
fix: 访问不存在的会话时返回明确提示 (#2892)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1036,7 +1036,9 @@ export const Workspace: React.FC = () => {
         .getSession(restoreSessionId, false)
         .then((response) => {
           if (!response.success) {
-            setError(t('sessionNotFound', language) || 'Session does not exist or has been deleted');
+            setError(
+              t('sessionNotFound', language) || 'Session does not exist or has been deleted'
+            );
             setSessionVerified(false);
           } else {
             setSessionVerified(true);

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1040,6 +1040,10 @@ export const Workspace: React.FC = () => {
               t('sessionNotFound', language) || 'Session does not exist or has been deleted'
             );
             setSessionVerified(false);
+          } else if (!response.data.project_path) {
+            // Issue #2892: Validate project path exists
+            setError(t('projectNotFound', language) || 'Project path does not exist');
+            setSessionVerified(false);
           } else {
             setSessionVerified(true);
           }

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -135,6 +135,9 @@ export const Workspace: React.FC = () => {
   // Flag to track if tabs have been initialized (Issue #65)
   const [tabsInitialized, setTabsInitialized] = useState(false);
 
+  // Issue #2892: Session verification state
+  const [sessionVerified, setSessionVerified] = useState<boolean | null>(null);
+
   // Remote projects list (Issue #417: Populate "Your Projects" for remote workspace)
   const [remoteProjects, setRemoteProjects] = useState<RemoteProject[]>([]);
 
@@ -1027,6 +1030,31 @@ export const Workspace: React.FC = () => {
     const urlResumeHint = searchParams.get('resumeHint') === 'true';
     const restoreSessionId = urlSessionId ?? restoreSession;
 
+    // Issue #2892: Validate session exists before restoration (non-terminal only)
+    if (restoreSessionId && urlWorkspaceType !== 'terminal' && sessionVerified === null) {
+      sessionsApi
+        .getSession(restoreSessionId, false)
+        .then((response) => {
+          if (!response.success) {
+            setError(t('sessionNotFound', language) || 'Session does not exist or has been deleted');
+            setSessionVerified(false);
+          } else {
+            setSessionVerified(true);
+          }
+        })
+        .catch((err) => {
+          console.error('[Workspace] Failed to verify session:', err);
+          setError(t('sessionNotFound', language) || 'Session does not exist or has been deleted');
+          setSessionVerified(false);
+        });
+      return;
+    }
+
+    // Skip if session verification failed
+    if (restoreSessionId && urlWorkspaceType !== 'terminal' && sessionVerified === false) {
+      return;
+    }
+
     // Determine if we should restore from store or create new
     // Priority: URL restore params > Store saved state > New session
     let initialTabs: WorkspaceTab[] = [];
@@ -1268,6 +1296,7 @@ export const Workspace: React.FC = () => {
     addStoredTab,
 
     setStoredActiveTabId,
+    sessionVerified, // Issue #2892
   ]);
 
   // Handle URL parameter for creating new tab

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -200,6 +200,8 @@ export const translations: Record<Language, Translations> = {
     workspaceNotConfiguredHelp: 'Please contact administrator to configure workspace URL',
     workspaceUnavailable: 'Workspace unavailable',
     workspaceUnavailableHelp: 'Please log in to access your workspace',
+    sessionNotFound: 'Session does not exist or has been deleted',
+    projectNotFound: 'Project path does not exist',
     security: 'Security',
 
     // Mode - Dual-track system
@@ -2286,6 +2288,8 @@ export const translations: Record<Language, Translations> = {
     workspaceNotConfiguredHelp: '请联系管理员配置工作区 URL',
     workspaceUnavailable: '工作区不可用',
     workspaceUnavailableHelp: '请登录后访问您的工作区',
+    sessionNotFound: '会话不存在或已被删除',
+    projectNotFound: '项目路径不存在',
     security: '安全',
 
     // Mode - Dual-track system


### PR DESCRIPTION
Closes #2892

## 修复内容

**问题**：访问不存在的会话 URL 时，系统未返回明确的错误提示，用户无法判断会话是否存在。

**修复方案**：
1. 添加会话验证逻辑：在恢复会话前调用 `sessionsApi.getSession()` 验证会话是否存在
2. 错误提示：如果会话不存在，显示明确的错误提示"会话不存在或已被删除"
3. 国际化：添加中英文翻译 `sessionNotFound` 和 `projectNotFound`

## 代码变更

- `frontend/src/components/features/Workspace.tsx`：添加会话验证逻辑
- `frontend/src/i18n/index.ts`：添加翻译键

## 测试场景

1. 访问不存在的会话 ID → 显示"会话不存在或已被删除"错误
2. 访问存在的会话 ID → 正常创建标签页
3. 终端会话恢复 → 不验证（使用 terminalId）

## 修复方案来源

基于已批准的修复方案1（评估报告结论：✅ 方案完整，可实施）