### PR TITLE
fix(usage): repair PostgreSQL models_used merge with jsonb operators (Bug 8)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -898,7 +898,7 @@ class AutonomousAgentRunner:
             models_used = [result.model] if hasattr(result, "model") and result.model else None
 
             # Call increment_usage (atomic UPSERT)
-            repo.increment_usage(
+            increment_ok = repo.increment_usage(
                 tool_name=tool_name,
                 host_name=host_name,
                 tenant_id=tenant_id,
@@ -909,6 +909,15 @@ class AutonomousAgentRunner:
                 request_count=result.request_count or 0,
                 models_used=models_used,
             )
+
+            if not increment_ok:
+                # Keep daily_usage_synced unset so subsequent activity can
+                # still be recorded; this round's usage is not retried.
+                logger.warning(
+                    "increment_usage failed for session=%s; leaving daily_usage_synced unset",
+                    session_id[:8],
+                )
+                return
 
             # Set sync flag to mark as synced (idempotency)
             if self.session_manager:

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -264,10 +264,10 @@ class UsageRepository:
                             WHEN EXCLUDED.models_used IS NULL
                             THEN daily_usage.models_used
                             ELSE (
-                                SELECT json_agg(DISTINCT elem)
-                                FROM json_array_elements(
-                                    COALESCE(daily_usage.models_used::json, '[]')
-                                    || EXCLUDED.models_used::json
+                                SELECT jsonb_agg(DISTINCT elem)::text
+                                FROM jsonb_array_elements(
+                                    COALESCE(daily_usage.models_used::jsonb, '[]'::jsonb)
+                                    || EXCLUDED.models_used::jsonb
                                 ) elem
                             )
                         END

--- a/docs/superpowers/plans/2026-08-21-daily-usage-jsonb-operator.md
+++ b/docs/superpowers/plans/2026-08-21-daily-usage-jsonb-operator.md
@@ -1,0 +1,105 @@
+# 修复方案：daily_usage 增量 UPSERT 的 PostgreSQL json 拼接操作符错误（Bug 8）
+
+- 日期：2026-08-21
+- 状态：待审查
+- 影响范围：用量统计（daily_usage）写入、配额核算数据完整性
+- 引入来源：commit `bc6e2067`（auto: development changes (round 1)，Issue #2732 原子增量特性），经 PR #2878 合入 main，2026-08-20 21:50 部署至生产服务器
+
+## 1. Bug 描述
+
+`UsageRepository._increment_usage_postgresql()` 的 UPSERT 语句在 `models_used` 合并分支中使用了 PostgreSQL 不存在的 `json || json` 拼接操作符，导致所有携带 `models_used` 的用量增量写入失败。
+
+## 2. 生产证据
+
+1. journalctl（openace-scheduler.service）自 2026-08-21 02:49:58 起持续报错，截至 19:00 共 190 次：
+   - `app.repositories.database - WARNING - Rolling back transaction due to error: operator does not exist: json || json`
+   - `app.repositories.usage_repo - ERROR - Failed to increment usage (PostgreSQL): operator does not exist: json || json`
+   - `LINE 19: || EXCLUDED.models_used:... HINT: No operator matches the given name and argument types.`
+2. `daily_usage` 表 `CURRENT_DATE`（2026-08-21）零行记录；最近 5 天仅 2026-08-18 有 2 行（该特性部署前的测试数据）。即该特性上线后没有任何一条用量被成功记录。
+3. 服务器代码 `/home/openace/app/repositories/usage_repo.py` 与本地 main 一致（mtime 2026-08-20 21:50，buggy 代码在第 263-273 行）。
+
+## 3. 根因分析
+
+问题 SQL（app/repositories/usage_repo.py L263-273）：
+
+```sql
+models_used = CASE
+    WHEN EXCLUDED.models_used IS NULL
+    THEN daily_usage.models_used
+    ELSE (
+        SELECT json_agg(DISTINCT elem)
+        FROM json_array_elements(
+            COALESCE(daily_usage.models_used::json, '[]')
+            || EXCLUDED.models_used::json
+        ) elem
+    )
+END
+```
+
+两处缺陷：
+
+1. **`json || json` 操作符不存在**：PostgreSQL 的 `||` JSON 拼接操作符仅定义在 `jsonb` 类型上，`json` 类型没有该操作符。`daily_usage.models_used` 列为 `text`，`::json` 转换后无法拼接。CASE 的 ELSE 分支仅在 `EXCLUDED.models_used IS NOT NULL` 时求值，因此只有携带 models 的增量才失败（工作流 AI 调用几乎都携带 model，故全量失败）。
+2. **`json_agg(DISTINCT elem)` 非法**（第二处隐藏缺陷，验证时发现）：`json` 类型没有相等操作符，`DISTINCT` 聚合无法用于 `json` 元素。即使修复了 `||`，`json_agg(DISTINCT ...)` 仍会报 `could not identify an equality operator for type json`。
+
+CI 未拦截原因：`tests/unit/test_usage_repo_increment.py` 对 PostgreSQL 分支全部 skip（L17-23），仅覆盖 SQLite 路径；该 SQL 字符串从未在测试中针对 PostgreSQL 执行过。
+
+## 4. 影响面（含放大器）
+
+1. 用量丢失：每次增量失败后整个事务回滚，tokens/requests/models 全部不入库。
+2. 放大器（`app/modules/workspace/autonomous/agent_runner.py` L846, L900-919）：`_sync_usage_to_daily_usage()` 不检查 `increment_usage()` 返回值，失败后仍将 session 标记为 `daily_usage_synced=True`，丢失的用量永不重试。
+3. 配额核算失真：调度器周期运行 `quota_enforcement` 任务，但 `daily_usage` 无当日数据，租户/用户用量配额无法正确核算。
+4. 受影响调用方清单：`agent_runner._sync_usage_to_daily_usage()`（scheduler 进程，不检查返回值）；`usage_sink.DailyUsageSink.consume()`（LLM 代理/Web 进程，已正确处理 False 返回值）；`scripts/backfill_daily_usage.py`（离线脚本，已检查返回值）。仅 agent_runner 需要代码修复。
+
+## 5. 修复设计
+
+### 5.1 主修复（usage_repo.py）
+
+将合并分支改为 jsonb 语义（已在生产服务器用 TEMP TABLE 验证通过）：
+
+```sql
+models_used = CASE
+    WHEN EXCLUDED.models_used IS NULL
+    THEN daily_usage.models_used
+    ELSE (
+        SELECT jsonb_agg(DISTINCT elem)::text
+        FROM jsonb_array_elements(
+            COALESCE(daily_usage.models_used::jsonb, '[]'::jsonb)
+            || EXCLUDED.models_used::jsonb
+        ) elem
+    )
+END
+```
+
+要点：
+- `text → jsonb` 转换后 `||` 拼接合法；`'[]'::jsonb` 作为 NULL 缺省。
+- `jsonb_array_elements` 直接消费 jsonb；`jsonb` 有相等操作符，`jsonb_agg(DISTINCT elem)` 合法。
+- `::text` 显式转回列类型（列为 text，jsonb 赋值需显式转换）。
+- 语义与 SQLite 路径一致：EXCLUDED 为 NULL 时保留现有 models；否则做集合并集去重。
+- 旧数据风险：增量始终指向 `CURRENT_DATE`，历史行（可能含非法 JSON 文本）不会被触碰；当日行由修复后代码以合法 JSON 创建。
+
+### 5.2 放大器修复（agent_runner.py）
+
+`_sync_usage_to_daily_usage()` 仅在 `increment_usage()` 返回 True 时才标记 `daily_usage_synced=True`；返回 False 时记 warning 并保留未同步标记。注意：失败那次的用量本身不会自动补回（per-milestone 增量随运行结束丢弃），保留标记只保证后续活动的用量仍可写入，与 5.3 的不回填决定一致。此为最小改动，不改变调用时序。
+
+### 5.3 不修复项（明确排除）
+
+- 不迁移列类型 text → jsonb（涉及历史数据与读取方，超出本 Bug 范围）。
+- 不回填 08-21 丢失的用量数据（会话级明细仍在 agent_sessions，如需精确补偿属后续独立任务）。
+
+## 6. 测试计划
+
+1. 新增契约测试 `tests/unit/test_usage_repo_increment.py::TestPostgresqlUpsertContract`：
+   - 用 mock 捕获 `_increment_usage_postgresql` 发出的 SQL 文本（mock `repo.db.connection()` 的 cursor.execute）；
+   - 负向断言（空白归一化后）：不含 `json_array_elements(` 与 `json_agg(`（实现时发现原建议的 `::json(?!\w)\s*\|\|` 正则漏检真实 bug 形态——旧 SQL 中 `::json` 与 `||` 之间隔着 `, '[]')`，故改为直接禁用 json 类型的原语；已验证两条负向断言对旧 buggy SQL 均命中）；
+   - 正向断言（SQL 文本先做空白归一化再匹配，防排版变化导致假失败）：含 `jsonb_agg(DISTINCT elem)::text`、`jsonb_array_elements(`、`COALESCE(daily_usage.models_used::jsonb, '[]'::jsonb)`、`|| EXCLUDED.models_used::jsonb`；
+   - 断言 `WHEN EXCLUDED.models_used IS NULL THEN daily_usage.models_used` 保留分支仍在。
+2. 新增 `agent_runner._sync_usage_to_daily_usage` 失败不置位测试：patch `app.modules.workspace.autonomous.agent_runner.UsageRepository`，mock `increment_usage` 返回 False，断言 session 未被标记 synced；返回 True 时正常标记。
+3. 回归：现有 SQLite 增量测试全绿（`HOME=/tmp/fakehome pytest tests/unit/test_usage_repo_increment.py tests/unit/test_usage_sink.py`）。
+4. 部署后生产验证：观察 journalctl 不再出现 `json || json`；`daily_usage` 当日出现新行且多次增量后 tokens 累加、models 去重合并。
+
+## 7. 部署与验证步骤
+
+1. PR 合并后同步 `app/repositories/usage_repo.py`、`app/modules/workspace/autonomous/agent_runner.py` 至 `/home/openace`。
+2. 重启两个加载 usage_repo 的常驻服务：`systemctl restart openace-scheduler.service`（scheduler 进程，agent_runner 路径）与 `systemctl restart open-ace.service`（Web/LLM 代理进程，DailyUsageSink 路径）。
+3. 等待工作流产生一次带 model 的 AI 调用后查 `daily_usage` 当日行与 journalctl 错误消失。
+4. 无需 resume 任何工作流（本 Bug 不阻塞工作流推进，仅丢统计）。

--- a/tests/unit/test_agent_runner_usage_sync.py
+++ b/tests/unit/test_agent_runner_usage_sync.py
@@ -1,0 +1,50 @@
+"""Regression: _sync_usage_to_daily_usage must not mark sessions synced on failure.
+
+Bug 8 (2026-08-21): increment_usage() failures were ignored and the session
+was still flagged ``daily_usage_synced=True``, permanently discarding usage
+data. The flag may only be set when the increment succeeds.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+
+def _make_runner() -> tuple[AutonomousAgentRunner, MagicMock]:
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    session_manager = MagicMock()
+    session_manager.get_session.return_value = None
+    runner.session_manager = session_manager
+    return runner, session_manager
+
+
+def _make_result() -> AgentTaskResult:
+    return AgentTaskResult(
+        request_count=5,
+        total_tokens=100,
+        total_input_tokens=60,
+        total_output_tokens=40,
+    )
+
+
+def test_increment_failure_leaves_synced_unset():
+    runner, session_manager = _make_runner()
+
+    with patch("app.modules.workspace.autonomous.agent_runner.UsageRepository") as repo_cls:
+        repo_cls.return_value.increment_usage.return_value = False
+        runner._sync_usage_to_daily_usage("sess-1", "qwen-code", 1, _make_result())
+
+    session_manager.update_session_fields.assert_not_called()
+
+
+def test_increment_success_marks_synced():
+    runner, session_manager = _make_runner()
+
+    with patch("app.modules.workspace.autonomous.agent_runner.UsageRepository") as repo_cls:
+        repo_cls.return_value.increment_usage.return_value = True
+        runner._sync_usage_to_daily_usage("sess-1", "qwen-code", 1, _make_result())
+
+    session_manager.update_session_fields.assert_called_once_with(
+        "sess-1", {"daily_usage_synced": True}, require_tenant=False
+    )

--- a/tests/unit/test_usage_repo_increment.py
+++ b/tests/unit/test_usage_repo_increment.py
@@ -1,6 +1,8 @@
 """Unit tests for UsageRepository.increment_usage() (Issue #2732)."""
 
 import json
+import re
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -357,3 +359,84 @@ class TestIncrementUsageIssue2585:
         # Different variants should normalize to same tool family
         assert normalize_tool_name("qwen-code") == normalize_tool_name("QWEN")
         assert normalize_tool_name("qwen-code-cli") == normalize_tool_name("QWEN")
+
+
+class TestPostgresqlUpsertContract:
+    """Contract tests for the PostgreSQL increment UPSERT.
+
+    Bug 8 (2026-08-21): the models_used merge used ``json || json`` and
+    ``json_agg(DISTINCT ...)`` which PostgreSQL rejects (no ``||`` operator
+    and no equality operator for the ``json`` type), failing every usage
+    increment that carried a model. CI has no PostgreSQL server, so the
+    SQL text is pinned here instead: the merge must be expressed purely
+    with jsonb operators.
+    """
+
+    @staticmethod
+    def _capture_upsert_sql() -> str:
+        """Run _increment_usage_postgresql against a fake connection."""
+        repo = UsageRepository.__new__(UsageRepository)
+
+        cursor = MagicMock()
+        captured: dict = {}
+
+        def _record_execute(sql, params=None):
+            captured["sql"] = sql
+
+        cursor.execute.side_effect = _record_execute
+
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        db = MagicMock()
+        db.connection.return_value.__enter__.return_value = conn
+        repo.db = db
+
+        ok = repo._increment_usage_postgresql(
+            tool_name="qwen-code",
+            host_name="localhost",
+            tenant_id=1,
+            tokens_used=10,
+            input_tokens=6,
+            output_tokens=4,
+            cache_tokens=0,
+            request_count=1,
+            models_json='["m1"]',
+        )
+        assert ok is True
+        return captured["sql"]
+
+    @classmethod
+    def _normalized_sql(cls) -> str:
+        return re.sub(r"\s+", " ", cls._capture_upsert_sql())
+
+    def test_no_json_typed_merge_primitives(self):
+        """The json type supports neither ``||`` nor DISTINCT aggregates.
+
+        The buggy form was ``COALESCE(...::json, '[]') || EXCLUDED...::json``
+        with ``json_array_elements``/``json_agg(DISTINCT ...)``. Pin the
+        json-typed primitives out of the statement so the merge can only
+        be expressed with jsonb.
+        """
+        normalized = self._normalized_sql()
+        assert "json_array_elements(" not in normalized, (
+            "json_array_elements implies json-typed operands; json has no "
+            "|| or equality operators — use jsonb_array_elements"
+        )
+        assert "json_agg(" not in normalized, (
+            "json_agg(DISTINCT ...) is invalid (json has no equality "
+            "operator); use jsonb_agg(DISTINCT ...)"
+        )
+
+    def test_merge_uses_jsonb_operators(self):
+        """The models_used merge must be expressed with jsonb primitives."""
+        normalized = self._normalized_sql()
+        assert "jsonb_agg(DISTINCT elem)::text" in normalized
+        assert "jsonb_array_elements(" in normalized
+        assert "COALESCE(daily_usage.models_used::jsonb, '[]'::jsonb)" in normalized
+        assert "|| EXCLUDED.models_used::jsonb" in normalized
+
+    def test_null_models_preserved_branch(self):
+        """EXCLUDED.models_used NULL must keep the existing models_used."""
+        normalized = self._normalized_sql()
+        assert "WHEN EXCLUDED.models_used IS NULL THEN daily_usage.models_used" in normalized


### PR DESCRIPTION
## 问题

`UsageRepository._increment_usage_postgresql()` 的 models_used 合并分支使用了 PostgreSQL 不存在的 `json || json` 拼接操作符与非法的 `json_agg(DISTINCT ...)`，导致所有携带 model 的用量增量写入失败：

- 生产证据（192.168.31.159）：自 2026-08-21 02:49 起调度器日志报 `operator does not exist: json || json` 共 190 次；`daily_usage` 当日零行（特性上线后无一条成功）。
- 引入来源：commit bc6e2067（Issue #2732 原子增量特性，PR #2878），2026-08-20 21:50 部署。
- CI 未拦截原因：PostgreSQL 分支测试全部 skip，该 SQL 从未在测试中执行。

放大器：`agent_runner._sync_usage_to_daily_usage()` 不检查 `increment_usage()` 返回值，失败仍标记 `daily_usage_synced=True`，丢失的用量永不重试。

## 修复

1. **SQL（app/repositories/usage_repo.py）**：合并改用 jsonb 原语（已在生产以 TEMP TABLE 验证）：
   - `jsonb_array_elements(COALESCE(daily_usage.models_used::jsonb, '[]'::jsonb) || EXCLUDED.models_used::jsonb)`
   - `jsonb_agg(DISTINCT elem)::text`
   - 语义与 SQLite 路径一致（新 models 为 NULL 保留现有；否则集合并集去重）。
2. **置位（app/modules/workspace/autonomous/agent_runner.py）**：仅当 increment 成功才标记 `daily_usage_synced=True`，失败保留标记使后续活动仍可写入。
3. **测试**：契约测试（捕获 SQL 文本，负向禁用 json 原语、正向钉住 jsonb 形态，已验证对旧 buggy SQL 命中）+ agent_runner 失败不置位回归测试。

## 测试

- `pytest tests/unit/test_agent_runner_usage_sync.py tests/unit/test_agent_runner_session_id_capture.py tests/unit/test_usage_repo_increment.py tests/unit/test_usage_sink.py tests/unit/test_usage_service.py tests/unit/test_usage_dedup.py` → 49 passed, 1 skipped（PG-only skip）。

## 部署说明

合并后需同步 usage_repo.py 与 agent_runner.py 至服务器并重启 `openace-scheduler.service` 与 `open-ace.service`（两个进程均加载 usage_repo）。无需 resume 工作流（本 Bug 不阻塞推进，仅丢统计）。

修复方案：docs/superpowers/plans/2026-08-21-daily-usage-jsonb-operator.md（独立 agent 审查两轮，零未处理意见通过）