### PR TITLE
fix: use database-dialect-aware JSON query in _load_synced_teams (#2885)

### DIFF
--- a/app/services/dingtalk_org_sync.py
+++ b/app/services/dingtalk_org_sync.py
@@ -927,14 +927,23 @@ class DingTalkOrgSyncService:
         to avoid full table scan.
         """
         # Use WHERE clause to filter at database level
-        # This leverages the idx_teams_dingtalk_sync partial index
-        # Note: Using JSON_EXTRACT for SQLite compatibility (Issue #2174)
-        # PostgreSQL supports settings->>'sync_source', but SQLite requires json_extract
-        query = """
-            SELECT team_id, name, settings
-            FROM teams
-            WHERE json_extract(settings, '$.sync_source') = ?
-        """
+        # This leverages the idx_teams_sync_source index
+        # Issue #2885: Branch by database dialect — PostgreSQL has no json_extract().
+        # The settings column is TEXT, so PostgreSQL requires ::jsonb cast before
+        # using the ->> operator. This matches the index expression in migration
+        # 20260731_003_add_teams_sync_source_indexes.
+        if self.db.is_postgresql:
+            query = """
+                SELECT team_id, name, settings
+                FROM teams
+                WHERE settings::jsonb->>'sync_source' = ?
+            """
+        else:
+            query = """
+                SELECT team_id, name, settings
+                FROM teams
+                WHERE json_extract(settings, '$.sync_source') = ?
+            """
         rows = self.db.fetch_all(query, (DINGTALK_PROVIDER_NAME,))
 
         synced: dict[str, dict[str, Any]] = {}

--- a/app/services/feishu_org_sync.py
+++ b/app/services/feishu_org_sync.py
@@ -891,14 +891,23 @@ class FeishuOrgSyncService:
         to avoid full table scan.
         """
         # Use WHERE clause to filter at database level
-        # This leverages the idx_teams_feishu_sync partial index
-        # Note: Using JSON_EXTRACT for SQLite compatibility (Issue #2174)
-        # PostgreSQL supports settings->>'sync_source', but SQLite requires json_extract
-        query = """
-            SELECT team_id, name, settings
-            FROM teams
-            WHERE json_extract(settings, '$.sync_source') = ?
-        """
+        # This leverages the idx_teams_sync_source index
+        # Issue #2885: Branch by database dialect — PostgreSQL has no json_extract().
+        # The settings column is TEXT, so PostgreSQL requires ::jsonb cast before
+        # using the ->> operator. This matches the index expression in migration
+        # 20260731_003_add_teams_sync_source_indexes.
+        if self.db.is_postgresql:
+            query = """
+                SELECT team_id, name, settings
+                FROM teams
+                WHERE settings::jsonb->>'sync_source' = ?
+            """
+        else:
+            query = """
+                SELECT team_id, name, settings
+                FROM teams
+                WHERE json_extract(settings, '$.sync_source') = ?
+            """
         rows = self.db.fetch_all(query, (FEISHU_PROVIDER_NAME,))
 
         synced: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
## 修复说明

关联 Issue：#2885

## 根因

`app/services/feishu_org_sync.py` 和 `app/services/dingtalk_org_sync.py` 的 `_load_synced_teams()` 方法硬编码了 SQLite 的 `json_extract()` 函数。当 Open ACE 使用 PostgreSQL 后端时，该函数不存在，导致同步在目录快照阶段完成后、团队/用户写入前失败（HTTP 500）。

## 修复方案

按 `self.db.is_postgresql` 分支选择正确的 JSON 查询语法：

- **PostgreSQL**：`settings::jsonb->>'sync_source' = ?`（`settings` 列为 TEXT，需 `::jsonb` 转换后使用 `->>` 操作符，与迁移文件 `20260731_003` 的索引表达式一致）
- **SQLite**：`json_extract(settings, '$.sync_source') = ?`（保持不变）

占位符 `?` 由 `Database._adapt_sql()` 自动转换为 PostgreSQL 的 `%s`。

## 主要变更

- `app/services/dingtalk_org_sync.py`：`_load_synced_teams()` 添加 `self.db.is_postgresql` 分支
- `app/services/feishu_org_sync.py`：`_load_synced_teams()` 添加 `self.db.is_postgresql` 分支

## 测试

- 测试环境：本地 SQLite 临时数据库
- 已验证 SQLite 分支：DingTalk 同步仅返回 `sync_source=dingtalk` 的团队，Feishu 同步仅返回 `sync_source=feishu` 的团队
- 已验证 PostgreSQL SQL 生成：`_adapt_sql()` 正确将 `?` 转换为 `%s`，生成 `settings::jsonb->>'sync_source' = %s`
- 已有单元测试因环境问题（本地无可用 PostgreSQL 实例）无法运行，但这是预先存在的问题，与本次修改无关

## 风险

- **兼容性风险**：无。SQLite 分支保持不变，PostgreSQL 使用项目已有的方言分支模式
- **性能风险**：无。PostgreSQL 查询表达式与迁移文件索引表达式完全一致，可正确利用 `idx_teams_sync_source`
- **安全风险**：无
- **回归风险**：低。仅修改查询语句构建，不涉及业务逻辑