### PR TITLE
test: realign 1125 session-contract fixtures; prune 3 baseline entries (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -27,30 +27,6 @@
     {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
-      "issue_number": "1125",
-      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_does_not_fallback_to_daily_messages",
-      "outcome": "failure",
-      "summary": "assert 500 == 404"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "AttributeError",
-      "issue_number": "1125",
-      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_keeps_agent_sessions_request_count",
-      "outcome": "failure",
-      "summary": "AttributeError: 'tuple' object has no attribute 'get_json'"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
-      "issue_number": "1125",
-      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_list_sessions_hides_autonomous_tracking_wrappers",
-      "outcome": "failure",
-      "summary": "AssertionError: assert ['track-123',...l-claude-123'] == ['actual-claude-123']"
-    },
-    {
-      "category": "assertion_failure",
-      "exception_type": "AssertionError",
       "issue_number": "1277",
       "nodeid": "tests/issues/1277/test_test_skip_false_positive.py::TestRetryCounterPersistence::test_skip_retries_persisted_on_test_skip",
       "outcome": "failure",
@@ -294,7 +270,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_database_migration",
       "outcome": "failure",
-      "summary": "AssertionError: linux_account \u5b57\u6bb5\u672a\u6dfb\u52a0\u5230 users \u8868"
+      "summary": "AssertionError: linux_account 字段未添加到 users 表"
     },
     {
       "category": "assertion_failure",
@@ -310,7 +286,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_update_user_with_linux_account",
       "outcome": "failure",
-      "summary": "AssertionError: \u521b\u5efa\u7528\u6237\u5931\u8d25"
+      "summary": "AssertionError: 创建用户失败"
     },
     {
       "category": "test_body_exception",
@@ -478,7 +454,7 @@
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '\u5931\u8d25\u6458\u5f55' not in \"PR #42 \u5728\u5408\u5e76\u524d...9180888144'>\""
+      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9180888144'>\""
     },
     {
       "category": "test_body_exception",
@@ -515,8 +491,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "2026-08-22 prune 9 entries (73->64). Fixed by this PR's test realignments: 211 e2e (1) - the projects page renders an empty-state with no <table> on a fresh DB and the table gained a spacer column plus non-sortable columns, so the test now seeds projects via the API and asserts caret icons only on columns that actually toggle; 2121 sso provisioning (2) - #2893 added the auto_provision_users tenant check (stubbed for hermetic unit tests) and #1826 F6 removed the silent tenant-1 fallback, so the two no-binding cases now assert rejection. Resolved independently on main, observed in the verification run: 210 e2e project stats accuracy (1). Moved to quarantine, NOT fixed: 144 e2e (1) + 394 terminal e2e (4) - these legacy sync-playwright scripts are wired onto the async 'page' fixture; on CI the fixture wedges chromium and async teardown sits outside pytest-timeout's coverage, so issue-tests shards 1/2 hung for the full 180-minute job timeout on runs 32509705360/32561885885. They are deselected via ci/legacy-issue-quarantine.json pending the #2457 rewrite onto self-contained sync subprocess plumbing.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32565288903",
+    "prune_note": "2026-08-22 prune 3 entries (64->61). Fixed by this PR's test realignments: 1125 session-contract fixtures drifted from the evolved routes — get_session fakes lacked the tenant_id kwarg (TypeError->500), the non-admin user carried no tenant against the fail-closed _session_lookup_tenant_id guard, and the fake DB keyed wrapper-hiding on the retired cli_session_id predicate instead of visible_session_clause's context-marker match. Contracts verified intact or stronger in production; no code change.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/32579145971",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/1125/test_workspace_session_summary_contract.py
+++ b/tests/issues/1125/test_workspace_session_summary_contract.py
@@ -30,14 +30,17 @@ class _FakeListDatabase:
         raise AssertionError(f"Unexpected fetch_all query: {query}")
 
     def _visible_rows(self, query: str) -> list[dict]:
-        if "COALESCE(cli_session_id, '') != ''" not in query:
+        # Mirrors visible_session_clause(): workflow rows whose context
+        # carries the workflow_id marker are hidden regardless of whether
+        # cli_session_id was backfilled (wrappers are created eagerly, so
+        # agents that fail to start would otherwise leak as orphans).
+        if "COALESCE(context, '') LIKE" not in query:
             return self.session_rows
         return [
             row
             for row in self.session_rows
             if not (
                 row.get("session_type") == "workflow"
-                and row.get("cli_session_id")
                 and '"workflow_id"' in (row.get("context") or "")
             )
         ]
@@ -128,7 +131,17 @@ def test_list_sessions_hides_autonomous_tracking_wrappers(monkeypatch):
         "title": "claude - actual",
         "cli_session_id": "",
     }
-    fake_db = _FakeListDatabase([tracking_row, provider_row])
+    # Wrapper whose agent never started: no cli_session_id backfill, but the
+    # workflow context marker is present — must stay hidden (orphan case).
+    orphan_row = {
+        **tracking_row,
+        "id": 3,
+        "session_id": "track-orphan-456",
+        "title": "Autonomous: wf-2",
+        "cli_session_id": "",
+        "context": '{"workflow_id": "wf-2"}',
+    }
+    fake_db = _FakeListDatabase([tracking_row, provider_row, orphan_row])
 
     monkeypatch.setattr("app.repositories.database.Database", lambda: fake_db)
     monkeypatch.setattr("app.repositories.database.adapt_sql", lambda sql: sql)
@@ -162,7 +175,8 @@ def test_get_session_keeps_agent_sessions_request_count(monkeypatch):
         ],
     )
     manager = SimpleNamespace(
-        get_session=lambda session_id, include_messages=False: session,
+        # **kwargs: the route passes tenant_id= alongside include_messages.
+        get_session=lambda session_id, include_messages=False, **kwargs: session,
         get_messages_page=lambda session_id, limit=None, milestone_id=None: {
             "messages": session.messages,
             "has_more": False,
@@ -175,7 +189,9 @@ def test_get_session_keeps_agent_sessions_request_count(monkeypatch):
 
     app = _make_app()
     with app.test_request_context("/api/workspace/sessions/sess-1125-detail?include_messages=true"):
-        g.user = {"id": 7, "role": "user"}
+        # tenant_id included: _session_lookup_tenant_id fails closed (403)
+        # for non-admins whose tenant cannot be resolved.
+        g.user = {"id": 7, "role": "user", "tenant_id": 1}
         response = workspace_route.get_session("sess-1125-detail")
 
     payload = response.get_json()
@@ -185,7 +201,10 @@ def test_get_session_keeps_agent_sessions_request_count(monkeypatch):
 
 
 def test_get_session_does_not_fallback_to_daily_messages(monkeypatch):
-    manager = SimpleNamespace(get_session=lambda session_id, include_messages=False: None)
+    manager = SimpleNamespace(
+        # **kwargs: the route passes tenant_id= alongside include_messages.
+        get_session=lambda session_id, include_messages=False, **kwargs: None
+    )
 
     monkeypatch.setattr(workspace_route, "get_session_manager", lambda: manager)
 


### PR DESCRIPTION
Refs #2457

## What

Closes out the issue-1125 cluster: 3 baselined failures, all fixture drift against intact (or stronger) production contracts — no production change.

## Root causes

1. `get_session` fakes did not accept the `tenant_id` kwarg the route now passes `manager.get_session`, so both detail tests died as `TypeError -> 500` before reaching their assertions (one masked the bare-`Response` success shape, the other the 404 tuple for missing sessions).
2. The request-count test's non-admin user carried no `tenant_id`, and `_session_lookup_tenant_id` now fails closed (`abort 403)`) for exactly that case — the null-tenant read-any-session hole it guards against is the same family as the #2981 tenant fixes. The fake user now carries `tenant_id: 1` (`AgentSession` already defaults to 1).
3. The fake DB keyed wrapper-hiding on the retired `COALESCE(cli_session_id, '') != ''` predicate; `visible_session_clause` now hides workflow rows by the context marker alone, regardless of `cli_session_id` backfill (wrappers are created eagerly, so agents that fail to start would leak as permanent orphans). The fake mirrors the new clause and the test gains an orphan wrapper row to pin that.

## Evidence

- Lane reproduce (sqlite HOME): 3 failed / 1 passed pre-change; 4 passed post-change (the reproduce run doubles as the negative control).
- Run A 32579145971 (fix head): exit 1, **resolved=3 (exactly the three 1125 nodeids), new=0, changed=0, collection errors=0**.
- Prune commit: baseline 64 -> 61 with root-cause `prune_note` + run URL.
- Run B 32579902188 (pruned head): **exit 0, new=0, resolved=0, changed=0**.
- Branch rebased onto post-#2984 main before the PR (quarantine file follows main; CI evidence unaffected — the rebase only changed quarantine ancestry).
