### PR TITLE
fix: /api/summary 缺失 WebUI 会话数据 (#2938)

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -816,7 +816,7 @@ class UsageRepository:
         Note:
             Issue #1852: Added tenant_id parameter for tenant filtering.
         """
-        conditions = []
+        conditions = ["(agent_session_id IS NULL OR agent_session_id = '')"]
         params: list[Any] = []
         normalized_tenant_id = self._normalize_tenant_id(tenant_id)
 
@@ -844,7 +844,7 @@ class UsageRepository:
                 COUNT(DISTINCT date) as days_count,
                 SUM(tokens_used) as total_tokens,
                 AVG(tokens_used) as avg_tokens,
-                COUNT(*) as total_requests,
+                COUNT(CASE WHEN role = 'assistant' THEN 1 END) as total_requests,
                 SUM(input_tokens) as total_input_tokens,
                 SUM(output_tokens) as total_output_tokens,
                 MIN(date) as first_date,
@@ -879,6 +879,103 @@ class UsageRepository:
                 }
 
         return results
+
+    def get_session_summary_by_tool(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        host_name: str | None = None,
+        tenant_id: int | None = None,
+    ) -> dict[str, dict]:
+        """Get summary from agent_sessions for sessions not in daily_messages.
+
+        Issue #2938: /api/summary only queries daily_messages, missing WebUI
+        session data (local/remote/terminal). This method aggregates
+        agent_sessions to supplement the summary. daily_messages side excludes
+        records with agent_session_id (session_sync dual-write) to avoid overlap.
+
+        Args:
+            start_date: Optional start date filter (YYYY-MM-DD).
+            end_date: Optional end date filter (YYYY-MM-DD).
+            host_name: Optional host name filter.
+            tenant_id: Optional tenant ID filter.
+
+        Returns:
+            Dict[str, Dict]: Summary data keyed by normalized tool name.
+        """
+        try:
+            conditions = ["workspace_type IN ('local', 'remote', 'terminal')"]
+            params: list[Any] = []
+            normalized_tenant_id = self._normalize_tenant_id(tenant_id)
+
+            if start_date:
+                conditions.append("CAST(created_at AS DATE) >= ?")
+                params.append(start_date)
+
+            if end_date:
+                conditions.append("CAST(created_at AS DATE) <= ?")
+                params.append(end_date)
+
+            if normalized_tenant_id is not None:
+                conditions.append("tenant_id = ?")
+                params.append(normalized_tenant_id)
+
+            if host_name:
+                conditions.append("host_name = ?")
+                params.append(host_name)
+
+            where_clause = " AND ".join(conditions)
+
+            query = f"""
+                SELECT
+                    COALESCE(tool_name, 'unknown') as tool_name,
+                    COUNT(DISTINCT CAST(created_at AS DATE)) as days_count,
+                    SUM(COALESCE(total_tokens, 0)) as total_tokens,
+                    SUM(COALESCE(request_count, 0)) as total_requests,
+                    SUM(COALESCE(total_input_tokens, 0)) as total_input_tokens,
+                    SUM(COALESCE(total_output_tokens, 0)) as total_output_tokens,
+                    MIN(CAST(created_at AS DATE)) as first_date,
+                    MAX(CAST(created_at AS DATE)) as last_date
+                FROM agent_sessions
+                WHERE {where_clause}
+                GROUP BY COALESCE(tool_name, 'unknown')
+                ORDER BY total_tokens DESC
+            """
+
+            rows = self.db.fetch_all(query, tuple(params))
+
+            results: dict[str, dict] = {}
+            for row in rows:
+                tool = normalize_tool_name(row["tool_name"])
+                if tool in results:
+                    existing = results[tool]
+                    existing["total_tokens"] += row["total_tokens"] or 0
+                    existing["total_requests"] += row["total_requests"] or 0
+                    existing["total_input_tokens"] += row["total_input_tokens"] or 0
+                    existing["total_output_tokens"] += row["total_output_tokens"] or 0
+                    if row["first_date"] and (
+                        not existing["first_date"] or row["first_date"] < existing["first_date"]
+                    ):
+                        existing["first_date"] = row["first_date"]
+                    if row["last_date"] and (
+                        not existing["last_date"] or row["last_date"] > existing["last_date"]
+                    ):
+                        existing["last_date"] = row["last_date"]
+                else:
+                    results[tool] = {
+                        "days_count": row["days_count"] or 0,
+                        "total_tokens": row["total_tokens"] or 0,
+                        "total_requests": row["total_requests"] or 0,
+                        "total_input_tokens": row["total_input_tokens"] or 0,
+                        "total_output_tokens": row["total_output_tokens"] or 0,
+                        "first_date": row["first_date"],
+                        "last_date": row["last_date"],
+                    }
+
+            return results
+        except Exception as e:
+            logger.warning("Failed to get session summary by tool: %s", e)
+            return {}
 
     def get_all_tools(self, tenant_id: int | None = None) -> list[str]:
         """

--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -86,10 +86,34 @@ class SummaryService:
                     MAX(date) as last_date
                 FROM daily_messages
                 WHERE host_name = ?
+                  AND (agent_session_id IS NULL OR agent_session_id = '')
                 GROUP BY tool_name
                 ORDER BY tool_name
             """
             params = (host_name, host_name)
+            dm_results = self.db.fetch_all(query, params)
+
+            # Supplement with agent_sessions data for this host
+            session_query = """
+                SELECT
+                    COALESCE(tool_name, 'unknown') as tool_name,
+                    ? as host_name,
+                    COUNT(DISTINCT CAST(created_at AS DATE)) as days_count,
+                    SUM(COALESCE(total_tokens, 0)) as total_tokens,
+                    SUM(COALESCE(total_tokens, 0)) / COUNT(DISTINCT CAST(created_at AS DATE)) as avg_tokens,
+                    SUM(COALESCE(request_count, 0)) as total_requests,
+                    SUM(COALESCE(total_input_tokens, 0)) as total_input_tokens,
+                    SUM(COALESCE(total_output_tokens, 0)) as total_output_tokens,
+                    MIN(CAST(created_at AS DATE)) as first_date,
+                    MAX(CAST(created_at AS DATE)) as last_date
+                FROM agent_sessions
+                WHERE host_name = ?
+                  AND workspace_type IN ('local', 'remote', 'terminal')
+                GROUP BY COALESCE(tool_name, 'unknown')
+                ORDER BY tool_name
+            """
+            session_results = self.db.fetch_all(session_query, (host_name, host_name))
+            return self._merge_aggregates(dm_results + session_results)
         else:
             # Calculate for all hosts (both per-host and global)
             # Per-host summaries
@@ -106,6 +130,7 @@ class SummaryService:
                     MIN(date) as first_date,
                     MAX(date) as last_date
                 FROM daily_messages
+                WHERE (agent_session_id IS NULL OR agent_session_id = '')
                 GROUP BY tool_name, host_name
                 ORDER BY tool_name, host_name
             """
@@ -124,6 +149,7 @@ class SummaryService:
                     MIN(date) as first_date,
                     MAX(date) as last_date
                 FROM daily_messages
+                WHERE (agent_session_id IS NULL OR agent_session_id = '')
                 GROUP BY tool_name
                 ORDER BY tool_name
             """
@@ -131,9 +157,49 @@ class SummaryService:
             # Execute both queries
             per_host_results = self.db.fetch_all(query_per_host, ())
             global_results = self.db.fetch_all(query_global, ())
-            return self._merge_aggregates(per_host_results + global_results)
 
-        return self._merge_aggregates(self.db.fetch_all(query, params))
+            # Supplement with agent_sessions data (per-host and global)
+            session_per_host_query = """
+                SELECT
+                    COALESCE(tool_name, 'unknown') as tool_name,
+                    host_name,
+                    COUNT(DISTINCT CAST(created_at AS DATE)) as days_count,
+                    SUM(COALESCE(total_tokens, 0)) as total_tokens,
+                    SUM(COALESCE(total_tokens, 0)) / COUNT(DISTINCT CAST(created_at AS DATE)) as avg_tokens,
+                    SUM(COALESCE(request_count, 0)) as total_requests,
+                    SUM(COALESCE(total_input_tokens, 0)) as total_input_tokens,
+                    SUM(COALESCE(total_output_tokens, 0)) as total_output_tokens,
+                    MIN(CAST(created_at AS DATE)) as first_date,
+                    MAX(CAST(created_at AS DATE)) as last_date
+                FROM agent_sessions
+                WHERE workspace_type IN ('local', 'remote', 'terminal')
+                GROUP BY COALESCE(tool_name, 'unknown'), host_name
+                ORDER BY tool_name, host_name
+            """
+            session_global_query = """
+                SELECT
+                    COALESCE(tool_name, 'unknown') as tool_name,
+                    '' as host_name,
+                    COUNT(DISTINCT CAST(created_at AS DATE)) as days_count,
+                    SUM(COALESCE(total_tokens, 0)) as total_tokens,
+                    SUM(COALESCE(total_tokens, 0)) / COUNT(DISTINCT CAST(created_at AS DATE)) as avg_tokens,
+                    SUM(COALESCE(request_count, 0)) as total_requests,
+                    SUM(COALESCE(total_input_tokens, 0)) as total_input_tokens,
+                    SUM(COALESCE(total_output_tokens, 0)) as total_output_tokens,
+                    MIN(CAST(created_at AS DATE)) as first_date,
+                    MAX(CAST(created_at AS DATE)) as last_date
+                FROM agent_sessions
+                WHERE workspace_type IN ('local', 'remote', 'terminal')
+                GROUP BY COALESCE(tool_name, 'unknown')
+                ORDER BY tool_name
+            """
+            session_per_host_results = self.db.fetch_all(session_per_host_query, ())
+            session_global_results = self.db.fetch_all(session_global_query, ())
+
+            return self._merge_aggregates(
+                per_host_results + global_results
+                + session_per_host_results + session_global_results
+            )
 
     def _merge_aggregates(self, rows: list[dict]) -> list[dict]:
         merged: dict[tuple, dict] = {}
@@ -143,7 +209,7 @@ class SummaryService:
             key = (tool, host)
             if key in merged:
                 existing = merged[key]
-                existing["days_count"] = max(existing["days_count"], row["days_count"] or 0)
+                existing["days_count"] += row["days_count"] or 0
                 existing["total_tokens"] += row["total_tokens"] or 0
                 existing["total_requests"] += row["total_requests"] or 0
                 existing["total_input_tokens"] += row["total_input_tokens"] or 0

--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -197,8 +197,10 @@ class SummaryService:
             session_global_results = self.db.fetch_all(session_global_query, ())
 
             return self._merge_aggregates(
-                per_host_results + global_results
-                + session_per_host_results + session_global_results
+                per_host_results
+                + global_results
+                + session_per_host_results
+                + session_global_results
             )
 
     def _merge_aggregates(self, rows: list[dict]) -> list[dict]:

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -101,21 +101,67 @@ class UsageService:
         end_date: str | None = None,
         tenant_id: int | None = None,
     ) -> dict[str, dict]:
-        """
-        Get usage summary for all tools.
+        """Get usage summary for all tools, merging daily_messages and agent_sessions.
+
+        Issue #2938: /api/summary previously only queried daily_messages, missing
+        local WebUI session data. Now merges daily_messages (CLI fetch scripts,
+        excluding session_sync dual-write) with agent_sessions (WebUI local/remote/
+        terminal sessions).
 
         Args:
             host_name: Optional host name filter.
+            start_date: Optional start date filter.
+            end_date: Optional end date filter.
+            tenant_id: Optional tenant ID filter.
 
         Returns:
             Dict[str, Dict]: Summary data keyed by tool name.
         """
-        return self.usage_repo.get_summary_by_tool(
+        dm_summary = self.usage_repo.get_summary_by_tool(
             host_name=host_name,
             start_date=start_date,
             end_date=end_date,
             tenant_id=tenant_id,
         )
+
+        session_summary = self.usage_repo.get_session_summary_by_tool(
+            start_date=start_date,
+            end_date=end_date,
+            host_name=host_name,
+            tenant_id=tenant_id,
+        )
+
+        merged: dict[str, dict] = {}
+        for source in (dm_summary, session_summary):
+            for tool, data in source.items():
+                if tool not in merged:
+                    merged[tool] = {
+                        "days_count": 0,
+                        "total_tokens": 0,
+                        "avg_tokens": 0,
+                        "total_requests": 0,
+                        "total_input_tokens": 0,
+                        "total_output_tokens": 0,
+                        "first_date": None,
+                        "last_date": None,
+                    }
+                m = merged[tool]
+                m["total_tokens"] += data["total_tokens"] or 0
+                m["total_requests"] += data["total_requests"] or 0
+                m["total_input_tokens"] += data["total_input_tokens"] or 0
+                m["total_output_tokens"] += data["total_output_tokens"] or 0
+                m["days_count"] += data["days_count"] or 0
+                if data.get("first_date"):
+                    if not m["first_date"] or data["first_date"] < m["first_date"]:
+                        m["first_date"] = data["first_date"]
+                if data.get("last_date"):
+                    if not m["last_date"] or data["last_date"] > m["last_date"]:
+                        m["last_date"] = data["last_date"]
+
+        for m in merged.values():
+            m["avg_tokens"] = round(m["total_tokens"] / max(m["days_count"], 1), 2)
+
+        return merged
 
     @cached(ttl=60, key_prefix="usage", skip_args=[0])
     def get_tool_usage(

--- a/tests/unit/test_issue_2938_summary_webui_sessions.py
+++ b/tests/unit/test_issue_2938_summary_webui_sessions.py
@@ -1,0 +1,509 @@
+"""Tests for Issue #2938: /api/summary missing WebUI session data.
+
+Verifies that:
+1. get_summary_by_tool() excludes session_sync dual-write records (agent_session_id IS NOT NULL)
+2. get_summary_by_tool() uses COUNT(CASE WHEN role='assistant') instead of COUNT(*)
+3. get_session_summary_by_tool() queries agent_sessions with workspace_type IN ('local','remote','terminal')
+4. get_usage_summary() merges both sources correctly with proper avg_tokens recalculation
+5. summary_service._calculate_aggregates() includes agent_sessions data
+6. Edge cases: empty data, host_name filter, tenant_id filter, date filters
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.repositories.usage_repo import UsageRepository
+from app.services.summary_service import SummaryService
+from app.services.usage_service import UsageService
+from app.utils.cache import get_cache
+
+
+def _make_repo(db):
+    repo = UsageRepository()
+    repo.db = db
+    return repo
+
+
+class TestGetSummaryByToolExclusion:
+    """Test that get_summary_by_tool excludes session_sync dual-write records."""
+
+    def test_sql_excludes_agent_session_id(self):
+        """The daily_messages query must filter out records with agent_session_id."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_summary_by_tool()
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "agent_session_id IS NULL" in sql
+        assert "agent_session_id = ''" in sql
+
+    def test_sql_uses_assistant_count(self):
+        """total_requests must use COUNT(CASE WHEN role='assistant') not COUNT(*)."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_summary_by_tool()
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "CASE WHEN role = 'assistant'" in sql
+        assert "COUNT(*)" not in sql
+
+    @pytest.mark.regression
+    @pytest.mark.issue(2938)
+    def test_exclusion_with_host_name(self):
+        """Exclusion filter works alongside host_name filter."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_summary_by_tool(host_name="my-host")
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "agent_session_id IS NULL" in sql
+        assert "host_name = ?" in sql
+        assert "my-host" in params
+
+
+class TestGetSessionSummaryByTool:
+    """Test the new get_session_summary_by_tool method."""
+
+    def test_queries_agent_sessions_table(self):
+        """Must query agent_sessions, not daily_messages."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_summary_by_tool()
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "FROM agent_sessions" in sql
+        assert "daily_messages" not in sql
+
+    def test_filters_workspace_type(self):
+        """Must filter to workspace_type IN ('local', 'remote', 'terminal')."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_summary_by_tool()
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
+
+    def test_returns_empty_on_exception(self):
+        """Should return empty dict on error, not raise."""
+        db = MagicMock()
+        db.fetch_all.side_effect = Exception("DB error")
+        repo = _make_repo(db)
+
+        result = repo.get_session_summary_by_tool()
+        assert result == {}
+
+    def test_normalizes_tool_name(self):
+        """Results should be keyed by normalized tool name."""
+        db = MagicMock()
+        db.fetch_all.return_value = [
+            {
+                "tool_name": "qwen-code",
+                "days_count": 3,
+                "total_tokens": 5000,
+                "total_requests": 15,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 1000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-03",
+            }
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_summary_by_tool()
+
+        assert "qwen" in result  # normalize_tool_name("qwen-code") -> "qwen"
+        assert result["qwen"]["total_tokens"] == 5000
+
+    def test_merges_duplicate_tool_names(self):
+        """Multiple rows with different tool_name variants should merge after normalization."""
+        db = MagicMock()
+        db.fetch_all.return_value = [
+            {
+                "tool_name": "qwen-code",
+                "days_count": 2,
+                "total_tokens": 1000,
+                "total_requests": 5,
+                "total_input_tokens": 800,
+                "total_output_tokens": 200,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-02",
+            },
+            {
+                "tool_name": "qwen-code-cli",
+                "days_count": 3,
+                "total_tokens": 2000,
+                "total_requests": 10,
+                "total_input_tokens": 1500,
+                "total_output_tokens": 500,
+                "first_date": "2026-08-02",
+                "last_date": "2026-08-04",
+            },
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_summary_by_tool()
+
+        # Both normalize to "qwen"
+        assert "qwen" in result
+        assert result["qwen"]["total_tokens"] == 3000
+        assert result["qwen"]["total_requests"] == 15
+        assert result["qwen"]["first_date"] == "2026-08-01"
+        assert result["qwen"]["last_date"] == "2026-08-04"
+
+    def test_date_filters_applied(self):
+        """start_date and end_date should be applied to CAST(created_at AS DATE)."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_summary_by_tool(start_date="2026-08-01", end_date="2026-08-31")
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "CAST(created_at AS DATE) >= ?" in sql
+        assert "CAST(created_at AS DATE) <= ?" in sql
+        assert "2026-08-01" in params
+        assert "2026-08-31" in params
+
+    def test_host_name_filter_applied(self):
+        """host_name should be applied as a filter."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_summary_by_tool(host_name="my-host")
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "host_name = ?" in sql
+        assert "my-host" in params
+
+    def test_tenant_id_filter_applied(self):
+        """tenant_id should be applied as a filter."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_summary_by_tool(tenant_id=42)
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "tenant_id = ?" in sql
+        assert 42 in params
+
+
+class TestGetUsageSummaryMerge:
+    """Test that get_usage_summary merges both data sources."""
+
+    def _make_service(self):
+        mock_repo = MagicMock()
+        svc = UsageService(usage_repo=mock_repo)
+        return svc, mock_repo
+
+    def setup_method(self):
+        get_cache().clear()
+
+    def test_merges_dm_and_session_data(self):
+        """Summary should include tools from both daily_messages and agent_sessions."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {
+            "claude": {
+                "days_count": 5,
+                "total_tokens": 10000,
+                "avg_tokens": 2000,
+                "total_requests": 50,
+                "total_input_tokens": 8000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-05",
+            }
+        }
+        mock_repo.get_session_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 3,
+                "total_tokens": 6000,
+                "total_requests": 20,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-03",
+                "last_date": "2026-08-05",
+            }
+        }
+
+        result = svc.get_usage_summary()
+
+        assert "claude" in result
+        assert "qwen" in result
+        assert result["claude"]["total_tokens"] == 10000
+        assert result["qwen"]["total_tokens"] == 6000
+
+    def test_merges_same_tool_from_both_sources(self):
+        """When the same tool appears in both sources, values should be summed."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 5,
+                "total_tokens": 10000,
+                "avg_tokens": 2000,
+                "total_requests": 50,
+                "total_input_tokens": 8000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-05",
+            }
+        }
+        mock_repo.get_session_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 3,
+                "total_tokens": 6000,
+                "total_requests": 20,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-03",
+                "last_date": "2026-08-07",
+            }
+        }
+
+        result = svc.get_usage_summary()
+
+        assert result["qwen"]["total_tokens"] == 16000
+        assert result["qwen"]["total_requests"] == 70
+        assert result["qwen"]["total_input_tokens"] == 12000
+        assert result["qwen"]["total_output_tokens"] == 4000
+        assert result["qwen"]["days_count"] == 8  # 5 + 3
+        assert result["qwen"]["first_date"] == "2026-08-01"
+        assert result["qwen"]["last_date"] == "2026-08-07"
+
+    def test_avg_tokens_recalculated_after_merge(self):
+        """avg_tokens should be total_tokens / days_count, not max of sources."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 5,
+                "total_tokens": 10000,
+                "avg_tokens": 2000,
+                "total_requests": 50,
+                "total_input_tokens": 8000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-05",
+            }
+        }
+        mock_repo.get_session_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 3,
+                "total_tokens": 6000,
+                "total_requests": 20,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-03",
+                "last_date": "2026-08-07",
+            }
+        }
+
+        result = svc.get_usage_summary()
+
+        # avg = 16000 / 8 = 2000.0
+        assert result["qwen"]["avg_tokens"] == 2000.0
+
+    def test_empty_both_sources(self):
+        """When both sources return empty, result should be empty dict."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {}
+        mock_repo.get_session_summary_by_tool.return_value = {}
+
+        result = svc.get_usage_summary()
+        assert result == {}
+
+    def test_only_dm_data(self):
+        """When agent_sessions has no data, result should be dm data only."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 5,
+                "total_tokens": 10000,
+                "avg_tokens": 2000,
+                "total_requests": 50,
+                "total_input_tokens": 8000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-05",
+            }
+        }
+        mock_repo.get_session_summary_by_tool.return_value = {}
+
+        result = svc.get_usage_summary()
+
+        assert "qwen" in result
+        assert result["qwen"]["total_tokens"] == 10000
+        assert result["qwen"]["days_count"] == 5
+
+    def test_only_session_data(self):
+        """When daily_messages has no data, result should be session data only."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {}
+        mock_repo.get_session_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 3,
+                "total_tokens": 6000,
+                "total_requests": 20,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-03",
+                "last_date": "2026-08-05",
+            }
+        }
+
+        result = svc.get_usage_summary()
+
+        assert "qwen" in result
+        assert result["qwen"]["total_tokens"] == 6000
+        assert result["qwen"]["days_count"] == 3
+
+    def test_passes_filters_to_both_repos(self):
+        """All filter parameters should be passed to both repo methods."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_summary_by_tool.return_value = {}
+        mock_repo.get_session_summary_by_tool.return_value = {}
+
+        svc.get_usage_summary(
+            host_name="my-host",
+            start_date="2026-08-01",
+            end_date="2026-08-31",
+            tenant_id=42,
+        )
+
+        mock_repo.get_summary_by_tool.assert_called_once_with(
+            host_name="my-host",
+            start_date="2026-08-01",
+            end_date="2026-08-31",
+            tenant_id=42,
+        )
+        mock_repo.get_session_summary_by_tool.assert_called_once_with(
+            start_date="2026-08-01",
+            end_date="2026-08-31",
+            host_name="my-host",
+            tenant_id=42,
+        )
+
+
+class TestSummaryServiceAggregatesWithSessions:
+    """Test that _calculate_aggregates includes agent_sessions data."""
+
+    def _make_service(self):
+        mock_db = MagicMock()
+        mock_repo = MagicMock()
+        svc = SummaryService(db=mock_db, usage_repo=mock_repo)
+        return svc, mock_db, mock_repo
+
+    def test_calculate_aggregates_with_host_excludes_session_sync(self):
+        """Per-host query must exclude agent_session_id records."""
+        svc, mock_db, _ = self._make_service()
+
+        # First call: daily_messages, Second call: agent_sessions
+        mock_db.fetch_all.side_effect = [
+            [],  # dm results
+            [],  # session results
+        ]
+
+        svc._calculate_aggregates(host_name="my-host")
+
+        # First call should be daily_messages with exclusion
+        dm_sql = mock_db.fetch_all.call_args_list[0][0][0]
+        assert "FROM daily_messages" in dm_sql
+        assert "agent_session_id IS NULL" in dm_sql
+
+    def test_calculate_aggregates_with_host_includes_agent_sessions(self):
+        """Per-host path must also query agent_sessions."""
+        svc, mock_db, _ = self._make_service()
+
+        mock_db.fetch_all.side_effect = [
+            [],  # dm results
+            [],  # session results
+        ]
+
+        svc._calculate_aggregates(host_name="my-host")
+
+        # Second call should be agent_sessions
+        session_sql = mock_db.fetch_all.call_args_list[1][0][0]
+        assert "FROM agent_sessions" in session_sql
+        assert "workspace_type IN ('local', 'remote', 'terminal')" in session_sql
+
+    def test_calculate_aggregates_no_host_excludes_session_sync(self):
+        """Global per-host and global queries must exclude agent_session_id records."""
+        svc, mock_db, _ = self._make_service()
+
+        # 4 calls: dm per_host, dm global, session per_host, session global
+        mock_db.fetch_all.side_effect = [[], [], [], []]
+
+        svc._calculate_aggregates()
+
+        # All daily_messages queries should have exclusion
+        for i in range(2):
+            sql = mock_db.fetch_all.call_args_list[i][0][0]
+            assert "FROM daily_messages" in sql
+            assert "agent_session_id IS NULL" in sql
+
+    def test_calculate_aggregates_no_host_includes_agent_sessions(self):
+        """Global path must also query agent_sessions (per-host and global)."""
+        svc, mock_db, _ = self._make_service()
+
+        mock_db.fetch_all.side_effect = [[], [], [], []]
+
+        svc._calculate_aggregates()
+
+        # Calls 2 and 3 should be agent_sessions
+        for i in range(2, 4):
+            sql = mock_db.fetch_all.call_args_list[i][0][0]
+            assert "FROM agent_sessions" in sql
+            assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
+
+    def test_merge_aggregates_sums_days_count(self):
+        """_merge_aggregates should sum days_count, not max."""
+        svc, _, _ = self._make_service()
+
+        rows = [
+            {
+                "tool_name": "qwen-code",
+                "host_name": "h1",
+                "days_count": 5,
+                "total_tokens": 10000,
+                "avg_tokens": 2000,
+                "total_requests": 50,
+                "total_input_tokens": 8000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-01",
+                "last_date": "2026-08-05",
+            },
+            {
+                "tool_name": "qwen-code",
+                "host_name": "h1",
+                "days_count": 3,
+                "total_tokens": 6000,
+                "avg_tokens": 2000,
+                "total_requests": 20,
+                "total_input_tokens": 4000,
+                "total_output_tokens": 2000,
+                "first_date": "2026-08-03",
+                "last_date": "2026-08-07",
+            },
+        ]
+
+        result = svc._merge_aggregates(rows)
+
+        assert len(result) == 1
+        assert result[0]["days_count"] == 8  # 5 + 3, not max(5, 3)
+        assert result[0]["total_tokens"] == 16000
+        assert result[0]["avg_tokens"] == 16000 // 8  # 2000

--- a/tests/unit/test_usage_service.py
+++ b/tests/unit/test_usage_service.py
@@ -75,7 +75,19 @@ class TestUsageService:
 
     def test_get_usage_summary(self):
         svc, mock_repo = self._make_service()
-        mock_repo.get_summary_by_tool.return_value = {"qwen": {"total": 1000}}
+        mock_repo.get_summary_by_tool.return_value = {
+            "qwen": {
+                "days_count": 5,
+                "total_tokens": 1000,
+                "avg_tokens": 200,
+                "total_requests": 10,
+                "total_input_tokens": 800,
+                "total_output_tokens": 200,
+                "first_date": "2026-01-01",
+                "last_date": "2026-01-05",
+            }
+        }
+        mock_repo.get_session_summary_by_tool.return_value = {}
         result = svc.get_usage_summary()
         assert "qwen" in result
 


### PR DESCRIPTION
## 修复内容

Issue #2938: Dashboard `/api/summary` 缺失 WebUI 会话数据

### 问题根因

`/api/summary` 仅查询 `daily_messages` 表，但 WebUI 创建的 local/remote/terminal 会话只写入 `agent_sessions`，不写 `daily_messages`。仅 `session_sync`（Remote CLI）双写两表。导致 `/api/summary` 低估用量，与 `/api/today` 显示不一致。

### 修复方案（方案2，经双Agent评审通过）

1. **`get_summary_by_tool()`** — 排除 `agent_session_id IS NOT NULL` 的双写记录，`COUNT(*)` 改为 `COUNT(CASE WHEN role='assistant')` 与 `summary_service` 口径一致
2. **新增 `get_session_summary_by_tool()`** — 查询 `agent_sessions` 中 `workspace_type IN ('local','remote','terminal')` 的会话数据
3. **`get_usage_summary()`** — 合并 `daily_messages` 和 `agent_sessions` 两个数据源，`avg_tokens` 按合并后总量重新计算
4. **`summary_service._calculate_aggregates()`** — 同步排除双写记录并补充 `agent_sessions` 聚合（per-host 和 global）
5. **`_merge_aggregates()`** — `days_count` 从 `max` 改为累加

### 去重保证

- `daily_messages` 排除有 `agent_session_id` 的记录后，剩余的是 CLI fetch 脚本数据
- `agent_sessions` 查询覆盖所有 workspace_type，包含 session_sync 的会话
- 两者无重叠

### 测试

- 23 个新增单元测试覆盖：SQL 排除逻辑、workspace_type 过滤、合并逻辑、avg_tokens 重算、边界条件、host_name/tenant_id 过滤、异常处理
- 既有测试无回归