### PR TITLE
fix(#2994,#2995): record verifier session/usage on the acceptance milestone + missing warning button style

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9109,7 +9109,7 @@ class AutonomousOrchestrator:
             self._remove_verification_worktree(checkout_path)
         if result is None or getattr(result, "success", False) is not True:
             error_code = getattr(result, "error_code", None) if result is not None else None
-            failure = {
+            failure: dict = {
                 "verdicts": [],
                 "snapshot": None,
                 "verified_by": verified_by,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -163,12 +163,13 @@ def _remove_worktree_dir(gh, path: str, project_path: str = "") -> None:
 def _attach_verifier_runtime(payload: dict, result) -> None:
     """Attach the verifier run's session id + usage increment to its dict (#2994).
 
-    Mutates ``payload`` in place with ``session_id`` (tracking id preferred —
-    the spawn-failure result constructions blank ``session_id`` but always set
-    ``tracking_session_id``) and ``usage`` (this call's own increment, matching
-    the per-milestone phase_* convention). Called only from
-    ``_run_verification_agent`` after ``_parse_verifier_output``, whose exact-
-    shape contract must not gain these keys.
+    Mutates ``payload`` in place with ``session_id`` (the tracking id — the
+    stable milestone-identity convention; the runner may overwrite
+    ``session_id`` with the real CLI transcript id on success) and ``usage``
+    (this call's own increment, matching the per-milestone phase_*
+    convention). Called only from ``_run_verification_agent`` after
+    ``_parse_verifier_output``, whose exact-shape contract must not gain
+    these keys.
     """
     payload["session_id"] = str(getattr(result, "tracking_session_id", "") or "") or str(
         getattr(result, "session_id", "") or ""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -160,6 +160,27 @@ def _remove_worktree_dir(gh, path: str, project_path: str = "") -> None:
         pass
 
 
+def _attach_verifier_runtime(payload: dict, result) -> None:
+    """Attach the verifier run's session id + usage increment to its dict (#2994).
+
+    Mutates ``payload`` in place with ``session_id`` (tracking id preferred —
+    the spawn-failure result constructions blank ``session_id`` but always set
+    ``tracking_session_id``) and ``usage`` (this call's own increment, matching
+    the per-milestone phase_* convention). Called only from
+    ``_run_verification_agent`` after ``_parse_verifier_output``, whose exact-
+    shape contract must not gain these keys.
+    """
+    payload["session_id"] = str(getattr(result, "tracking_session_id", "") or "") or str(
+        getattr(result, "session_id", "") or ""
+    )
+    payload["usage"] = {
+        "total_tokens": int(getattr(result, "total_tokens", 0) or 0),
+        "total_input_tokens": int(getattr(result, "total_input_tokens", 0) or 0),
+        "total_output_tokens": int(getattr(result, "total_output_tokens", 0) or 0),
+        "request_count": int(getattr(result, "request_count", 0) or 0),
+    }
+
+
 def _infer_test_framework(project_path: str, cli_tool: str) -> str:
     """Infer test framework type from project structure and CLI tool.
 
@@ -2580,6 +2601,13 @@ class AutonomousOrchestrator:
         # milestone. Live milestone totals apply this runtime offset when the
         # stable main/review/test session starts its next provider request.
         self._session_usage_offsets: dict[str, dict[str, int]] = {}
+        # True only while the acceptance verifier agent is running (#2994).
+        # Gates the in-run milestone writers (_write_realtime_phase_usage /
+        # _link_session_to_current_milestone): the acceptance milestone is
+        # created at settle time, so a leftover in_progress milestone (e.g. the
+        # merge phase's pr_zero_check_runs tracker) would otherwise absorb the
+        # verifier's usage/session id and double-count against the settle write.
+        self._verification_agent_active = False
         self._cancel_requested = threading.Event()  # in-memory cancel signal
         # Set only by the application shutdown path. Unlike a user stop, this
         # interrupts the current attempt without changing the workflow's active
@@ -7032,6 +7060,10 @@ class AutonomousOrchestrator:
 
     def _link_session_to_current_milestone(self, session_id: str):
         """Write session_id to the latest in_progress milestone immediately."""
+        # #2994: never link the verifier session onto an earlier phase's leaked
+        # in-progress milestone — the acceptance milestone gets the id at settle.
+        if getattr(self, "_verification_agent_active", False):
+            return
         try:
             milestones = self.repo.list_milestones(self._workflow_id, status="in_progress")
             if milestones:
@@ -8168,6 +8200,12 @@ class AutonomousOrchestrator:
         so total_requests climbs in lockstep with total_tokens instead of only
         jumping once the call returns.
         """
+        # #2994: the acceptance milestone is created at settle time, so during
+        # a verifier run the "in-progress" milestone (if any leaked, e.g. the
+        # pr_zero_check_runs tracker) belongs to an earlier phase — the
+        # verifier's usage must land only on its own settle-time milestone.
+        if getattr(self, "_verification_agent_active", False):
+            return
         try:
             milestones = self.repo.list_milestones(self._workflow_id, status="in_progress")
             if not milestones:
@@ -9035,17 +9073,23 @@ class AutonomousOrchestrator:
             # repo_integrity_violation ("Agent changed the workflow branch").
             # The repo-escape guard is a separate check and still applies.
             verify_wf["branch_name"] = ""
-            result = self._run_agent(
-                verify_wf,
-                session_line="verification",
-                prompt=prompt,
-                allowed_tools=VERIFICATION_ALLOWED_TOOLS.get(cli_tool, []),
-                permission_mode="bypassPermissions",
-                cli_tool=cli_tool,
-                model=model,
-                project_path=checkout_path,
-                workflow_id=self._workflow_id,
-            )
+            self._verification_agent_active = True
+            try:
+                result = self._run_agent(
+                    verify_wf,
+                    session_line="verification",
+                    prompt=prompt,
+                    allowed_tools=VERIFICATION_ALLOWED_TOOLS.get(cli_tool, []),
+                    permission_mode="bypassPermissions",
+                    cli_tool=cli_tool,
+                    model=model,
+                    project_path=checkout_path,
+                    workflow_id=self._workflow_id,
+                )
+            finally:
+                # Covers the WorkflowPaused re-raise and every other exit, so
+                # later phases' realtime usage writes resume immediately.
+                self._verification_agent_active = False
         except WorkflowPaused:
             # The pause is already persisted with its marker (quota window or
             # hard quota); the generic handler below would swallow it into an
@@ -9065,14 +9109,23 @@ class AutonomousOrchestrator:
             self._remove_verification_worktree(checkout_path)
         if result is None or getattr(result, "success", False) is not True:
             error_code = getattr(result, "error_code", None) if result is not None else None
-            return {
+            failure = {
                 "verdicts": [],
                 "snapshot": None,
                 "verified_by": verified_by,
                 "infra_error": f"verification agent failed ({error_code or 'runner error'})",
             }
+            if result is not None:
+                # A failed run may still have burned tokens; surface whatever
+                # it consumed so the settle milestone records it (#2994).
+                _attach_verifier_runtime(failure, result)
+            return failure
         parsed = self._parse_verifier_output(result)
         parsed["verified_by"] = verified_by
+        # Runtime facts for the settle-time milestone: session + this call's
+        # usage increment. Attached AFTER _parse_verifier_output so its exact-
+        # shape contract (tests/issues/2335/test_verifier_checkout.py) holds.
+        _attach_verifier_runtime(parsed, result)
         return parsed
 
     def _build_verification_prompt(self, snapshot, merge_sha, base_sha, issue_number) -> str:

--- a/app/modules/workspace/autonomous/phase_contract.py
+++ b/app/modules/workspace/autonomous/phase_contract.py
@@ -159,6 +159,7 @@ class PhaseResult:
         workflow_patch: dict | None = None,
         milestone_events: list[dict] | None = None,
         structured_error: object | None = None,
+        usage_delta: object | None = None,
     ) -> PhaseResult:
         """Build a result that pauses the workflow (user-facing pause)."""
         return PhaseResult(
@@ -168,6 +169,7 @@ class PhaseResult:
             workflow_patch=workflow_patch or {},
             milestone_events=milestone_events or [],
             structured_error=structured_error,
+            usage_delta=usage_delta,
         )
 
     @staticmethod

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -775,7 +775,9 @@ def _prior_infra_error_kind(wf: dict, merge_sha: str, snap_hash: str) -> str | N
     return kind if isinstance(kind, str) and kind else None
 
 
-def _acceptance_milestone(*, workflow_id, dev_round, attempt, status, report) -> dict:
+def _acceptance_milestone(
+    *, workflow_id, dev_round, attempt, status, report, session_id: str = "", usage: dict | None = None
+) -> dict:
     """Build the acceptance-verification milestone row.
 
     ``result_summary`` / ``metadata`` are DB columns inserted verbatim by
@@ -783,8 +785,16 @@ def _acceptance_milestone(*, workflow_id, dev_round, attempt, status, report) ->
     — passing the raw ``report`` dict crashed with ``can't adapt type 'dict'``
     the moment a verdict was committed (#2394). ``metadata`` keeps the full
     structured report as JSON; ``result_summary`` is a short readable line.
+
+    ``session_id`` is the verifier run's tracking session id and ``usage`` its
+    own increment for THIS attempt (#2994) — both from
+    ``_run_verification_agent``'s runtime attachment. They land in the same
+    ``phase_*`` columns every other AI milestone uses, so workflow totals
+    (summed from those columns) finally include verification consumption and
+    the UI card gets its session button + token/request chips.
     """
     summary = _acceptance_summary(status, report)
+    usage = usage or {}
     return {
         "workflow_id": workflow_id,
         "phase": "acceptance_verification",
@@ -795,6 +805,11 @@ def _acceptance_milestone(*, workflow_id, dev_round, attempt, status, report) ->
         "title": f"Acceptance verification: {status}",
         "result_summary": summary,
         "metadata": json.dumps(report, ensure_ascii=False),
+        "session_id": session_id or "",
+        "phase_total_tokens": int(usage.get("total_tokens", 0) or 0),
+        "phase_input_tokens": int(usage.get("total_input_tokens", 0) or 0),
+        "phase_output_tokens": int(usage.get("total_output_tokens", 0) or 0),
+        "phase_request_count": int(usage.get("request_count", 0) or 0),
     }
 
 
@@ -910,6 +925,11 @@ def handle(ctx, deps) -> PhaseResult:
         )
         or {}
     )
+    # Verifier runtime facts (#2994): tracking session id + this attempt's own
+    # usage increment — recorded on the settle-time milestone (and reflected
+    # into workflow totals via usage_delta on the settled PhaseResult).
+    verifier_session_id = str(agent_out.get("session_id") or "")
+    verifier_usage = agent_out.get("usage") or {}
     verifier_verdicts: list[ItemVerdict] = []
     for index, raw_verdict in enumerate(agent_out.get("verdicts") or []):
         if not isinstance(raw_verdict, dict):
@@ -1093,6 +1113,8 @@ def handle(ctx, deps) -> PhaseResult:
         attempt=common_patch["verification_attempt"],
         status=status,
         report=report,
+        session_id=verifier_session_id,
+        usage=verifier_usage,
     )
     # A deterministic parse failure that repeats identically across consecutive
     # attempts is certain to keep failing, so cap it below the transient budget
@@ -1130,6 +1152,7 @@ def handle(ctx, deps) -> PhaseResult:
             },
             milestone_events=[milestone],
             structured_error={"message": "verifier-infrastructure-exhausted", "report": report},
+            usage_delta=verifier_usage or None,
         )
 
     if status == "confirmed":
@@ -1148,6 +1171,7 @@ def handle(ctx, deps) -> PhaseResult:
                 "error_message": None,
             },
             milestone_events=[milestone],
+            usage_delta=verifier_usage or None,
         )
     if status == "rejected":
         _post_verdict_comment(deps, issue_number, report)
@@ -1161,6 +1185,7 @@ def handle(ctx, deps) -> PhaseResult:
                 "error_message": "Acceptance verification rejected; awaiting review",
             },
             milestone_events=[milestone],
+            usage_delta=verifier_usage or None,
         )
     # indeterminate
     _post_verdict_comment(deps, issue_number, report)
@@ -1171,4 +1196,5 @@ def handle(ctx, deps) -> PhaseResult:
         },
         milestone_events=[milestone],
         structured_error={"message": "indeterminate", "report": report},
+        usage_delta=verifier_usage or None,
     )

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -776,7 +776,14 @@ def _prior_infra_error_kind(wf: dict, merge_sha: str, snap_hash: str) -> str | N
 
 
 def _acceptance_milestone(
-    *, workflow_id, dev_round, attempt, status, report, session_id: str = "", usage: dict | None = None
+    *,
+    workflow_id,
+    dev_round,
+    attempt,
+    status,
+    report,
+    session_id: str = "",
+    usage: dict | None = None,
 ) -> dict:
     """Build the acceptance-verification milestone row.
 

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -114,6 +114,8 @@ export interface AutonomousWorkflow {
   verification_status?: string | null;
   verification_merge_sha?: string | null;
   verified_by?: string | null;
+  /** Tracking id of the acceptance-verifier session line (#2335/#2994). */
+  verification_session_id?: string | null;
 }
 
 export interface WorkflowMilestone {

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -869,6 +869,16 @@
   background: color-mix(in srgb, var(--color-danger) 4%, var(--bg-primary) 96%);
 }
 
+/* #2995: the acceptance-report button's variant — without this rule it fell
+   back to the base style (flat --bg-primary) and looked unstyled next to its
+   siblings. Text mixes toward black like the other warning variants so the
+   tinted background keeps readable contrast in the light theme. */
+.timeline-inline-btn--warning.btn {
+  color: color-mix(in srgb, var(--color-warning) 74%, black 26%);
+  border-color: color-mix(in srgb, var(--color-warning) 15%, var(--border-color) 85%);
+  background: color-mix(in srgb, var(--color-warning) 4%, var(--bg-primary) 96%);
+}
+
 .timeline-milestone-activity {
   margin-top: 12px;
   padding: 12px;

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -532,6 +532,60 @@ describe('acceptance milestone card (#2985)', () => {
   });
 });
 
+describe('acceptance milestone usage wiring (#2994)', () => {
+  it('shows token/request chips, the session button, and no system-step chip once the milestone carries the verifier runtime', () => {
+    const { container } = renderWithMilestones(
+      pausedWorkflow({ status: 'completed', verification_status: 'confirmed' }),
+      [
+        acceptanceMilestone({
+          session_id: 'verif-tracking-session-1',
+          llm_total_tokens: 730000,
+          llm_request_count: 33,
+        }),
+      ]
+    );
+
+    // Usage chips render from the milestone's phase usage.
+    expect(screen.getByText('730.00K')).toBeInTheDocument();
+    expect(screen.getByText('33 Requests')).toBeInTheDocument();
+    // Session button opens the verifier tracking session.
+    expect(screen.getByText(/Session ID.*verif-tr/)).toBeInTheDocument();
+    // The verifier is an agent milestone, not a system step.
+    expect(screen.queryByText('System step')).not.toBeInTheDocument();
+    // #2995: the acceptance-report button carries the warning variant class
+    // (the CSS rule this class was missing used to leave it unstyled).
+    expect(container.querySelector('button.timeline-inline-btn--warning')).toBeTruthy();
+  });
+
+  it('keeps the AI-session presentation for a zero-usage verified milestone', () => {
+    const { container } = renderWithMilestones(
+      pausedWorkflow({ status: 'completed', verification_status: 'confirmed' }),
+      [
+        acceptanceMilestone({
+          session_id: 'verif-tracking-session-2',
+          llm_total_tokens: 0,
+          llm_request_count: 0,
+        }),
+      ]
+    );
+
+    const badges = container.querySelector('.timeline-milestone-badges');
+    expect(badges?.textContent).toContain('0');
+    expect(badges?.textContent).toContain('0 Requests');
+    expect(screen.queryByText('System step')).not.toBeInTheDocument();
+  });
+
+  it('no longer labels a session-less acceptance milestone a system step', () => {
+    // Legacy rows predating the wiring: no session id, no usage.
+    renderWithMilestones(
+      pausedWorkflow({ status: 'completed', verification_status: 'confirmed' }),
+      [acceptanceMilestone()]
+    );
+
+    expect(screen.queryByText('System step')).not.toBeInTheDocument();
+  });
+});
+
 describe('milestone time format (#2985)', () => {
   it('shows month-day with the time; adds the year only across years', () => {
     // formatMilestoneTime compares the milestone year against the wall

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -552,8 +552,9 @@ describe('acceptance milestone usage wiring (#2994)', () => {
     expect(screen.getByText(/Session ID.*verif-tr/)).toBeInTheDocument();
     // The verifier is an agent milestone, not a system step.
     expect(screen.queryByText('System step')).not.toBeInTheDocument();
-    // #2995: the acceptance-report button carries the warning variant class
-    // (the CSS rule this class was missing used to leave it unstyled).
+    // #2995: the acceptance-report button carries the warning variant class,
+    // pinning the class hookup for the new CSS rule (jsdom cannot assert the
+    // stylesheet itself).
     expect(container.querySelector('button.timeline-inline-btn--warning')).toBeTruthy();
   });
 
@@ -570,7 +571,6 @@ describe('acceptance milestone usage wiring (#2994)', () => {
     );
 
     const badges = container.querySelector('.timeline-milestone-badges');
-    expect(badges?.textContent).toContain('0');
     expect(badges?.textContent).toContain('0 Requests');
     expect(screen.queryByText('System step')).not.toBeInTheDocument();
   });

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -41,6 +41,7 @@ describe('WorkflowTimeline.utils', () => {
       main_session_id: 'main-session',
       review_session_id: 'review-session',
       test_session_id: 'test-session',
+      verification_session_id: 'verification-session',
     };
 
     expect(getWorkflowSessionIdForMilestone('pr_updated', workflow)).toBe('main-session');
@@ -48,6 +49,9 @@ describe('WorkflowTimeline.utils', () => {
     expect(getWorkflowSessionIdForMilestone('pr_reviewed', workflow)).toBe('review-session');
     expect(getWorkflowSessionIdForMilestone('plan_reviewed', workflow)).toBe('review-session');
     expect(getWorkflowSessionIdForMilestone('tests_run', workflow)).toBe('test-session');
+    expect(getWorkflowSessionIdForMilestone('acceptance_verification', workflow)).toBe(
+      'verification-session'
+    );
   });
 
   it('classifies AI-backed and system-only milestone cards', () => {
@@ -63,6 +67,7 @@ describe('WorkflowTimeline.utils', () => {
       'pr_updated',
       'ci_repair_applied',
       'conflicts_resolved',
+      'acceptance_verification',
     ]) {
       expect(isAiMilestoneType(type), type).toBe(true);
     }

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -12,6 +12,10 @@ const AI_MILESTONE_TYPES = new Set([
   'pr_updated',
   'ci_repair_applied',
   'conflicts_resolved',
+  // #2994: the acceptance verifier is a real agent session — with its session
+  // id + usage now recorded on the milestone, the card must render the usage
+  // chips / session button instead of the "system step" fallback.
+  'acceptance_verification',
 ]);
 
 export function isAiMilestoneType(milestoneType: string): boolean {

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -67,6 +67,7 @@ export interface WorkflowSessionLinesLike {
   main_session_id?: string;
   review_session_id?: string;
   test_session_id?: string;
+  verification_session_id?: string | null;
 }
 
 /** Return the stable session line that owns an in-flight AI milestone. */
@@ -77,6 +78,13 @@ export function getWorkflowSessionIdForMilestone(
   if (milestoneType === 'tests_run') return workflow.test_session_id?.trim() ?? '';
   if (milestoneType === 'plan_reviewed' || milestoneType === 'pr_reviewed') {
     return workflow.review_session_id?.trim() ?? '';
+  }
+  // Unreachable today (acceptance milestones are never activity hosts — they
+  // are only created at settle, never in_progress), but map the line
+  // explicitly so widening the host logic later can't render the verifier
+  // session's activity under the main session's card. #2994.
+  if (milestoneType === 'acceptance_verification') {
+    return workflow.verification_session_id?.trim() ?? '';
   }
   return workflow.main_session_id?.trim() ?? '';
 }

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -1,0 +1,467 @@
+"""#2994: wire the verifier run's session id + usage into the acceptance milestone.
+
+Regression coverage for the accounting/display gap: acceptance milestones were
+created with zero ``phase_*`` and no session field, so workflow totals (summed
+from milestone ``phase_*``) excluded all verification consumption and the UI
+card rendered the "system step" fallback instead of the session button and
+token/request chips.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import (
+    AutonomousOrchestrator,
+    WorkflowPaused,
+)
+from app.modules.workspace.autonomous.phase_contract import PhaseResult
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+pytestmark = [pytest.mark.issue(2994)]
+
+USAGE = {
+    "total_tokens": 730049,
+    "total_input_tokens": 721308,
+    "total_output_tokens": 8741,
+    "request_count": 33,
+}
+SESSION_ID = "verif-tracking-session-1"
+
+
+def _ctx(workflow):
+    from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+
+    return WorkflowContext(
+        workflow=workflow,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings=MagicMock(),
+        cancellation=MagicMock(),
+    )
+
+
+def _workflow(**extra):
+    base = {
+        "workflow_id": "wf-2994",
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 1,
+    }
+    base.update(extra)
+    return base
+
+
+def _agent_out_confirmed(**extra):
+    out = {
+        "verdicts": [
+            {
+                "item": "The endpoint rejects expired tokens",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "tests/test_auth.py:42", "note": "covered"}],
+            }
+        ],
+        "snapshot": None,
+        "session_id": SESSION_ID,
+        "usage": dict(USAGE),
+    }
+    out.update(extra)
+    return out
+
+
+def _deps_confirmed():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {
+        "body": "## Acceptance Criteria\n- [ ] The endpoint rejects expired tokens"
+    }
+    deps.gh.get_changed_files.return_value = []
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = _agent_out_confirmed()
+    return deps
+
+
+# ── _acceptance_milestone unit coverage ──────────────────────────────────────
+
+
+def test_acceptance_milestone_carries_session_and_usage():
+    milestone = av._acceptance_milestone(
+        workflow_id="wf-2994",
+        dev_round=1,
+        attempt=2,
+        status="confirmed",
+        report={"merge_sha": "merge"},
+        session_id=SESSION_ID,
+        usage=USAGE,
+    )
+    assert milestone["session_id"] == SESSION_ID
+    assert milestone["phase_total_tokens"] == USAGE["total_tokens"]
+    assert milestone["phase_input_tokens"] == USAGE["total_input_tokens"]
+    assert milestone["phase_output_tokens"] == USAGE["total_output_tokens"]
+    assert milestone["phase_request_count"] == USAGE["request_count"]
+
+
+def test_acceptance_milestone_defaults_zero_without_runtime():
+    milestone = av._acceptance_milestone(
+        workflow_id="wf-2994",
+        dev_round=1,
+        attempt=1,
+        status="rejected",
+        report={},
+    )
+    assert milestone["session_id"] == ""
+    assert milestone["phase_total_tokens"] == 0
+    assert milestone["phase_input_tokens"] == 0
+    assert milestone["phase_output_tokens"] == 0
+    assert milestone["phase_request_count"] == 0
+
+
+# ── handle(): settled paths record session + usage + usage_delta ─────────────
+
+
+def test_confirmed_result_records_session_usage_and_delta():
+    deps = _deps_confirmed()
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    assert result.usage_delta == USAGE
+    (milestone,) = result.milestone_events
+    assert milestone["session_id"] == SESSION_ID
+    assert milestone["phase_total_tokens"] == USAGE["total_tokens"]
+    assert milestone["phase_request_count"] == USAGE["request_count"]
+
+
+def test_rejected_pause_carries_session_usage_and_delta():
+    deps = _deps_confirmed()
+    deps.host.run_verification_agent.return_value = _agent_out_confirmed(
+        verdicts=[
+            {
+                "item": "The endpoint rejects expired tokens",
+                "verdict": "rejected",
+                "evidence": [{"ref": "src/auth.py:10", "note": "not covered"}],
+            }
+        ]
+    )
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.usage_delta == USAGE
+    (milestone,) = result.milestone_events
+    assert milestone["session_id"] == SESSION_ID
+    assert milestone["phase_total_tokens"] == USAGE["total_tokens"]
+
+
+def test_indeterminate_pause_carries_session_usage_and_delta():
+    deps = _deps_confirmed()
+    # Checklist item uncovered → indeterminate via _cover_missing_checklist_items.
+    deps.host.run_verification_agent.return_value = _agent_out_confirmed(verdicts=[])
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.usage_delta == USAGE
+    (milestone,) = result.milestone_events
+    assert milestone["session_id"] == SESSION_ID
+    assert milestone["phase_total_tokens"] == USAGE["total_tokens"]
+
+
+def test_infra_exhausted_pause_carries_partial_usage_and_delta():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    # The last (exhausting) attempt burned tokens before failing.
+    exhausted = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+        "session_id": SESSION_ID,
+        "usage": USAGE,
+    }
+    deps.host.run_verification_agent.side_effect = lambda **_kwargs: exhausted
+
+    workflow = _workflow()
+    outcomes = []
+    for _ in range(av.MAX_VERIFIER_INFRA_RETRIES):
+        result = av.handle(_ctx(workflow), deps)
+        outcomes.append(result)
+        workflow = {**workflow, **result.workflow_patch}
+
+    assert outcomes[-1].outcome == "pause"
+    assert outcomes[-1].usage_delta == USAGE
+    (milestone,) = outcomes[-1].milestone_events
+    assert milestone["session_id"] == SESSION_ID
+    assert milestone["phase_total_tokens"] == USAGE["total_tokens"]
+
+
+# ── handle(): paths that must NOT record anything new ────────────────────────
+
+
+def test_infra_retry_creates_no_milestone_and_no_delta():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+        "session_id": SESSION_ID,
+        "usage": USAGE,
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    assert result.milestone_events == []
+    assert result.usage_delta is None
+
+
+def test_already_confirmed_noop_creates_no_milestone_and_no_delta():
+    deps = _deps_confirmed()
+
+    result = av.handle(_ctx(_workflow(verification_status="confirmed")), deps)
+
+    assert result.outcome == "completed"
+    assert result.milestone_events == []
+    assert result.usage_delta is None
+    deps.host.run_verification_agent.assert_not_called()
+
+
+def test_legacy_agent_dict_without_runtime_keys_yields_zero_milestone():
+    """Older hosts/mocks return no runtime keys — milestone must default to zeros."""
+    deps = _deps_confirmed()
+    deps.host.run_verification_agent.return_value = _agent_out_confirmed(
+        session_id=None, usage=None
+    )
+    deps.host.run_verification_agent.return_value.pop("session_id")
+    deps.host.run_verification_agent.return_value.pop("usage")
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    (milestone,) = result.milestone_events
+    assert milestone["session_id"] == ""
+    assert milestone["phase_total_tokens"] == 0
+    assert milestone["phase_request_count"] == 0
+    # Nothing consumed → no refresh signal.
+    assert result.usage_delta is None
+
+
+# ── PhaseResult.pause() usage_delta passthrough ──────────────────────────────
+
+
+def test_phase_result_pause_accepts_and_passes_usage_delta():
+    result = PhaseResult.pause(
+        workflow_patch={"k": "v"},
+        milestone_events=[{"a": 1}],
+        structured_error={"message": "x"},
+        usage_delta=USAGE,
+    )
+    assert result.outcome == "pause"
+    assert result.usage_delta == USAGE
+    assert PhaseResult.pause().usage_delta is None
+
+
+# ── orchestrator: _run_verification_agent runtime attachment ────────────────
+
+
+def _orch_for_agent_run(run_agent_result):
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2994"
+    orch._build_verification_prompt = MagicMock(return_value="verify prompt")
+    orch._checkout_merged_main = MagicMock(return_value="/tmp/merged-checkout")
+    orch._remove_verification_worktree = MagicMock()
+    orch._parse_verifier_output = MagicMock(return_value={"verdicts": [], "snapshot": None})
+    orch._run_agent = MagicMock(return_value=run_agent_result)
+    return orch
+
+
+def _run_agent_result(**fields):
+    result = MagicMock()
+    result.success = fields.get("success", True)
+    result.tracking_session_id = fields.get("tracking_session_id", SESSION_ID)
+    result.session_id = fields.get("session_id", "")
+    result.total_tokens = fields.get("total_tokens", USAGE["total_tokens"])
+    result.total_input_tokens = fields.get("total_input_tokens", USAGE["total_input_tokens"])
+    result.total_output_tokens = fields.get("total_output_tokens", USAGE["total_output_tokens"])
+    result.request_count = fields.get("request_count", USAGE["request_count"])
+    return result
+
+
+def _wf_property(orch):
+    return patch.object(
+        type(orch),
+        "workflow",
+        new_callable=PropertyMock,
+        return_value={"cli_tool": "claude-code", "model": ""},
+    )
+
+
+def test_run_verification_agent_success_attaches_runtime():
+    orch = _orch_for_agent_run(_run_agent_result())
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["session_id"] == SESSION_ID
+    assert out["usage"] == USAGE
+    assert orch._verification_agent_active is False
+
+
+def test_run_verification_agent_failure_still_attaches_runtime():
+    orch = _orch_for_agent_run(_run_agent_result(success=False))
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["infra_error"]
+    assert out["session_id"] == SESSION_ID
+    assert out["usage"]["total_tokens"] == USAGE["total_tokens"]
+
+
+def test_run_verification_agent_none_result_has_no_runtime_keys():
+    orch = _orch_for_agent_run(None)
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert "session_id" not in out
+    assert "usage" not in out
+
+
+def test_run_verification_agent_checkout_failure_has_no_runtime_keys():
+    orch = _orch_for_agent_run(_run_agent_result())
+    orch._checkout_merged_main = MagicMock(return_value=None)
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["infra_error"] == "merged-main checkout failed"
+    assert "session_id" not in out
+    assert "usage" not in out
+    orch._run_agent.assert_not_called()
+
+
+def test_run_verification_agent_tracking_id_wins_over_blank_session_id():
+    orch = _orch_for_agent_run(
+        _run_agent_result(tracking_session_id=SESSION_ID, session_id="")
+    )
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["session_id"] == SESSION_ID
+
+
+def test_verification_flag_cleared_even_when_agent_raises_pause():
+    orch = _orch_for_agent_run(_run_agent_result())
+    orch._run_agent = MagicMock(side_effect=WorkflowPaused("quota window"))
+
+    with _wf_property(orch), pytest.raises(WorkflowPaused):
+        orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert orch._verification_agent_active is False
+
+
+# ── orchestrator: realtime writers suppressed during the verifier run ───────
+
+
+def _orch_for_writers():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2994"
+    orch.repo = MagicMock()
+    return orch
+
+
+def test_realtime_writers_noop_while_verification_agent_active():
+    orch = _orch_for_writers()
+    orch._verification_agent_active = True
+
+    orch._write_realtime_phase_usage({"total_tokens": 5})
+    orch._link_session_to_current_milestone("sess-1")
+
+    # Zero DB access: the gate must fire before list_milestones.
+    orch.repo.list_milestones.assert_not_called()
+    orch.repo.update_milestone.assert_not_called()
+
+
+def test_realtime_writers_resume_after_flag_clears():
+    orch = _orch_for_writers()
+    orch._verification_agent_active = False
+    orch.repo.list_milestones.return_value = [
+        {"milestone_id": "ms-1", "milestone_type": "pr_zero_check_runs"}
+    ]
+
+    orch._write_realtime_phase_usage({"total_tokens": 5, "request_count": 1})
+    orch._link_session_to_current_milestone("sess-1")
+
+    assert orch.repo.list_milestones.call_count == 2
+    assert orch.repo.update_milestone.call_count == 2
+
+
+# ── commit path: usage_delta triggers the totals refresh ─────────────────────
+
+
+def test_commit_phase_result_refreshes_totals_after_milestone_insert():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._update_workflow = MagicMock()
+    orch._create_milestone = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    result = av.handle(_ctx(_workflow()), _deps_confirmed())
+
+    orch._commit_phase_result(result)
+
+    orch._create_milestone.assert_called_once_with(**result.milestone_events[0])
+    orch._accumulate_tokens.assert_called_once()
+    # usage_delta carries the verifier usage dict verbatim.
+    assert orch._accumulate_tokens.call_args[0][0] == USAGE
+
+
+def test_commit_phase_result_without_delta_skips_refresh():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._update_workflow = MagicMock()
+    orch._create_milestone = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    result = PhaseResult.pause(workflow_patch={"x": 1})
+
+    orch._commit_phase_result(result)
+
+    orch._accumulate_tokens.assert_not_called()
+
+
+# ── report contents stay intact (no runtime keys leak into metadata) ────────
+
+
+def test_report_metadata_untouched_by_runtime_fields():
+    deps = _deps_confirmed()
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    (milestone,) = result.milestone_events
+    report = json.loads(milestone["metadata"])
+    assert "session_id" not in report
+    assert "usage" not in report

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -14,10 +14,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
-from app.modules.workspace.autonomous.orchestrator import (
-    AutonomousOrchestrator,
-    WorkflowPaused,
-)
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator, WorkflowPaused
 from app.modules.workspace.autonomous.phase_contract import PhaseResult
 from app.modules.workspace.autonomous.phases import acceptance_verification as av
 
@@ -363,9 +360,7 @@ def test_run_verification_agent_checkout_failure_has_no_runtime_keys():
 
 
 def test_run_verification_agent_tracking_id_wins_over_blank_session_id():
-    orch = _orch_for_agent_run(
-        _run_agent_result(tracking_session_id=SESSION_ID, session_id="")
-    )
+    orch = _orch_for_agent_run(_run_agent_result(tracking_session_id=SESSION_ID, session_id=""))
 
     with _wf_property(orch):
         out = orch._run_verification_agent(

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -307,7 +307,15 @@ def _wf_property(orch):
 
 
 def test_run_verification_agent_success_attaches_runtime():
-    orch = _orch_for_agent_run(_run_agent_result())
+    flag_during_run = {}
+    result = _run_agent_result()
+
+    def _capture_flag(*_args, **_kwargs):
+        flag_during_run["value"] = getattr(orch, "_verification_agent_active", None)
+        return result
+
+    orch = _orch_for_agent_run(result)
+    orch._run_agent = MagicMock(side_effect=_capture_flag)
 
     with _wf_property(orch):
         out = orch._run_verification_agent(
@@ -316,6 +324,8 @@ def test_run_verification_agent_success_attaches_runtime():
 
     assert out["session_id"] == SESSION_ID
     assert out["usage"] == USAGE
+    # The suppression window must span the run itself, not just its cleanup.
+    assert flag_during_run["value"] is True
     assert orch._verification_agent_active is False
 
 
@@ -423,9 +433,12 @@ def test_realtime_writers_resume_after_flag_clears():
 
 def test_commit_phase_result_refreshes_totals_after_milestone_insert():
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    # Shared parent so mock_calls records the load-bearing order:
+    # the milestone insert must land before the totals refresh reads it.
+    calls = MagicMock()
     orch._update_workflow = MagicMock()
-    orch._create_milestone = MagicMock()
-    orch._accumulate_tokens = MagicMock()
+    orch._create_milestone = calls.create_milestone
+    orch._accumulate_tokens = calls.accumulate_tokens
     result = av.handle(_ctx(_workflow()), _deps_confirmed())
 
     orch._commit_phase_result(result)
@@ -434,6 +447,7 @@ def test_commit_phase_result_refreshes_totals_after_milestone_insert():
     orch._accumulate_tokens.assert_called_once()
     # usage_delta carries the verifier usage dict verbatim.
     assert orch._accumulate_tokens.call_args[0][0] == USAGE
+    assert [c[0] for c in calls.mock_calls] == ["create_milestone", "accumulate_tokens"]
 
 
 def test_commit_phase_result_without_delta_skips_refresh():


### PR DESCRIPTION
Closes #2994
Closes #2995

## What

The acceptance verifier is a real agent session (production evidence: 0.5M–3.2M tokens / 19–119 requests per workflow), but its runtime facts never reached the milestone row — workflow totals (summed from milestone `phase_*`) excluded **all** verification consumption while the tenant quota side counted it, and the card rendered the "system step" fallback with no session button or usage chips. #2995 is the missing `.timeline-inline-btn--warning` CSS rule that left the acceptance-report button flat/unstyled.

## Changes

**Backend (#2994)**
- `_run_verification_agent` attaches `session_id` (tracking id preferred — spawn-failure constructions blank `session_id`) + this attempt's own usage increment to its returned dict, on the success path and the failed-run path, after `_parse_verifier_output` (its exact-shape contract is asserted by `tests/issues/2335/test_verifier_checkout.py`).
- `_acceptance_milestone()` persists `session_id` + the four `phase_*` columns (both already in `ALLOWED_MILESTONE_FIELDS` — no repo/schema change).
- All four milestone-creating returns carry `usage_delta` (`None` when nothing was consumed) so totals refresh at settle; `PhaseResult.pause()` gains the `usage_delta` param `completed()` already had (three of the four settles are pauses).
- Double-count guard: a `_verification_agent_active` flag (first statement of `_write_realtime_phase_usage` / `_link_session_to_current_milestone`, cleared in a `finally` covering the `WorkflowPaused` re-raise) keeps a leaked in_progress milestone — e.g. the merge phase's `pr_zero_check_runs` tracker — from absorbing the verifier's usage/session id and double-counting against the settle write.

**Frontend**
- `AI_MILESTONE_TYPES += acceptance_verification` — usage chips + session button render, "System step" chip no longer does.
- #2995: the missing warning inline-button variant, mirroring the other warning variants' contrast treatment.

## Tests

- `tests/unit/test_verification_usage_wiring_2994.py` (21 cases): milestone field wiring, all four settled paths + the three must-not-record paths (infra-retry, idempotent no-op, legacy dict without runtime keys), `pause()` passthrough, orchestrator runtime attachment (success / failed-run / None-result / checkout-failure / tracking-id-wins / flag-cleared-on-`WorkflowPaused`), realtime-writer suppression and resumption, commit-path refresh trigger and skip.
- Frontend: acceptance card renders usage chips + session button + warning button class; zero-usage and session-less variants stop showing "System step".
- Regression suites green locally: 2431 / 2335 (flow, checkout) / 2867 cap / verification-agent / realtime-activity (105+120 tests). The 2335 override-route errors also occur on a clean tree (local env lacks postgres config) — CI covers them.

## Known limits

- Infra-retry attempts and quota-`WorkflowPaused` interruptions mid-verification burn tokens that stay unattributed (dev phases differ: their milestone exists before the agent runs). Frequency is low (deterministic parse failures cap at 2, #2867).
- A one-time backfill for historical rows ships with the deployment (separate maintenance step, not in this PR): session id on all mainline acceptance milestones, usage on the last one per workflow (= the tracking session's cumulative total), then totals recompute. Verified targets: #2941 508,827 → 1,238,876; #2237 1,575,234 → 2,982,984.