### PR TITLE
ci: 最低支持版本(py3.10)跑全量单元 suite (python-min) (#2868)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       package: ${{ steps.select.outputs.package }}
       postgres: ${{ steps.select.outputs.postgres }}
       python_core: ${{ steps.select.outputs.python_core }}
+      python_min: ${{ steps.select.outputs.python_min }}
       selected: ${{ steps.select.outputs.selected }}
     steps:
       - uses: actions/checkout@v6
@@ -108,12 +109,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Minimum supported interpreter (requires-python >=3.10) runs the FULL
+          # unit suite + compileall (#2868), selected for every non-docs change.
+          # Version-specific regressions surface on the OLDEST interpreter first
+          # -- e.g. datetime.fromisoformat rejecting a 'Z' suffix before 3.11 --
+          # and the old matrix ran only a 7-file smoke here, so such a break
+          # sailed through the PR AND the post-merge main push. Unit-only keeps
+          # it fast (~2min) and deterministic (no integration flakiness, no
+          # coverage/timeout), unlike running the full python-core suite on the
+          # slower 3.10 interpreter.
           - python-version: '3.10'
-            suite: compatibility-smoke
+            suite: python-min
           - python-version: '3.11'
             suite: python-core
-          # Transitional compatibility context required by the current ruleset.
-          # Remove after branch protection requires the stable PR Gate context.
+          # Forward-compatibility smoke (compileall + a fast unit subset) on the
+          # newest interpreters; selected on dependency changes.
           - python-version: '3.12'
             suite: compatibility-smoke
           - python-version: '3.14'
@@ -130,6 +140,7 @@ jobs:
       - name: Explain skipped lane
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core != 'true') ||
+          (matrix.suite == 'python-min' && needs.changes.outputs.python_min != 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke != 'true')
         run: |
           MSG="Lane not needed: ${{ matrix.suite }} was not selected for this change set (no matching paths changed)."
@@ -140,6 +151,7 @@ jobs:
       - uses: actions/checkout@v6
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core == 'true') ||
+          (matrix.suite == 'python-min' && needs.changes.outputs.python_min == 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke == 'true')
         with:
           submodules: false
@@ -147,6 +159,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core == 'true') ||
+          (matrix.suite == 'python-min' && needs.changes.outputs.python_min == 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke == 'true')
         uses: actions/setup-python@v6
         with:
@@ -157,6 +170,7 @@ jobs:
       - name: Install test dependencies
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core == 'true') ||
+          (matrix.suite == 'python-min' && needs.changes.outputs.python_min == 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke == 'true')
         run: |
           python -m pip install --upgrade pip
@@ -181,6 +195,7 @@ jobs:
       - name: Run selected test suite
         if: >-
           (matrix.suite == 'python-core' && needs.changes.outputs.python_core == 'true') ||
+          (matrix.suite == 'python-min' && needs.changes.outputs.python_min == 'true') ||
           (matrix.suite == 'compatibility-smoke' && needs.changes.outputs.compatibility_smoke == 'true')
         run: python scripts/ci.py run ${{ matrix.suite }}
 

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -3,7 +3,8 @@
   "baseline_runbook": "docs/TEST_LAYERS.md#baseline",
   "toolchain": {
     "production_python": "3.11",
-    "compatibility_python": ["3.10", "3.14"],
+    "min_python": "3.10",
+    "compatibility_python": ["3.12", "3.14"],
     "node": "20",
     "runner": "ubuntu-24.04"
   },
@@ -18,7 +19,8 @@
     "legacy-pr",
     "package",
     "postgres",
-    "python-core"
+    "python-core",
+    "python-min"
   ],
   "suites": {
     "default-collection": {
@@ -61,6 +63,14 @@
       "commands": [
         ["{python}", "-m", "pytest", "tests/", "-q", "--maxfail=1", "--cov=scripts/shared", "--cov=app/auth", "--cov=app/remote_ws_handler", "--cov=app/modules/sso", "--cov=app/routes", "--cov=app/services", "--cov-fail-under=47", "--cov-report=term", "--cov-report=xml", "-m", "not postgres and not performance"],
         ["{python}", "scripts/scan_test_false_positives.py", "tests", "--exclude-dirs", "tests/issues", "--baseline", ".false-positive-baseline.json"]
+      ]
+    },
+    "python-min": {
+      "description": "compileall + full unit suite on the minimum supported Python (catches version-specific regressions on the oldest interpreter; #2868)",
+      "timeout_seconds": 420,
+      "commands": [
+        ["{python}", "-m", "compileall", "-q", "app", "scripts", "cli.py", "server.py"],
+        ["{python}", "-m", "pytest", "tests/unit/", "-q", "--maxfail=1", "-m", "not postgres and not performance"]
       ]
     },
     "compatibility-smoke": {

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -90,11 +90,27 @@ python scripts/run_extended_tests.py --category issues --split-total 4 --split-g
    tests 根目录测试文件，以及 `tests/regression/`、`tests/security/`。
 
 所有 suite 的命令、超时和工具链版本以 `ci/suites.json` 为唯一来源；本地和
-GitHub Actions 都通过 `python scripts/ci.py` 执行。PR 使用生产 Python 3.11
-做全量确定性测试；为兼容当前 ruleset，3.10、3.12、3.14 的同名 check 只执行
-compileall 和 unit smoke，并不代表全量跨版本覆盖。Python 3.13 仍是声明支持版本，
-但不在 PR 矩阵中。定时工作流在 3.10、3.11、3.14 上执行完整 Python suite，
-并承担 E2E、legacy shards 和易受 runner 噪声影响的检查。
+GitHub Actions 都通过 `python scripts/ci.py` 执行。PR 矩阵按版本分工（#2868）：
+
+- **3.11（生产运行时）**：`python-core`——全量 `pytest tests/`（含 integration）
+  + 覆盖率 + 假阳性扫描，每个非文档改动都跑。
+- **3.10（最低支持版本）**：`python-min`——`compileall` + 全量 `pytest tests/unit/`，
+  每个非文档改动都跑。版本特有的回归几乎总先在最老解释器上暴露（例如 3.11 之前
+  `datetime.fromisoformat` 不接受 `Z` 后缀），旧矩阵只在 3.10 跑 7 文件 smoke，使
+  这类**单元级**回归在 PR 与合并后 main 推送上都漏网、红 main 75 分钟无人察觉。
+  只跑 unit 使其快（~2min）且确定（无 integration flake、无覆盖率/超时——直接在
+  较慢的 3.10 上跑全量 `tests/` 会撞 10 分钟预算并放大 flake）。
+- **3.12、3.14（前向兼容）**：`compatibility-smoke`——`compileall` + 少量关键单元
+  文件，按依赖变更选择。
+
+`python-min` 与 `python-core` 都对每个代码改动生效，故 `app/**` 改动必在最低支持
+版本真跑全量单元。Python 3.13 仍是声明支持版本但不在 PR 矩阵中。定时工作流在
+3.10、3.11、3.14 上执行完整 Python suite，并承担 E2E、legacy shards 和易受 runner
+噪声影响的检查。`tests/unit/test_ci_runner.py::test_min_supported_python_runs_the_full_unit_suite`
+把「最低支持版本必须跑全量 tests/unit」锁进门禁。合并后对 main 的验证由既有
+`push: [main]`（`ci.yml` 与 `schema-sync.yml`）承担，本改动使其对最低版本真正
+生效——红 main 因此成为提交上诚实可见的红 check。（注：当前 ruleset 未开启
+"require branches up to date"，跨 PR 陈旧基线仍可能红 main，属独立 ruleset 配置项。）
 
 提交前可运行 `python scripts/ci.py doctor --strict` 验证本地 Python/Node
 主版本与 PR 一致，再用 `python scripts/ci.py pr --base origin/main` 按相同路径

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -189,7 +189,17 @@ def select_pr_suites(changed_files: list[str]) -> list[str]:
 
     # Collection is cheap (~2s) and catches legacy imports broken by product
     # changes, so both baselines accompany every non-documentation PR.
-    selected = {"default-collection", "issue-collection", "legacy-pr", "python-core"}
+    # python-min runs the full unit suite on the minimum supported interpreter
+    # for every code change (#2868): version-specific regressions surface on the
+    # oldest Python first (e.g. datetime.fromisoformat rejecting 'Z' before
+    # 3.11), and it is unit-only so it stays fast and deterministic.
+    selected = {
+        "default-collection",
+        "issue-collection",
+        "legacy-pr",
+        "python-core",
+        "python-min",
+    }
     if policy_change:
         selected.update(load_config()["pr_suites"])
         return sorted(selected)

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -180,7 +180,7 @@ def select_pr_suites(changed_files: list[str]) -> list[str]:
     """Select coarse, fail-safe PR lanes from repository-relative paths."""
     clean = sorted({path.strip().lstrip("./") for path in changed_files if path.strip()})
     if not clean:
-        return ["default-collection", "issue-collection", "legacy-pr", "python-core"]
+        return ["default-collection", "issue-collection", "legacy-pr", "python-core", "python-min"]
 
     policy_change = any(matches(path, POLICY_PATTERNS) for path in clean)
     docs_only = all(matches(path, DOC_PATTERNS) for path in clean)

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -5,8 +5,11 @@ import subprocess
 from pathlib import Path
 from unittest.mock import Mock, call
 
+import yaml
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 try:
     import tomllib
@@ -19,6 +22,30 @@ assert SPEC and SPEC.loader
 ci = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(ci)
 
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _requires_python_spec() -> SpecifierSet:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    return SpecifierSet(project["project"]["requires-python"])
+
+
+def _min_supported_python() -> str:
+    """Return the lowest supported interpreter as a 'major.minor' string."""
+    lowers = [
+        Version(s.version) for s in _requires_python_spec() if s.operator in (">=", "==", "~=")
+    ]
+    assert lowers, "requires-python must declare a lower bound"
+    low = min(lowers)
+    return f"{low.major}.{low.minor}"
+
+
+def _test_matrix() -> dict[str, dict]:
+    """Map 'major.minor' -> matrix include entry for the ci.yml `test` job."""
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    include = workflow["jobs"]["test"]["strategy"]["matrix"]["include"]
+    return {str(entry["python-version"]): entry for entry in include}
+
 
 def test_docs_only_change_selects_no_runtime_suite():
     assert ci.select_pr_suites(["docs/TEST_LAYERS.md", "README.md"]) == []
@@ -30,7 +57,59 @@ def test_backend_change_selects_production_python_suite():
         "issue-collection",
         "legacy-pr",
         "python-core",
+        "python-min",
     ]
+
+
+def test_min_supported_python_runs_the_full_unit_suite():
+    """#2868: the OLDEST supported interpreter must run the FULL unit suite.
+
+    A version-specific regression surfaces on the lowest interpreter first
+    (e.g. datetime.fromisoformat rejecting a 'Z' suffix before 3.11). The old
+    matrix ran only a hand-picked 7-file smoke on 3.10, so #2868's failing unit
+    test (test_models_session) was not covered and the break sailed through the
+    PR AND the post-merge main push. Assert the min lane runs `python-min`,
+    which runs `pytest tests/unit/` (the WHOLE tree) + compileall.
+    """
+    matrix = _test_matrix()
+    min_py = _min_supported_python()
+    assert min_py in matrix, f"min supported python {min_py} missing from ci test matrix"
+    assert matrix[min_py]["suite"] == "python-min", (
+        f"min supported python {min_py} must run the python-min suite, "
+        f"got {matrix[min_py].get('suite')!r}"
+    )
+
+    import json
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    commands = suites["python-min"]["commands"]
+    flat = [tuple(c) for c in commands]
+    assert any(
+        c[:3] == ("{python}", "-m", "compileall") for c in flat
+    ), "python-min must compileall"
+    pytest_cmd = next((c for c in flat if c[:3] == ("{python}", "-m", "pytest")), None)
+    assert pytest_cmd is not None, "python-min must run pytest"
+    # The WHOLE unit tree, not a hand-picked subset — that is the #2868 fix.
+    assert (
+        "tests/unit/" in pytest_cmd
+    ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
+
+
+def test_backend_change_runs_the_min_version_unit_lane():
+    """End-to-end of the #2868 fix: an app/** change selects python-min, and the
+    matrix runs python-min on the minimum supported interpreter -- so the full
+    unit suite actually executes on py-min for source changes (on the PR and on
+    the post-merge push to main)."""
+    selected = ci.select_pr_suites(["app/models/session.py"])
+    assert "python-min" in selected
+    assert _test_matrix()[_min_supported_python()]["suite"] == "python-min"
+
+
+def test_every_matrix_python_is_supported():
+    """No matrix lane may target an interpreter outside requires-python."""
+    spec = _requires_python_spec()
+    for key in _test_matrix():
+        assert Version(key) in spec, f"ci test matrix targets unsupported python {key}"
 
 
 def test_frontend_change_selects_frontend_and_critical_e2e():


### PR DESCRIPTION
## 问题（已核实）

`test` 矩阵此前只在生产运行时 **3.11** 跑全量 `python-core`（`pytest tests/`）；3.10/3.12/3.14 跑 7 文件 `compatibility-smoke`，且它仅在**依赖文件变更**时被 `scripts/ci.py` 选中。于是一个 `app/**`-only 改动让 3.10/3.12/3.14 **空跑绿（3-4 秒）**。`datetime.fromisoformat('...Z')` 只在 **3.10** 炸（3.11+ 才接受 `Z`），其失败测试 `test_models_session` 在 `tests/unit/`——恰好落在被跳过的 3.10 上。**同一路径选择也跑在合并后的 `push: main`**，所以 merge commit 的 `test (3.10)` 也是空跑绿 → 红 main 75 分钟无人察觉。

## 方案（回答 issue criterion 1 的 lane 选择 + CI 成本）

新增 **`python-min`** suite = `compileall` + 全量 `pytest tests/unit/`，在**最低支持版本 3.10** 上对每个非文档改动都跑。

**为什么是 unit-only 而非在 3.10 跑全量 `python-core`**：排障中先在 3.10 上试跑了全量 `python-core`，暴露两个结构性问题——
1. **超时**：全量 `tests/`+覆盖率在较慢的 3.10 解释器上 ~2× 慢，撞 `python-core` 的 599s 预算被杀（3.11 ~340s）。
2. **flake**：全量含 integration/并发测试，在 3.10 放大既有 flake。排障中已分别修掉 [#2959](https://github.com/open-ace/open-ace/pull/2959)（mapping-rules `mock.patch`-in-threads）与 [#2869](https://github.com/open-ace/open-ace/pull/2967)（共享 `app.db` 跨会话污染），但全量 integration 在 3.10 的不稳定面仍大。

`tests/unit/` 只跑单元（进程内、快、确定），**本地 `python-min` 5271 passed / 120s**，无超时无 flake，且覆盖版本特有回归的主战场（语法、stdlib API 如 `fromisoformat`——都是单元级）。

矩阵分工：
- **3.11**（生产运行时）：`python-core` 全量 `tests/`（含 integration）+ 覆盖率，不变。
- **3.10**（最低支持）：`python-min` `compileall` + 全量 `tests/unit/`，每个代码改动都跑。
- **3.12/3.14**（前向）：`compatibility-smoke`（有界 7 文件），依赖变更时跑，不变。

## 验收标准对照

- [x] **criterion 1**：lane 选择保留（成本），但 `app/**` 改动必在最低版本 3.10 真跑全量单元（含 compileall）。
- [x] **criterion 2**：合并后 main 验证由既有 `push:[main]`（`ci.yml`+`schema-sync.yml`）承担，本改动使其对 3.10 真正生效。
- [x] **criterion 5**：`tests/unit/test_ci_runner.py` 结构测试锁「最低版本必跑全量 `tests/unit`」+ workflow 注释 + `docs/TEST_LAYERS.md`。

**有意 out-of-scope**：criterion 3（红 main 主动告警——由现已诚实的红 check + 原生失败通知覆盖，废弃了脆弱的自动开 issue 草案）；criterion 4（下游 auto-dev main-sync 归因，属自主编排器较高风险子系统）作为 follow-up。

**补充（供维护者）**：`protect-main` ruleset 的 `strict_required_status_checks_policy=false`（未开 "require branches up to date"）——跨 PR 陈旧基线仍可能红 main，是降低红 main 概率最高杠杆项，属 ruleset 配置（需 admin），不在本代码改动内。

## 测试
```
python scripts/ci.py run python-min   # 本地 5271 passed / 120s, exit 0
pytest tests/unit/test_ci_runner.py -q   # 22 passed
actionlint .github/workflows/ci.yml   # clean
```

Refs #2868
🤖 Generated with [Claude Code](https://claude.com/claude-code)