### PR TITLE
fix: main-regression hotfix + CI shard-deadlock quarantine (baseline 73 -> 64)

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -331,13 +331,20 @@ class RemoteSessionManager:
         if not machine:
             return None
 
-        # Issue #2597: Verify machine DB status is 'online' to prevent zombie sessions
-        # during heartbeat tolerance window (180s). The in-memory is_connected() check
-        # may return True during this window even if the agent is actually dead.
+        # Issue #2597: Verify the machine's DB status is in the online family to
+        # prevent zombie sessions during the heartbeat tolerance window (180s).
+        # The in-memory is_connected() check may return True during this window
+        # even if the agent is actually dead. Issue #2537 split "online" into a
+        # lifecycle: registration is transient 'online', heartbeats report
+        # 'idle' (no sessions) or 'busy' (active sessions) — all three mean the
+        # agent is alive, so only 'offline'/'unknown' reject here. Gating on
+        # 'online' alone would refuse every session on a busy multi-session
+        # machine.
         machine_status = machine.get("status", "")
-        if machine_status != "online":
+        if machine_status not in ("online", "idle", "busy"):
             logger.warning(
-                f"Machine {machine_id} DB status is '{machine_status}', not 'online' - rejecting session creation"
+                f"Machine {machine_id} DB status is '{machine_status}', not in the "
+                f"online family (online/idle/busy) - rejecting session creation"
             )
             return None
 

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -283,6 +283,14 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
             # default tenant) so the runtime tenant predicate does not silently
             # degrade to global scope (Issue #1832 F8).
             ("tenant_id", "INTEGER", "1"),
+            # Issue #2585 sync flag: idx_agent_sessions_daily_usage_synced in the
+            # authoritative schema references this column, so legacy DBs need it
+            # back-filled before the schema's CREATE INDEX runs (Issue #1128).
+            (
+                "daily_usage_synced",
+                "INTEGER" if not is_postgres else "boolean",
+                "0" if not is_postgres else "false",
+            ),
         ]
         for col_name, col_type, default in agent_sessions_columns:
             if not _column_exists(conn, "agent_sessions", col_name, dialect):

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -74,14 +74,6 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "144",
-      "nodeid": "tests/issues/144/e2e_file_changes_panel.py::test_panel_features",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "setup_error",
       "exception_type": "",
       "issue_number": "166",
       "nodeid": "tests/issues/166/test_launchd_env.py::test_qwen_cli",
@@ -209,38 +201,6 @@
       "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
     },
     {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "210",
-      "nodeid": "tests/issues/210/e2e_project_stats_accuracy.py::test_project_stats_accuracy",
-      "outcome": "failure",
-      "summary": "AssertionError: Stats API failed: 403"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "211",
-      "nodeid": "tests/issues/211/e2e_project_sort.py::test_project_sort",
-      "outcome": "failure",
-      "summary": "AssertionError: Stats API failed: 403"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "2121",
-      "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_not_found",
-      "outcome": "failure",
-      "summary": "assert None == 42"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "2121",
-      "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_tenant_id_is_none",
-      "outcome": "failure",
-      "summary": "assert None == 42"
-    },
-    {
       "category": "test_body_exception",
       "exception_type": "ValueError",
       "issue_number": "22",
@@ -263,38 +223,6 @@
       "nodeid": "tests/issues/25/test_issue25.py::test_issue25",
       "outcome": "failure",
       "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "",
-      "issue_number": "394",
-      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_session_sync_api",
-      "outcome": "error",
-      "summary": "failed on setup with \"file tests/issues/394/e2e_terminal_tab.py, line 183"
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "394",
-      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_connection_and_interaction",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "setup_error",
-      "exception_type": "AssertionError",
-      "issue_number": "394",
-      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_option_in_modal",
-      "outcome": "error",
-      "summary": "failed on setup with \"AssertionError\""
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "394",
-      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_tab",
-      "outcome": "failure",
-      "summary": "AssertionError: Login failed: {\"error\":\"Invalid username or password\"}"
     },
     {
       "category": "assertion_failure",
@@ -366,7 +294,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_database_migration",
       "outcome": "failure",
-      "summary": "AssertionError: linux_account 字段未添加到 users 表"
+      "summary": "AssertionError: linux_account \u5b57\u6bb5\u672a\u6dfb\u52a0\u5230 users \u8868"
     },
     {
       "category": "assertion_failure",
@@ -382,7 +310,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_update_user_with_linux_account",
       "outcome": "failure",
-      "summary": "AssertionError: 创建用户失败"
+      "summary": "AssertionError: \u521b\u5efa\u7528\u6237\u5931\u8d25"
     },
     {
       "category": "test_body_exception",
@@ -550,7 +478,7 @@
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9180888144'>\""
+      "summary": "assert '\u5931\u8d25\u6458\u5f55' not in \"PR #42 \u5728\u5408\u5e76\u524d...9180888144'>\""
     },
     {
       "category": "test_body_exception",
@@ -587,8 +515,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-20 prune 12 resolved entries across three clusters (85->73). 172 quota e2e (4): the file was a manual deployment diagnostic whose check functions took plain args pytest misread as fixtures; moved to manual_e2e_quota_enforcement.py out of discovery, historical path kept as a pointer+guard so the round-robin shard layout is unchanged. 1895 redis auth (4): production evolved to fail-closed - dev empty REDIS_PASSWORD now raises RuntimeError instead of warning, so the fail-open assertion was inverted and special-char passwords lengthened past the validation minimum. 987 prompt truncation (4): fixtures drifted from the phase-migrated autonomous review - agent result must be a REVIEW_RESULT JSON verdict, gh.get_current_branch/_validate_autonomous_change_scope mocked, zh content-language case constructed accordingly.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32373066502",
+    "prune_note": "2026-08-22 prune 9 entries (73->64). Fixed by this PR's test realignments: 211 e2e (1) - the projects page renders an empty-state with no <table> on a fresh DB and the table gained a spacer column plus non-sortable columns, so the test now seeds projects via the API and asserts caret icons only on columns that actually toggle; 2121 sso provisioning (2) - #2893 added the auto_provision_users tenant check (stubbed for hermetic unit tests) and #1826 F6 removed the silent tenant-1 fallback, so the two no-binding cases now assert rejection. Resolved independently on main, observed in the verification run: 210 e2e project stats accuracy (1). Moved to quarantine, NOT fixed: 144 e2e (1) + 394 terminal e2e (4) - these legacy sync-playwright scripts are wired onto the async 'page' fixture; on CI the fixture wedges chromium and async teardown sits outside pytest-timeout's coverage, so issue-tests shards 1/2 hung for the full 180-minute job timeout on runs 32509705360/32561885885. They are deselected via ci/legacy-issue-quarantine.json pending the #2457 rewrite onto self-contained sync subprocess plumbing.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32565288903",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/ci/legacy-issue-quarantine.json
+++ b/ci/legacy-issue-quarantine.json
@@ -10,6 +10,51 @@
       "exit_condition": "The remote LLM-proxy handler returns a non-deadlocking result (500/502) after exhausting failover keys; verified when the weekly subprocess probe for this nodeid passes.",
       "expires_on": "2026-09-09",
       "expected_probe_outcome": "timeout"
+    },
+    {
+      "nodeid": "tests/issues/144/e2e_file_changes_panel.py::test_panel_features",
+      "reason": "Legacy sync-playwright e2e wired onto the async page fixture (pytest-asyncio): fixture setup wedges chromium, pytest-timeout kills the test but async fixture teardown is outside its coverage, so the CI shard never exits (two nightly runs lost issue-tests shards 1/2 to this for the full 180-minute job timeout).",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+      "exit_condition": "Issue-144 e2e rewritten onto self-contained sync subprocess plumbing (skip without a reachable server) and re-added to discovery under #2457 cluster closeout.",
+      "expires_on": "2026-09-05",
+      "expected_probe_outcome": "timeout"
+    },
+    {
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_option_in_modal",
+      "reason": "Legacy sync-playwright e2e wired onto the async page fixture (pytest-asyncio): same CI shard deadlock as the issue-144 entry; pytest-timeout cannot recover the session once async fixture teardown wedges.",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+      "exit_condition": "Issue-394 e2e rewrite (subprocess entry, cohabitation-safe against issue-165 session pollution) lands under #2457 cluster closeout.",
+      "expires_on": "2026-09-05",
+      "expected_probe_outcome": "timeout"
+    },
+    {
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_session_sync_api",
+      "reason": "Legacy sync-playwright e2e wired onto the async page fixture (pytest-asyncio): same CI shard deadlock as the issue-144 entry.",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+      "exit_condition": "Issue-394 e2e rewrite (subprocess entry, cohabitation-safe against issue-165 session pollution) lands under #2457 cluster closeout.",
+      "expires_on": "2026-09-05",
+      "expected_probe_outcome": "timeout"
+    },
+    {
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_connection_and_interaction",
+      "reason": "Legacy sync-playwright e2e wired onto the async page fixture (pytest-asyncio): same CI shard deadlock as the issue-144 entry.",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+      "exit_condition": "Issue-394 e2e rewrite (subprocess entry, cohabitation-safe against issue-165 session pollution) lands under #2457 cluster closeout.",
+      "expires_on": "2026-09-05",
+      "expected_probe_outcome": "timeout"
+    },
+    {
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_tab",
+      "reason": "Legacy sync-playwright e2e wired onto the async page fixture (pytest-asyncio): same CI shard deadlock as the issue-144 entry.",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+      "exit_condition": "Issue-394 e2e rewrite (subprocess entry, cohabitation-safe against issue-165 session pollution) lands under #2457 cluster closeout.",
+      "expires_on": "2026-09-05",
+      "expected_probe_outcome": "timeout"
     }
   ]
 }

--- a/tests/issues/211/e2e_project_sort.py
+++ b/tests/issues/211/e2e_project_sort.py
@@ -63,6 +63,31 @@ def test_project_sort():
     stats = r.json().get("stats", [])
     print(f"  OK - {len(stats)} projects found")
 
+    # Seed projects when the DB is fresh: the projects page renders an
+    # empty-state component (no <table>) when there are no projects, which
+    # dead-waits below. The old flow hit that wait before its own
+    # "need at least 2 projects" skip ever ran.
+    if len(stats) < 2:
+        print("\n[1a] Seed projects for sorting")
+        for i in (1, 2, 3):
+            r = session.post(
+                f"{BASE_URL}/api/projects",
+                json={
+                    "name": f"E2E 211 Sort {i}",
+                    "path": f"/tmp/e2e-211-sort-{i}",
+                    "description": "seeded by issue 211 e2e",
+                    "create_dir": False,
+                },
+            )
+            assert r.status_code in (
+                200,
+                201,
+            ), f"Seed project {i} failed: {r.status_code} {r.text[:200]}"
+        r = session.get(f"{BASE_URL}/api/projects/stats")
+        assert r.status_code == 200, f"Stats API failed: {r.status_code}"
+        stats = r.json().get("stats", [])
+        print(f"  OK - seeded, {len(stats)} projects now")
+
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=HEADLESS)
         context = browser.new_context(viewport={"width": 1400, "height": 900})
@@ -96,19 +121,25 @@ def test_project_sort():
         headers = page.locator("table thead th")
         header_count = headers.count()
 
+        # The table now has a leading spacer column (empty header) and
+        # non-sortable data columns (requests, work time); only columns whose
+        # header renders a caret after a click are sortable.
+        sortable_columns = []
         for i in range(header_count - 1):  # skip last column (Actions)
             header_text = headers.nth(i).inner_text().strip()
-            print(f"\n  Testing column: {header_text}")
+            print(f"\n  Testing column: {header_text!r}")
 
-            # First click - should activate sort with desc direction
+            # First click - activates sort with desc direction on sortable
+            # columns; non-sortable ones stay icon-less and are skipped.
             headers.nth(i).click()
             page.wait_for_timeout(500)
 
-            # Check sort icon appears (bi-caret-up-fill or bi-caret-down-fill)
             icon = headers.nth(i).locator("i.bi-caret-down-fill, i.bi-caret-up-fill")
-            assert (
-                icon.count() == 1
-            ), f"Sort icon not found for column '{header_text}' after first click"
+            if icon.count() == 0:
+                print("    (not sortable - no sort icon after click)")
+                continue
+            assert icon.count() == 1, f"Expected exactly one sort icon for column '{header_text}'"
+            sortable_columns.append(header_text)
             print("    Click 1: sort icon visible (desc)")
             shot(page, f"02_sort_{header_text}_desc")
 
@@ -145,6 +176,9 @@ def test_project_sort():
         actions_icon = actions_header.locator("i.bi-caret-down-fill, i.bi-caret-up-fill")
         assert actions_icon.count() == 0, "Actions column should not have sort icon"
         print("  OK - Actions column is not sortable")
+
+        assert sortable_columns, "No sortable column found - sort UI missing?"
+        print(f"\n  Sortable columns verified: {sortable_columns}")
 
         print("\n" + "=" * 60)
         print("ALL TESTS PASSED")

--- a/tests/issues/2121/test_sso_user_tenant_id.py
+++ b/tests/issues/2121/test_sso_user_tenant_id.py
@@ -92,7 +92,7 @@ class TestCreateUserFromSsoTenantId:
         call_kwargs = user_repo_mock.create_user.call_args.kwargs
         assert call_kwargs["tenant_id"] == 5
 
-    def test_uses_default_tenant_id_when_provider_not_found(self, app_ctx):
+    def test_provider_not_found_rejects_creation(self, app_ctx):
         """Provider not found leaves no tenant binding: creation is rejected.
 
         #1826 F6 removed the silent fallback to tenant 1 — SSO_NULL_TENANT_POLICY
@@ -121,7 +121,7 @@ class TestCreateUserFromSsoTenantId:
         assert result is None
         user_repo_mock.create_user.assert_not_called()
 
-    def test_uses_default_tenant_id_when_provider_tenant_id_is_none(self, app_ctx):
+    def test_provider_tenant_id_none_rejects_creation(self, app_ctx):
         """Provider tenant_id None leaves no binding: creation is rejected.
 
         Same #1826 F6 fail-closed contract as a missing provider — no silent

--- a/tests/issues/2121/test_sso_user_tenant_id.py
+++ b/tests/issues/2121/test_sso_user_tenant_id.py
@@ -46,6 +46,19 @@ def _make_provider_config(tenant_id=2):
     )
 
 
+def _auto_provision_tenant_repo():
+    """TenantRepository stub for the #2893 auto-provision policy check.
+
+    _create_user_from_sso now reads tenant.settings.auto_provision_users
+    before provisioning; the unit tests must not touch a real database.
+    """
+    tenant = MagicMock()
+    tenant.settings.auto_provision_users = True
+    repo = MagicMock()
+    repo.get_by_id.return_value = tenant
+    return repo
+
+
 class TestCreateUserFromSsoTenantId:
     """Test cases for _create_user_from_sso tenant_id handling."""
 
@@ -66,6 +79,10 @@ class TestCreateUserFromSsoTenantId:
         with (
             patch.object(sso_module, "get_sso_manager", return_value=manager),
             patch.object(sso_module, "user_repo", user_repo_mock),
+            patch(
+                "app.repositories.tenant_repo.TenantRepository",
+                return_value=_auto_provision_tenant_repo(),
+            ),
         ):
             result = sso_module._create_user_from_sso(sso_user, "test-provider")
 
@@ -76,7 +93,12 @@ class TestCreateUserFromSsoTenantId:
         assert call_kwargs["tenant_id"] == 5
 
     def test_uses_default_tenant_id_when_provider_not_found(self, app_ctx):
-        """When Provider is not found, use default tenant_id=1."""
+        """Provider not found leaves no tenant binding: creation is rejected.
+
+        #1826 F6 removed the silent fallback to tenant 1 — SSO_NULL_TENANT_POLICY
+        defaults to reject (and even warn returns None), so a missing binding
+        must fail closed instead of provisioning into the default tenant.
+        """
         sso_user = _make_sso_user()
 
         manager = MagicMock()
@@ -89,15 +111,22 @@ class TestCreateUserFromSsoTenantId:
         with (
             patch.object(sso_module, "get_sso_manager", return_value=manager),
             patch.object(sso_module, "user_repo", user_repo_mock),
+            patch(
+                "app.repositories.tenant_repo.TenantRepository",
+                return_value=_auto_provision_tenant_repo(),
+            ),
         ):
             result = sso_module._create_user_from_sso(sso_user, "unknown-provider")
 
-        assert result == 42
-        call_kwargs = user_repo_mock.create_user.call_args.kwargs
-        assert call_kwargs["tenant_id"] == 1
+        assert result is None
+        user_repo_mock.create_user.assert_not_called()
 
     def test_uses_default_tenant_id_when_provider_tenant_id_is_none(self, app_ctx):
-        """When Provider's tenant_id is None, use default tenant_id=1."""
+        """Provider tenant_id None leaves no binding: creation is rejected.
+
+        Same #1826 F6 fail-closed contract as a missing provider — no silent
+        provisioning into tenant 1.
+        """
         sso_user = _make_sso_user()
         provider_config = _make_provider_config(tenant_id=None)
 
@@ -113,12 +142,15 @@ class TestCreateUserFromSsoTenantId:
         with (
             patch.object(sso_module, "get_sso_manager", return_value=manager),
             patch.object(sso_module, "user_repo", user_repo_mock),
+            patch(
+                "app.repositories.tenant_repo.TenantRepository",
+                return_value=_auto_provision_tenant_repo(),
+            ),
         ):
             result = sso_module._create_user_from_sso(sso_user, "test-provider")
 
-        assert result == 42
-        call_kwargs = user_repo_mock.create_user.call_args.kwargs
-        assert call_kwargs["tenant_id"] == 1
+        assert result is None
+        user_repo_mock.create_user.assert_not_called()
 
     def test_uses_tenant_id_1_when_provider_tenant_id_is_1(self, app_ctx):
         """When Provider's tenant_id is 1, use tenant_id=1."""
@@ -137,6 +169,10 @@ class TestCreateUserFromSsoTenantId:
         with (
             patch.object(sso_module, "get_sso_manager", return_value=manager),
             patch.object(sso_module, "user_repo", user_repo_mock),
+            patch(
+                "app.repositories.tenant_repo.TenantRepository",
+                return_value=_auto_provision_tenant_repo(),
+            ),
         ):
             result = sso_module._create_user_from_sso(sso_user, "test-provider")
 

--- a/tests/issues/559/test_terminal_ws_handler.py
+++ b/tests/issues/559/test_terminal_ws_handler.py
@@ -244,10 +244,13 @@ class TestHandleTerminalWs:
         mock_send_close.assert_called_once_with(handler.socket, 4001)
         assert handler.close_connection is True
 
+    @patch("app.modules.workspace.remote_agent_manager.get_remote_agent_manager")
     @patch("app.ws_frame.send_close")
     @patch("app.ws_frame.perform_handshake")
     @patch("app.modules.workspace.terminal_store.terminal_info_store")
-    def test_missing_remote_url_closes(self, mock_store, mock_handshake, mock_send_close):
+    def test_missing_remote_url_closes(
+        self, mock_store, mock_handshake, mock_send_close, mock_get_mgr
+    ):
         handler = self._make_handler(query_string="token=my-token")
         mock_store.find_by_terminal_id.return_value = (
             "machine-123",
@@ -259,6 +262,14 @@ class TestHandleTerminalWs:
             },
         )
         handler._check_relay_redirect = lambda *args: None
+        # The offline fast-path consults the remote_agent_manager singleton's
+        # in-memory _connections. Other tests in the same pytest process can
+        # leave "machine-123" registered there, which flips this scenario into
+        # the 30s relay wait (close 1001 'Relay timeout') instead. Pin the
+        # manager so the branch under test is deterministic.
+        mock_mgr = MagicMock()
+        mock_mgr.is_connected.return_value = False
+        mock_get_mgr.return_value = mock_mgr
 
         RemoteWSHandler._handle_terminal_ws(handler)
 

--- a/tests/issues/559/test_terminal_ws_handler.py
+++ b/tests/issues/559/test_terminal_ws_handler.py
@@ -262,7 +262,9 @@ class TestHandleTerminalWs:
 
         RemoteWSHandler._handle_terminal_ws(handler)
 
-        mock_send_close.assert_called_once_with(handler.socket, 1011)
+        # 28abe659 added a close reason so clients can distinguish failures:
+        # an empty original_ws_url means the agent is offline.
+        mock_send_close.assert_called_once_with(handler.socket, 1011, "Agent offline")
         assert handler.close_connection is True
 
     @patch("app.ws_frame.send_close")

--- a/tests/issues/604/test_remote_session_ha.py
+++ b/tests/issues/604/test_remote_session_ha.py
@@ -37,6 +37,8 @@ def _connected_machine(machine_id="mac-1", tenant_id=1):
         "tenant_id": tenant_id,
         "machine_name": "test-machine",
         "hostname": "test-host",
+        # #2597 zombie-session gate: creation requires an online-family status
+        "status": "online",
     }
     mgr_mock.check_user_access.return_value = True
     return mgr_mock

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -21,6 +21,7 @@ import pytest
 from app.modules.workspace.autonomous.evidence import Evidence, Verdict
 from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator, WorkflowPaused
+from app.modules.workspace.autonomous.phases import merge as merge_phase
 
 
 def _make_workflow(**overrides):
@@ -684,8 +685,14 @@ class TestDoMergeDeferredRetry:
         mock_gh.merge_pr.side_effect = GitHubOpsError("GraphQL: review required")
         o._resolve_merge_conflicts = MagicMock()
 
+        # Exhaust the settle budget (#2964) so the policy block pauses instead
+        # of deferring with a retry.
         with pytest.raises(WorkflowPaused, match="Merge blocked by repository policy"):
-            o._do_merge(_make_workflow())
+            o._do_merge(
+                _make_workflow(
+                    merge_policy_settle_retries=merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX
+                )
+            )
 
         o._resolve_merge_conflicts.assert_not_called()
         pause_update = o._update_workflow.call_args.args[0]
@@ -698,7 +705,12 @@ class TestDoMergeDeferredRetry:
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_policy_pause_survives_advance_success_cleanup(self, mock_gh_cls):
         """An older transient retry counter must not clear the pause reason."""
-        wf = _make_workflow(transient_retry_count=2)
+        # Exhaust the settle budget (#2964) so this still-pause scenario does
+        # not defer with a retry instead.
+        wf = _make_workflow(
+            transient_retry_count=2,
+            merge_policy_settle_retries=merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX,
+        )
         o, _ = _make_orchestrator(wf)
         o._ensure_worktree = MagicMock()
         mock_gh = MagicMock()
@@ -2073,8 +2085,14 @@ class TestAddWorktreeExistingBranch:
         o._branch_contains_main = MagicMock(return_value=True)
         o._resolve_merge_conflicts = MagicMock()
 
+        # Exhaust the settle budget (#2964): the stale-dirty policy rejection
+        # must still reach the pause, not defer with a retry.
         with pytest.raises(WorkflowPaused, match="Merge blocked by repository policy"):
-            o._do_merge(_make_workflow())
+            o._do_merge(
+                _make_workflow(
+                    merge_policy_settle_retries=merge_phase._MERGE_POLICY_SETTLE_RETRY_MAX
+                )
+            )
 
         o._resolve_merge_conflicts.assert_not_called()
         o._branch_contains_main.assert_called_once()


### PR DESCRIPTION
# Main-regression hotfix + shard-deadlock quarantine (baseline 73 → 64)

Refs #2457

Two consecutive nightlies (Aug 20: new=99; Aug 21: shards 1/2 deadlocked for
the full 180-minute job timeout) left the issue-lane gate red. This PR fixes
the real regressions, realigns drifted fixtures, and quarantines the five
legacy e2e nodeids that deadlock CI shards.

## Production fixes

- **1128 (schema migration crash)** — `daily_usage_synced` (#2585) was added
  to the authoritative schema (CREATE TABLE + partial index) but not to the
  legacy-DB backfill list, so any pre-existing database fails
  `load_schema_from_file()` at the CREATE INDEX with
  `no such column: daily_usage_synced`. Backfill it (sqlite INTEGER / pg
  boolean).
- **165 (remote session 400s)** — the zombie-session guard (#2597) required
  machine status == 'online' exactly, but #2537 introduced the online family
  (registration 'online' → heartbeat 'idle'/'busy'). Every multi-session
  machine reports 'busy' after its first heartbeat, so all subsequent session
  creations were rejected. Accept online/idle/busy; offline/unknown still
  reject.

## Fixture realignments (production evolved intentionally)

- **559** — terminal WS close for an offline agent now carries a reason
  (`'Agent offline'`, 28abe659).
- **822 ×3** — the bounded merge-policy settle retry (#2964) defers policy
  pauses while `merge_policy_settle_retries` is unexhausted; preset the
  budget to its cap in the three still-pause regressions (the same pattern
  #2964 applied to its own tests).
- **211** — projects page renders an empty-state (no `<table>`) on a fresh
  DB, and the table gained a leading spacer column plus non-sortable
  columns; seed projects via the API and assert caret icons only on columns
  that toggle.
- **2121 ×2 + 2 local-only** — #2893 added the `auto_provision_users` tenant
  check (stub `TenantRepository` for hermetic tests) and #1826 F6 removed the
  silent tenant-1 fallback (no-binding cases now assert rejection).
- **604 ×2 (new since #2597)** — the zombie-session gate requires an
  online-family DB status; the fixture's `get_machine` dict never carried
  one, so `create_remote_session` returned None.
- **559 (env-dependent branch)** — the offline fast-path consults the
  `remote_agent_manager` singleton's in-memory `_connections`; sibling tests
  in the same pytest process can leave `machine-123` registered there and
  flip the scenario into the 30s relay wait (CI observed close 1001
  'Relay timeout'). Patch `get_remote_agent_manager` to pin the branch.

## CI shard deadlock quarantine

Shards 1/4 and 2/4 hung at exactly `tests/issues/144/e2e_file_changes_panel.py`
and `tests/issues/394/e2e_terminal_tab.py` on runs 32509705360 and
32561885885 (last log line precedes the file; chrome-headless-shell orphaned
at cancellation). Root cause: these legacy sync-playwright scripts are wired
onto the **async `page` fixture** from `tests/conftest.py`; pytest-timeout
kills the test body but async fixture teardown is outside its coverage, so
the CI process never exits. Local 90s-timeout shard replicas reproduce the
hangs at exactly these five nodeids and complete cleanly past them once
deselected. The five nodeids (144×1, 394×4) are quarantined pending the
#2457 rewrite onto self-contained sync subprocess plumbing; their baseline
entries leave the ledger via the prune commit (annotated as moved-to-
quarantine, not fixed).

1329 (8 entries, new on Aug 20) had already self-healed on later main; no
change needed. 210 (1 baseline entry) resolved independently on main and is
carried in the prune with the verification-run evidence.

## Evidence

- Local: 1128 `5 passed`; 165 lane `10 passed`; 559 `120 passed` (with 604);
  822 `75 passed`; 2121 `4 passed`; 211 lane `1 passed`; 1329 `44 passed`
  (isolated HOME). Local shard replicas (timeout 90s): shard 1 `1006 passed`,
  shard 2 `1034 passed` — hangs confined to the five quarantined nodeids.
- Run A#1 (32564378711): all four shards completed (deadlock gone);
  resolved=9 but new=3 (604×2 status-gate fixtures, 559 singleton pollution)
  → fixed in `e570c4fe`.
- Run A (final, commit `e570c4fe`): https://github.com/open-ace/open-ace/actions/runs/32565288903 — exit 1 as expected,
  `resolved = 9` (211 + 2121×2 fixed; 210 main-resolved; 144 + 394×4
  quarantine-moved), new/changed/invalid/collection_errors all 0,
  quarantined = 6.
- Prune: 73 → 64 citing that run (`prune_source_run_url`).
- Run B (pruned head): https://github.com/open-ace/open-ace/actions/runs/32565915396 — exit 0, all-zero diff.