### PR TITLE
fix(#559): connect TerminalTab when xterm init completes after wsUrl arrives

### DIFF
--- a/frontend/src/components/features/TerminalTab.test.tsx
+++ b/frontend/src/components/features/TerminalTab.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * TerminalTab connect-race regression test (follow-up to PR #2984).
+ *
+ * initTerminal completes asynchronously (dynamic xterm chunk import) and
+ * only writes xtermRef. A ref write does not re-run effects, so a
+ * wsUrl/token delivered before the import finishes was silently dropped —
+ * the connect effect never fired again and no WebSocket was ever opened.
+ * The component must connect once xterm becomes ready.
+ */
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    options: Record<string, unknown> = {};
+    open = vi.fn();
+    onData = vi.fn();
+    onResize = vi.fn();
+    loadAddon = vi.fn();
+    dispose = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn();
+    focus = vi.fn();
+  },
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn();
+    dispose = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+  },
+}));
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}));
+
+const wsInstances: Array<{ url: string }> = [];
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = 0;
+  binaryType = '';
+  url: string;
+  close = vi.fn();
+  send = vi.fn();
+  constructor(url: string) {
+    this.url = url;
+    wsInstances.push(this);
+  }
+}
+
+import { TerminalTab } from './TerminalTab';
+
+describe('TerminalTab', () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  it('connects when xterm finishes initializing after wsUrl already arrived', async () => {
+    // wsUrl/token are present from the first render; xterm's dynamic chunk
+    // import resolves only in a microtask after the mount effects ran.
+    render(<TerminalTab wsUrl="/ws/terminal/abc" token="tok123" isActive={true} />);
+
+    // At mount the connect effect ran before initTerminal completed.
+    expect(wsInstances.length).toBe(0);
+
+    // Flush the dynamic-import microtasks: xterm becomes ready and the
+    // pending connect must fire instead of being dropped.
+    await act(async () => {});
+    expect(wsInstances.length).toBe(1);
+    expect(wsInstances[0].url).toContain('/ws/terminal/abc');
+    expect(wsInstances[0].url).toContain('token=tok123');
+
+    // No duplicate connection on subsequent effect runs.
+    await act(async () => {});
+    expect(wsInstances.length).toBe(1);
+  });
+});

--- a/frontend/src/components/features/TerminalTab.tsx
+++ b/frontend/src/components/features/TerminalTab.tsx
@@ -80,6 +80,11 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   onErrorRef.current = onError;
 
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
+  // initTerminal sets xtermRef asynchronously (dynamic chunk import); a ref
+  // write does not re-run effects, so mirror readiness as state. Without it,
+  // a wsUrl/token arriving before the import finishes is silently dropped —
+  // the connect effect never fires again and no WebSocket is opened.
+  const [xtermReady, setXtermReady] = useState(false);
 
   const connect = useCallback(() => {
     console.log('[TerminalTab] connect called:', {
@@ -359,6 +364,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
 
       xtermRef.current = terminal;
       fitAddonRef.current = fitAddon;
+      setXtermReady(true);
 
       console.log('[TerminalTab] xterm.js initialized, ready to connect');
 
@@ -400,15 +406,16 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   // Connect when xterm is ready or wsUrl/token change
   useEffect(() => {
     console.log('[TerminalTab] Connect effect triggered:', {
+      xtermReady,
       hasXterm: !!xtermRef.current,
       wsUrl,
       token: !!token,
     });
-    if (xtermRef.current && wsUrl && token) {
+    if (xtermReady && xtermRef.current && wsUrl && token) {
       console.log('[TerminalTab] Calling connect() from effect');
       connect();
     }
-  }, [connect, wsUrl, token]);
+  }, [connect, wsUrl, token, xtermReady]);
 
   // Handle resize and focus when tab becomes active
   useEffect(() => {


### PR DESCRIPTION
## Summary

Follow-up to PR #2984 (terminal-ws cluster): the **TerminalTab connect race** it identified and left as a known frontend bug. `TerminalTab`'s connect effect keyed on `wsUrl`/`token` values only. `initTerminal` finishes asynchronously (dynamic xterm chunk import) and only writes `xtermRef` — a ref write re-runs no effects — so a ws_url delivered **before** the import finished was silently dropped: the browser never opened the WebSocket. Production masked the race behind slow proxy spawns; #2984's intercept replay proved the empty-event-log case.

## Changes

- `frontend/src/components/features/TerminalTab.tsx`: mirror init completion as state (`xtermReady`, set right after `xtermRef`/`fitAddonRef` are assigned) and include it in the connect effect deps. Guard unchanged (still requires `wsUrl && token` and an actual xterm instance); no behavior change once connected.
- `frontend/src/components/features/TerminalTab.test.tsx`: first component-level test for this component (repo's first feature-component render test). Renders with `wsUrl`/`token` from the start while the xterm module mock resolves only after mount effects; asserts exactly one WebSocket is created with the token in the URL once xterm is ready, and no duplicates on later flushes.

## Verification

- RED on previous code: `wsInstances.length` stays 0 — the race, reproduced (test run against stashed fix).
- GREEN with fix: 1 WebSocket, URL contains `/ws/terminal/abc` and `token=tok123`.
- Full frontend suite: 67 files / 1105 tests passed (includes the new test).

Refs #559
