### PR TITLE
fix: 配额编辑弹窗显示实际可用额度而非数据库上限 (#2889)

### DIFF
--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -32,11 +32,16 @@ import {
 import { useConfirm } from '@/components/common';
 import { formatTokens, formatDateTime, formatNumber, createMatcherConfig } from '@/utils';
 import { parseApiError } from '@/utils/error';
-import { QuotaType, TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
+import {
+  QuotaType,
+  TOKEN_QUOTA_MULTIPLIER,
+  MAX_TOKEN_QUOTA,
+  MAX_REQUEST_QUOTA,
+} from '@/constants/quota';
 import {
   parseAndValidateQuota,
   formatQuotaForDisplay,
-  getMaxQuotaDisplay,
+  formatNumberAsString,
 } from '@/utils/quotaFormatter';
 import { alertsApi, type Alert, type NotificationPreferences } from '@/api';
 import type { QuotaUsage, UpdateQuotaRequest } from '@/api';
@@ -183,6 +188,51 @@ export const QuotaAlerts: React.FC = () => {
     setEditingUser(null);
     setQuotaErrors({});
   };
+
+  // Get available quota hint for input field (shows actual available quota)
+  const getAvailableQuotaHint = useCallback(
+    (quotaType: QuotaType): string => {
+      const typeMap = {
+        [QuotaType.DAILY_TOKEN]: {
+          remaining: quotaStats?.remaining.daily_token ?? 0,
+          current: editingUser?.daily_token_quota ?? 0,
+          max: MAX_TOKEN_QUOTA,
+          isToken: true,
+        },
+        [QuotaType.MONTHLY_TOKEN]: {
+          remaining: quotaStats?.remaining.monthly_token ?? 0,
+          current: editingUser?.monthly_token_quota ?? 0,
+          max: MAX_TOKEN_QUOTA,
+          isToken: true,
+        },
+        [QuotaType.DAILY_REQUEST]: {
+          remaining: quotaStats?.remaining.daily_request ?? 0,
+          current: editingUser?.daily_request_quota ?? 0,
+          max: MAX_REQUEST_QUOTA,
+          isToken: false,
+        },
+        [QuotaType.MONTHLY_REQUEST]: {
+          remaining: quotaStats?.remaining.monthly_request ?? 0,
+          current: editingUser?.monthly_request_quota ?? 0,
+          max: MAX_REQUEST_QUOTA,
+          isToken: false,
+        },
+      };
+
+      const info = typeMap[quotaType];
+      const available = Math.max(0, Math.min(info.remaining + info.current, info.max));
+
+      if (!quotaStats) {
+        return info.isToken ? `Max: ${info.max}M` : `Max: ${formatNumberAsString(info.max)}`;
+      }
+
+      if (info.isToken) {
+        return `可用: ${available.toFixed(2)}M (上限: ${info.max}M)`;
+      }
+      return `可用: ${formatNumberAsString(available)} (上限: ${formatNumberAsString(info.max)})`;
+    },
+    [quotaStats, editingUser]
+  );
 
   // Handle quota input change with validation
   const handleQuotaInputChange = (
@@ -703,7 +753,7 @@ export const QuotaAlerts: React.FC = () => {
                   <label className="form-label">
                     {t('dailyTokenQuota', language)} (M)
                     <small className="text-muted ms-1">
-                      ({getMaxQuotaDisplay(QuotaType.DAILY_TOKEN)})
+                      ({getAvailableQuotaHint(QuotaType.DAILY_TOKEN)})
                     </small>
                   </label>
                   <TextInput
@@ -729,7 +779,7 @@ export const QuotaAlerts: React.FC = () => {
                   <label className="form-label">
                     {t('monthlyTokenQuota', language)} (M)
                     <small className="text-muted ms-1">
-                      ({getMaxQuotaDisplay(QuotaType.MONTHLY_TOKEN)})
+                      ({getAvailableQuotaHint(QuotaType.MONTHLY_TOKEN)})
                     </small>
                   </label>
                   <TextInput
@@ -755,7 +805,7 @@ export const QuotaAlerts: React.FC = () => {
                   <label className="form-label">
                     {t('dailyRequestQuota', language)}
                     <small className="text-muted ms-1">
-                      ({getMaxQuotaDisplay(QuotaType.DAILY_REQUEST)})
+                      ({getAvailableQuotaHint(QuotaType.DAILY_REQUEST)})
                     </small>
                   </label>
                   <TextInput
@@ -781,7 +831,7 @@ export const QuotaAlerts: React.FC = () => {
                   <label className="form-label">
                     {t('monthlyRequestQuota', language)}
                     <small className="text-muted ms-1">
-                      ({getMaxQuotaDisplay(QuotaType.MONTHLY_REQUEST)})
+                      ({getAvailableQuotaHint(QuotaType.MONTHLY_REQUEST)})
                     </small>
                   </label>
                   <TextInput


### PR DESCRIPTION
Closes #2889

## 问题

在 `/manage/quota` 页面编辑用户配额时，输入框旁的 Max 提示显示的是 PostgreSQL INTEGER 上限（`2,147,483,647` / `2147M`），而非用户实际可配置的最大值。

实际可配置上限受限于租户配额余量（租户限额 - 其他用户已分配），两者可能差几个数量级，对用户造成严重误导。

## 修复内容

1. **添加 `getAvailableQuotaHint()` 函数**：计算实际可用额度
   - 可用额度 = 租户剩余 + 当前用户已分配（编辑时需加回当前用户配额）
   - 处理 `quotaStats` 为 null 时的 fallback

2. **修改输入框 hint 显示**：
   - Token 配额: `可用: 100.00M (上限: 2147M)`
   - Request 配额: `可用: 10,000 (上限: 2,147,483,647)`

## 变更文件

- `frontend/src/components/features/management/QuotaAlerts.tsx`

## 测试

- TypeScript 编译通过
- 需要验证实际 UI 显示效果

Generated with Qwen Code