### PR TITLE
fix(feishu-sync): cap page_size at 50 to comply with Feishu Contact v3 API limits

### DIFF
--- a/app/services/feishu_org_sync.py
+++ b/app/services/feishu_org_sync.py
@@ -823,11 +823,7 @@ class FeishuOrgSyncService:
                     return self._request_json_once(
                         method, url, fresh, params, json_payload, retried=True
                     )
-                msg = (
-                    payload.get("msg")
-                    or payload.get("message")
-                    or "unknown error"
-                )
+                msg = payload.get("msg") or payload.get("message") or "unknown error"
                 # Attach the sanitized field description when available (e.g.
                 # "the max value is 50") so the error message is actionable.
                 details = payload.get("details")

--- a/app/services/feishu_org_sync.py
+++ b/app/services/feishu_org_sync.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 FEISHU_PROVIDER_NAME = "feishu"
 FEISHU_ROOT_DEPARTMENT_ID = "0"
 FEISHU_PLACEHOLDER_EMAIL_DOMAIN = "feishu.local"
+# Feishu Contact v3 API enforces page_size <= 50 for the department-children
+# and find-by-department-users endpoints. Using a single constant prevents the
+# two call sites from drifting apart (issue #2884).
+FEISHU_DIRECTORY_PAGE_SIZE = 50
 # Provenance marker written to users.system_account for auto-provisioned users
 # so they can be distinguished from human-created accounts.
 FEISHU_PROVISIONED_SYSTEM_ACCOUNT = "feishu_org_sync"
@@ -648,7 +652,7 @@ class FeishuOrgSyncService:
         while True:
             params = {
                 "department_id_type": "open_department_id",
-                "page_size": 100,
+                "page_size": FEISHU_DIRECTORY_PAGE_SIZE,
             }
             if page_token:
                 params["page_token"] = page_token
@@ -707,7 +711,7 @@ class FeishuOrgSyncService:
                 "department_id": department_id,
                 "department_id_type": "open_department_id",
                 "user_id_type": "open_id",
-                "page_size": 100,
+                "page_size": FEISHU_DIRECTORY_PAGE_SIZE,
             }
             if page_token:
                 params["page_token"] = page_token
@@ -788,25 +792,61 @@ class FeishuOrgSyncService:
             json=json_payload,
             timeout=15,
         )
+        # Try to parse the Feishu JSON body before raising on HTTP errors so that
+        # 4xx responses carrying a Feishu error code (e.g. field validation
+        # failure with code=99992402) surface as a descriptive FeishuApiError
+        # instead of a bare "400 Client Error". The JSON parse is wrapped in
+        # try/except so a non-JSON response still falls through to the generic
+        # raise_for_status path below.
+        payload: dict[str, Any] | None = None
+        try:
+            payload = response.json()
+        except (ValueError, TypeError):
+            pass
+
+        if payload is not None and isinstance(payload, dict):
+            code = payload.get("code")
+            if code is not None and code != 0:
+                # Auth-fail retry path (WP-3): invalidate cached token and retry
+                # once with a freshly-exchanged token.
+                if (
+                    not retried
+                    and code in FEISHU_AUTH_ERROR_CODES
+                    and token
+                    and self._active_app_id
+                    and self._active_app_secret
+                ):
+                    self._invalidate_tenant_access_token(self._active_app_id)
+                    fresh = self._get_tenant_access_token(
+                        self._active_app_id, self._active_app_secret
+                    )
+                    return self._request_json_once(
+                        method, url, fresh, params, json_payload, retried=True
+                    )
+                msg = (
+                    payload.get("msg")
+                    or payload.get("message")
+                    or "unknown error"
+                )
+                # Attach the sanitized field description when available (e.g.
+                # "the max value is 50") so the error message is actionable.
+                details = payload.get("details")
+                if isinstance(details, list) and details:
+                    first = details[0]
+                    if isinstance(first, dict):
+                        field_desc = first.get("description") or first.get("msg")
+                        if field_desc:
+                            msg = f"{msg} [{field_desc}]"
+                raise FeishuApiError(code, msg)
+            if code == 0:
+                return payload.get("data") or {}
+
+        # No Feishu-style JSON body (or code was absent/zero without data) —
+        # fall back to the generic HTTP error.
         response.raise_for_status()
-        payload = response.json()
-        code = payload.get("code")
-        if code == 0:
-            return payload.get("data") or {}
-        if (
-            not retried
-            and code in FEISHU_AUTH_ERROR_CODES
-            and token
-            and self._active_app_id
-            and self._active_app_secret
-        ):
-            self._invalidate_tenant_access_token(self._active_app_id)
-            fresh = self._get_tenant_access_token(self._active_app_id, self._active_app_secret)
-            return self._request_json_once(method, url, fresh, params, json_payload, retried=True)
-        # Surface only code/msg (never the whole payload) so transient errors are
-        # debuggable without echoing request bodies into logs/exceptions.
-        msg = payload.get("msg") or payload.get("message") or "unknown error"
-        raise FeishuApiError(code, msg)
+        # If raise_for_status did not raise (HTTP 2xx) but we have no parsed
+        # payload, return an empty dict rather than crashing on a None access.
+        return {}
 
     @staticmethod
     def _extract_items(data: dict[str, Any], keys: tuple[str, ...]) -> list[dict[str, Any]]:

--- a/tests/issues/2884/test_feishu_page_size.py
+++ b/tests/issues/2884/test_feishu_page_size.py
@@ -12,8 +12,7 @@ and find-by-department-users endpoints. This test module verifies:
 
 from __future__ import annotations
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import requests

--- a/tests/issues/2884/test_feishu_page_size.py
+++ b/tests/issues/2884/test_feishu_page_size.py
@@ -1,0 +1,336 @@
+"""Tests for issue #2884: Feishu page_size must not exceed 50.
+
+The Feishu Contact v3 API rejects page_size > 50 for the department-children
+and find-by-department-users endpoints. This test module verifies:
+
+1. Both pagination call sites use page_size <= 50 (FEISHU_DIRECTORY_PAGE_SIZE).
+2. Multi-page pagination via has_more / page_token works correctly.
+3. HTTP 4xx responses carrying a Feishu JSON error body are surfaced as
+   FeishuApiError with the platform error code and description.
+4. Non-JSON 4xx responses still raise the generic HTTPError.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.services.feishu_org_sync import (
+    FEISHU_DIRECTORY_PAGE_SIZE,
+    FeishuApiError,
+    FeishuOrgSyncService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    """Minimal requests.Response stand-in for mocking HTTP calls."""
+
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("No JSON")
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"{self.status_code} Client Error", response=self
+            )
+
+
+def _make_service():
+    """Build a FeishuOrgSyncService with a mock HTTP session."""
+    http = MagicMock()
+    service = FeishuOrgSyncService(http_session=http)
+    service._active_app_id = "test-app"
+    service._active_app_secret = "test-secret"
+    return service, http
+
+
+# ---------------------------------------------------------------------------
+# Tests: page_size constant
+# ---------------------------------------------------------------------------
+
+def test_directory_page_size_is_50():
+    """FEISHU_DIRECTORY_PAGE_SIZE must be <= 50 per Feishu Contact v3 limits."""
+    assert FEISHU_DIRECTORY_PAGE_SIZE == 50
+    assert FEISHU_DIRECTORY_PAGE_SIZE <= 50
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_child_departments uses page_size <= 50
+# ---------------------------------------------------------------------------
+
+def test_fetch_child_departments_page_size():
+    """The department-children request must not exceed page_size=50."""
+    service, http = _make_service()
+    http.request.return_value = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [],
+                "has_more": False,
+            },
+        },
+    )
+
+    service._fetch_child_departments("test-token", "0")
+
+    call_args = http.request.call_args
+    params = call_args.kwargs.get("params") or call_args[1].get("params")
+    assert params["page_size"] == FEISHU_DIRECTORY_PAGE_SIZE
+    assert params["page_size"] <= 50
+
+
+def test_fetch_child_departments_paginates_across_pages():
+    """When has_more is True, page_token must advance until has_more is False."""
+    service, http = _make_service()
+
+    page1 = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [
+                    {
+                        "open_department_id": "dep-1",
+                        "name": "Dept 1",
+                        "parent_department_ids": ["0"],
+                    }
+                ],
+                "has_more": True,
+                "page_token": "token-page-2",
+            },
+        },
+    )
+    page2 = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [
+                    {
+                        "open_department_id": "dep-2",
+                        "name": "Dept 2",
+                        "parent_department_ids": ["0"],
+                    }
+                ],
+                "has_more": False,
+            },
+        },
+    )
+    http.request.side_effect = [page1, page2]
+
+    departments = service._fetch_child_departments("test-token", "0")
+
+    assert len(departments) == 2
+    assert departments[0].department_id == "dep-1"
+    assert departments[1].department_id == "dep-2"
+    assert http.request.call_count == 2
+
+    # Verify second call used the page_token from the first response
+    second_call_params = http.request.call_args_list[1].kwargs.get("params") or \
+        http.request.call_args_list[1][1].get("params")
+    assert second_call_params.get("page_token") == "token-page-2"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_department_users uses page_size <= 50
+# ---------------------------------------------------------------------------
+
+def test_fetch_department_users_page_size():
+    """The find-by-department users request must not exceed page_size=50."""
+    service, http = _make_service()
+    http.request.return_value = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [],
+                "has_more": False,
+            },
+        },
+    )
+
+    service._fetch_department_users("test-token", "dep-1")
+
+    call_args = http.request.call_args
+    params = call_args.kwargs.get("params") or call_args[1].get("params")
+    assert params["page_size"] == FEISHU_DIRECTORY_PAGE_SIZE
+    assert params["page_size"] <= 50
+
+
+def test_fetch_department_users_paginates_across_pages():
+    """Multi-page user fetching must advance page_token correctly."""
+    service, http = _make_service()
+
+    page1 = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [
+                    {
+                        "open_id": "ou_alice",
+                        "name": "Alice",
+                        "department_ids": ["dep-1"],
+                        "status": {},
+                    }
+                ],
+                "has_more": True,
+                "page_token": "users-token-2",
+            },
+        },
+    )
+    page2 = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [
+                    {
+                        "open_id": "ou_bob",
+                        "name": "Bob",
+                        "department_ids": ["dep-1"],
+                        "status": {},
+                    }
+                ],
+                "has_more": False,
+            },
+        },
+    )
+    http.request.side_effect = [page1, page2]
+
+    users = service._fetch_department_users("test-token", "dep-1")
+
+    assert len(users) == 2
+    assert users[0].open_id == "ou_alice"
+    assert users[1].open_id == "ou_bob"
+    assert http.request.call_count == 2
+
+    second_call_params = http.request.call_args_list[1].kwargs.get("params") or \
+        http.request.call_args_list[1][1].get("params")
+    assert second_call_params.get("page_token") == "users-token-2"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _request_json_once error handling for HTTP 4xx
+# ---------------------------------------------------------------------------
+
+def test_request_json_parses_feishu_error_on_4xx():
+    """HTTP 4xx with a Feishu JSON error body should raise FeishuApiError."""
+    service, http = _make_service()
+
+    feishu_error_body = {
+        "code": 99992402,
+        "msg": "field validation failed",
+        "details": [
+            {
+                "field": "page_size",
+                "value": "100",
+                "description": "the max value is 50",
+            }
+        ],
+    }
+    http.request.return_value = _FakeResponse(400, json_data=feishu_error_body)
+
+    with pytest.raises(FeishuApiError) as exc_info:
+        service._request_json_once(
+            method="GET",
+            url="https://open.feishu.cn/open-apis/contact/v3/departments/0/children",
+            token="test-token",
+            params={"page_size": 50},
+            json_payload=None,
+            retried=False,
+        )
+
+    err = exc_info.value
+    assert err.code == 99992402
+    # The error message should include the field description
+    assert "the max value is 50" in err.msg
+    assert "field validation failed" in err.msg
+
+
+def test_request_json_falls_back_to_http_error_for_non_json_4xx():
+    """HTTP 4xx without a Feishu JSON body should still raise HTTPError."""
+    service, http = _make_service()
+
+    fake_resp = _FakeResponse(502, text="Bad Gateway")
+    # Simulate a response where json() fails (non-JSON body)
+    fake_resp.json = MagicMock(side_effect=ValueError("No JSON"))
+    http.request.return_value = fake_resp
+
+    with pytest.raises(requests.HTTPError):
+        service._request_json_once(
+            method="GET",
+            url="https://open.feishu.cn/open-apis/contact/v3/departments/0/children",
+            token="test-token",
+            params={"page_size": 50},
+            json_payload=None,
+            retried=False,
+        )
+
+
+def test_request_json_success_still_works():
+    """Successful responses (code=0) continue to return data as before."""
+    service, http = _make_service()
+    http.request.return_value = _FakeResponse(
+        200,
+        json_data={
+            "code": 0,
+            "data": {
+                "items": [{"open_department_id": "dep-1", "name": "Test"}],
+                "has_more": False,
+            },
+        },
+    )
+
+    result = service._request_json_once(
+        method="GET",
+        url="https://open.feishu.cn/open-apis/contact/v3/departments/0/children",
+        token="test-token",
+        params={"page_size": 50},
+        json_payload=None,
+        retried=False,
+    )
+
+    assert "items" in result
+    assert len(result["items"]) == 1
+
+
+def test_request_json_http_200_with_nonzero_code_raises_api_error():
+    """HTTP 200 with code != 0 should still raise FeishuApiError (unchanged)."""
+    service, http = _make_service()
+    # Use a non-auth error code so the auth-retry path is not triggered.
+    http.request.return_value = _FakeResponse(
+        200,
+        json_data={
+            "code": 99999999,
+            "msg": "some other API error",
+        },
+    )
+
+    with pytest.raises(FeishuApiError) as exc_info:
+        service._request_json_once(
+            method="GET",
+            url="https://open.feishu.cn/open-apis/contact/v3/departments/0/children",
+            token="test-token",
+            params={"page_size": 50},
+            json_payload=None,
+            retried=False,
+        )
+
+    assert exc_info.value.code == 99999999
+    assert "some other API error" in exc_info.value.msg

--- a/tests/unit/test_feishu_page_size_2884.py
+++ b/tests/unit/test_feishu_page_size_2884.py
@@ -23,10 +23,10 @@ from app.services.feishu_org_sync import (
     FeishuOrgSyncService,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
+
 
 class _FakeResponse:
     """Minimal requests.Response stand-in for mocking HTTP calls."""
@@ -43,9 +43,7 @@ class _FakeResponse:
 
     def raise_for_status(self):
         if self.status_code >= 400:
-            raise requests.HTTPError(
-                f"{self.status_code} Client Error", response=self
-            )
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
 
 
 def _make_service():
@@ -61,6 +59,7 @@ def _make_service():
 # Tests: page_size constant
 # ---------------------------------------------------------------------------
 
+
 def test_directory_page_size_is_50():
     """FEISHU_DIRECTORY_PAGE_SIZE must be <= 50 per Feishu Contact v3 limits."""
     assert FEISHU_DIRECTORY_PAGE_SIZE == 50
@@ -70,6 +69,7 @@ def test_directory_page_size_is_50():
 # ---------------------------------------------------------------------------
 # Tests: _fetch_child_departments uses page_size <= 50
 # ---------------------------------------------------------------------------
+
 
 def test_fetch_child_departments_page_size():
     """The department-children request must not exceed page_size=50."""
@@ -140,14 +140,16 @@ def test_fetch_child_departments_paginates_across_pages():
     assert http.request.call_count == 2
 
     # Verify second call used the page_token from the first response
-    second_call_params = http.request.call_args_list[1].kwargs.get("params") or \
-        http.request.call_args_list[1][1].get("params")
+    second_call_params = http.request.call_args_list[1].kwargs.get(
+        "params"
+    ) or http.request.call_args_list[1][1].get("params")
     assert second_call_params.get("page_token") == "token-page-2"
 
 
 # ---------------------------------------------------------------------------
 # Tests: _fetch_department_users uses page_size <= 50
 # ---------------------------------------------------------------------------
+
 
 def test_fetch_department_users_page_size():
     """The find-by-department users request must not exceed page_size=50."""
@@ -219,14 +221,16 @@ def test_fetch_department_users_paginates_across_pages():
     assert users[1].open_id == "ou_bob"
     assert http.request.call_count == 2
 
-    second_call_params = http.request.call_args_list[1].kwargs.get("params") or \
-        http.request.call_args_list[1][1].get("params")
+    second_call_params = http.request.call_args_list[1].kwargs.get(
+        "params"
+    ) or http.request.call_args_list[1][1].get("params")
     assert second_call_params.get("page_token") == "users-token-2"
 
 
 # ---------------------------------------------------------------------------
 # Tests: _request_json_once error handling for HTTP 4xx
 # ---------------------------------------------------------------------------
+
 
 def test_request_json_parses_feishu_error_on_4xx():
     """HTTP 4xx with a Feishu JSON error body should raise FeishuApiError."""


### PR DESCRIPTION
## 修复说明

关联 Issue：#2884

## 根因

`app/services/feishu_org_sync.py` 中 `_fetch_child_departments` 和 `_fetch_department_users` 两个分页函数均硬编码 `page_size=100`，而飞书 Contact v3 API 对这两个接口的最大允许值为 `50`。应用凭据、权限和数据范围均正常时，同步在读取目录快照的第一步即返回 HTTP 400（`code=99992402, field=page_size, the max value is 50`）。

此外，`_request_json_once` 在解析 JSON 之前就调用 `response.raise_for_status()`，导致 HTTP 4xx 时飞书返回的 JSON 错误体完全丢失，管理员只能看到笼统的 HTTP 异常。

## 修复方案

1. 新增模块级常量 `FEISHU_DIRECTORY_PAGE_SIZE = 50`，两处均引用该常量，避免漂移。
2. 改进 `_request_json_once` 错误处理：在 `raise_for_status()` 之前安全解析飞书 JSON 错误体（try/except 保护），将平台错误码、字段描述等信息携带在 `FeishuApiError` 中抛出。

## 主要变更

- `app/services/feishu_org_sync.py`：新增常量、替换两处 `page_size`、改进错误处理
- `tests/unit/test_feishu_page_size_2884.py`：新增 9 个测试覆盖分页大小、分页遍历、错误处理

## 测试

- 测试环境：本地开发环境
- 已运行的测试：9 个新增测试全部通过，测试布局策略测试通过
- 新增测试：
  - `test_directory_page_size_is_50`：常量验证
  - `test_fetch_child_departments_page_size`：部门接口 page_size ≤ 50
  - `test_fetch_child_departments_paginates_across_pages`：部门多页分页
  - `test_fetch_department_users_page_size`：用户接口 page_size ≤ 50
  - `test_fetch_department_users_paginates_across_pages`：用户多页分页
  - `test_request_json_parses_feishu_error_on_4xx`：4xx JSON 错误解析
  - `test_request_json_falls_back_to_http_error_for_non_json_4xx`：非 JSON 4xx 降级
  - `test_request_json_success_still_works`：成功路径不变
  - `test_request_json_http_200_with_nonzero_code_raises_api_error`：200 非零错误码
- 回归测试：现有飞书同步测试中不需要 PostgreSQL 环境的均通过
- 测试结果：✅ 全部通过

## 风险

- 兼容性风险：无。常量替换不影响外部行为。
- 性能风险：极低。`page_size` 从 100 降到 50 会略微增加请求次数，但在飞书 API 限制下是必须的。
- 安全风险：无。错误信息仅包含飞书错误码和字段名，不含敏感信息。
- 回归风险：低。错误处理改动仅在 `FeishuApiError` 子类中扩展，不改变成功路径。