### PR TITLE
feat(#3003): acceptance milestone hosts live AI activities (early in_progress lifecycle)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -160,6 +160,16 @@ def _remove_worktree_dir(gh, path: str, project_path: str = "") -> None:
         pass
 
 
+def _verification_usage_baseline(row: dict) -> dict:
+    """The usage-baseline shape built from a milestone row's phase_* columns."""
+    return {
+        "total_tokens": int(row.get("phase_total_tokens", 0) or 0),
+        "total_input_tokens": int(row.get("phase_input_tokens", 0) or 0),
+        "total_output_tokens": int(row.get("phase_output_tokens", 0) or 0),
+        "request_count": int(row.get("phase_request_count", 0) or 0),
+    }
+
+
 def _attach_early_milestone(payload: dict, early: dict) -> None:
     """Attach the verifier run's early milestone facts to its dict (#3003).
 
@@ -175,12 +185,7 @@ def _attach_early_milestone(payload: dict, early: dict) -> None:
     if not milestone_id:
         return
     payload["milestone_id"] = milestone_id
-    payload["usage_baseline"] = {
-        "total_tokens": int(early.get("phase_total_tokens", 0) or 0),
-        "total_input_tokens": int(early.get("phase_input_tokens", 0) or 0),
-        "total_output_tokens": int(early.get("phase_output_tokens", 0) or 0),
-        "request_count": int(early.get("phase_request_count", 0) or 0),
-    }
+    payload["usage_baseline"] = _verification_usage_baseline(early)
 
 
 def _attach_verifier_runtime(payload: dict, result) -> None:
@@ -9115,13 +9120,40 @@ class AutonomousOrchestrator:
                 # Any other still-in_progress acceptance row is residue of an
                 # interrupted attempt (older by construction — attempt never
                 # resets). Finalize it so it cannot keep hosting activities.
+                swept_id = row.get("milestone_id", "")
                 self.repo.update_milestone(
-                    row.get("milestone_id", ""),
+                    swept_id,
                     {
                         "status": "failed",
                         "error_message": "interrupted: superseded by a later verification attempt",
                     },
                 )
+                self._emit_milestone_updated(swept_id, "failed")
+        if current is None:
+            # The pause paths inside _run_agent terminalize the early row
+            # (quota → failed, cancel/shutdown → cancelled) before raising, so
+            # an auto-resume finds no in_progress row. A same-attempt
+            # failed/cancelled row IS this paused attempt — resurrect it (with
+            # its recorded usage as the resume baseline) instead of minting a
+            # duplicate round_number card. Settled verdict rows can never
+            # match: settling bumps verification_attempt past this attempt.
+            for terminal_status in ("failed", "cancelled"):
+                for row in self.repo.list_milestones(
+                    self._workflow_id,
+                    phase="acceptance_verification",
+                    status=terminal_status,
+                ):
+                    if int(row.get("round_number") or 0) == attempt:
+                        current = row
+                        break
+                if current is not None:
+                    resumed_id = current.get("milestone_id", "")
+                    self.repo.update_milestone(
+                        resumed_id,
+                        {"status": "in_progress", "error_message": ""},
+                    )
+                    self._emit_milestone_updated(resumed_id, "in_progress")
+                    break
         if current is None:
             current = self._create_milestone(
                 phase="acceptance_verification",
@@ -9144,16 +9176,22 @@ class AutonomousOrchestrator:
         if not milestone_id:
             return
         self.repo.update_milestone(milestone_id, fields)
-        self._emit(
-            "milestone_updated",
-            {
-                "milestone_id": milestone_id,
-                "status": fields.get("status", ""),
-                "title": fields.get("title", ""),
-            },
-        )
+        self._emit_milestone_updated(milestone_id, fields.get("status", ""))
         if getattr(self, "_verification_milestone_id", None) == milestone_id:
             self._verification_milestone_id = None
+
+    def _emit_milestone_updated(self, milestone_id: str, status: str) -> None:
+        """Emit a milestone_updated event (#3003).
+
+        No listener switches on the type — the frontend's generic workflow
+        event consumer invalidates its query cache on ANY event, so this is
+        what makes a live timeline refetch when a row flips status outside
+        the poll interval.
+        """
+        self._emit(
+            "milestone_updated",
+            {"milestone_id": milestone_id, "status": status},
+        )
 
     def _run_verification_agent(
         self, *, snapshot, merge_sha, base_sha, issue_number, pr_number
@@ -9191,12 +9229,7 @@ class AutonomousOrchestrator:
         early: dict = {}
         try:
             early = self._ensure_verification_milestone(wf)
-            usage_baseline = {
-                "total_tokens": int(early.get("phase_total_tokens", 0) or 0),
-                "total_input_tokens": int(early.get("phase_input_tokens", 0) or 0),
-                "total_output_tokens": int(early.get("phase_output_tokens", 0) or 0),
-                "request_count": int(early.get("phase_request_count", 0) or 0),
-            }
+            usage_baseline = _verification_usage_baseline(early)
             # Spawn the agent against the merged-main checkout, NOT the dev
             # worktree. We override worktree_path/project_path on a shallow
             # copy so _resolve_effective_repo_context resolves to the checkout.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9105,7 +9105,10 @@ class AutonomousOrchestrator:
         so a retry sweeps this row's predecessor to ``failed`` ("interrupted")
         and mints a fresh one; a WorkflowPaused/crash resume re-enters with the
         same attempt number and reuses the row, seeding its already-recorded
-        usage as the call's ``prior_usage`` baseline.
+        usage as the call's ``prior_usage`` baseline. The pause paths inside
+        ``_run_agent`` terminalize the row before raising, so resume also
+        resurrects a same-attempt failed/cancelled row instead of minting a
+        duplicate card.
         """
         attempt = int(wf.get("verification_attempt") or 0) + 1
         dev_round = int(wf.get("dev_round") or 1)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -160,6 +160,29 @@ def _remove_worktree_dir(gh, path: str, project_path: str = "") -> None:
         pass
 
 
+def _attach_early_milestone(payload: dict, early: dict) -> None:
+    """Attach the verifier run's early milestone facts to its dict (#3003).
+
+    ``milestone_id`` identifies the in_progress acceptance row minted at spawn
+    (the phase handler finalizes it at settle); ``usage_baseline`` is that
+    row's already-recorded usage so a resumed attempt's totals continue from
+    it instead of resetting. A falsy ``early`` (checkout failed before the row
+    was minted) attaches nothing — the caller then takes the create fallback.
+    """
+    if not early:
+        return
+    milestone_id = str(early.get("milestone_id", "") or "")
+    if not milestone_id:
+        return
+    payload["milestone_id"] = milestone_id
+    payload["usage_baseline"] = {
+        "total_tokens": int(early.get("phase_total_tokens", 0) or 0),
+        "total_input_tokens": int(early.get("phase_input_tokens", 0) or 0),
+        "total_output_tokens": int(early.get("phase_output_tokens", 0) or 0),
+        "request_count": int(early.get("phase_request_count", 0) or 0),
+    }
+
+
 def _attach_verifier_runtime(payload: dict, result) -> None:
     """Attach the verifier run's session id + usage increment to its dict (#2994).
 
@@ -2602,13 +2625,13 @@ class AutonomousOrchestrator:
         # milestone. Live milestone totals apply this runtime offset when the
         # stable main/review/test session starts its next provider request.
         self._session_usage_offsets: dict[str, dict[str, int]] = {}
-        # True only while the acceptance verifier agent is running (#2994).
-        # Gates the in-run milestone writers (_write_realtime_phase_usage /
-        # _link_session_to_current_milestone): the acceptance milestone is
-        # created at settle time, so a leftover in_progress milestone (e.g. the
-        # merge phase's pr_zero_check_runs tracker) would otherwise absorb the
-        # verifier's usage/session id and double-count against the settle write.
-        self._verification_agent_active = False
+        # The in_progress acceptance milestone minted for the running verifier
+        # (#3003). The in-run milestone writers (_write_realtime_phase_usage /
+        # _link_session_to_current_milestone) prefer it over their
+        # milestones[-1] heuristic so the verifier's live usage/session land on
+        # its own row; None outside a verifier run (a stale id left after the
+        # row went terminal is inert — the writers only match in_progress rows).
+        self._verification_milestone_id: str | None = None
         self._cancel_requested = threading.Event()  # in-memory cancel signal
         # Set only by the application shutdown path. Unlike a user stop, this
         # interrupts the current attempt without changing the workflow's active
@@ -7059,16 +7082,29 @@ class AutonomousOrchestrator:
                 return True
         return False
 
+    def _preferred_in_progress_milestone_id(self, milestones: list[dict]) -> str:
+        """The milestone the in-run writers should target (#3003).
+
+        During a verifier run this is the stashed acceptance row (created at
+        spawn, so it is also the newest by created_at/id order); the explicit
+        preference keeps a future background writer from stealing the slot.
+        """
+        target = getattr(self, "_verification_milestone_id", None)
+        if target:
+            for ms in milestones:
+                if ms.get("milestone_id") == target:
+                    return target
+        return milestones[-1].get("milestone_id", "")
+
     def _link_session_to_current_milestone(self, session_id: str):
         """Write session_id to the latest in_progress milestone immediately."""
-        # #2994: never link the verifier session onto an earlier phase's leaked
-        # in-progress milestone — the acceptance milestone gets the id at settle.
-        if getattr(self, "_verification_agent_active", False):
-            return
         try:
             milestones = self.repo.list_milestones(self._workflow_id, status="in_progress")
             if milestones:
                 ms = milestones[-1]  # most recent
+                preferred = self._preferred_in_progress_milestone_id(milestones)
+                if preferred and preferred != ms.get("milestone_id"):
+                    ms = next((m for m in milestones if m.get("milestone_id") == preferred), ms)
                 field_name = (
                     "review_session_id"
                     if ms.get("milestone_type") in REVIEW_SESSION_MILESTONE_TYPES
@@ -8201,17 +8237,11 @@ class AutonomousOrchestrator:
         so total_requests climbs in lockstep with total_tokens instead of only
         jumping once the call returns.
         """
-        # #2994: the acceptance milestone is created at settle time, so during
-        # a verifier run the "in-progress" milestone (if any leaked, e.g. the
-        # pr_zero_check_runs tracker) belongs to an earlier phase — the
-        # verifier's usage must land only on its own settle-time milestone.
-        if getattr(self, "_verification_agent_active", False):
-            return
         try:
             milestones = self.repo.list_milestones(self._workflow_id, status="in_progress")
             if not milestones:
                 return
-            ms_id = milestones[-1].get("milestone_id", "")
+            ms_id = self._preferred_in_progress_milestone_id(milestones)
             if not ms_id:
                 return
             self.repo.update_milestone(
@@ -9060,6 +9090,71 @@ class AutonomousOrchestrator:
         wf = self.workflow or {}
         _remove_worktree_dir(gh, path, str(wf.get("project_path") or ""))
 
+    def _ensure_verification_milestone(self, wf: dict) -> dict:
+        """Find-or-create the in_progress acceptance milestone for THIS attempt (#3003).
+
+        Created after the merged-main checkout succeeds and before the verifier
+        spawns, so the running verification has a live card to host AI
+        activities (and to receive realtime usage/session writes). One row per
+        attempt: infra-retry bumps ``verification_attempt`` in its retry patch,
+        so a retry sweeps this row's predecessor to ``failed`` ("interrupted")
+        and mints a fresh one; a WorkflowPaused/crash resume re-enters with the
+        same attempt number and reuses the row, seeding its already-recorded
+        usage as the call's ``prior_usage`` baseline.
+        """
+        attempt = int(wf.get("verification_attempt") or 0) + 1
+        dev_round = int(wf.get("dev_round") or 1)
+        rows = self.repo.list_milestones(
+            self._workflow_id, phase="acceptance_verification", status="in_progress"
+        )
+        current = None
+        for row in rows:
+            if int(row.get("round_number") or 0) == attempt:
+                current = row
+            else:
+                # Any other still-in_progress acceptance row is residue of an
+                # interrupted attempt (older by construction — attempt never
+                # resets). Finalize it so it cannot keep hosting activities.
+                self.repo.update_milestone(
+                    row.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "error_message": "interrupted: superseded by a later verification attempt",
+                    },
+                )
+        if current is None:
+            current = self._create_milestone(
+                phase="acceptance_verification",
+                milestone_type="acceptance_verification",
+                dev_round=dev_round,
+                round_number=attempt,
+                status="in_progress",
+                title="Acceptance verification: running",
+            )
+        self._verification_milestone_id = current.get("milestone_id", "") or None
+        return current
+
+    def finalize_acceptance_milestone(self, milestone_id: str, fields: dict) -> None:
+        """Terminal-update the verifier's in_progress milestone (#3003).
+
+        Delegates to repo.update_milestone and emits a ``milestone_updated``
+        event; clears the writer-preference stash. Missing id is a no-op so the
+        phase's fallback path (settle-by-create) stays independent.
+        """
+        if not milestone_id:
+            return
+        self.repo.update_milestone(milestone_id, fields)
+        self._emit(
+            "milestone_updated",
+            {
+                "milestone_id": milestone_id,
+                "status": fields.get("status", ""),
+                "title": fields.get("title", ""),
+            },
+        )
+        if getattr(self, "_verification_milestone_id", None) == milestone_id:
+            self._verification_milestone_id = None
+
     def _run_verification_agent(
         self, *, snapshot, merge_sha, base_sha, issue_number, pr_number
     ) -> dict:
@@ -9070,6 +9165,14 @@ class AutonomousOrchestrator:
         ``verification``. On any checkout/spawn/parse failure it returns empty
         verdicts, which aggregate to ``indeterminate`` (pause) — never a false
         ``confirmed``. The temp worktree is always cleaned up (try/finally).
+
+        #3003: an in_progress acceptance milestone is minted for this attempt
+        before the spawn. Its id rides every post-checkout return as
+        ``milestone_id`` (with ``usage_baseline`` = the row's recorded usage, for
+        attempt-resume), the ``_run_agent`` call links it directly and gets the
+        baseline as ``prior_usage``, and the phase handler finalizes the row at
+        settle instead of creating one. Only the checkout-failure return omits
+        the key — no row exists there.
         """
         wf = self.workflow or {}
         cli_tool = wf.get("cli_tool", "claude-code")
@@ -9085,7 +9188,15 @@ class AutonomousOrchestrator:
                 "verified_by": verified_by,
                 "infra_error": "merged-main checkout failed",
             }
+        early: dict = {}
         try:
+            early = self._ensure_verification_milestone(wf)
+            usage_baseline = {
+                "total_tokens": int(early.get("phase_total_tokens", 0) or 0),
+                "total_input_tokens": int(early.get("phase_input_tokens", 0) or 0),
+                "total_output_tokens": int(early.get("phase_output_tokens", 0) or 0),
+                "request_count": int(early.get("phase_request_count", 0) or 0),
+            }
             # Spawn the agent against the merged-main checkout, NOT the dev
             # worktree. We override worktree_path/project_path on a shallow
             # copy so _resolve_effective_repo_context resolves to the checkout.
@@ -9100,48 +9211,54 @@ class AutonomousOrchestrator:
             # repo_integrity_violation ("Agent changed the workflow branch").
             # The repo-escape guard is a separate check and still applies.
             verify_wf["branch_name"] = ""
-            self._verification_agent_active = True
-            try:
-                result = self._run_agent(
-                    verify_wf,
-                    session_line="verification",
-                    prompt=prompt,
-                    allowed_tools=VERIFICATION_ALLOWED_TOOLS.get(cli_tool, []),
-                    permission_mode="bypassPermissions",
-                    cli_tool=cli_tool,
-                    model=model,
-                    project_path=checkout_path,
-                    workflow_id=self._workflow_id,
-                )
-            finally:
-                # Covers the WorkflowPaused re-raise and every other exit, so
-                # later phases' realtime usage writes resume immediately.
-                self._verification_agent_active = False
+            result = self._run_agent(
+                verify_wf,
+                session_line="verification",
+                prompt=prompt,
+                allowed_tools=VERIFICATION_ALLOWED_TOOLS.get(cli_tool, []),
+                permission_mode="bypassPermissions",
+                cli_tool=cli_tool,
+                model=model,
+                project_path=checkout_path,
+                workflow_id=self._workflow_id,
+                milestone_id=early.get("milestone_id", ""),
+                # Attempt-resume baseline: _run_agent seeds it into the
+                # session-usage offsets so live usage climbs from the row's
+                # already-recorded totals, and _write_phase_usage folds it into
+                # the final write. Seeding the offsets directly here would be
+                # clobbered at call start (they are rebuilt from prior_usage).
+                prior_usage=usage_baseline,
+            )
         except WorkflowPaused:
             # The pause is already persisted with its marker (quota window or
             # hard quota); the generic handler below would swallow it into an
             # infra_error whose retry patch overwrites error_message and
             # strands the auto-resume scan (#2709). Propagate to advance()'s
-            # WorkflowPaused handling; the finally below still cleans up.
+            # WorkflowPaused handling; the finally below still cleans up. The
+            # in_progress row stays open — resume re-enters with the same
+            # attempt number and reuses it.
             raise
         except Exception:
             logger.exception("acceptance verifier spawn failed for issue %s", issue_number)
-            return {
+            failure: dict = {
                 "verdicts": [],
                 "snapshot": None,
                 "verified_by": verified_by,
                 "infra_error": "verification agent spawn failed",
             }
+            _attach_early_milestone(failure, early)
+            return failure
         finally:
             self._remove_verification_worktree(checkout_path)
         if result is None or getattr(result, "success", False) is not True:
             error_code = getattr(result, "error_code", None) if result is not None else None
-            failure: dict = {
+            failure = {
                 "verdicts": [],
                 "snapshot": None,
                 "verified_by": verified_by,
                 "infra_error": f"verification agent failed ({error_code or 'runner error'})",
             }
+            _attach_early_milestone(failure, early)
             if result is not None:
                 # A failed run may still have burned tokens; surface whatever
                 # it consumed so the settle milestone records it (#2994).
@@ -9153,6 +9270,7 @@ class AutonomousOrchestrator:
         # usage increment. Attached AFTER _parse_verifier_output so its exact-
         # shape contract (tests/issues/2335/test_verifier_checkout.py) holds.
         _attach_verifier_runtime(parsed, result)
+        _attach_early_milestone(parsed, early)
         return parsed
 
     def _build_verification_prompt(self, snapshot, merge_sha, base_sha, issue_number) -> str:

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -104,6 +104,16 @@ class PhaseHost(Protocol):
     def emit_audit_event(self, name: str, payload: dict) -> None:
         """Emit a generic audit event (e.g. acceptance_reopened_issue)."""
 
+    def finalize_acceptance_milestone(self, milestone_id: str, fields: dict) -> None:
+        """Terminal-update the verifier's in_progress acceptance milestone (#3003).
+
+        The row is minted at verifier spawn so the running verification has a
+        live activity-host card; the handler flips it to its verdict here
+        (update, not create — _create_milestone's dedupe would silently skip).
+        Delegates to repo.update_milestone via the orchestrator and clears the
+        writers' target preference. Empty id is a no-op (create fallback).
+        """
+
     def tag_session_messages(self, session_id: str, milestone_id: str) -> int:
         """Tag a session's milestone-less messages with the settle milestone (#3000).
 

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1144,16 +1144,17 @@ def handle(ctx, deps) -> PhaseResult:
         }
 
     if early_milestone_id:
+        # NO phase_* overwrite here: the row already holds the authoritative
+        # usage — _run_agent's _write_phase_usage writes baseline + the SUM of
+        # every in-run invocation delta, which can exceed baseline + the final
+        # result's own delta when the call retried in-run. Overwriting would
+        # silently drop those burned tokens from the card and the totals.
         finalize_fields = {
             "status": status,
             "title": f"Acceptance verification: {status}",
             "result_summary": _acceptance_summary(status, report),
             "metadata": json.dumps(report, ensure_ascii=False),
             "session_id": verifier_session_id,
-            "phase_total_tokens": _merged_usage()["total_tokens"],
-            "phase_input_tokens": _merged_usage()["total_input_tokens"],
-            "phase_output_tokens": _merged_usage()["total_output_tokens"],
-            "phase_request_count": _merged_usage()["request_count"],
         }
         milestone = None  # finalize path carries no milestone_events
         tag_milestone_id = early_milestone_id
@@ -1224,7 +1225,13 @@ def handle(ctx, deps) -> PhaseResult:
         return [milestone] if milestone is not None else []
 
     def _usage_delta() -> dict | None:
-        return (_merged_usage() if early_milestone_id else (verifier_usage or None)) or None
+        # Early path: the row's phase_* already hold the authoritative totals
+        # (written by _run_agent); this value only triggers the idempotent
+        # refresh, so an all-zero delta collapses to None like the fallback.
+        if early_milestone_id:
+            merged = _merged_usage()
+            return merged if any(merged.values()) else None
+        return verifier_usage or None
 
     if agent_out.get("infra_error"):
         exhausted_msg = (

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1172,7 +1172,7 @@ def handle(ctx, deps) -> PhaseResult:
             usage=verifier_usage,
             milestone_id=settle_milestone_id,
         )
-        finalize_fields = None
+        finalize_fields = {}  # unused on the fallback path
         tag_milestone_id = settle_milestone_id
 
     # A deterministic parse failure that repeats identically across consecutive

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -944,6 +944,11 @@ def handle(ctx, deps) -> PhaseResult:
     # into workflow totals via usage_delta on the settled PhaseResult).
     verifier_session_id = str(agent_out.get("session_id") or "")
     verifier_usage = agent_out.get("usage") or {}
+    # #3003: the in_progress acceptance row minted at spawn (absent when the
+    # merged-main checkout failed before minting) and its already-recorded
+    # usage — a resumed attempt's totals continue from the baseline.
+    early_milestone_id = str(agent_out.get("milestone_id") or "")
+    usage_baseline = agent_out.get("usage_baseline") or {}
     verifier_verdicts: list[ItemVerdict] = []
     for index, raw_verdict in enumerate(agent_out.get("verdicts") or []):
         if not isinstance(raw_verdict, dict):
@@ -1121,22 +1126,55 @@ def handle(ctx, deps) -> PhaseResult:
         "verified_by": verified_by,
         "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
     }
-    # Mint the milestone id here so the verifier session's messages can be
-    # tagged with it before the row itself is inserted (create_milestone
-    # honors a caller-supplied id; session_messages has no FK, so the
-    # tag-before-insert ordering is safe). Best-effort attribution only
-    # (#3000) — the viewer's full-transcript path does not depend on the tag.
-    settle_milestone_id = str(uuid.uuid4())
-    milestone = _acceptance_milestone(
-        workflow_id=wf.get("workflow_id"),
-        dev_round=int(wf.get("dev_round") or 1),
-        attempt=common_patch["verification_attempt"],
-        status=status,
-        report=report,
-        session_id=verifier_session_id,
-        usage=verifier_usage,
-        milestone_id=settle_milestone_id,
-    )
+
+    # #3003: with an early milestone (minted at verifier spawn), settle
+    # FINALIZES that row; only the create fallback (checkout failed before the
+    # row existed) builds a milestone_events payload. The two shapes share the
+    # tag target and the usage arithmetic (early rows fold the resume
+    # baseline into their totals).
+    def _merged_usage() -> dict:
+        return {
+            key: int(usage_baseline.get(key, 0) or 0) + int(verifier_usage.get(key, 0) or 0)
+            for key in (
+                "total_tokens",
+                "total_input_tokens",
+                "total_output_tokens",
+                "request_count",
+            )
+        }
+
+    if early_milestone_id:
+        finalize_fields = {
+            "status": status,
+            "title": f"Acceptance verification: {status}",
+            "result_summary": _acceptance_summary(status, report),
+            "metadata": json.dumps(report, ensure_ascii=False),
+            "session_id": verifier_session_id,
+            "phase_total_tokens": _merged_usage()["total_tokens"],
+            "phase_input_tokens": _merged_usage()["total_input_tokens"],
+            "phase_output_tokens": _merged_usage()["total_output_tokens"],
+            "phase_request_count": _merged_usage()["request_count"],
+        }
+        milestone = None  # finalize path carries no milestone_events
+        tag_milestone_id = early_milestone_id
+    else:
+        # Create fallback (#3000 semantics): pre-mint the id so the session's
+        # messages can be tagged before the row is inserted (create_milestone
+        # honors a caller-supplied id; session_messages has no FK).
+        settle_milestone_id = str(uuid.uuid4())
+        milestone = _acceptance_milestone(
+            workflow_id=wf.get("workflow_id"),
+            dev_round=int(wf.get("dev_round") or 1),
+            attempt=common_patch["verification_attempt"],
+            status=status,
+            report=report,
+            session_id=verifier_session_id,
+            usage=verifier_usage,
+            milestone_id=settle_milestone_id,
+        )
+        finalize_fields = None
+        tag_milestone_id = settle_milestone_id
+
     # A deterministic parse failure that repeats identically across consecutive
     # attempts is certain to keep failing, so cap it below the transient budget
     # (#2867). The first occurrence still gets one retry (a genuine one-off is
@@ -1152,7 +1190,22 @@ def handle(ctx, deps) -> PhaseResult:
         # Infrastructure failures are not acceptance evidence and must not
         # create a terminal milestone. Keep the workflow in its current phase
         # so the scheduler can retry automatically; the attempt report remains
-        # persisted for diagnostics.
+        # persisted for diagnostics. The early row is finalized as a failed
+        # diagnostic card KEEPING its realtime-recorded usage (a partial fix
+        # for #2999: infra-retry attempts finally have somewhere to land), and
+        # this attempt's messages are tagged onto it (#3003 per-attempt
+        # attribution).
+        if early_milestone_id:
+            deps.host.finalize_acceptance_milestone(
+                early_milestone_id,
+                {
+                    "status": "failed",
+                    "title": "Acceptance verification: failed",
+                    "error_message": "Acceptance verifier infrastructure failure; retrying",
+                },
+            )
+            if verifier_session_id:
+                deps.host.tag_session_messages(verifier_session_id, early_milestone_id)
         return PhaseResult.retry(
             workflow_patch={
                 **common_patch,
@@ -1161,14 +1214,17 @@ def handle(ctx, deps) -> PhaseResult:
         )
 
     def _tag_settle_messages() -> None:
-        # #3000: sweep the verifier session's still-untagged messages
-        # (including any burned by earlier infra-retry attempts) onto the
-        # settle milestone. Invoked at every milestone-carrying return ONLY —
-        # a retrying attempt (infra retry, or the lock/cancellation guards in
-        # the confirmed branch) inserts no milestone row, so tagging on those
-        # exits would leave a milestone_id pointing at nothing.
+        # Sweep the verifier session's still-untagged messages onto the settle
+        # milestone. Idempotent — per-attempt rows tag their own messages at
+        # infra-retry finalize; this catches anything left untagged.
         if verifier_session_id:
-            deps.host.tag_session_messages(verifier_session_id, settle_milestone_id)
+            deps.host.tag_session_messages(verifier_session_id, tag_milestone_id)
+
+    def _settle_milestone_events() -> list[dict]:
+        return [milestone] if milestone is not None else []
+
+    def _usage_delta() -> dict | None:
+        return (_merged_usage() if early_milestone_id else (verifier_usage or None)) or None
 
     if agent_out.get("infra_error"):
         exhausted_msg = (
@@ -1177,15 +1233,20 @@ def handle(ctx, deps) -> PhaseResult:
             if deterministic_repeat
             else "Acceptance verifier infrastructure retries exhausted; awaiting review"
         )
+        if early_milestone_id:
+            deps.host.finalize_acceptance_milestone(
+                early_milestone_id,
+                {**finalize_fields, "error_message": exhausted_msg},
+            )
         _tag_settle_messages()
         return PhaseResult.pause(
             workflow_patch={
                 **common_patch,
                 "error_message": exhausted_msg,
             },
-            milestone_events=[milestone],
+            milestone_events=_settle_milestone_events(),
             structured_error={"message": "verifier-infrastructure-exhausted", "report": report},
-            usage_delta=verifier_usage or None,
+            usage_delta=_usage_delta(),
         )
 
     if status == "confirmed":
@@ -1196,6 +1257,8 @@ def handle(ctx, deps) -> PhaseResult:
             return PhaseResult.retry()
         gh.close_issue(issue_number)
         common_patch["issue_closed_by_workflow_at"] = _now_iso()
+        if early_milestone_id:
+            deps.host.finalize_acceptance_milestone(early_milestone_id, finalize_fields)
         _tag_settle_messages()
         return PhaseResult.completed(
             next_phase="completed",
@@ -1204,11 +1267,13 @@ def handle(ctx, deps) -> PhaseResult:
                 "completed_at": _now_iso(),
                 "error_message": None,
             },
-            milestone_events=[milestone],
-            usage_delta=verifier_usage or None,
+            milestone_events=_settle_milestone_events(),
+            usage_delta=_usage_delta(),
         )
     if status == "rejected":
         _post_verdict_comment(deps, issue_number, report)
+        if early_milestone_id:
+            deps.host.finalize_acceptance_milestone(early_milestone_id, finalize_fields)
         _tag_settle_messages()
         return PhaseResult.pause(
             structured_error={
@@ -1219,18 +1284,20 @@ def handle(ctx, deps) -> PhaseResult:
                 **common_patch,
                 "error_message": "Acceptance verification rejected; awaiting review",
             },
-            milestone_events=[milestone],
-            usage_delta=verifier_usage or None,
+            milestone_events=_settle_milestone_events(),
+            usage_delta=_usage_delta(),
         )
     # indeterminate
     _post_verdict_comment(deps, issue_number, report)
+    if early_milestone_id:
+        deps.host.finalize_acceptance_milestone(early_milestone_id, finalize_fields)
     _tag_settle_messages()
     return PhaseResult.pause(
         workflow_patch={
             **common_patch,
             "error_message": "Acceptance indeterminate: awaiting evidence",
         },
-        milestone_events=[milestone],
+        milestone_events=_settle_milestone_events(),
         structured_error={"message": "indeterminate", "report": report},
-        usage_delta=verifier_usage or None,
+        usage_delta=_usage_delta(),
     )

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -125,9 +125,7 @@ describe('WorkflowTimeline.utils', () => {
         dev_round: 1,
       },
     ];
-    expect(getActivityHostMilestoneId(milestones, 1, 'verification_pending')).toBe(
-      'verifying'
-    );
+    expect(getActivityHostMilestoneId(milestones, 1, 'verification_pending')).toBe('verifying');
     // Without a live row (e.g. the merge-SHA retry loop), verification must
     // NOT fall back to the previous phase's card — no host at all.
     const noLiveRow = milestones.map((m) => ({ ...m, status: 'completed' }));

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -110,6 +110,30 @@ describe('WorkflowTimeline.utils', () => {
     expect(getActivityHostMilestoneId(betweenMilestones, 2, 'completed')).toBeNull();
   });
 
+  it('hosts the in_progress acceptance milestone during verification (#3003)', () => {
+    const milestones = [
+      {
+        milestone_id: 'merged',
+        milestone_type: 'merged',
+        status: 'completed',
+        dev_round: 1,
+      },
+      {
+        milestone_id: 'verifying',
+        milestone_type: 'acceptance_verification',
+        status: 'in_progress',
+        dev_round: 1,
+      },
+    ];
+    expect(getActivityHostMilestoneId(milestones, 1, 'verification_pending')).toBe(
+      'verifying'
+    );
+    // Without a live row (e.g. the merge-SHA retry loop), verification must
+    // NOT fall back to the previous phase's card — no host at all.
+    const noLiveRow = milestones.map((m) => ({ ...m, status: 'completed' }));
+    expect(getActivityHostMilestoneId(noLiveRow, 1, 'verification_pending')).toBeNull();
+  });
+
   it('never mounts AI activity on system-only cards or idle workflow phases', () => {
     const systemOnly = [
       {

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -79,10 +79,10 @@ export function getWorkflowSessionIdForMilestone(
   if (milestoneType === 'plan_reviewed' || milestoneType === 'pr_reviewed') {
     return workflow.review_session_id?.trim() ?? '';
   }
-  // Unreachable today (acceptance milestones are never activity hosts — they
-  // are only created at settle, never in_progress), but map the line
-  // explicitly so widening the host logic later can't render the verifier
-  // session's activity under the main session's card. #2994.
+  // The acceptance line: used when the verifier's in_progress milestone
+  // hosts the live panel during a verification run (#3003; the row is minted
+  // at spawn) — mapped explicitly so the verifier session's activity can
+  // never render under the main session's card.
   if (milestoneType === 'acceptance_verification') {
     return workflow.verification_session_id?.trim() ?? '';
   }
@@ -95,7 +95,13 @@ export function getActivityHostMilestoneId(
   workflowStatus: string
 ): string | null {
   const agentPhaseStatuses = ['planning', 'developing', 'pr_review'];
-  if (![...agentPhaseStatuses, 'merging'].includes(workflowStatus)) return null;
+  // verification_pending: the verifier's in_progress acceptance milestone
+  // (#3003) is a live host. The FALLBACK gate below stays on
+  // agentPhaseStatuses — during verification the merge-SHA retry loop has no
+  // running agent, and pinning the panel to the previous phase's card would
+  // only show stale activity.
+  const hostStatuses = [...agentPhaseStatuses, 'merging', 'verification_pending'];
+  if (!hostStatuses.includes(workflowStatus)) return null;
 
   // Forked workflows can retain a copied in-progress milestone from the
   // parent. Timeline order is oldest-first, so always choose the newest

--- a/tests/unit/test_orchestrator_verification_agent.py
+++ b/tests/unit/test_orchestrator_verification_agent.py
@@ -24,6 +24,11 @@ def test_run_verification_agent_passes_workflow_id():
     orch._build_verification_prompt = MagicMock(return_value="verify prompt")
     orch._checkout_merged_main = MagicMock(return_value="/tmp/merged-checkout")
     orch._remove_verification_worktree = MagicMock()
+    # #3003: the in_progress acceptance row minted at spawn.
+    orch._verification_milestone_id = None
+    orch._ensure_verification_milestone = MagicMock(
+        return_value={"milestone_id": "ms-early", "phase_total_tokens": 0}
+    )
     # success=False so the method returns the infra_error dict early (no parsing).
     orch._run_agent = MagicMock(return_value=MagicMock(success=False, error_code=""))
 
@@ -68,6 +73,11 @@ def test_run_verification_agent_clears_branch_name_for_detached_checkout():
     orch._build_verification_prompt = MagicMock(return_value="verify prompt")
     orch._checkout_merged_main = MagicMock(return_value="/tmp/merged-checkout")
     orch._remove_verification_worktree = MagicMock()
+    # #3003: the in_progress acceptance row minted at spawn.
+    orch._verification_milestone_id = None
+    orch._ensure_verification_milestone = MagicMock(
+        return_value={"milestone_id": "ms-early", "phase_total_tokens": 0}
+    )
     orch._run_agent = MagicMock(return_value=MagicMock(success=False, error_code=""))
 
     with patch.object(

--- a/tests/unit/test_upstream_quota_pause.py
+++ b/tests/unit/test_upstream_quota_pause.py
@@ -339,6 +339,12 @@ def test_verification_agent_re_raise_workflow_pause():
         patch.object(AutonomousOrchestrator, "_checkout_merged_main", return_value="/tmp/vw"),
         patch.object(AutonomousOrchestrator, "_run_agent", side_effect=_raise),
         patch.object(AutonomousOrchestrator, "_remove_verification_worktree") as cleanup,
+        # #3003: the in_progress acceptance row minted before the spawn.
+        patch.object(
+            AutonomousOrchestrator,
+            "_ensure_verification_milestone",
+            return_value={"milestone_id": "ms-early", "phase_total_tokens": 0},
+        ),
     ):
         with pytest.raises(UpstreamQuotaPaused):
             orchestrator._run_verification_agent(

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -306,9 +306,11 @@ def test_confirmed_settle_finalizes_early_milestone():
     fields = deps.host.finalize_acceptance_milestone.call_args[0][1]
     assert fields["status"] == "confirmed"
     assert fields["session_id"] == SESSION_ID
-    # Resume baseline + this attempt's increment.
-    assert fields["phase_total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
-    assert fields["phase_request_count"] == BASELINE["request_count"] + USAGE["request_count"]
+    # The row's phase_* are NOT overwritten — _run_agent's _write_phase_usage
+    # already wrote baseline + Σ(in-run deltas), which may exceed the final
+    # result's own delta when the call retried in-run (#3005 review MAJOR-2).
+    assert "phase_total_tokens" not in fields
+    assert "phase_request_count" not in fields
     assert result.usage_delta["total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
     deps.host.tag_session_messages.assert_called_once_with(SESSION_ID, EARLY_MILESTONE_ID)
 
@@ -388,7 +390,7 @@ def test_infra_exhausted_with_early_milestone_finalizes_with_report():
     assert outcomes[-1].milestone_events == []
     fields = deps.host.finalize_acceptance_milestone.call_args[0][1]
     assert fields["status"] == "indeterminate"
-    assert fields["phase_total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
+    assert "phase_total_tokens" not in fields
 
 
 # ── PhaseResult.pause() usage_delta passthrough ──────────────────────────────
@@ -658,27 +660,39 @@ def test_realtime_writers_stale_stash_is_inert():
 
 
 def test_realtime_writers_default_to_last_in_progress_row():
+    """No stash → NON-verification phases keep targeting milestones[-1]."""
     orch = _orch_for_writers()
     orch.repo.list_milestones.return_value = [
-        {"milestone_id": "ms-1", "milestone_type": "pr_zero_check_runs"}
+        {"milestone_id": "ms-1", "milestone_type": "pr_zero_check_runs"},
+        {"milestone_id": "ms-2", "milestone_type": "dev_started"},
     ]
 
     orch._write_realtime_phase_usage({"total_tokens": 5, "request_count": 1})
     orch._link_session_to_current_milestone("sess-1")
 
-    assert orch.repo.list_milestones.call_count == 2
-    assert orch.repo.update_milestone.call_count == 2
+    assert orch.repo.update_milestone.call_args_list[0][0][0] == "ms-2"
+    assert orch.repo.update_milestone.call_args_list[1][0][0] == "ms-2"
 
 
 # ── orchestrator: _ensure_verification_milestone lifecycle (#3003) ──────────
 
 
-def _orch_for_ensure(in_progress_rows):
+def _orch_for_ensure(in_progress_rows, terminal_rows=None):
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._workflow_id = "wf-2994"
     orch.repo = MagicMock()
-    orch.repo.list_milestones.return_value = in_progress_rows
+    terminal_rows = terminal_rows or []
+
+    def _list(_workflow_id, phase=None, status=None, **_kwargs):
+        if status == "failed":
+            return [r for r in terminal_rows if r.get("status") == "failed"]
+        if status == "cancelled":
+            return [r for r in terminal_rows if r.get("status") == "cancelled"]
+        return in_progress_rows
+
+    orch.repo.list_milestones.side_effect = _list
     orch._create_milestone = MagicMock(side_effect=lambda **kw: {"milestone_id": "ms-new", **kw})
+    orch._emit = MagicMock()
     orch._verification_milestone_id = None
     return orch
 
@@ -720,6 +734,50 @@ def test_ensure_sweeps_interrupted_older_rows():
     swept = orch.repo.update_milestone.call_args_list[0]
     assert swept[0][0] == "ms-old"
     assert swept[0][1]["status"] == "failed"
+    # The sweep is not silent — live timelines refetch off the event.
+    assert orch._emit.call_args[0][0] == "milestone_updated"
+
+
+def test_ensure_resumes_terminalized_same_attempt_row():
+    """Quota/cancel pause terminalized the row; auto-resume must resurrect it.
+
+    Without this the resume mints a duplicate same-round_number card and
+    loses the attempt's recorded usage (#3005 review MAJOR-1).
+    """
+    orch = _orch_for_ensure(
+        [],
+        terminal_rows=[
+            {
+                "milestone_id": "ms-paused",
+                "round_number": 3,
+                "status": "failed",
+                "phase_total_tokens": 900,
+            }
+        ],
+    )
+
+    row = orch._ensure_verification_milestone({"verification_attempt": 2, "dev_round": 1})
+
+    assert row["milestone_id"] == "ms-paused"
+    orch._create_milestone.assert_not_called()
+    resumed = orch.repo.update_milestone.call_args
+    assert resumed[0][0] == "ms-paused"
+    assert resumed[0][1]["status"] == "in_progress"
+    assert resumed[0][1]["error_message"] == ""
+
+
+def test_ensure_does_not_resurrect_settled_rows():
+    """A settled verdict row for this attempt must not be reused or blocked."""
+    orch = _orch_for_ensure(
+        [],
+        terminal_rows=[{"milestone_id": "ms-old-fail", "round_number": 2, "status": "failed"}],
+    )
+
+    row = orch._ensure_verification_milestone({"verification_attempt": 2, "dev_round": 1})
+
+    # round_number 3 ≠ the failed row's 2 → fresh row, old row untouched.
+    assert row["milestone_id"] == "ms-new"
+    assert row["round_number"] == 3
 
 
 def test_finalize_updates_row_emits_event_and_clears_stash():

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -766,8 +766,13 @@ def test_ensure_resumes_terminalized_same_attempt_row():
     assert resumed[0][1]["error_message"] == ""
 
 
-def test_ensure_does_not_resurrect_settled_rows():
-    """A settled verdict row for this attempt must not be reused or blocked."""
+def test_ensure_leaves_mismatched_terminal_rows_alone():
+    """Only the CURRENT attempt's terminal row may be resurrected.
+
+    A same-attempt settled row is unreachable by the attempt invariant
+    (settling bumps the counter); the practical guard is the round mismatch —
+    an older failed row must neither be reused nor modified.
+    """
     orch = _orch_for_ensure(
         [],
         terminal_rows=[{"milestone_id": "ms-old-fail", "round_number": 2, "status": "failed"}],
@@ -778,6 +783,7 @@ def test_ensure_does_not_resurrect_settled_rows():
     # round_number 3 ≠ the failed row's 2 → fresh row, old row untouched.
     assert row["milestone_id"] == "ms-new"
     assert row["round_number"] == 3
+    orch.repo.update_milestone.assert_not_called()
 
 
 def test_finalize_updates_row_emits_event_and_clears_stash():

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -289,7 +289,7 @@ BASELINE = {
 
 
 def _agent_out_early(**extra):
-    out = _agent_out_confirmed(milestone_id=EARLY_MILESTONE_ID, usage_baseline=dict(BASELINE))
+    out = _agent_out_confirmed(milestone_id=EARLY_MILESTONE_ID, usage_baseline={**BASELINE})
     out.update(extra)
     return out
 
@@ -509,12 +509,12 @@ def test_run_verification_agent_passes_reuse_baseline_as_prior_usage():
     }
     orch = _orch_for_agent_run(
         _run_agent_result(),
-        early_row=dict(
-            phase_total_tokens=500,
-            phase_input_tokens=400,
-            phase_output_tokens=100,
-            phase_request_count=4,
-        ),
+        early_row={
+            "phase_total_tokens": 500,
+            "phase_input_tokens": 400,
+            "phase_output_tokens": 100,
+            "phase_request_count": 4,
+        },
     )
 
     with _wf_property(orch):

--- a/tests/unit/test_verification_usage_wiring_2994.py
+++ b/tests/unit/test_verification_usage_wiring_2994.py
@@ -278,6 +278,119 @@ def test_legacy_agent_dict_without_runtime_keys_yields_zero_milestone():
     assert result.usage_delta is None
 
 
+# ── handle(): early-milestone finalize path (#3003) ──────────────────────────
+
+BASELINE = {
+    "total_tokens": 500,
+    "total_input_tokens": 400,
+    "total_output_tokens": 100,
+    "request_count": 4,
+}
+
+
+def _agent_out_early(**extra):
+    out = _agent_out_confirmed(milestone_id=EARLY_MILESTONE_ID, usage_baseline=dict(BASELINE))
+    out.update(extra)
+    return out
+
+
+def test_confirmed_settle_finalizes_early_milestone():
+    deps = _deps_confirmed()
+    deps.host.run_verification_agent.return_value = _agent_out_early()
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    # No create-events: the early row is finalized in place.
+    assert result.milestone_events == []
+    fields = deps.host.finalize_acceptance_milestone.call_args[0][1]
+    assert fields["status"] == "confirmed"
+    assert fields["session_id"] == SESSION_ID
+    # Resume baseline + this attempt's increment.
+    assert fields["phase_total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
+    assert fields["phase_request_count"] == BASELINE["request_count"] + USAGE["request_count"]
+    assert result.usage_delta["total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
+    deps.host.tag_session_messages.assert_called_once_with(SESSION_ID, EARLY_MILESTONE_ID)
+
+
+def test_rejected_settle_finalizes_early_milestone():
+    deps = _deps_confirmed()
+    deps.host.run_verification_agent.return_value = _agent_out_early(
+        verdicts=[
+            {
+                "item": "The endpoint rejects expired tokens",
+                "verdict": "rejected",
+                "evidence": [{"ref": "src/auth.py:10", "note": "not covered"}],
+            }
+        ]
+    )
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.milestone_events == []
+    assert deps.host.finalize_acceptance_milestone.call_args[0][1]["status"] == "rejected"
+    deps.host.tag_session_messages.assert_called_once_with(SESSION_ID, EARLY_MILESTONE_ID)
+
+
+def test_infra_retry_with_early_milestone_finalizes_failed_and_tags():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+        "session_id": SESSION_ID,
+        "usage": USAGE,
+        "milestone_id": EARLY_MILESTONE_ID,
+        "usage_baseline": dict(BASELINE),
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    assert result.milestone_events == []
+    fields = deps.host.finalize_acceptance_milestone.call_args[0][1]
+    assert fields["status"] == "failed"
+    # The row's realtime-recorded usage is preserved (no phase_* overwrite).
+    assert "phase_total_tokens" not in fields
+    deps.host.tag_session_messages.assert_called_once_with(SESSION_ID, EARLY_MILESTONE_ID)
+
+
+def test_infra_exhausted_with_early_milestone_finalizes_with_report():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    exhausted = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+        "session_id": SESSION_ID,
+        "usage": USAGE,
+        "milestone_id": EARLY_MILESTONE_ID,
+        "usage_baseline": dict(BASELINE),
+    }
+    deps.host.run_verification_agent.side_effect = lambda **_kwargs: exhausted
+
+    workflow = _workflow()
+    outcomes = []
+    for _ in range(av.MAX_VERIFIER_INFRA_RETRIES):
+        result = av.handle(_ctx(workflow), deps)
+        outcomes.append(result)
+        workflow = {**workflow, **result.workflow_patch}
+
+    assert outcomes[-1].outcome == "pause"
+    assert outcomes[-1].milestone_events == []
+    fields = deps.host.finalize_acceptance_milestone.call_args[0][1]
+    assert fields["status"] == "indeterminate"
+    assert fields["phase_total_tokens"] == BASELINE["total_tokens"] + USAGE["total_tokens"]
+
+
 # ── PhaseResult.pause() usage_delta passthrough ──────────────────────────────
 
 
@@ -296,7 +409,28 @@ def test_phase_result_pause_accepts_and_passes_usage_delta():
 # ── orchestrator: _run_verification_agent runtime attachment ────────────────
 
 
-def _orch_for_agent_run(run_agent_result):
+EARLY_MILESTONE_ID = "ms-early-3003"
+ZERO_BASELINE = {
+    "total_tokens": 0,
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "request_count": 0,
+}
+
+
+def _early_row(**overrides):
+    row = {
+        "milestone_id": EARLY_MILESTONE_ID,
+        "phase_total_tokens": 0,
+        "phase_input_tokens": 0,
+        "phase_output_tokens": 0,
+        "phase_request_count": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def _orch_for_agent_run(run_agent_result, early_row=None):
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._workflow_id = "wf-2994"
     orch._build_verification_prompt = MagicMock(return_value="verify prompt")
@@ -304,6 +438,16 @@ def _orch_for_agent_run(run_agent_result):
     orch._remove_verification_worktree = MagicMock()
     orch._parse_verifier_output = MagicMock(return_value={"verdicts": [], "snapshot": None})
     orch._run_agent = MagicMock(return_value=run_agent_result)
+
+    def _ensure(_wf):
+        row = _early_row(**(early_row or {}))
+        # Mirror the real method's side effect: the row becomes the writers'
+        # preferred target for the duration of the run.
+        orch._verification_milestone_id = row["milestone_id"]
+        return row
+
+    orch._ensure_verification_milestone = MagicMock(side_effect=_ensure)
+    orch._verification_milestone_id = None
     return orch
 
 
@@ -328,16 +472,16 @@ def _wf_property(orch):
     )
 
 
-def test_run_verification_agent_success_attaches_runtime():
-    flag_during_run = {}
+def test_run_verification_agent_success_attaches_runtime_and_early_milestone():
+    stash_during_run = {}
     result = _run_agent_result()
 
-    def _capture_flag(*_args, **_kwargs):
-        flag_during_run["value"] = getattr(orch, "_verification_agent_active", None)
+    def _capture_stash(*_args, **_kwargs):
+        stash_during_run["value"] = getattr(orch, "_verification_milestone_id", None)
         return result
 
     orch = _orch_for_agent_run(result)
-    orch._run_agent = MagicMock(side_effect=_capture_flag)
+    orch._run_agent = MagicMock(side_effect=_capture_stash)
 
     with _wf_property(orch):
         out = orch._run_verification_agent(
@@ -346,9 +490,40 @@ def test_run_verification_agent_success_attaches_runtime():
 
     assert out["session_id"] == SESSION_ID
     assert out["usage"] == USAGE
-    # The suppression window must span the run itself, not just its cleanup.
-    assert flag_during_run["value"] is True
-    assert orch._verification_agent_active is False
+    assert out["milestone_id"] == EARLY_MILESTONE_ID
+    assert out["usage_baseline"] == ZERO_BASELINE
+    # The early row exists (and is the writers' preferred target) DURING the run.
+    assert stash_during_run["value"] == EARLY_MILESTONE_ID
+    # #3003: the call links the early row and carries the resume baseline.
+    call_kwargs = orch._run_agent.call_args[1]
+    assert call_kwargs["milestone_id"] == EARLY_MILESTONE_ID
+    assert call_kwargs["prior_usage"] == ZERO_BASELINE
+
+
+def test_run_verification_agent_passes_reuse_baseline_as_prior_usage():
+    baseline = {
+        "total_tokens": 500,
+        "total_input_tokens": 400,
+        "total_output_tokens": 100,
+        "request_count": 4,
+    }
+    orch = _orch_for_agent_run(
+        _run_agent_result(),
+        early_row=dict(
+            phase_total_tokens=500,
+            phase_input_tokens=400,
+            phase_output_tokens=100,
+            phase_request_count=4,
+        ),
+    )
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["usage_baseline"] == baseline
+    assert orch._run_agent.call_args[1]["prior_usage"] == baseline
 
 
 def test_run_verification_agent_failure_still_attaches_runtime():
@@ -362,6 +537,22 @@ def test_run_verification_agent_failure_still_attaches_runtime():
     assert out["infra_error"]
     assert out["session_id"] == SESSION_ID
     assert out["usage"]["total_tokens"] == USAGE["total_tokens"]
+    # Post-checkout failures keep the early milestone facts (#3003).
+    assert out["milestone_id"] == EARLY_MILESTONE_ID
+
+
+def test_run_verification_agent_spawn_exception_carries_early_milestone():
+    orch = _orch_for_agent_run(_run_agent_result())
+    orch._run_agent = MagicMock(side_effect=RuntimeError("spawn blew up"))
+
+    with _wf_property(orch):
+        out = orch._run_verification_agent(
+            snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
+        )
+
+    assert out["infra_error"] == "verification agent spawn failed"
+    assert out["milestone_id"] == EARLY_MILESTONE_ID
+    assert out["usage_baseline"] == ZERO_BASELINE
 
 
 def test_run_verification_agent_none_result_has_no_runtime_keys():
@@ -374,6 +565,8 @@ def test_run_verification_agent_none_result_has_no_runtime_keys():
 
     assert "session_id" not in out
     assert "usage" not in out
+    # The early row still exists — the handler must finalize it.
+    assert out["milestone_id"] == EARLY_MILESTONE_ID
 
 
 def test_run_verification_agent_checkout_failure_has_no_runtime_keys():
@@ -388,7 +581,10 @@ def test_run_verification_agent_checkout_failure_has_no_runtime_keys():
     assert out["infra_error"] == "merged-main checkout failed"
     assert "session_id" not in out
     assert "usage" not in out
+    # No row was minted — the handler's create fallback applies.
+    assert "milestone_id" not in out
     orch._run_agent.assert_not_called()
+    orch._ensure_verification_milestone.assert_not_called()
 
 
 def test_run_verification_agent_tracking_id_wins_over_blank_session_id():
@@ -402,7 +598,7 @@ def test_run_verification_agent_tracking_id_wins_over_blank_session_id():
     assert out["session_id"] == SESSION_ID
 
 
-def test_verification_flag_cleared_even_when_agent_raises_pause():
+def test_workflow_pause_leaves_early_row_open_for_resume():
     orch = _orch_for_agent_run(_run_agent_result())
     orch._run_agent = MagicMock(side_effect=WorkflowPaused("quota window"))
 
@@ -411,34 +607,58 @@ def test_verification_flag_cleared_even_when_agent_raises_pause():
             snapshot=MagicMock(), merge_sha="m", base_sha="b", issue_number=1, pr_number=2
         )
 
-    assert orch._verification_agent_active is False
+    # The row stays the writers' target across the pause — resume re-enters
+    # with the same attempt number and reuses it (#3003).
+    assert orch._verification_milestone_id == EARLY_MILESTONE_ID
 
 
-# ── orchestrator: realtime writers suppressed during the verifier run ───────
+# ── orchestrator: realtime writers target the verifier's row (#3003) ───────
 
 
 def _orch_for_writers():
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._workflow_id = "wf-2994"
     orch.repo = MagicMock()
+    orch._verification_milestone_id = None
     return orch
 
 
-def test_realtime_writers_noop_while_verification_agent_active():
+def test_realtime_writers_prefer_stashed_verification_milestone():
+    """Even when a leaked row sorts last, the stashed verifier row wins."""
     orch = _orch_for_writers()
-    orch._verification_agent_active = True
+    orch._verification_milestone_id = "ms-verif"
+    orch.repo.list_milestones.return_value = [
+        {"milestone_id": "ms-leak", "milestone_type": "pr_zero_check_runs"},
+        {"milestone_id": "ms-verif", "milestone_type": "acceptance_verification"},
+    ]
 
-    orch._write_realtime_phase_usage({"total_tokens": 5})
+    orch._write_realtime_phase_usage({"total_tokens": 5, "request_count": 1})
     orch._link_session_to_current_milestone("sess-1")
 
-    # Zero DB access: the gate must fire before list_milestones.
-    orch.repo.list_milestones.assert_not_called()
-    orch.repo.update_milestone.assert_not_called()
+    usage_target = orch.repo.update_milestone.call_args_list[0][0][0]
+    link_fields = orch.repo.update_milestone.call_args_list[1][0][1]
+    assert usage_target == "ms-verif"
+    assert orch.repo.update_milestone.call_args_list[1][0][0] == "ms-verif"
+    assert "sess-1" in link_fields.values()
 
 
-def test_realtime_writers_resume_after_flag_clears():
+def test_realtime_writers_stale_stash_is_inert():
+    """A stash whose row went terminal (not in_progress) must not redirect."""
     orch = _orch_for_writers()
-    orch._verification_agent_active = False
+    orch._verification_milestone_id = "ms-gone"
+    orch.repo.list_milestones.return_value = [
+        {"milestone_id": "ms-1", "milestone_type": "dev_started"}
+    ]
+
+    orch._write_realtime_phase_usage({"total_tokens": 5, "request_count": 1})
+    orch._link_session_to_current_milestone("sess-1")
+
+    assert orch.repo.update_milestone.call_args_list[0][0][0] == "ms-1"
+    assert orch.repo.update_milestone.call_args_list[1][0][0] == "ms-1"
+
+
+def test_realtime_writers_default_to_last_in_progress_row():
+    orch = _orch_for_writers()
     orch.repo.list_milestones.return_value = [
         {"milestone_id": "ms-1", "milestone_type": "pr_zero_check_runs"}
     ]
@@ -448,6 +668,80 @@ def test_realtime_writers_resume_after_flag_clears():
 
     assert orch.repo.list_milestones.call_count == 2
     assert orch.repo.update_milestone.call_count == 2
+
+
+# ── orchestrator: _ensure_verification_milestone lifecycle (#3003) ──────────
+
+
+def _orch_for_ensure(in_progress_rows):
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2994"
+    orch.repo = MagicMock()
+    orch.repo.list_milestones.return_value = in_progress_rows
+    orch._create_milestone = MagicMock(side_effect=lambda **kw: {"milestone_id": "ms-new", **kw})
+    orch._verification_milestone_id = None
+    return orch
+
+
+def test_ensure_creates_row_for_current_attempt():
+    orch = _orch_for_ensure([])
+
+    row = orch._ensure_verification_milestone({"verification_attempt": 2, "dev_round": 1})
+
+    assert row["milestone_id"] == "ms-new"
+    assert orch._create_milestone.call_args[1]["round_number"] == 3
+    assert orch._create_milestone.call_args[1]["status"] == "in_progress"
+    assert orch._verification_milestone_id == "ms-new"
+
+
+def test_ensure_reuses_same_attempt_row():
+    orch = _orch_for_ensure(
+        [{"milestone_id": "ms-resume", "round_number": 3, "phase_total_tokens": 500}]
+    )
+
+    row = orch._ensure_verification_milestone({"verification_attempt": 2, "dev_round": 1})
+
+    assert row["milestone_id"] == "ms-resume"
+    orch._create_milestone.assert_not_called()
+    orch.repo.update_milestone.assert_not_called()
+
+
+def test_ensure_sweeps_interrupted_older_rows():
+    orch = _orch_for_ensure(
+        [
+            {"milestone_id": "ms-old", "round_number": 1},
+            {"milestone_id": "ms-resume", "round_number": 3},
+        ]
+    )
+
+    row = orch._ensure_verification_milestone({"verification_attempt": 2, "dev_round": 1})
+
+    assert row["milestone_id"] == "ms-resume"
+    swept = orch.repo.update_milestone.call_args_list[0]
+    assert swept[0][0] == "ms-old"
+    assert swept[0][1]["status"] == "failed"
+
+
+def test_finalize_updates_row_emits_event_and_clears_stash():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch.repo = MagicMock()
+    orch._emit = MagicMock()
+    orch._verification_milestone_id = "ms-verif"
+
+    orch.finalize_acceptance_milestone("ms-verif", {"status": "confirmed"})
+
+    orch.repo.update_milestone.assert_called_once_with("ms-verif", {"status": "confirmed"})
+    assert orch._emit.call_args[0][0] == "milestone_updated"
+    assert orch._verification_milestone_id is None
+
+
+def test_finalize_with_empty_id_is_noop():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch.repo = MagicMock()
+
+    orch.finalize_acceptance_milestone("", {"status": "confirmed"})
+
+    orch.repo.update_milestone.assert_not_called()
 
 
 # ── commit path: usage_delta triggers the totals refresh ─────────────────────


### PR DESCRIPTION
Closes #3003

## What

The acceptance milestone row previously existed only at settle (#2335 design), so a running verification (`verification_pending`) had no card to host the live activity panel — and the panel is live-only (host gate: `planning/developing/pr_review/merging`). This mints the acceptance milestone **in_progress at verifier spawn** (one row per attempt, ci_repair pattern) and finalizes it in place at settle, so the running verification shows a live card with AI activities, a session button, and realtime-climbing token/request chips.

Implements the plan reviewed to zero remaining opinions over three rounds (posted as a PR comment). Key mechanics:

- **`_ensure_verification_milestone`** — mint after the merged-main checkout succeeds; sweep older still-in_progress acceptance rows to `failed` ("interrupted"); reuse a same-attempt row on quota-pause/crash resume (the attempt number is unchanged there — infra-retry bumps it via its retry patch, verified) and seed its recorded usage as the call's **`prior_usage`** baseline (the offsets mechanism then makes live usage climb from the row's totals instead of resetting).
- **`_run_verification_agent`** links the early row directly (`milestone_id`) — pre-linking the session id before the first event — and every post-checkout return carries `milestone_id` + `usage_baseline`; checkout-fail returns neither (no row), which is exactly the create-fallback trigger.
- **#2994's `_verification_agent_active` suppression is removed**: the realtime writers now target the verifier's row via a `_verification_milestone_id` preference (stale stash inert once terminal). `_write_phase_usage` folds baseline+result on every exit — failed runs included, so **infra-retry attempts finally land their burned tokens** on their own failed row (partial fix for #2999).
- **`finalize_acceptance_milestone`** (PhaseHost Protocol + orchestrator): settle updates the row in place (`_create_milestone`'s dedupe would silently skip a create), emits `milestone_updated`, clears the stash. Infra-retry finalizes `failed` keeping realtime usage, and tags its own messages (per-attempt attribution). The no-early-row fallback keeps the #3000 pre-mint create semantics for every settle shape — existing phase-level tests exercise it unchanged.
- **Frontend**: `verification_pending` joins the primary host gate; the fallback gate deliberately stays on agent phases (the merge-SHA retry loop has no running agent — widening it would pin a stale host on the previous phase's card).

## Tests

Ensure lifecycle (create/reuse/sweep), finalize semantics + stash clearing, `prior_usage`/`milestone_id` call kwargs, post-checkout returns carrying early facts (incl. spawn-exception), per-attempt writer targeting with stale-stash inertness, four settle finalize shapes with baseline arithmetic, infra-retry finalize+tag, frontend host selection + null-fallback under `verification_pending`. 51 tests in the rewired suites; 157 across affected backend suites locally; the pre-existing SIM103 in `github_ops.py` is untouched by this diff.

## Ops

Backend 3 files + frontend; both services restart; no data backfill. The next natural verification is the end-to-end observation window (an in_progress "Acceptance verification: running" card with live activities, settling to its verdict).