### PR TITLE
fix(e2e): realign the 4 nightly Full E2E Governance new-failures to current UI contracts

### DIFF
--- a/tests/e2e/ui/test_user_segmentation_chart.py
+++ b/tests/e2e/ui/test_user_segmentation_chart.py
@@ -76,7 +76,10 @@ def change_language(page, language_code):
         "en": ["English", "英语"],
         "zh": ["Chinese", "中文"],
         "ja": ["Japanese", "日语"],
-        "ko": ["Korean", "韩语"],
+        # Items are labeled in the CURRENT language: reaching ko goes
+        # en -> zh -> ja -> ko, so the ja-state label 韓国語 is the one
+        # that has to match here.
+        "ko": ["Korean", "韩语", "韓国語"],
     }
 
     lang_toggle = page.locator("button.header-icon-btn.dropdown-toggle:has(i.bi-globe)").first

--- a/tests/e2e/ui/test_user_segmentation_chart.py
+++ b/tests/e2e/ui/test_user_segmentation_chart.py
@@ -56,13 +56,12 @@ def login(page):
 
 
 def navigate_to_analysis(page):
-    """Navigate to Analysis page."""
+    """Navigate to the Trend Analysis page hosting the user segmentation card."""
     print("\n[Navigate] Going to Analysis page...")
-    analysis_nav = page.locator('a:has-text("Analysis"), #nav-analysis, [href="#/analysis"]')
-    if analysis_nav.count() > 0:
-        analysis_nav.first.click()
-    else:
-        page.goto(f"{BASE_URL}#/analysis")
+    # The manage sidebar groups nav items under collapsible sections; clicking
+    # the section-hidden link is intercepted by the section header. Navigate
+    # straight to the current route instead.
+    page.goto(f"{BASE_URL.rstrip('/')}/manage/analysis/trend")
     page.wait_for_load_state("networkidle")
     time.sleep(3)
 
@@ -70,27 +69,30 @@ def navigate_to_analysis(page):
 def change_language(page, language_code):
     """Change the language setting."""
     print(f"\n[Language] Changing to {language_code}...")
-    # Find language dropdown in header (globe icon dropdown)
-    globe_icon = page.locator(".bi-globe").first
-    if globe_icon.is_visible():
-        globe_icon.click()
-        time.sleep(0.5)
+    # Language dropdown lives in the header: a dropdown-toggle button with a
+    # globe icon. Clicking the icon itself does not open the menu; the toggle
+    # button does. Items are labeled in the CURRENT language, so try both.
+    language_names = {
+        "en": ["English", "英语"],
+        "zh": ["Chinese", "中文"],
+        "ja": ["Japanese", "日语"],
+        "ko": ["Korean", "韩语"],
+    }
 
-        # Find the dropdown item for the specified language
-        # Language codes: en, zh, ja, ko
-        language_names = {
-            "en": ["English", "英语"],
-            "zh": ["Chinese", "中文"],
-            "ja": ["Japanese", "日语"],
-            "ko": ["Korean", "韩语"],
-        }
+    lang_toggle = page.locator("button.header-icon-btn.dropdown-toggle:has(i.bi-globe)").first
+    if not lang_toggle.is_visible():
+        print("  ⚠ Language toggle not found")
+        return False
+    lang_toggle.click()
+    page.wait_for_timeout(300)
 
-        for name in language_names.get(language_code, [language_code]):
-            lang_option = page.locator(".dropdown-item").filter(has_text=name)
-            if lang_option.count() > 0:
-                lang_option.first.click()
-                time.sleep(1)
-                print(f"  ✓ Language changed to {language_code}")
+    for name in language_names.get(language_code, [language_code]):
+        lang_option = page.locator("button.dropdown-item").filter(has_text=name).first
+        if lang_option.count() > 0 and lang_option.is_visible():
+            lang_option.click()
+            time.sleep(1)
+            print(f"  ✓ Language changed to {language_code}")
+            return True
 
     print("  ⚠ Language change not successful")
     return False

--- a/tests/e2e/ui/test_work_assist_panel_prompts.py
+++ b/tests/e2e/ui/test_work_assist_panel_prompts.py
@@ -19,6 +19,7 @@ sys.path.insert(
     0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 )
 
+import re
 import time
 
 from playwright.sync_api import expect, sync_playwright
@@ -79,14 +80,23 @@ def test_assist_panel_prompts():
         # Step 6: Check category filters
         print("Step 6: Check category filters...")
         category_filters = page.locator(".category-filter-btn")
+        # Categories arrive via a separate async query; wait for the prompt
+        # data to load so the filter branch is not skipped by a data race.
+        page.wait_for_selector(".prompt-list", timeout=10000)
+        for _ in range(10):
+            if category_filters.count() > 0:
+                break
+            page.wait_for_timeout(500)
         count = category_filters.count()
         if count > 0:
             results.append(("Category filters exist", "Passed"))
             # Click a category filter
             category_filters.first.click()
             page.wait_for_timeout(500)
-            # Check if category filter is active
-            expect(category_filters.first).to_have_class(".*active.*")
+            # Check if category filter is active. A string argument would be
+            # an exact-match against the full class attribute
+            # ("category-filter-btn active"), so pass a regex.
+            expect(category_filters.first).to_have_class(re.compile(r"\bactive\b"))
             results.append(("Category filter clickable", "Passed"))
         else:
             results.append(("Category filters (no categories)", "Passed"))


### PR DESCRIPTION
## Summary

Nightly **Full E2E Governance** has been red on `main` since 8/9 (every scheduled run since then failed): the comparator reports 4 `new_failures` outside the known-failure budget, which drives `verdict_exit_code: 1` and fails the gate (`Nightly Quality Gate` fails downstream). Latest evidence: run [32588174685](https://github.com/open-ace/open-ace/actions/runs/32588174685) — `tests/e2e/ui/test_user_segmentation_chart.py` ×3 + `tests/e2e/ui/test_work_assist_panel_prompts.py` ×1.

All four are test drift against current UI contracts (no production change needed):

| Test | Root cause |
|---|---|
| `test_user_segmentation_{tooltip,i18n,responsive}` | `navigate_to_analysis` clicks `a:has-text("Analysis")`, which resolves to a nav item collapsed under the manage sidebar's `.nav-section-header` — pointer events intercepted, 30s click timeout. The segmentation card lives at `/manage/analysis/trend` (TrendAnalysis). |
| same, `i18n` only (second layer) | `change_language` clicks the bare `.bi-globe` icon — the Bootstrap menu never opens and the item is invisible. The verified toggle is `button.header-icon-btn.dropdown-toggle:has(i.bi-globe)`. Also dropped the unconditional "⚠ not successful" print after a successful switch. |
| `test_assist_panel_prompts` | `to_have_class(".*active.*")` passes a **string** — exact match against the full class attribute `"category-filter-btn active"` — so it can never match. Pass `re.compile(r"\bactive\b")`. Also waited for the async categories query so the filter branch is not skipped by a data race (locally it counted 0 buttons and silently soft-passed). |

## Changes

Two test files, no production code:
- `tests/e2e/ui/test_user_segmentation_chart.py` — direct navigation to `/manage/analysis/trend`; language switcher via the header toggle button with item-visibility check and per-item `button.dropdown-item` targeting.
- `tests/e2e/ui/test_work_assist_panel_prompts.py` — regex class assertion; deterministic category wait (`.prompt-list` + poll).

## Verification

- Reproduced pre-fix in an isolated lane on `main`: 3 failed (nav intercept — same CI signature) + assist soft-passed via the category data race.
- Post-fix isolated lane: **4/4 passed**.
- Assist branch exercised with real data: persistent lane server with a seeded `writing`-category prompt (5 categories via API); probe proves class becomes exactly `'category-filter-btn active'`, new regex passes, old string form fails (the CI signature). Test stdout shows `Category filter clickable: Passed` with categories present.
- Branch evidence run [32613172596](https://github.com/open-ace/open-ace/actions/runs/32613172596) (category=all, this head): **Full E2E Governance success** — `verdict_exit_code: 0`, `new_failures: []`, missing/unexpected/duplicates/unexpected_skips/budget_errors all 0; all 4 tests PASSED across both shards; Issue Tests 4/4 and Legacy issue failure baseline green; overall run conclusion **success**.

Refs #2491
