### PR TITLE
fix: restore OAuth form autofill prevention lost during PR #2933 rebase

### DIFF
--- a/frontend/src/components/features/settings/SSOSettings.test.tsx
+++ b/frontend/src/components/features/settings/SSOSettings.test.tsx
@@ -1,10 +1,11 @@
 /**
- * SSOSettings Component Tests - Accessibility
+ * SSOSettings Component Tests - Accessibility & Autofill Prevention
  *
  * Tests cover:
  * - aria-describedby attributes
  * - Visually hidden description elements
  * - Checkbox state and keyboard interaction
+ * - Issue #2895: OAuth form autofill prevention (name/autoComplete attributes)
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -61,6 +62,22 @@ vi.mock('@/i18n', () => ({
       tableActions: 'Actions',
       enabled: 'Enabled',
       disabled: 'Disabled',
+      // Issue #2895: SSO Provider registration form
+      registerProvider: 'Register Provider',
+      selectProvider: 'Select Provider',
+      providerType: 'Provider Type',
+      clientId: 'Client ID',
+      clientSecret: 'Client Secret',
+      clientSecretConfirm: 'Confirm Client Secret',
+      redirectUri: 'Redirect URI',
+      scope: 'Scope',
+      enterClientId: 'Enter Client ID',
+      enterClientSecret: 'Enter Client Secret',
+      enterClientSecretConfirm: 'Confirm Client Secret',
+      enterRedirectUri: 'Enter Redirect URI',
+      enterProviderName: 'Enter Provider Name',
+      register: 'Register',
+      cancel: 'Cancel',
     };
     return translations[key] || key;
   },
@@ -103,6 +120,7 @@ vi.mock('@/components/common', () => ({
     children,
     onClick,
     type,
+    form,
     loading,
     disabled,
     variant,
@@ -111,6 +129,7 @@ vi.mock('@/components/common', () => ({
     children: React.ReactNode;
     onClick?: () => void;
     type?: string;
+    form?: string;
     loading?: boolean;
     disabled?: boolean;
     variant?: string;
@@ -118,6 +137,7 @@ vi.mock('@/components/common', () => ({
   }) => (
     <button
       type={type || 'button'}
+      form={form}
       onClick={onClick}
       disabled={disabled || loading}
       className={`btn btn-${variant || 'primary'} ${size ? `btn-${size}` : ''}`}
@@ -138,11 +158,13 @@ vi.mock('@/components/common', () => ({
     onClose,
     title,
     children,
+    footer,
   }: {
     isOpen: boolean;
     onClose: () => void;
     title: string;
     children: React.ReactNode;
+    footer?: React.ReactNode;
   }) =>
     isOpen ? (
       <div className="modal">
@@ -151,6 +173,7 @@ vi.mock('@/components/common', () => ({
           <button onClick={onClose}>Close</button>
         </div>
         <div className="modal-body">{children}</div>
+        {footer && <div className="modal-footer">{footer}</div>}
       </div>
     ) : null,
   TextInput: ({
@@ -158,17 +181,26 @@ vi.mock('@/components/common', () => ({
     onChange,
     placeholder,
     type,
+    id,
+    name,
+    autoComplete,
   }: {
     value: string;
     onChange: (value: string) => void;
     placeholder?: string;
     type?: string;
+    id?: string;
+    name?: string;
+    autoComplete?: string;
   }) => (
     <input
       type={type || 'text'}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
+      id={id}
+      name={name}
+      autoComplete={autoComplete}
     />
   ),
   Select: ({
@@ -362,6 +394,81 @@ describe('SSOSettings Accessibility', () => {
         const descIndex = children.indexOf(desc!);
         expect(descIndex).toBeGreaterThan(labelIndex);
       });
+    });
+  });
+});
+
+// Issue #2895: Autofill prevention tests
+describe('SSOSettings OAuth Form Autofill Prevention (Issue #2895)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Register Provider Modal', () => {
+    it('should have form with autoComplete="off"', async () => {
+      const { container } = render(<SSOSettings />);
+
+      // Wait for component to load and click "Add Provider" button
+      await screen.findByRole('button', { name: /Add Provider/i });
+      fireEvent.click(screen.getByRole('button', { name: /Add Provider/i }));
+
+      // Find the register form
+      const form = container.querySelector('#register-provider-form');
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAttribute('autocomplete', 'off');
+    });
+
+    it('should have Client ID input with correct name and autoComplete', async () => {
+      const { container } = render(<SSOSettings />);
+
+      await screen.findByRole('button', { name: /Add Provider/i });
+      fireEvent.click(screen.getByRole('button', { name: /Add Provider/i }));
+
+      const clientIdInput = container.querySelector('#register-client-id');
+      expect(clientIdInput).toBeInTheDocument();
+      expect(clientIdInput).toHaveAttribute('name', 'oauth_provider_client_id');
+      expect(clientIdInput).toHaveAttribute('autocomplete', 'off');
+    });
+
+    it('should have Client Secret input with autoComplete="new-password"', async () => {
+      const { container } = render(<SSOSettings />);
+
+      await screen.findByRole('button', { name: /Add Provider/i });
+      fireEvent.click(screen.getByRole('button', { name: /Add Provider/i }));
+
+      const clientSecretInput = container.querySelector('#register-client-secret');
+      expect(clientSecretInput).toBeInTheDocument();
+      expect(clientSecretInput).toHaveAttribute('name', 'oauth_provider_client_secret');
+      expect(clientSecretInput).toHaveAttribute('type', 'password');
+      expect(clientSecretInput).toHaveAttribute('autocomplete', 'new-password');
+    });
+
+    it('should have Client Secret Confirm input with autoComplete="new-password"', async () => {
+      const { container } = render(<SSOSettings />);
+
+      await screen.findByRole('button', { name: /Add Provider/i });
+      fireEvent.click(screen.getByRole('button', { name: /Add Provider/i }));
+
+      const clientSecretConfirmInput = container.querySelector('#register-client-secret-confirm');
+      expect(clientSecretConfirmInput).toBeInTheDocument();
+      expect(clientSecretConfirmInput).toHaveAttribute(
+        'name',
+        'oauth_provider_client_secret_confirmation'
+      );
+      expect(clientSecretConfirmInput).toHaveAttribute('type', 'password');
+      expect(clientSecretConfirmInput).toHaveAttribute('autocomplete', 'new-password');
+    });
+
+    it('should have submit button with form attribute pointing to register form', async () => {
+      render(<SSOSettings />);
+
+      await screen.findByRole('button', { name: /Add Provider/i });
+      fireEvent.click(screen.getByRole('button', { name: /Add Provider/i }));
+
+      // Find the Register button in modal
+      const registerButton = await screen.findByRole('button', { name: /Register/i });
+      expect(registerButton).toHaveAttribute('type', 'submit');
+      expect(registerButton).toHaveAttribute('form', 'register-provider-form');
     });
   });
 });

--- a/frontend/src/components/features/settings/SSOSettings.tsx
+++ b/frontend/src/components/features/settings/SSOSettings.tsx
@@ -73,7 +73,7 @@ export const SSOSettings: React.FC = () => {
   // SSO settings state (sso_enabled is system-level, autoProvision is tenant-level)
   // Use three-state for ssoEnabled: null = loading, true/false = loaded
   const [ssoEnabled, setSsoEnabled] = useState<boolean | null>(null);
-  const [ssoLoadError, setSsoLoadError] = useState<string | null>(null);
+  const [ssoLoadError, setSsoLoadError] = useState(false);
   const [autoProvision, setAutoProvision] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const isMountedRef = useRef(true);
@@ -183,16 +183,16 @@ export const SSOSettings: React.FC = () => {
       .then(({ sso_enabled }) => {
         if (isMountedRef.current) {
           setSsoEnabled(sso_enabled);
-          setSsoLoadError(null);
+          setSsoLoadError(false);
         }
       })
       .catch((err) => {
         console.error('Failed to fetch system settings:', err);
         if (isMountedRef.current) {
-          setSsoLoadError(t('failedToLoadSSOSettings', language));
+          setSsoLoadError(true);
         }
       });
-  }, [language]);
+  }, []);
 
   // Fetch tenant settings
   useEffect(() => {
@@ -287,15 +287,22 @@ export const SSOSettings: React.FC = () => {
 
   const handlePredefinedChange = (value: string) => {
     const isPredefined = value !== '';
+    // Reset credential fields when switching providers to prevent stale values
     setFormData({
       ...formData,
       name: value,
       predefined: isPredefined,
       provider_type: value === 'okta' ? 'oidc' : 'oauth2',
+      client_id: '',
+      client_secret: '',
     });
+    setClientSecretConfirm('');
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e?: React.FormEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
     setRegisterError(null);
 
     // Validate required fields
@@ -402,7 +409,10 @@ export const SSOSettings: React.FC = () => {
   };
 
   // Update provider
-  const handleUpdateProvider = async () => {
+  const handleUpdateProvider = async (e?: React.FormEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
     setEditError(null);
 
     if (!providerDetail) {
@@ -545,7 +555,7 @@ export const SSOSettings: React.FC = () => {
               {ssoLoadError && (
                 <div className="alert alert-warning mt-2 py-1 px-2 small">
                   <i className="bi bi-exclamation-triangle me-1" />
-                  {ssoLoadError}
+                  {t('failedToLoadSSOSettings', language)}
                 </div>
               )}
               <small className="text-muted d-block mt-1">
@@ -695,153 +705,214 @@ export const SSOSettings: React.FC = () => {
             <Button variant="secondary" onClick={handleCloseModal}>
               {t('cancel', language)}
             </Button>
-            <Button variant="primary" onClick={handleSubmit} loading={isRegistering}>
+            <Button
+              variant="primary"
+              type="submit"
+              form="register-provider-form"
+              loading={isRegistering}
+            >
               {t('register', language)}
             </Button>
           </>
         }
       >
-        {/* Error message */}
-        {registerError && (
-          <div className="alert alert-danger mb-3">
-            <i className="bi bi-exclamation-circle me-2" />
-            {registerError}
-          </div>
-        )}
-        <div className="row g-3">
-          {/* Predefined Provider Selection */}
-          <div className="col-12">
-            <label className="form-label">{t('selectProvider', language)}</label>
-            <Select
-              options={PREDEFINED_PROVIDERS}
-              value={formData.predefined ? formData.name : ''}
-              onChange={handlePredefinedChange}
-            />
-          </div>
-
-          {/* Custom Provider Name */}
-          {!formData.predefined && (
-            <div className="col-md-6">
-              <label className="form-label">{t('providerName', language)} *</label>
-              <TextInput
-                value={formData.name}
-                onChange={(value: string) => setFormData({ ...formData, name: value })}
-                placeholder={t('enterProviderName', language)}
-              />
+        <form id="register-provider-form" autoComplete="off" onSubmit={handleSubmit}>
+          {/* Error message */}
+          {registerError && (
+            <div className="alert alert-danger mb-3">
+              <i className="bi bi-exclamation-circle me-2" />
+              {registerError}
             </div>
           )}
+          <div className="row g-3">
+            {/* Predefined Provider Selection */}
+            <div className="col-12">
+              <label className="form-label" htmlFor="register-provider-select">
+                {t('selectProvider', language)}
+              </label>
+              <Select
+                options={PREDEFINED_PROVIDERS}
+                value={formData.predefined ? formData.name : ''}
+                onChange={handlePredefinedChange}
+              />
+            </div>
 
-          {/* Provider Type */}
-          <div className="col-md-6">
-            <label className="form-label">{t('providerType', language)}</label>
-            <Select
-              options={[
-                { value: 'oauth2', label: 'OAuth 2.0' },
-                { value: 'oidc', label: 'OpenID Connect' },
-              ]}
-              value={formData.provider_type ?? 'oauth2'}
-              onChange={(value) =>
-                setFormData({ ...formData, provider_type: value as 'oauth2' | 'oidc' })
-              }
-            />
-          </div>
-
-          {/* Client ID */}
-          <div className="col-md-6">
-            <label className="form-label">{t('clientId', language)} *</label>
-            <TextInput
-              value={formData.client_id}
-              onChange={(value: string) => setFormData({ ...formData, client_id: value })}
-              placeholder={t('enterClientId', language)}
-            />
-          </div>
-
-          {/* Client Secret */}
-          <div className="col-md-6">
-            <label className="form-label">{t('clientSecret', language)} *</label>
-            <TextInput
-              type="password"
-              value={formData.client_secret}
-              onChange={(value: string) => setFormData({ ...formData, client_secret: value })}
-              placeholder={t('enterClientSecret', language)}
-            />
-          </div>
-
-          {/* Client Secret Confirm */}
-          <div className="col-md-6">
-            <label className="form-label">{t('clientSecretConfirm', language)} *</label>
-            <TextInput
-              type="password"
-              value={clientSecretConfirm}
-              onChange={(value: string) => setClientSecretConfirm(value)}
-              placeholder={t('enterClientSecretConfirm', language)}
-            />
-          </div>
-
-          {/* Redirect URI */}
-          <div className="col-md-6">
-            <label className="form-label">{t('redirectUri', language)}</label>
-            <TextInput
-              value={formData.redirect_uri ?? ''}
-              onChange={(value: string) => setFormData({ ...formData, redirect_uri: value })}
-              placeholder={t('enterRedirectUri', language)}
-            />
-          </div>
-
-          {/* Scope */}
-          <div className="col-md-6">
-            <label className="form-label">{t('scope', language)}</label>
-            <TextInput
-              value={formData.scope ?? ''}
-              onChange={(value: string) => setFormData({ ...formData, scope: value })}
-              placeholder="openid profile email"
-            />
-          </div>
-
-          {/* Custom Provider URLs */}
-          {!formData.predefined && (
-            <>
-              <div className="col-12">
-                <hr />
-                <h6>{t('customProviderUrls', language)}</h6>
-              </div>
+            {/* Custom Provider Name */}
+            {!formData.predefined && (
               <div className="col-md-6">
-                <label className="form-label">{t('authorizationUrl', language)}</label>
+                <label className="form-label" htmlFor="register-provider-name">
+                  {t('providerName', language)} *
+                </label>
                 <TextInput
-                  value={formData.authorization_url ?? ''}
-                  onChange={(value: string) =>
-                    setFormData({ ...formData, authorization_url: value })
-                  }
-                  placeholder="https://provider.com/oauth/authorize"
+                  id="register-provider-name"
+                  name="oauth_provider_name"
+                  autoComplete="off"
+                  value={formData.name}
+                  onChange={(value: string) => setFormData({ ...formData, name: value })}
+                  placeholder={t('enterProviderName', language)}
                 />
               </div>
-              <div className="col-md-6">
-                <label className="form-label">{t('tokenUrl', language)}</label>
-                <TextInput
-                  value={formData.token_url ?? ''}
-                  onChange={(value: string) => setFormData({ ...formData, token_url: value })}
-                  placeholder="https://provider.com/oauth/token"
-                />
-              </div>
-              <div className="col-md-6">
-                <label className="form-label">{t('userinfoUrl', language)}</label>
-                <TextInput
-                  value={formData.userinfo_url ?? ''}
-                  onChange={(value: string) => setFormData({ ...formData, userinfo_url: value })}
-                  placeholder="https://provider.com/oauth/userinfo"
-                />
-              </div>
-              <div className="col-md-6">
-                <label className="form-label">{t('issuerUrl', language)}</label>
-                <TextInput
-                  value={formData.issuer_url ?? ''}
-                  onChange={(value: string) => setFormData({ ...formData, issuer_url: value })}
-                  placeholder="https://provider.com"
-                />
-              </div>
-            </>
-          )}
-        </div>
+            )}
+
+            {/* Provider Type */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-provider-type">
+                {t('providerType', language)}
+              </label>
+              <Select
+                options={[
+                  { value: 'oauth2', label: 'OAuth 2.0' },
+                  { value: 'oidc', label: 'OpenID Connect' },
+                ]}
+                value={formData.provider_type ?? 'oauth2'}
+                onChange={(value) =>
+                  setFormData({ ...formData, provider_type: value as 'oauth2' | 'oidc' })
+                }
+              />
+            </div>
+
+            {/* Client ID */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-client-id">
+                {t('clientId', language)} *
+              </label>
+              <TextInput
+                id="register-client-id"
+                name="oauth_provider_client_id"
+                autoComplete="off"
+                value={formData.client_id}
+                onChange={(value: string) => setFormData({ ...formData, client_id: value })}
+                placeholder={t('enterClientId', language)}
+              />
+            </div>
+
+            {/* Client Secret */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-client-secret">
+                {t('clientSecret', language)} *
+              </label>
+              <TextInput
+                id="register-client-secret"
+                name="oauth_provider_client_secret"
+                type="password"
+                autoComplete="new-password"
+                value={formData.client_secret}
+                onChange={(value: string) => setFormData({ ...formData, client_secret: value })}
+                placeholder={t('enterClientSecret', language)}
+              />
+            </div>
+
+            {/* Client Secret Confirm */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-client-secret-confirm">
+                {t('clientSecretConfirm', language)} *
+              </label>
+              <TextInput
+                id="register-client-secret-confirm"
+                name="oauth_provider_client_secret_confirmation"
+                type="password"
+                autoComplete="new-password"
+                value={clientSecretConfirm}
+                onChange={(value: string) => setClientSecretConfirm(value)}
+                placeholder={t('enterClientSecretConfirm', language)}
+              />
+            </div>
+
+            {/* Redirect URI */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-redirect-uri">
+                {t('redirectUri', language)}
+              </label>
+              <TextInput
+                id="register-redirect-uri"
+                name="oauth_provider_redirect_uri"
+                autoComplete="off"
+                value={formData.redirect_uri ?? ''}
+                onChange={(value: string) => setFormData({ ...formData, redirect_uri: value })}
+                placeholder={t('enterRedirectUri', language)}
+              />
+            </div>
+
+            {/* Scope */}
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="register-scope">
+                {t('scope', language)}
+              </label>
+              <TextInput
+                id="register-scope"
+                name="oauth_provider_scope"
+                autoComplete="off"
+                value={formData.scope ?? ''}
+                onChange={(value: string) => setFormData({ ...formData, scope: value })}
+                placeholder="openid profile email"
+              />
+            </div>
+
+            {/* Custom Provider URLs */}
+            {!formData.predefined && (
+              <>
+                <div className="col-12">
+                  <hr />
+                  <h6>{t('customProviderUrls', language)}</h6>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="register-authorization-url">
+                    {t('authorizationUrl', language)}
+                  </label>
+                  <TextInput
+                    id="register-authorization-url"
+                    name="oauth_provider_authorization_url"
+                    autoComplete="off"
+                    value={formData.authorization_url ?? ''}
+                    onChange={(value: string) =>
+                      setFormData({ ...formData, authorization_url: value })
+                    }
+                    placeholder="https://provider.com/oauth/authorize"
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="register-token-url">
+                    {t('tokenUrl', language)}
+                  </label>
+                  <TextInput
+                    id="register-token-url"
+                    name="oauth_provider_token_url"
+                    autoComplete="off"
+                    value={formData.token_url ?? ''}
+                    onChange={(value: string) => setFormData({ ...formData, token_url: value })}
+                    placeholder="https://provider.com/oauth/token"
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="register-userinfo-url">
+                    {t('userinfoUrl', language)}
+                  </label>
+                  <TextInput
+                    id="register-userinfo-url"
+                    name="oauth_provider_userinfo_url"
+                    autoComplete="off"
+                    value={formData.userinfo_url ?? ''}
+                    onChange={(value: string) => setFormData({ ...formData, userinfo_url: value })}
+                    placeholder="https://provider.com/oauth/userinfo"
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="register-issuer-url">
+                    {t('issuerUrl', language)}
+                  </label>
+                  <TextInput
+                    id="register-issuer-url"
+                    name="oauth_provider_issuer_url"
+                    autoComplete="off"
+                    value={formData.issuer_url ?? ''}
+                    onChange={(value: string) => setFormData({ ...formData, issuer_url: value })}
+                    placeholder="https://provider.com"
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </form>
       </Modal>
 
       {/* Provider Detail Modal */}
@@ -967,7 +1038,7 @@ export const SSOSettings: React.FC = () => {
             <Button variant="secondary" onClick={() => setShowEditModal(false)}>
               {t('cancel', language)}
             </Button>
-            <Button variant="primary" onClick={handleUpdateProvider} loading={isUpdating}>
+            <Button variant="primary" type="submit" form="edit-provider-form" loading={isUpdating}>
               {t('save', language)}
             </Button>
           </>
@@ -976,7 +1047,7 @@ export const SSOSettings: React.FC = () => {
         {isLoadingDetail ? (
           <Loading size="md" text={t('loading', language)} />
         ) : providerDetail ? (
-          <>
+          <form id="edit-provider-form" autoComplete="off" onSubmit={handleUpdateProvider}>
             {editError && (
               <div className="alert alert-danger mb-3">
                 <i className="bi bi-exclamation-circle me-2" />
@@ -997,8 +1068,13 @@ export const SSOSettings: React.FC = () => {
 
               {/* Client ID */}
               <div className="col-md-6">
-                <label className="form-label">{t('clientId', language)} *</label>
+                <label className="form-label" htmlFor="edit-client-id">
+                  {t('clientId', language)} *
+                </label>
                 <TextInput
+                  id="edit-client-id"
+                  name="oauth_provider_client_id_edit"
+                  autoComplete="off"
                   value={editFormData.client_id ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, client_id: value })
@@ -1009,12 +1085,17 @@ export const SSOSettings: React.FC = () => {
 
               {/* Client Secret (optional for edit) */}
               <div className="col-md-6">
-                <label className="form-label">{t('clientSecret', language)}</label>
+                <label className="form-label" htmlFor="edit-client-secret">
+                  {t('clientSecret', language)}
+                </label>
                 <small className="text-muted d-block mb-1">
                   {t('clientSecretEditHint', language)}
                 </small>
                 <TextInput
+                  id="edit-client-secret"
+                  name="oauth_provider_client_secret_edit"
                   type="password"
+                  autoComplete="new-password"
                   value={editFormData.client_secret ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, client_secret: value })
@@ -1026,9 +1107,14 @@ export const SSOSettings: React.FC = () => {
               {/* Client Secret Confirm */}
               {editFormData.client_secret && (
                 <div className="col-md-6">
-                  <label className="form-label">{t('clientSecretConfirm', language)} *</label>
+                  <label className="form-label" htmlFor="edit-client-secret-confirm">
+                    {t('clientSecretConfirm', language)} *
+                  </label>
                   <TextInput
+                    id="edit-client-secret-confirm"
+                    name="oauth_provider_client_secret_confirmation_edit"
                     type="password"
+                    autoComplete="new-password"
                     value={editClientSecretConfirm}
                     onChange={(value: string) => setEditClientSecretConfirm(value)}
                     placeholder={t('enterClientSecretConfirm', language)}
@@ -1038,8 +1124,13 @@ export const SSOSettings: React.FC = () => {
 
               {/* Redirect URI */}
               <div className="col-md-6">
-                <label className="form-label">{t('redirectUri', language)}</label>
+                <label className="form-label" htmlFor="edit-redirect-uri">
+                  {t('redirectUri', language)}
+                </label>
                 <TextInput
+                  id="edit-redirect-uri"
+                  name="oauth_provider_redirect_uri_edit"
+                  autoComplete="off"
                   value={editFormData.redirect_uri ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, redirect_uri: value })
@@ -1050,8 +1141,13 @@ export const SSOSettings: React.FC = () => {
 
               {/* Scope */}
               <div className="col-md-6">
-                <label className="form-label">{t('scope', language)}</label>
+                <label className="form-label" htmlFor="edit-scope">
+                  {t('scope', language)}
+                </label>
                 <TextInput
+                  id="edit-scope"
+                  name="oauth_provider_scope_edit"
+                  autoComplete="off"
                   value={editFormData.scope ?? ''}
                   onChange={(value: string) => setEditFormData({ ...editFormData, scope: value })}
                   placeholder="openid profile email"
@@ -1064,8 +1160,13 @@ export const SSOSettings: React.FC = () => {
                 <h6>{t('providerUrls', language)}</h6>
               </div>
               <div className="col-md-6">
-                <label className="form-label">{t('authorizationUrl', language)}</label>
+                <label className="form-label" htmlFor="edit-authorization-url">
+                  {t('authorizationUrl', language)}
+                </label>
                 <TextInput
+                  id="edit-authorization-url"
+                  name="oauth_provider_authorization_url_edit"
+                  autoComplete="off"
                   value={editFormData.authorization_url ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, authorization_url: value })
@@ -1074,8 +1175,13 @@ export const SSOSettings: React.FC = () => {
                 />
               </div>
               <div className="col-md-6">
-                <label className="form-label">{t('tokenUrl', language)}</label>
+                <label className="form-label" htmlFor="edit-token-url">
+                  {t('tokenUrl', language)}
+                </label>
                 <TextInput
+                  id="edit-token-url"
+                  name="oauth_provider_token_url_edit"
+                  autoComplete="off"
                   value={editFormData.token_url ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, token_url: value })
@@ -1084,8 +1190,13 @@ export const SSOSettings: React.FC = () => {
                 />
               </div>
               <div className="col-md-6">
-                <label className="form-label">{t('userinfoUrl', language)}</label>
+                <label className="form-label" htmlFor="edit-userinfo-url">
+                  {t('userinfoUrl', language)}
+                </label>
                 <TextInput
+                  id="edit-userinfo-url"
+                  name="oauth_provider_userinfo_url_edit"
+                  autoComplete="off"
                   value={editFormData.userinfo_url ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, userinfo_url: value })
@@ -1094,8 +1205,13 @@ export const SSOSettings: React.FC = () => {
                 />
               </div>
               <div className="col-md-6">
-                <label className="form-label">{t('issuerUrl', language)}</label>
+                <label className="form-label" htmlFor="edit-issuer-url">
+                  {t('issuerUrl', language)}
+                </label>
                 <TextInput
+                  id="edit-issuer-url"
+                  name="oauth_provider_issuer_url_edit"
+                  autoComplete="off"
                   value={editFormData.issuer_url ?? ''}
                   onChange={(value: string) =>
                     setEditFormData({ ...editFormData, issuer_url: value })
@@ -1104,7 +1220,7 @@ export const SSOSettings: React.FC = () => {
                 />
               </div>
             </div>
-          </>
+          </form>
         ) : (
           <EmptyState
             icon="bi-exclamation-circle"


### PR DESCRIPTION
## 修复说明

关联 Issue：#2896（后续修复）
关联 PR：#2933

## 问题

PR #2933 在 rebase 解决冲突时丢失了已合并的 PR #2935（commit `d9dae578`）的 autofill 防护代码。PR #2933 已在评审发现此问题前被合并（合并时间 09:00:46Z，修复推送时间 09:01 UTC），导致以下回退进入 main 分支：

1. OAuth Provider 注册/编辑表单所有输入的 `id`/`name`/`autoComplete` 属性被删除
2. Modal 中的 `<form autoComplete="off">` 包裹被移除
3. `handlePredefinedChange` 中的凭据字段重置被删除
4. Issue #2895 的 autofill 防护测试被删除

## 修复方案

恢复 PR #2935 的所有 autofill 防护代码：

- 恢复所有 OAuth 表单输入的 `id`/`name`/`autoComplete` 属性
- 恢复 Register/Edit Modal 中的 `<form autoComplete="off">` 包裹
- 恢复 `handlePredefinedChange` 中的凭据字段重置
- 恢复 Modal submit 按钮的 `form` 属性
- 恢复 Issue #2895 的 5 个 autofill 防护测试
- 恢复测试 mock 中的 `form`/`footer`/`id`/`name`/`autoComplete` props

## 验证

- ✅ ESLint: 0 errors
- ✅ Vitest: 17/17 测试通过（12 可访问性 + 5 autofill）
- ✅ 本修复仅恢复 main 分支已有代码，不引入新功能