### PR TITLE
fix: 配额编辑保存无反应 — null字段被误传为EXPLICIT_NULL且错误提示被Modal遮挡 (#2887)

### DIFF
--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -106,7 +106,7 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({
   return createPortal(
     <div
       className={cn('toast-container position-fixed p-3', positionClasses[position])}
-      style={{ zIndex: 9999 }}
+      style={{ zIndex: 10600 }}
     >
       {toasts.map((toast) => (
         <Toast key={toast.id} {...toast} onClose={onClose} />

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -158,7 +158,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
               position: 'fixed',
               top: position.top,
               left: position.left,
-              zIndex: 9999,
+              zIndex: 10600,
             }}
             role="tooltip"
           >

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -340,8 +340,8 @@ export const QuotaAlerts: React.FC = () => {
       const submitData: UpdateQuotaRequest = {
         daily_token_quota: formData.daily_token_quota ?? undefined,
         monthly_token_quota: formData.monthly_token_quota ?? undefined,
-        daily_request_quota: formData.daily_request_quota,
-        monthly_request_quota: formData.monthly_request_quota,
+        daily_request_quota: formData.daily_request_quota ?? undefined,
+        monthly_request_quota: formData.monthly_request_quota ?? undefined,
       };
       await updateQuota.mutateAsync({ userId: editingUser.id, data: submitData });
       toast.success(t('quotaUpdated', language), t('quotaUpdatedDesc', language));

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -774,7 +774,7 @@ pre code {
   align-items: center;
   justify-content: center;
   background-color: rgba(255, 255, 255, 0.8);
-  z-index: 9999;
+  z-index: 10600;
 }
 
 [data-theme='dark'] .loading-overlay {
@@ -2249,7 +2249,7 @@ table .latency-row:hover td {
 /* Tooltip Styles */
 .tooltip {
   position: fixed;
-  z-index: 9999;
+  z-index: 10600;
 }
 
 .tooltip-inner {


### PR DESCRIPTION
Closes #2887

## 修复内容

修复配额编辑页面保存无反应的问题，包含两个前端 Bug：

### Bug 1: null 值被误传为 EXPLICIT_NULL
- **问题**: QuotaAlerts.tsx 中 `daily_request_quota` 和 `monthly_request_quota` 未使用 `?? undefined` 处理 null 值
- **影响**: 用户未修改 request 配额时，前端发送 null 字段，后端将其解释为"设为 unlimited"，导致 400 错误
- **修复**: 给这两个字段添加 `?? undefined`

### Bug 2: Toast 被 Modal 遮挡
- **问题**: Toast.tsx z-index = 9999，低于 Modal 的 10050
- **影响**: 即使后端返回错误，toast 也无法显示在 Modal 上层
- **修复**: 将 Toast、Tooltip、loading-overlay 的 z-index 从 9999 提升至 10600

## 修改文件
- `frontend/src/components/features/management/QuotaAlerts.tsx`: 添加 `?? undefined` 处理 null 值
- `frontend/src/components/common/Toast.tsx`: z-index 9999 → 10600
- `frontend/src/components/common/Tooltip.tsx`: z-index 9999 → 10600
- `frontend/src/styles/main.css`: .loading-overlay 和 .tooltip z-index 9999 → 10600

## 修复方案
详见 Issue 评论: https://github.com/open-ace/open-ace/issues/2887#issuecomment-5369600332

Generated with Qwen Code