### PR TITLE
fix: preserve GH_TOKEN in create_issue under multi-user sudo (#2949)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1054,14 +1054,38 @@ class GitHubOps:
 
     # ── Issue Operations ────────────────────────────────────────────
 
-    def create_issue(self, title: str, body: str = "", labels: list[str] | None = None) -> dict:
-        """Create a GitHub issue."""
+    def create_issue(
+        self,
+        title: str,
+        body: str = "",
+        labels: list[str] | None = None,
+        repo: str | None = None,
+    ) -> dict:
+        """Create a GitHub issue.
+
+        Args:
+            title: Issue title
+            body: Issue body
+            labels: Optional labels to apply
+            repo: Optional target repo in 'owner/repo' format (for new project scenarios)
+        """
         args = ["issue", "create", "--title", title, "--body", body or ""]
         if labels:
             for label in labels:
                 args.extend(["--label", label])
 
-        result = self._run_gh(args)
+        # When repo is provided, explicitly target that repository.
+        # This is needed for new project scenarios where the local directory
+        # doesn't have a git origin configured yet.
+        if repo:
+            args.extend(["--repo", repo])
+
+        # api_only=True: avoid sudo path clearing GH_TOKEN (#2949)
+        # Issue creation is a pure GitHub API call that needs no local repo
+        # access, so when a bot token is configured and the command would
+        # otherwise sudo (cross-user), run gh as the service user to keep
+        # GH_TOKEN from being stripped by sudo env_reset.
+        result = self._run_gh(args, api_only=True)
         # gh issue create doesn't support --json; parse URL from stdout
         output = result.stdout.strip()
         issue_url = output.split("\n")[-1].strip()

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9676,10 +9676,21 @@ class AutonomousOrchestrator:
 
         if not issue_number and requirements_text:
             # Create issue from text
+            # For new project scenarios, extract owner/repo from repo_url
+            # so create_issue can target the repository explicitly.
+            issue_repo = None
+            project_repo_url = wf.get("project_repo_url", "")
+            if project_repo_url:
+                # Extract owner/repo from URL like https://github.com/owner/repo
+                match = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", project_repo_url)
+                if match:
+                    issue_repo = match.group(1)
+
             try:
                 issue_data = gh.create_issue(
                     title=wf.get("title") or f"Autonomous Dev: {requirements_text[:60]}",
                     body=requirements_text,
+                    repo=issue_repo,
                 )
                 issue_number = issue_data.get("number")
                 # The issue number is an irreversible external-resource id: a

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -97,6 +97,53 @@ class TestGitHubOpsIssue:
         assert result["number"] == 43
 
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_issue_with_repo(self, mock_run):
+        """Issue #2949: create_issue should accept explicit repo parameter."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/owner/new-project/issues/44"
+        )
+        result = self.gh.create_issue(
+            "Bug in new project", body="Fix needed", repo="owner/new-project"
+        )
+        assert result["number"] == 44
+        # Verify --repo flag is passed
+        cmd = mock_run.call_args[0][0]
+        assert "--repo" in cmd
+        assert "owner/new-project" in cmd
+
+    @patch("app.utils.config.get_ai_github_env")
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_issue_preserves_gh_token(self, mock_run, mock_get_env):
+        """Issue #2949: create_issue should use api_only=True to preserve GH_TOKEN."""
+        # Simulate bot token configured
+        mock_get_env.return_value = {"GH_TOKEN": "test-bot-token"}
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/user/test/issues/45"
+        )
+
+        # Create GitHubOps with system_account (cross-user scenario)
+        gh = GitHubOps("/tmp/test-repo", system_account="testuser")
+        result = gh.create_issue("Test", body="Body")
+
+        assert result["number"] == 45
+        # Verify gh was called (not sudo -u)
+        cmd = mock_run.call_args[0][0]
+        assert "sudo" not in cmd
+        assert "gh" in cmd
+
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_issue_api_only_flag(self, mock_run):
+        """Verify create_issue uses api_only=True in _run_gh."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/user/test/issues/46"
+        )
+        result = self.gh.create_issue("Test api_only", body="Verify flag")
+
+        assert result["number"] == 46
+        # The api_only=True flag is internal to _run_gh; the test verifies
+        # the call succeeds (actual api_only behavior tested in integration)
+
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     def test_get_issue(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,


### PR DESCRIPTION
Closes #2949

## 修复内容

在多用户模式下，`create_issue()` 方法未使用 `api_only=True`，导致通过 sudo 执行时 `GH_TOKEN` 被 `env_reset` 清除，创建 Issue 失败。

## 修复方案

1. **核心修复**：`create_issue()` 添加 `api_only=True` 参数，避免 sudo 清除 GH_TOKEN
2. **新项目支持**：添加可选 `repo` 参数，支持新项目场景显式指定目标仓库
3. **调用方更新**：`orchestrator.py` 在创建仓库后提取 owner/repo 并传递给 `create_issue()`
4. **回归测试**：添加测试验证 GH_TOKEN 保留和多用户场景

## 代码变更

- `app/modules/workspace/autonomous/github_ops.py`：添加 `api_only=True` 和 `repo` 参数
- `app/modules/workspace/autonomous/orchestrator.py`：更新 `create_issue()` 调用方式
- `tests/issues/716/test_github_ops.py`：添加回归测试

## 修复方案评审

- 方案已通过独立评审：https://github.com/open-ace/open-ace/issues/2949#issuecomment-5368450836
- 结论：✅ 方案完整，可实施