### PR TITLE
fix(merge): add bounded merge-policy settle retry before manual pause

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -87,6 +87,9 @@ class AutonomousWorkflow:
     # to a fresh development round. Capped by MAX_MERGE_FAIL_DEV_ROUNDS; at the
     # cap the workflow falls through to a Tier2 terminal report + failed.
     merge_fail_dev_rounds: int = 0
+    # Bounded merge-policy settle budget (merge residual-race guard); cleared
+    # on pause so a resume gets a fresh budget.
+    merge_policy_settle_retries: int = 0
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
     # at creation; persisted content is generated in this language and rendered
     # verbatim (it does NOT switch per viewer). System-authored structured
@@ -178,6 +181,7 @@ class AutonomousWorkflow:
             "last_ci_failure_signature": self.last_ci_failure_signature,
             "last_ci_failure_head_sha": self.last_ci_failure_head_sha,
             "merge_fail_dev_rounds": self.merge_fail_dev_rounds,
+            "merge_policy_settle_retries": self.merge_policy_settle_retries,
             "content_language": self.content_language,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
@@ -250,6 +254,7 @@ class AutonomousWorkflow:
             last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
             last_ci_failure_head_sha=data.get("last_ci_failure_head_sha", ""),
             merge_fail_dev_rounds=data.get("merge_fail_dev_rounds", 0),
+            merge_policy_settle_retries=data.get("merge_policy_settle_retries", 0),
             content_language=data.get("content_language", "en"),
             created_at=(
                 datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -100,6 +100,11 @@ logger = logging.getLogger(__name__)
 # lag (#2673); half of it here would re-freeze slow-provisioning heads.
 _POLICY_SETTLE_GRACE_SECONDS = 1200
 
+# Extra merge-policy settle polls before a manual-recovery pause. Each is one
+# scheduler cycle (~10s), so a genuine external block (missing review/draft/
+# rule) waits at most a few seconds more before a human is signalled.
+_MERGE_POLICY_SETTLE_RETRY_MAX = 3
+
 
 def _required_contexts(gh, pr_number: int, base_branch: str) -> set[str] | None:
     """Required-check contexts for ``base_branch``, or None if undeterminable.
@@ -557,6 +562,25 @@ def handle(ctx, deps) -> PhaseResult:
                             _POLICY_SETTLE_GRACE_SECONDS,
                         )
                         return PhaseResult.retry()
+                # Residual race (#27 / #2804 follow-up): a bounded settle budget
+                # absorbs a "clean rollup but GitHub still blocked" transient
+                # that outlives the 1200s grace window, before persisting a
+                # manual-recovery pause. Cap is tiny so a genuine external block
+                # (missing review / draft / rule) pauses after at most a few
+                # scheduler cycles.
+                settle_retries = int(wf.get("merge_policy_settle_retries") or 0)
+                if settle_retries < _MERGE_POLICY_SETTLE_RETRY_MAX:
+                    logger.info(
+                        "PR #%s: blocked with a settled rollup (%s); settle "
+                        "retry %d/%d before pausing",
+                        pr_number,
+                        mergeable_state or "unknown",
+                        settle_retries + 1,
+                        _MERGE_POLICY_SETTLE_RETRY_MAX,
+                    )
+                    return PhaseResult.retry(
+                        workflow_patch={"merge_policy_settle_retries": settle_retries + 1}
+                    )
                 # No pending checks and GitHub has finished computing, yet
                 # repository policy still requires external action (approval,
                 # marking ready, or a rule change). Persist a manually
@@ -583,7 +607,12 @@ def handle(ctx, deps) -> PhaseResult:
                 # a pause (see advance()), so a normal return is enough.
                 return PhaseResult.pause(
                     structured_error={"message": message},
-                    workflow_patch={"error_message": message, "agent_pid": None},
+                    workflow_patch={
+                        "error_message": message,
+                        "agent_pid": None,
+                        # Clear the settle budget so a resume gets a fresh one.
+                        "merge_policy_settle_retries": 0,
+                    },
                 )
 
             # A mergeable/blocked/unknown PR is not by itself evidence of

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -96,6 +96,8 @@ class AutonomousWorkflowRepository:
         "last_ci_failure_signature",
         "last_ci_failure_head_sha",
         "merge_fail_dev_rounds",
+        # Bounded merge-policy settle budget (merge residual-race guard).
+        "merge_policy_settle_retries",
         # Worktree transition journal for SIGKILL-resilient recovery (#2050).
         "worktree_transition_state",
         "transition_original_path",
@@ -310,8 +312,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
-                     last_ci_failure_head_sha, merge_fail_dev_rounds, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, merge_fail_dev_rounds, merge_policy_settle_retries, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -359,6 +361,7 @@ class AutonomousWorkflowRepository:
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     data.get("merge_fail_dev_rounds", 0),
+                    data.get("merge_policy_settle_retries", 0),
                     now,
                     now,
                 ),
@@ -380,8 +383,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
-                     last_ci_failure_head_sha, merge_fail_dev_rounds, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, merge_fail_dev_rounds, merge_policy_settle_retries, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -428,6 +431,7 @@ class AutonomousWorkflowRepository:
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     data.get("merge_fail_dev_rounds", 0),
+                    data.get("merge_policy_settle_retries", 0),
                     now,
                     now,
                 ),

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1260,6 +1260,9 @@ def retry_workflow(workflow_id):
         # PR-C (#2443): reset the Tier1 dev-round escalation budget too, so a
         # retried workflow gets a fresh MAX_MERGE_FAIL_DEV_ROUNDS allowance.
         "merge_fail_dev_rounds": 0,
+        # Bounded merge-policy settle budget; reset on retry so a resumed
+        # workflow gets a fresh merge-settle allowance.
+        "merge_policy_settle_retries": 0,
     }
     # Optional per-workflow scope bump (#2309): a failed round whose only
     # blocker was the changed-files cap can be retried with a higher limit

--- a/migrations/versions/20260821_001_add_merge_policy_settle_retries.py
+++ b/migrations/versions/20260821_001_add_merge_policy_settle_retries.py
@@ -1,0 +1,67 @@
+"""Add merge_policy_settle_retries to autonomous_workflows.
+
+Bounded settle budget for the merge-phase residual race: a "clean rollup but
+GitHub still blocked" transient that outlives the policy-settle grace window.
+``merge.py`` counts each such settled-but-blocked cycle against this budget
+before persisting a manual-recovery pause, so a genuine block
+(missing review / draft / rule) pauses after at most a few scheduler cycles,
+while a self-healing transient no longer freezes the workflow.
+
+Revision ID: 20260821_001_add_merge_policy_settle_retries
+Revises: 20260820_004
+Create Date: 2026-08-21
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260821_001"
+down_revision: str | None = "20260820_004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the merge_policy_settle_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the column directly in CREATE TABLE; nothing
+        # to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    if "merge_policy_settle_retries" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(
+                "merge_policy_settle_retries",
+                sa.Integer(),
+                nullable=True,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove the merge_policy_settle_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        if "merge_policy_settle_retries" in existing_columns:
+            batch_op.drop_column("merge_policy_settle_retries")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -524,7 +524,8 @@ CREATE TABLE autonomous_workflows (
     verified_by text,
     verification_session_id text,
     issue_closed_by_workflow_at timestamp with time zone,
-    merge_fail_dev_rounds integer DEFAULT 0
+    merge_fail_dev_rounds integer DEFAULT 0,
+    merge_policy_settle_retries integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -363,7 +363,8 @@ CREATE TABLE autonomous_workflows (
  verified_by text,
  verification_session_id text,
  issue_closed_by_workflow_at TIMESTAMP,
- merge_fail_dev_rounds integer DEFAULT 0
+ merge_fail_dev_rounds integer DEFAULT 0,
+ merge_policy_settle_retries integer DEFAULT 0
 );
 
 CREATE TABLE backfill_logs (

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -97,6 +97,14 @@ def _workflow(pr_number: int | None = 123, dev_round: int = 1) -> dict:
     }
 
 
+def _policy_exhausted_workflow() -> dict:
+    """A workflow whose merge-policy settle budget is already exhausted, so the
+    residual-settle guard must NOT defer — it falls straight to the pause."""
+    wf = _workflow()
+    wf["merge_policy_settle_retries"] = merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX
+    return wf
+
+
 # ── registration ─────────────────────────────────────────────────────────
 
 
@@ -333,7 +341,7 @@ def test_merge_policy_block_with_settled_ci_still_pauses():
     deps.gh.get_branch_protection.return_value = {
         "required_status_checks": {"contexts": ["PR Gate"]}
     }
-    result = merge_phase.handle(_ctx(_workflow()), deps)
+    result = merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps)
 
     assert result.outcome == "pause"
     host.emit_status_change.assert_called_once()
@@ -383,7 +391,7 @@ def test_merge_policy_block_with_missing_required_on_stale_head_pauses():
         checks=[{"name": "Select suites", "bucket": "pass"}],
         committed_at=datetime.now(timezone.utc) - timedelta(hours=2),
     )
-    result = merge_phase.handle(_ctx(_workflow()), deps)
+    result = merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps)
 
     assert result.outcome == "pause"
     host.emit_status_change.assert_called_once()
@@ -397,14 +405,14 @@ def test_merge_policy_block_with_unresolvable_commit_time_pauses():
         checks=[{"name": "Select suites", "bucket": "pass"}],
         committed_at=None,
     )
-    assert merge_phase.handle(_ctx(_workflow()), deps).outcome == "pause"
+    assert merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps).outcome == "pause"
 
     deps_raise, _ = _policy_unsettled_deps(
         checks=[{"name": "Select suites", "bucket": "pass"}],
         committed_at=None,
     )
     deps_raise.gh.get_commit_committed_at.side_effect = GitHubOpsError("api down")
-    assert merge_phase.handle(_ctx(_workflow()), deps_raise).outcome == "pause"
+    assert merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps_raise).outcome == "pause"
 
 
 def test_merge_policy_block_with_unobservable_required_still_pauses():
@@ -416,7 +424,7 @@ def test_merge_policy_block_with_unobservable_required_still_pauses():
         committed_at=datetime.now(timezone.utc),
     )
     deps.gh.get_branch_protection.side_effect = GitHubOpsError("no access")
-    result = merge_phase.handle(_ctx(_workflow()), deps)
+    result = merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps)
 
     assert result.outcome == "pause"
     host.emit_status_change.assert_called_once()
@@ -429,10 +437,71 @@ def test_merge_policy_block_with_required_present_skips_commit_time_lookup():
         checks=[{"name": "PR Gate", "bucket": "pass"}],
         committed_at=datetime.now(timezone.utc),
     )
-    result = merge_phase.handle(_ctx(_workflow()), deps)
+    result = merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps)
 
     assert result.outcome == "pause"
     deps.gh.get_commit_committed_at.assert_not_called()
+    host.emit_status_change.assert_called_once()
+
+
+# ── bounded merge-policy settle budget (residual-race guard) ──────────────
+
+
+def test_settle_retry_before_pause():
+    """A 'clean rollup but GitHub still blocked' shape with budget remaining
+    defers (retry) and increments the settle counter — not a pause."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],  # required context present
+        committed_at=datetime.now(timezone.utc),
+    )
+    wf = _workflow()
+    wf["merge_policy_settle_retries"] = 0
+    result = merge_phase.handle(_ctx(wf), deps)
+
+    assert result.outcome == "retry"
+    assert result.workflow_patch["merge_policy_settle_retries"] == 1
+    host.emit_status_change.assert_not_called()
+
+
+def test_settle_retry_accumulates_then_pauses():
+    """The settle counter accumulates across scheduler cycles; when it reaches
+    the cap the workflow pauses, and the pause resets the counter so a resume
+    gets a fresh budget."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc),
+    )
+    cap = merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX
+    for counter in range(cap):  # 0,1,2 → retry and increment
+        wf = _workflow()
+        wf["merge_policy_settle_retries"] = counter
+        result = merge_phase.handle(_ctx(wf), deps)
+        assert result.outcome == "retry"
+        assert result.workflow_patch["merge_policy_settle_retries"] == counter + 1
+        host.emit_status_change.assert_not_called()
+
+    # counter == cap → pause, and the pause resets the counter to 0.
+    wf = _workflow()
+    wf["merge_policy_settle_retries"] = cap
+    result = merge_phase.handle(_ctx(wf), deps)
+    assert result.outcome == "pause"
+    assert result.workflow_patch["merge_policy_settle_retries"] == 0
+    host.emit_status_change.assert_called_once()
+
+
+def test_genuine_block_still_pauses_within_budget():
+    """With the budget exhausted, a still-blocked settled rollup is a genuine
+    external block: it must still pause (never retry forever), and the pause
+    keeps the human-facing message/resume semantics."""
+    deps, host = _policy_unsettled_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],
+        committed_at=datetime.now(timezone.utc),
+    )
+    result = merge_phase.handle(_ctx(_policy_exhausted_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.workflow_patch["merge_policy_settle_retries"] == 0
+    assert "not merge-ready" in result.structured_error["message"]
     host.emit_status_change.assert_called_once()
 
 

--- a/tests/unit/test_merge_stale_conflict_branch_has_main.py
+++ b/tests/unit/test_merge_stale_conflict_branch_has_main.py
@@ -20,6 +20,7 @@ import pytest
 from app.modules.workspace.autonomous.evidence import Evidence, Verdict
 from app.modules.workspace.autonomous.github_ops import GitHubOpsError
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator, WorkflowPaused
+from app.modules.workspace.autonomous.phases import merge as merge_phase
 
 
 def _make_workflow(**overrides):
@@ -144,8 +145,14 @@ def test_policy_rejection_on_branch_with_main_still_pauses(mock_gh_cls):
     o._branch_contains_main = MagicMock(return_value=True)
     o._resolve_merge_conflicts = MagicMock()
 
+    # The branch-has-main + policy-rejection path falls through to the
+    # merge-policy handler. That handler now defers (not pauses) while the
+    # settle budget is unexhausted, so preset the budget to its cap to keep
+    # asserting that a GENUINE policy block still pauses (regression guard for
+    # the bounded merge-policy settle retry).
+    wf = _make_workflow(merge_policy_settle_retries=merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX)
     with pytest.raises(WorkflowPaused, match="Merge blocked by repository policy"):
-        o._do_merge(_make_workflow())
+        o._do_merge(wf)
 
     # The ancestry probe ran (proving the branch-has-main path was taken, not
     # some other pause route), and no git conflict means resolution never ran.


### PR DESCRIPTION
## 背景
merge 阶段存在一个已知长尾竞态（#27 / #2804 follow-up）：GitHub 的状态传播存在瞬时滞后，当已有两处守卫（`any_pending`/`unknown` 守卫、缺失 required+head fresh 宽限守卫）都恰好放行时，`merge.py::handle()` 仍会零容忍地对 merge_policy 暂停，把一个"clean rollup 但 GitHub 短暂 blocked"的自愈瞬时态挂起为人工可恢复暂停。

## 修复
在暂停分支前加**有界重试**：新增 `autonomous_workflows.merge_policy_settle_retries` 计数列（cap=3），未满预算 `PhaseResult.retry()` 并 +1，满预算才 `pause()` 并清零（resume 重新获得完整预算）。

- 真实外部阻塞（缺 review / 草稿 / 规则）最多延迟 ~3×调度周期（~30s）后照常暂停，消息与恢复语义不变。
- 预算用专用计数，不吃 `advance()` 对 retry 的 `transient_retry_count` 清零（复用它不可行，已在方案核实）。

## 改动
- `app/modules/workspace/autonomous/phases/merge.py`：新增 `_MERGE_POLICY_SETTLE_RETRY_MAX`，暂停前插入 settle-retry 分支，pause patch 清零计数。
- `app/repositories/autonomous_repo.py`：`ALLOWED_WORKFLOW_FIELDS` + `create_workflow`（PG/SQLite 两分支 INSERT）接入新列。
- `app/modules/workspace/autonomous/models.py`：`WorkflowModel` 字段/to_dict/from_dict。
- `app/routes/autonomous.py`：`retry_workflow` 重置计数。
- `migrations/versions/20260821_001_add_merge_policy_settle_retries.py`：Alembic 迁移（先例风格）。
- `schema/schema-postgres.sql`、`schema/schema-sqlite.sql`：快照同步。
- `tests/autonomous/phases/test_merge.py`：3 条新契约测试 + 5 条既有"仍应暂停"测试的回归护栏。

## 验证
本地全绿：
- `tests/autonomous/phases/test_merge.py`（23 passed）
- `tests/issues/2428/test_merge_wiring.py` + `test_merge_primary_fallback.py`（16 passed）
- `tests/issues/716/test_autonomous_repo.py`（42 passed）
- `tests/autonomous/test_phase_host_contract.py` + `test_phase_b_acceptance.py`（18 passed）
- schema 同步校验：committed postgres→sqlite、alembic head→sqlite 均匹配
- pre-commit 全钩子通过