### PR TITLE
fix(#1111): average tokens over the whole alias family in summary merge

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -881,11 +881,12 @@ class UsageRepository:
                 }
 
         # Aliases merged from several raw names inherit days_count /
-        # first_date / last_date from ONE alias's grouped row, which
-        # undercounts days and misreports the range whenever another alias
-        # spans further (migration 038 used to rebuild these during upgrade;
-        # the read-boundary merge must keep the same union semantics —
-        # Issue #1111). Recompute the span over the whole alias family.
+        # first_date / last_date / avg_tokens from ONE alias's grouped row,
+        # which undercounts days, misreports the range, and reports the
+        # dominant alias's average whenever another alias spans further
+        # (migration 038 used to rebuild these during upgrade; the
+        # read-boundary merge must keep the same union semantics —
+        # Issue #1111). Recompute the aggregates over the whole alias family.
         for tool, raw_names in raw_names_by_tool.items():
             if len(raw_names) < 2 or tool not in results:
                 continue
@@ -894,7 +895,8 @@ class UsageRepository:
                 f"""
                     SELECT COUNT(DISTINCT date) as days_count,
                            MIN(date) as first_date,
-                           MAX(date) as last_date
+                           MAX(date) as last_date,
+                           AVG(tokens_used) as avg_tokens
                     FROM daily_messages
                     {where_clause} AND tool_name IN ({placeholders})
                 """,
@@ -904,6 +906,9 @@ class UsageRepository:
                 results[tool]["days_count"] = span_row["days_count"]
                 results[tool]["first_date"] = span_row["first_date"]
                 results[tool]["last_date"] = span_row["last_date"]
+                results[tool]["avg_tokens"] = (
+                    round(span_row["avg_tokens"], 2) if span_row["avg_tokens"] else 0
+                )
 
         return results
 

--- a/tests/issues/1111/test_sqlite_normalize_derived_tables.py
+++ b/tests/issues/1111/test_sqlite_normalize_derived_tables.py
@@ -123,3 +123,30 @@ def test_summary_by_tool_counts_distinct_days_across_aliases(usage_repo):
     assert qwen["days_count"] == 2, f"same-date alias rows inflated the distinct day count: {qwen}"
     assert qwen["total_tokens"] == 700
     assert qwen["first_date"] == day1 and qwen["last_date"] == day2
+
+
+def test_summary_by_tool_avg_tokens_spans_aliases(usage_repo):
+    """avg_tokens must average the whole alias family, not one alias's rows.
+
+    The span recompute (Issue #1111) rebuilt days_count/first_date/last_date
+    across the family, but avg_tokens kept the highest-total alias's grouped
+    AVG — a small alias merging under a dominant one reported the dominant
+    average instead of the family-wide one.
+    """
+    day1 = "2026-05-01"
+    day2 = "2026-05-02"
+
+    # qwen-code carries the largest total (its grouped row is read first);
+    # qwen contributes one small row to the same family.
+    _insert_message(usage_repo, date=day1, tool_name="qwen-code", tokens=1000)
+    _insert_message(usage_repo, date=day2, tool_name="qwen-code", tokens=1000)
+    _insert_message(usage_repo, date=day1, tool_name="qwen", tokens=10)
+
+    summary = usage_repo.get_summary_by_tool()
+
+    qwen = summary.get("qwen")
+    assert qwen is not None, f"summary shape changed: {summary}"
+    # Family-wide average over all three rows, not the single-alias AVG(1000).
+    assert qwen["avg_tokens"] == round(
+        (1000 + 1000 + 10) / 3, 2
+    ), f"avg_tokens did not span the alias family: {qwen}"


### PR DESCRIPTION
## Summary

Follow-up to the #1111 alias-merge fix in #2988 (review MINOR): `get_summary_by_tool`'s span recompute rebuilt `days_count`/`first_date`/`last_date` across the whole alias family but left `avg_tokens` on the **highest-total alias's grouped AVG**. A small alias merging under a dominant one therefore reported the dominant average instead of the family-wide one.

## Changes

- `app/repositories/usage_repo.py`: extend the span query with `AVG(tokens_used)` and assign `avg_tokens` (rounded, 0 on NULL) alongside the other recomputed aggregates. Single-alias tools are untouched (the recompute only runs for `len(raw_names) >= 2`).
- `tests/issues/1111/test_sqlite_normalize_derived_tables.py`: new regression `test_summary_by_tool_avg_tokens_spans_aliases` — qwen-code (2×1000) + qwen (10) must report `670.0`, not the single-alias `1000.0`.

## Verification

- RED before fix: `avg_tokens: 1000.0` vs expected `670.0` (assertion output in test run).
- GREEN after: `tests/issues/1111/` 3 passed; adjacent suites `tests/unit/test_usage_service.py`, `tests/integration/test_usage_repo_tenant_scope.py`, `tests/unit/test_issue_2938_summary_webui_sessions.py` — 41 passed.

Refs #1111
