### PR TITLE
fix: anchor pytest count parsing to footer summary line (#2735)

### DIFF
--- a/app/modules/workspace/autonomous/command_evidence/test_evidence.py
+++ b/app/modules/workspace/autonomous/command_evidence/test_evidence.py
@@ -188,6 +188,33 @@ _ERRORS_PATTERNS = [
     re.compile(r"errors?[:：\s]+(\d+)", re.IGNORECASE),
 ]
 
+# pytest footer summary line recognition (#2735). pytest's authoritative counts
+# only ever appear on a standalone line wrapped in `=` and ending in
+# `in <sec>s` — e.g. `=== 1 failed, 6 passed, 2 skipped in 2.10s ===`. Nested
+# backend errors inside SKIPPED reasons (e.g. `port 5432 failed: FATAL ...`)
+# never sit on such a line, so anchoring count extraction to the footer removes
+# the ambiguity of reading a port/line number embedded in natural-language
+# error text as a test count. Language-agnostic: it keys on line structure
+# (`=` delimiters + `in Xs`), not on any pass/fail token.
+_PYTEST_FOOTER_LINE_RE = re.compile(r"^\s*=+\s*(.+?)\s*=+\s*$", re.MULTILINE)
+_PYTEST_FOOTER_IN_SEC_RE = re.compile(r"\bin\s+[\d.]+s\b")
+
+
+def _count_target(excerpt: str) -> str:
+    """Return the footer-summary lines, else the whole excerpt.
+
+    Anchors counting to pytest's authoritative summary line (#2735). For
+    simplified single-line callers that omit the `=` delimiters (and
+    header/footer echo cases), fall back to the full excerpt to stay
+    conservative.
+    """
+    footers = [
+        m.group(1)
+        for m in _PYTEST_FOOTER_LINE_RE.finditer(excerpt)
+        if _PYTEST_FOOTER_IN_SEC_RE.search(m.group(1))
+    ]
+    return "\n".join(footers) if footers else excerpt
+
 
 def _extract_count(excerpt: str, patterns: list[re.Pattern[str]]) -> int | None:
     """Return the strongest count any pattern matched, or None.
@@ -239,10 +266,11 @@ def _verdict_from_counts(
 
 def _parse_pytest(excerpt: str, exit_code: int | None, command_text: str) -> ParsedTestResult:
     """Parse pytest (and unittest) output into structured counts + scope."""
-    passed = _extract_count(excerpt, _PASSED_PATTERNS)
-    failed = _extract_count(excerpt, _FAILED_PATTERNS)
-    skipped = _extract_count(excerpt, _SKIPPED_PATTERNS)
-    errors = _extract_count(excerpt, _ERRORS_PATTERNS)
+    target = _count_target(excerpt)
+    passed = _extract_count(target, _PASSED_PATTERNS)
+    failed = _extract_count(target, _FAILED_PATTERNS)
+    skipped = _extract_count(target, _SKIPPED_PATTERNS)
+    errors = _extract_count(target, _ERRORS_PATTERNS)
 
     # unittest "OK (N tests)" / "FAILED (failures=N)" have no "passed" token;
     # synthesize a pass count so a clean unittest run is not stuck inconclusive.

--- a/tests/unit/test_test_evidence_parser.py
+++ b/tests/unit/test_test_evidence_parser.py
@@ -95,6 +95,63 @@ def test_pytest_parser_clean_exit_without_summary_is_medium_pass():
     assert te.parser_confidence == ParserConfidence.MEDIUM.value
 
 
+# ── pytest footer anchoring (#2735) ───────────────────────────────────────────
+
+
+def test_pytest_skipped_nested_db_error_not_failed():
+    # A skipped test's reason embeds a real backend connect error
+    # ("port 5432 failed: FATAL ..."). Without footer anchoring the pending
+    # "5432 failed" match is misread as a failure count (#2735).
+    excerpt = (
+        "tests/integration/test_multiuser_qwen_collection_2735.py::TestSessionDataPersistence::"
+        "test_daily_usage_persistence SKIPPED (connection to server\n"
+        'at "localhost" (::1), port 5432 failed: FATAL:  role "openace-agent"\n'
+        "does not exist)\n"
+        "============================ 6 skipped in 0.15s ============================"
+    )
+    te = parse_test_evidence(_ce("c1", "python -m pytest", 0, excerpt), "python")
+    assert te.failed is None
+    assert te.passed is None
+    assert te.skipped == 6
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.MEDIUM.value
+
+
+def test_pytest_mixed_passed_skipped_footer_high():
+    # Footer still governs: a real passed count wins, the nested error is ignored.
+    excerpt = (
+        "some node output\n"
+        'port 5432 failed: FATAL:  role "openace-agent" does not exist\n'
+        "================ 5 passed, 3 skipped in 2.10s ================"
+    )
+    te = parse_test_evidence(_ce("c1", "python -m pytest", 0, excerpt), "python")
+    assert te.passed == 5
+    assert te.failed is None
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_pytest_real_failure_footer_still_failed():
+    # Regression guard: anchoring must NOT swallow a real failure.
+    excerpt = "=========== 1 failed, 6 passed, 2 skipped in 2.10s ============="
+    te = parse_test_evidence(_ce("c1", "python -m pytest", 1, excerpt), "python")
+    assert te.failed == 1
+    assert te.passed == 6
+    assert te.verdict == ExecutionVerdict.FAILED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_cargo_failure_parse_unchanged():
+    # Pin cargo's current behavior (unchanged by this fix). cargo's `passed`
+    # only matches "test result: ok. N passed"; a FAILED run has no `ok.` so
+    # `passed` stays None rather than 0.
+    excerpt = "test result: FAILED. 1 failed; 0 passed; 0 ignored"
+    te = parse_test_evidence(_ce("c1", "cargo test", 1, excerpt), "rust")
+    assert te.verdict == ExecutionVerdict.FAILED.value
+    assert te.failed == 1
+    assert te.passed is None
+
+
 # ── jest / go / cargo ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 背景
issue #2735 工作流 dev agent 测试轮连续 3 次失败/无法解析。根因是 pytest 测试解析器把 SKIPPED 测试原因中嵌套的后端连接错误 `port 5432 failed: FATAL ...` 里的端口号误读为失败计数。

## 根因
`_parse_pytest` 用 `_FAILED_PATTERNS[0]` = `\b(\d+)\s+failed\b` 对**整个 output_excerpt** 做泛匹配提取计数。`5432 failed` 命中该正则 → `failed=5432` → 判定 FAILED(HIGH)。实际测试全部 PASSED/SKIPPED、`exit_code=0`，无任何真实失败。

## 修复
新增 pytest footer summary 行锚定：计数只从 `= ... in <sec>s =` 包裹的权威统计行提取（嵌套错误绝不在该行上），找不到 footer 时回退全文以兼容单行输入。

- 语言无关：识别行结构（`=` 分隔 + `in Xs`），非依赖 pass/fail token，覆盖 EN/ZH/JA/KO。
- `_extract_count`、`_verdict_from_counts`、go/jest/cargo/generic 解析器均不改。
- 方案文档：`docs/superpowers/plans/2026-08-21-pytest-skipped-nested-error-false-failed.md`

## 测试
`test_test_evidence_parser.py` 新增 4 个契约测试：
1. skipped-嵌套错误 → PASSED(MEDIUM)
2. 混合 passed+skipped footer + 嵌套错误 → PASSED(HIGH)
3. 真实失败 footer → FAILED(HIGH)（防回归锚定不吞真实失败）
4. cargo 行为钉桩（本次不改）

`pytest tests/unit/test_test_evidence_parser.py tests/unit/test_test_verdict.py` → 40 passed。mypy/black/isort/ruff 全绿。