### PR TITLE
fix: 修复 patch-qwen-webui-local-permission.py 模式不匹配 (#2936)

### DIFF
--- a/scripts/patch-qwen-webui-local-permission.py
+++ b/scripts/patch-qwen-webui-local-permission.py
@@ -31,29 +31,37 @@ INDEX_HTML = "/usr/lib/node_modules/qwen-code-webui/dist/static/index.html"
 CACHE_BUST = "v=local-perm-20260818"
 
 # Exact minified fragments for processStreamLine function (verified against qwen-code-webui@0.2.40).
-# Original: only handles claude_json, error, aborted
+# Original: handles claude_json, permission_request, error, aborted, heartbeat
+# Note: Uses M.useCallback, n (parsed JSON), u (callback function) in actual bundle
 OLD_PROCESS = (
-    "processStreamLine:(0,_.useCallback)((e,t)=>{try{let r=JSON.parse(e);"
-    "if(r.type===`claude_json`&&r.data){let e=r.data;n(e,t)}"
-    "else if(r.type===`error`){let e={type:`error`,subtype:`stream_error`,message:r.error||`Unknown error`,timestamp:Date.now()};t.addMessage(e)}"
-    "else if(r.type===`aborted`){let e={type:`system`,subtype:`abort`,message:`Operation was aborted by user`,timestamp:Date.now()};t.addMessage(e),t.setCurrentAssistantMessage(null)}}"
-    "catch(e){console.error(`Failed to parse stream line:`,e)}},[n])"
+    "processStreamLine:(0,M.useCallback)((e,t)=>{try{let n=JSON.parse(e);"
+    "if(n.type===`claude_json`&&n.data){let e=n.data;u(e,t),t.onPermissionOrphanCleanup&&t.onPermissionOrphanCleanup()}"
+    "else if(n.type===`permission_request`){if(t.onPermissionRequest){if(!n.permissionId||!n.toolName){console.warn(`Invalid permission_request: missing permissionId or toolName`);return}"
+    "t.onPermissionRequest({permissionId:n.permissionId,toolName:n.toolName,toolInput:n.toolInput||{},suggestions:n.suggestions||[],autoApproveMs:n.autoApproveMs,confirmationType:n.confirmationType,questions:n.questions})}}"
+    "else if(n.type===`error`){let e={type:`error`,subtype:`stream_error`,message:n.error||`Unknown error`,timestamp:Date.now()};t.addMessage(e),t.onStreamError?.(n.error||`Unknown error`)}"
+    "else if(n.type===`aborted`){let e={type:`system`,subtype:`abort`,message:`Operation was aborted by user`,timestamp:Date.now()};t.addMessage(e),t.setCurrentAssistantMessage(null)}"
+    "else n.type===`heartbeat`&&console.debug(`[Keepalive] Heartbeat received at`,new Date().toISOString())}"
+    "catch(e){console.error(`Failed to parse stream line:`,e)}},[u])"
 )
 
 # New: adds control_request handling before the catch block
+# control_request format: {"type":"control_request","request_id":"...","request":{"subtype":"can_use_tool",...}}
+# Uses onPermissionRequest (not onPermissionError) which exists in the actual bundle
 NEW_PROCESS = (
-    "processStreamLine:(0,_.useCallback)((e,t)=>{try{let r=JSON.parse(e);"
-    "if(r.type===`claude_json`&&r.data){let e=r.data;n(e,t)}"
-    "else if(r.type===`error`){let e={type:`error`,subtype:`stream_error`,message:r.error||`Unknown error`,timestamp:Date.now()};t.addMessage(e)}"
-    "else if(r.type===`aborted`){let e={type:`system`,subtype:`abort`,message:`Operation was aborted by user`,timestamp:Date.now()};t.addMessage(e),t.setCurrentAssistantMessage(null)}"
-    "else if(r.type===`control_request`&&r.request&&t.onPermissionError){"
-    "let e=r.request,n=r.request_id||``;"
+    "processStreamLine:(0,M.useCallback)((e,t)=>{try{let n=JSON.parse(e);"
+    "if(n.type===`claude_json`&&n.data){let e=n.data;u(e,t),t.onPermissionOrphanCleanup&&t.onPermissionOrphanCleanup()}"
+    "else if(n.type===`permission_request`){if(t.onPermissionRequest){if(!n.permissionId||!n.toolName){console.warn(`Invalid permission_request: missing permissionId or toolName`);return}"
+    "t.onPermissionRequest({permissionId:n.permissionId,toolName:n.toolName,toolInput:n.toolInput||{},suggestions:n.suggestions||[],autoApproveMs:n.autoApproveMs,confirmationType:n.confirmationType,questions:n.questions})}}"
+    "else if(n.type===`control_request`&&n.request&&t.onPermissionRequest){"
+    "let e=n.request,r=n.request_id||``;"
     "if(e.subtype===`can_use_tool`&&e.tool_name){"
-    "t.onPermissionError(e.tool_name,e.permission_suggestions?.map(s=>s.rule)||[],e.tool_use_id||``,n)"
+    "t.onPermissionRequest({permissionId:r,toolName:e.tool_name,toolInput:e.tool_input||{},suggestions:e.permission_suggestions||[],autoApproveMs:e.auto_approve_ms,confirmationType:e.confirmation_type,questions:e.questions||[]})"
     "}"
     "}"
-    "}"
-    "catch(e){console.error(`Failed to parse stream line:`,e)}},[n])"
+    "else if(n.type===`error`){let e={type:`error`,subtype:`stream_error`,message:n.error||`Unknown error`,timestamp:Date.now()};t.addMessage(e),t.onStreamError?.(n.error||`Unknown error`)}"
+    "else if(n.type===`aborted`){let e={type:`system`,subtype:`abort`,message:`Operation was aborted by user`,timestamp:Date.now()};t.addMessage(e),t.setCurrentAssistantMessage(null)}"
+    "else n.type===`heartbeat`&&console.debug(`[Keepalive] Heartbeat received at`,new Date().toISOString())}"
+    "catch(e){console.error(`Failed to parse stream line:`,e)}},[u])"
 )
 
 

--- a/scripts/patch-qwen-webui-local-permission.py
+++ b/scripts/patch-qwen-webui-local-permission.py
@@ -79,7 +79,7 @@ def main() -> int:
             file=sys.stderr,
         )
         # Already patched (NEW_PROCESS present) counts as success; drift fails.
-        if "else if(r.type===`control_request`" in data:
+        if "else if(n.type===`control_request`" in data:
             print(
                 "[patch-qwen-webui-local-permission] bundle already patched, skipping",
                 file=sys.stderr,


### PR DESCRIPTION
Closes #2936

## 修复内容

- 更新 `OLD_PROCESS` 模式匹配 `qwen-code-webui@0.2.40` 实际 bundle 代码结构
- 修正变量名：`M.useCallback`, `n`, `u`
- 包含所有消息类型：`permission_request`, `heartbeat`
- 保留额外回调逻辑：`onPermissionOrphanCleanup`, `onStreamError`
- **关键修正**：`control_request` 处理使用 `onPermissionRequest` 回调（而非 `onPermissionError`）

## 问题分析

Docker 构建失败，原因是脚本中硬编码的 `OLD_PROCESS` 模式与实际 bundle 不匹配：
- 变量名差异：`_.useCallback` → `M.useCallback`，`r` → `n`
- 消息类型缺失：原脚本只处理 3 种类型，实际 bundle 有 5 种
- 回调错误：原脚本使用 `onPermissionError`（不存在），应使用 `onPermissionRequest`

## 修复方案

详见 Issue #2936 中的方案讨论。

## 测试

- ✅ 模式匹配：唯一匹配实际 bundle
- ✅ 功能验证：`control_request` 处理已正确添加
- ✅ 字段映射：与 `permission_request` 格式一致