### PR TITLE
fix: 配额保存失败时显示详细错误信息 (#2890)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -160,7 +160,9 @@ class ApiClient {
             const contentType = response.headers.get('content-type');
             if (contentType?.includes('application/json')) {
               const errorData = await response.json();
-              error.message = errorData.error ?? errorData.message ?? error.message;
+              // Prioritize message (specific) over error (generic)
+              // e.g., "Tenant daily request quota exceeded" over "Tenant quota exceeded"
+              error.message = errorData.message ?? errorData.error ?? error.message;
               error.code = errorData.code;
               error.details = errorData.details;
             } else {

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/common';
 import { useConfirm } from '@/components/common';
 import { formatTokens, formatDateTime, formatNumber, createMatcherConfig } from '@/utils';
+import { parseApiError } from '@/utils/error';
 import { QuotaType, TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
 import {
   parseAndValidateQuota,
@@ -297,11 +298,77 @@ export const QuotaAlerts: React.FC = () => {
       handleCloseQuotaModal();
     } catch (err) {
       console.error('Failed to update quota:', err);
-      const errorMessage =
-        err && typeof err === 'object' && 'message' in err
-          ? String((err as { message: string }).message)
-          : t('error', language);
-      toast.error(t('error', language), errorMessage);
+      const errorDetail = parseApiError(err);
+
+      // Build detailed error message
+      let detailedMessage = errorDetail.message;
+
+      // If details available, add specific information
+      if (errorDetail.details && typeof errorDetail.details === 'object') {
+        const details = errorDetail.details as {
+          quota_type?: string;
+          tenant_limit?: number;
+          currently_allocated?: number;
+          available?: Record<string, number>;
+          suggestion?: string;
+        };
+
+        const detailParts: string[] = [];
+
+        if (details.quota_type) {
+          const quotaTypeMap: Record<string, string> = {
+            daily_request: language === 'zh' ? '每日请求配额' : 'Daily request quota',
+            daily_token: language === 'zh' ? '每日Token配额' : 'Daily token quota',
+            monthly_request: language === 'zh' ? '每月请求配额' : 'Monthly request quota',
+            monthly_token: language === 'zh' ? '每月Token配额' : 'Monthly token quota',
+          };
+          const quotaTypeLabel = quotaTypeMap[details.quota_type] || details.quota_type;
+          detailParts.push(
+            language === 'zh' ? `类型: ${quotaTypeLabel}` : `Type: ${quotaTypeLabel}`
+          );
+        }
+
+        if (details.tenant_limit !== undefined) {
+          detailParts.push(
+            language === 'zh'
+              ? `租户限额: ${details.tenant_limit.toLocaleString()}`
+              : `Tenant limit: ${details.tenant_limit.toLocaleString()}`
+          );
+        }
+
+        if (details.currently_allocated !== undefined) {
+          detailParts.push(
+            language === 'zh'
+              ? `已分配: ${details.currently_allocated.toLocaleString()}`
+              : `Allocated: ${details.currently_allocated.toLocaleString()}`
+          );
+        }
+
+        if (
+          details.available &&
+          details.quota_type &&
+          details.available[details.quota_type] !== undefined
+        ) {
+          const availableValue = details.available[details.quota_type];
+          detailParts.push(
+            language === 'zh'
+              ? `可用余量: ${availableValue.toLocaleString()}`
+              : `Available: ${availableValue.toLocaleString()}`
+          );
+        }
+
+        if (details.suggestion) {
+          detailParts.push(
+            language === 'zh' ? `建议: ${details.suggestion}` : `Suggestion: ${details.suggestion}`
+          );
+        }
+
+        if (detailParts.length > 0) {
+          detailedMessage += '\n' + detailParts.join('\n');
+        }
+      }
+
+      toast.error(t('error', language), detailedMessage);
     }
   };
 


### PR DESCRIPTION
Closes #2890

## 修复内容

### 问题
在 `/manage/quota` 页面保存配额失败时，前端 toast 只显示笼统的 `"Tenant quota exceeded"`，未展示后端返回的 `message` 和 `details` 中的具体原因（哪个配额维度超限、已分配多少、租户限额多少、建议操作等）。

### 根因分析
1. **`client.ts`**: 错误消息优先取 `error` 而非 `message`，导致显示笼统文案
2. **`QuotaAlerts.tsx`**: 只透传 `err.message`，未利用 `details` 字段

### 修复方案
详见 Issue #2890 评论中的方案协作记录。

## 代码变更
- `frontend/src/api/client.ts`: 调整错误消息优先级，`message`（具体）优先于 `error`（兜底）
- `frontend/src/components/features/management/QuotaAlerts.tsx`: 利用 `details` 构建详细错误提示

## 测试
- ✅ TypeScript 类型检查通过
- ✅ 前端测试全部通过 (918 tests)
- ✅ ESLint 检查通过 (0 errors)