### PR TITLE
fix: SSO 首次登录 wrapper 脚本需要 sudo 提权

### DIFF
--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -250,9 +250,7 @@ def _ensure_workspace_dirs(system_account: str, base_dir: str):
         # Issue #2894: wrapper 脚本需要 root 权限
         for directory in [workspace_dir, qwen_dir]:
             if _is_wrapper_available(OPENACE_CHOWN_WRAPPER):
-                result = run_as_root_if_needed(
-                    [OPENACE_CHOWN_WRAPPER, f"{uid}:{gid}", directory]
-                )
+                result = run_as_root_if_needed([OPENACE_CHOWN_WRAPPER, f"{uid}:{gid}", directory])
                 if result.returncode != 0:
                     logger.warning(f"Cannot chown {directory} via wrapper: {result.stderr}")
             else:

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -225,7 +225,7 @@ def _ensure_workspace_dirs(system_account: str, base_dir: str):
                 # Issue #2894: wrapper 脚本需要 root 权限
                 if _is_wrapper_available(OPENACE_MKDIR_WRAPPER):
                     result = run_as_root_if_needed(
-                        [OPENACE_MKDIR_WRAPPER, system_account, directory]
+                        [OPENACE_MKDIR_WRAPPER, system_account, directory],
                     )
                     if result.returncode != 0:
                         logger.warning(f"Cannot create {directory} via wrapper: {result.stderr}")

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -176,6 +176,7 @@ def ensure_system_user(system_account: str, uid: int | None = None) -> bool:
 
     # 创建用户（通过 wrapper 或 sudo）
     # Issue #1855: 优先使用安全 wrapper，wrapper 内部做参数校验和审计日志
+    # Issue #2894: wrapper 脚本需要 root 权限（锁文件、系统用户创建等）
     if _is_wrapper_available(OPENACE_USERADD_WRAPPER):
         cmd = [OPENACE_USERADD_WRAPPER, system_account]
         if uid is not None:
@@ -184,7 +185,7 @@ def ensure_system_user(system_account: str, uid: int | None = None) -> bool:
             f"Creating system user via wrapper: {system_account}"
             + (f" (UID: {uid})" if uid else "")
         )
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = run_as_root_if_needed(cmd)
     else:
         # Fallback: 使用传统 useradd 命令（需要 sudo）
         cmd = ["useradd", "-m", "-s", "/bin/bash"]
@@ -221,11 +222,10 @@ def _ensure_workspace_dirs(system_account: str, base_dir: str):
                 os.makedirs(directory, mode=0o755, exist_ok=True)
             except PermissionError:
                 # Issue #1855: 优先使用安全 wrapper
+                # Issue #2894: wrapper 脚本需要 root 权限
                 if _is_wrapper_available(OPENACE_MKDIR_WRAPPER):
-                    result = subprocess.run(
-                        [OPENACE_MKDIR_WRAPPER, system_account, directory],
-                        capture_output=True,
-                        text=True,
+                    result = run_as_root_if_needed(
+                        [OPENACE_MKDIR_WRAPPER, system_account, directory]
                     )
                     if result.returncode != 0:
                         logger.warning(f"Cannot create {directory} via wrapper: {result.stderr}")
@@ -247,12 +247,11 @@ def _ensure_workspace_dirs(system_account: str, base_dir: str):
 
         # 设置所有权（通过 wrapper 或 sudo）
         # Issue #1855: 优先使用安全 wrapper，wrapper 内部做路径校验和审计日志
+        # Issue #2894: wrapper 脚本需要 root 权限
         for directory in [workspace_dir, qwen_dir]:
             if _is_wrapper_available(OPENACE_CHOWN_WRAPPER):
-                result = subprocess.run(
-                    [OPENACE_CHOWN_WRAPPER, f"{uid}:{gid}", directory],
-                    capture_output=True,
-                    text=True,
+                result = run_as_root_if_needed(
+                    [OPENACE_CHOWN_WRAPPER, f"{uid}:{gid}", directory]
                 )
                 if result.returncode != 0:
                     logger.warning(f"Cannot chown {directory} via wrapper: {result.stderr}")


### PR DESCRIPTION
## 问题描述

Issue #2894: SSO 首次登录失败

**报错信息**:
```
openace-useradd: ERROR: failed to acquire lock on /var/lock/openace-useradd.lock: Permission denied
```

## 根因分析

1. `openace-useradd`/`mkdir`/`chown` wrapper 脚本内部使用 `flock` 锁文件
2. 锁文件 `/var/lock/openace-useradd.lock` 由 root 创建，权限为 `rw-------`
3. Package 模式下进程以非 root 用户运行
4. 代码直接调用 `subprocess.run()` 执行 wrapper，未触发 sudo 提权
5. wrapper 脚本尝试访问 root 所有的锁文件失败

**sudoers 配置已就位**:
```
open-ace ALL=(root) NOPASSWD: /usr/local/bin/openace-useradd *
open-ace ALL=(root) NOPASSWD: /usr/local/bin/openace-mkdir *
open-ace ALL=(root) NOPASSWD: /usr/local/bin/openace-chown *
```

但 `subprocess.run()` 不会自动使用 sudo。

## 修复方案

将 wrapper 调用从 `subprocess.run()` 改为 `run_as_root_if_needed()`:
- 利用 sudoers NOPASSWD 配置自动提权
- 保持与 fallback 路径（useradd/mkdir/chown）一致的安全模型

## 影响范围

- `ensure_system_user()`: useradd wrapper 调用
- `_ensure_workspace_dirs()`: mkdir/chown wrapper 调用

## 测试建议

1. Package 模式部署后验证 SSO 首次登录
2. 确认系统用户和 workspace 目录正确创建
3. 验证 Docker 模式仍正常工作