### PR TITLE
test: unit 测试按测试隔离 SQLite 库，消除共享 app.db 跨会话污染 (#2869)

### DIFF
--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -33,6 +33,16 @@
 历史文件继续按 inventory 逐步迁移；不要再新增新的“按功能域”顶层目录或
 tests 根目录测试文件。
 
+**测试数据库隔离（#2869）**：`tests/unit/conftest.py` 的 `_isolated_unit_db`
+autouse fixture 给每个 unit 测试指向自己的一次性 sqlite 库
+（`DATABASE_URL=sqlite:///<tmp>/unit-test.db`），非 `@pytest.mark.postgres` 测试
+一律如此。这样走 `create_app` 的测试不再共享工作区级 `app.db`——早先某个测试留下
+列形态不一致的同名表会让后续 `create_app` 的 schema 重放随机崩
+（`no such column`），本 fixture 从根上消除该共享态，并使测试默认库选择显式化
+（不静默继承开发机的 `DATABASE_URL`）。`tests/integration/conftest.py` 早已用
+每测试 `tmp_path` 库。需要 Postgres 的测试打 `@pytest.mark.postgres` 并放入
+`tests/integration/`（由独立 postgres lane 执行）。
+
 ## 回归测试写法
 
 新回归测试直接写到其规范目录，并在模块或测试函数上记录来源：

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,9 +9,40 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolated_unit_db(request, tmp_path, monkeypatch):
+    """Give every unit test its own throwaway SQLite database (#2869).
+
+    The full-suite CI lane runs many test files in one pytest process that all
+    share a workspace-level ``app.db``. Any test that goes through
+    ``create_app`` triggers ``ensure_all_tables`` -> ``load_schema_from_file``,
+    which replays the authoritative schema onto that shared DB. ``CREATE TABLE
+    IF NOT EXISTS`` does NOT reconcile an already-existing table's columns, so
+    if an earlier test left a table whose shape doesn't match the snapshot, a
+    later ``CREATE INDEX`` referencing the missing column raises
+    ``sqlite3.OperationalError: no such column`` — and an *unrelated* test's
+    setup crashes at random (``test_tenant_keywords_api`` was the first
+    casualty; the next could be any ``create_app``-using file).
+
+    Pointing ``DATABASE_URL`` at a fresh per-test path removes the shared state
+    entirely. It also makes the test DB choice EXPLICIT instead of silently
+    inheriting the developer's ambient ``DATABASE_URL`` (which, when it points
+    at Postgres, makes the same repositories fail with PG syntax errors — a
+    different false signal). ``@pytest.mark.postgres`` tests are exempt: they
+    intentionally use the ambient ``DATABASE_URL`` (the CI Postgres service).
+    """
+    if request.node.get_closest_marker("postgres"):
+        return
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/unit-test.db")
+
+
 @pytest.fixture
-def app():
-    """Create Flask app for testing."""
+def app(_isolated_unit_db):
+    """Create Flask app for testing.
+
+    Depends on ``_isolated_unit_db`` (also autouse) so the isolated
+    ``DATABASE_URL`` is in place before ``create_app`` bootstraps the schema.
+    """
     from app import create_app
 
     app = create_app({"TESTING": True, "SECRET_KEY": "test-secret-key"})

--- a/tests/unit/test_tenant_keywords_api.py
+++ b/tests/unit/test_tenant_keywords_api.py
@@ -3,21 +3,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _isolated_app_db(monkeypatch, tmp_path):
-    """Point this file's tests at a throwaway per-test database.
-
-    In the full-suite run the workspace-level app.db is shared across every
-    pytest session; leftover table shapes written by unrelated tests can make
-    create_app's ensure_all_tables() snapshot replay fail (CREATE INDEX on a
-    table whose columns don't match). A fresh DATABASE_URL per test sidesteps
-    that shared state entirely.
-    """
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/tenant-keywords.db")
-
 
 class TestTenantKeywordsApiAuth:
     """Test authentication and authorization for tenant keywords API."""

--- a/tests/unit/test_unit_db_isolation_2869.py
+++ b/tests/unit/test_unit_db_isolation_2869.py
@@ -1,0 +1,78 @@
+"""Regression: unit tests must not share a polluted ``app.db`` (#2869).
+
+The full-suite CI lane runs many test files in one pytest process. Any test that
+goes through ``create_app`` replays the authoritative schema onto whatever DB
+``DATABASE_URL`` resolves to. Before the per-test isolation fixture, that was a
+single workspace-level ``app.db`` shared across the whole session; a table left
+by an earlier test with a column shape that doesn't match the snapshot made a
+later ``CREATE INDEX`` raise ``no such column``, crashing an unrelated test's
+setup at random (``test_tenant_keywords_api`` was the first casualty).
+
+These tests (a) prove the pollution failure mode is real and (b) prove the
+``tests/unit`` autouse isolation fixture shields ``create_app`` from it.
+"""
+
+import os
+import sqlite3
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2869)]
+
+
+def test_isolation_fixture_points_at_a_private_sqlite_db():
+    """The autouse fixture makes the test DB choice explicit and per-test.
+
+    Not a silent inheritance of the developer's ambient ``DATABASE_URL`` — the
+    URL is a throwaway sqlite file under this test's own tmp dir (#2869 AC:
+    "不引入对开发机 DATABASE_URL 的静默依赖").
+    """
+    url = os.environ.get("DATABASE_URL", "")
+    assert url.startswith("sqlite:///")
+    assert url.endswith("/unit-test.db")
+
+
+def test_shared_db_pollution_does_not_reach_isolated_create_app(tmp_path, monkeypatch):
+    """A mismatched-shape table must not break an isolated ``create_app``.
+
+    Reproduces the exact cross-session failure, then shows a fresh per-test DB
+    (what the conftest fixture hands every unit test) bootstraps cleanly even
+    while the polluted DB still exists on disk.
+    """
+    from app import create_app
+    from app.repositories.schema_init import ensure_all_tables
+
+    # Pollute a DB the way an earlier session did: ``tenant_quotas`` exists but
+    # is missing ``tenant_id``, so the authoritative schema's
+    # ``CREATE UNIQUE INDEX ... ON tenant_quotas (tenant_id)`` raises. This table
+    # is NOT in ``_backfill_missing_columns`` hardcoded list, so the backfill
+    # can't silently paper over it — the crash is deterministic.
+    polluted = tmp_path / "polluted.db"
+    conn = sqlite3.connect(str(polluted))
+    conn.execute("CREATE TABLE tenant_quotas (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    # (1) Reproduce #2869: pointed at the polluted DB, schema bootstrap raises.
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{polluted}")
+    with pytest.raises(sqlite3.OperationalError, match="no such column"):
+        ensure_all_tables()
+
+    # (2) The fix: a fresh isolated DB — exactly what the autouse fixture hands
+    #     each test — bootstraps create_app cleanly, unaffected by the pollution.
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/isolated.db")
+    app = create_app({"TESTING": True, "SECRET_KEY": "test-secret-key"})
+    assert app is not None
+
+
+def test_create_app_uses_the_isolated_db_not_the_shared_default(client):
+    """Going through the shared ``client`` fixture must land on the isolated DB.
+
+    The ``client`` fixture builds ``create_app`` via the ``app`` fixture, which
+    depends on the isolation fixture; a healthy client proves ``create_app``
+    bootstrapped its schema on the per-test DB without tripping over any shared
+    state. (401 without auth confirms the app is wired and serving.)
+    """
+    assert os.environ["DATABASE_URL"].endswith("/unit-test.db")
+    response = client.get("/api/tenants/1/sensitive-keywords")
+    assert response.status_code in (401, 403)

--- a/tests/unit/test_user_stats.py
+++ b/tests/unit/test_user_stats.py
@@ -329,10 +329,19 @@ class TestSchedulerSafetyNet:
 
         scheduler = DataFetchScheduler()
 
+        # Grant leadership without touching the DB. _run_fetch's leader election
+        # reads the scheduler_leaders table and bails ("not leader") if it can't;
+        # under per-test DB isolation (#2869) that table isn't bootstrapped, so
+        # this unit test must mock the client to stay self-contained. It
+        # previously passed only because an earlier test had created
+        # scheduler_leaders in the shared app.db — the exact cross-test coupling
+        # #2869 removes.
         with (
             patch("app.routes.fetch.run_fetch_scripts"),
+            patch("app.services.leader_election.LeaderElectionClient") as mock_leader,
             patch.object(scheduler, "_refresh_materialized_views"),
             patch.object(scheduler, "_aggregate_user_stats") as mock_agg,
         ):
+            mock_leader.return_value.try_acquire_leadership.return_value = True
             scheduler._run_fetch()
             mock_agg.assert_called_once()


### PR DESCRIPTION
## 问题（已核实）

全套 lane 的多个 pytest 文件在同一进程共享工作区级 `app.db`。任何走 `create_app` 的测试触发 `ensure_all_tables` → `load_schema_from_file` 在该库上重放权威快照；`CREATE TABLE IF NOT EXISTS` **不修正已存在表的列形态**，所以早先某测试留下的列不一致同名表会让后续 `CREATE INDEX` 报 `sqlite3.OperationalError: no such column`，令**无关测试的 setup 随机崩**（`test_tenant_keywords_api` 首当其冲；下一个可以是任何 create_app 测试）。根因是共享态，修复方向是消除共享而非追污染者。

## 改动

- **`tests/unit/conftest.py`**：新增 autouse `_isolated_unit_db` fixture —— 每个 unit 测试指向自己的一次性 sqlite 库（`DATABASE_URL=sqlite:///<tmp>/unit-test.db`），`@pytest.mark.postgres` 测试豁免（用 CI Postgres 服务）。`app` fixture 依赖它，保证 `create_app` bootstrap schema 前 URL 已就位。这既消除共享态，也使测试默认库选择**显式化**（不再静默继承开发机的 `DATABASE_URL`——那在指向 Postgres 时会让同一 repo 以 PG 语法错失败，另一种假信号）。
- **`tests/unit/test_unit_db_isolation_2869.py`**（新，回归）：用缺 `tenant_id` 列的 `tenant_quotas` 同名表**复现** `no such column` 崩溃（该表不在 `_backfill_missing_columns` 硬编码清单，崩溃确定性），再证明隔离后的 `create_app` 不受影响；并断言库选择显式（criterion 5）。
- **移除 `test_tenant_keywords_api.py` 的文件级止血 fixture**（7233145e），由 conftest 统一承担（criterion 4）。
- **修 `test_user_stats::test_run_fetch_calls_aggregate`**：它此前**依赖别的测试**在共享库里建好 `scheduler_leaders` 表才通过——正是本 issue 要消除的跨测试耦合。改为 mock leader election 使其自足（隔离后暴露的真实潜藏依赖）。
- **`docs/TEST_LAYERS.md`**：记录该隔离契约（criterion 5）。

## 验收标准对照

- [x] 消除 unit 测试对共享 `app.db` 的依赖（conftest 每测试独立库；与 `tests/integration/conftest.py` 既有 tmp_path 库同构）
- [x] 回归测试：先造列不一致同名表 → 走 create_app → 断言 setup 不因污染而崩
- [x] 全套 lane 稳定绿（本地 `tests/unit/` 5229 passed；见下方 flake 说明；以合并后若干次 run 观察为准）
- [x] 7233145e 文件级 fixture 已移除
- [x] 不引入对开发机 `DATABASE_URL` 的静默依赖：库选择逻辑有 docstring + docs + 断言

## 测试

```
pytest tests/unit/ -m "not postgres"   # 本地 5229 passed（唯一失败为无关 flake，见下）
pytest tests/unit/test_unit_db_isolation_2869.py tests/unit/test_user_stats.py tests/unit/test_tenant_keywords_api.py -q  # green
```

**关于 `test_deepseek_tool_choice` flake**：本地全量跑偶发失败（SSRF 解析 `api.openai.com` 在本沙箱 DNS 偶发失败 → 403），但该测试**隔离下 10/10 通过（带/不带本 fixture 都是）**，是与本改动无关的既有网络 flake，非 DB 共享问题；CI（DNS 正常）应稳定通过。

Closes #2869

🤖 Generated with [Claude Code](https://claude.com/claude-code)