### PR TITLE
fix: remove .value from AuditAction enum in log_action calls

### DIFF
--- a/app/routes/feishu_config.py
+++ b/app/routes/feishu_config.py
@@ -123,7 +123,7 @@ def update_feishu_config():
 
             # Audit log for Feishu config save (do not log app_secret)
             audit_logger.log_action(
-                action=AuditAction.FEISHU_CONFIG_SAVE.value,
+                action=AuditAction.FEISHU_CONFIG_SAVE,
                 user_id=user_id,
                 resource_type="feishu_config",
                 resource_name=app_id,
@@ -203,7 +203,7 @@ def delete_feishu_config():
 
         # Audit log for Feishu config delete (do not log app_secret)
         audit_logger.log_action(
-            action=AuditAction.FEISHU_CONFIG_DELETE.value,
+            action=AuditAction.FEISHU_CONFIG_DELETE,
             user_id=user_id,
             resource_type="feishu_config",
             resource_name=config.get("app_id"),

--- a/app/routes/smtp_config.py
+++ b/app/routes/smtp_config.py
@@ -97,7 +97,7 @@ def update_smtp_config():
 
         # Audit log for SMTP config save (do not log password)
         audit_logger.log_action(
-            action=AuditAction.SMTP_CONFIG_SAVE.value,
+            action=AuditAction.SMTP_CONFIG_SAVE,
             user_id=user_id,
             resource_type="smtp_config",
             resource_id=config.get("id"),
@@ -174,7 +174,7 @@ def delete_smtp_config():
 
         # Audit log for SMTP config delete (do not log password)
         audit_logger.log_action(
-            action=AuditAction.SMTP_CONFIG_DELETE.value,
+            action=AuditAction.SMTP_CONFIG_DELETE,
             user_id=user_id,
             resource_type="smtp_config",
             resource_id=config.get("id"),


### PR DESCRIPTION
## 修复说明

关联 Issue：#2886, #2882

## 根因

`audit_logger.log_action()` 方法签名要求 `action: AuditAction` 枚举类型，内部会调用 `action.value`。调用方错误传入 `AuditAction.XXX.value`（字符串），导致 `AttributeError: 'str' object has no attribute 'value'`。

## 修复方案

移除 `.value`，直接传入 `AuditAction` 枚举。

## 主要变更

- `app/routes/feishu_config.py`: 修复 `FEISHU_CONFIG_SAVE` 和 `FEISHU_CONFIG_DELETE` 调用
- `app/routes/smtp_config.py`: 修复 `SMTP_CONFIG_SAVE` 和 `SMTP_CONFIG_DELETE` 调用

## 测试

- 本地测试环境：修改已通过代码审查验证
- CI 状态：待验证

## 风险

- 无兼容性风险：修改不影响外部接口
- 无性能风险：枚举访问 `.value` 在原方法内部执行
- 无安全风险：修复不涉及安全逻辑
- 无回归风险：修复仅修正参数类型错误