### PR TITLE
fix(#2963): new project local repo initialization and issue creation

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9833,6 +9833,7 @@ class AutonomousOrchestrator:
         # re-entry, so the gate must be on a durable field. Mirrors the
         # issue-side github_issue_number gate below. (#2044 Phase B P1-b,
         # 5th-round review.)
+        repo_url = ""  # Track newly created repo URL for issue creation (#2963)
         if wf.get("is_new_project"):
             existing_repo = wf.get("project_repo_url", "") or ""
             # A resolved GitHub repo URL starts with http(s)://; a bare
@@ -9841,6 +9842,7 @@ class AutonomousOrchestrator:
             # URL — routes/autonomous.py accepts it as input), so the URL
             # shape is the reliable "repo already created" signal.
             if existing_repo.startswith(("http://", "https://")):
+                repo_url = existing_repo  # Already resolved, use for issue (#2963)
                 logger.info(
                     "Workflow %s: project_repo_url already a resolved repo URL "
                     "(%s); skipping create_repo",
@@ -9865,6 +9867,44 @@ class AutonomousOrchestrator:
                     # between this write and the milestone still gates
                     # re-entry correctly. (#2044 Phase B P1-b.)
                     self._update_workflow({"project_repo_url": repo_url})
+                    wf["project_repo_url"] = repo_url  # Sync in-memory wf (#2963)
+
+                    # Clone the newly created repo to local workspace (#2963)
+                    # This ensures the local directory is a valid git repository
+                    # before subsequent git operations (fetch, branch, worktree).
+                    if not project_path:
+                        user_workspace = self._get_user_workspace(system_account)
+                        repo_name = repo_url.rstrip("/").split("/")[-1]
+                        project_path = os.path.join(user_workspace, repo_name)
+
+                    if os.path.exists(project_path):
+                        if os.path.isdir(os.path.join(project_path, ".git")):
+                            existing_url = gh.get_repo_url()
+                            if existing_url == repo_url:
+                                logger.info(
+                                    "Project already cloned at %s, skipping",
+                                    project_path,
+                                )
+                            else:
+                                raise GitHubOpsError(
+                                    f"Directory {project_path} is a different git repo"
+                                )
+                        else:
+                            if os.listdir(project_path):
+                                raise GitHubOpsError(
+                                    f"Directory {project_path} exists but is not empty "
+                                    "and not a git repo"
+                                )
+                    else:
+                        os.makedirs(os.path.dirname(project_path), exist_ok=True)
+
+                    if not os.path.isdir(os.path.join(project_path, ".git")):
+                        gh._run_git(["clone", repo_url, project_path])
+
+                    self._update_workflow({"project_path": project_path})
+                    wf["project_path"] = project_path
+                    self._gh = GitHubOps(project_path, system_account=system_account)
+
                     self._create_milestone(
                         phase="preparation",
                         milestone_type="repo_setup",
@@ -9918,11 +9958,12 @@ class AutonomousOrchestrator:
             # Create issue from text
             # For new project scenarios, extract owner/repo from repo_url
             # so create_issue can target the repository explicitly.
+            # Prefer local repo_url (from create_repo) over wf dict (#2963)
             issue_repo = None
-            project_repo_url = wf.get("project_repo_url", "")
-            if project_repo_url:
+            issue_repo_url = repo_url or wf.get("project_repo_url", "")
+            if issue_repo_url:
                 # Extract owner/repo from URL like https://github.com/owner/repo
-                match = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", project_repo_url)
+                match = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", issue_repo_url)
                 if match:
                     issue_repo = match.group(1)
 
@@ -10023,6 +10064,20 @@ class AutonomousOrchestrator:
 
         if strategy == "new-branch" or strategy == "worktree":
             try:
+                # Validate project_path before git operations (#2963)
+                if not project_path:
+                    raise GitHubOpsError(
+                        "project_path is not set for branch creation"
+                    )
+                if not os.path.isdir(project_path):
+                    raise GitHubOpsError(
+                        f"project_path {project_path} does not exist"
+                    )
+                if not os.path.isdir(os.path.join(project_path, ".git")):
+                    raise GitHubOpsError(
+                        f"{project_path} is not a valid git repository"
+                    )
+
                 # Ensure we branch from latest origin/main
                 gh._run_git(["fetch", "origin", "main"])
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10083,14 +10083,6 @@ class AutonomousOrchestrator:
 
         if strategy == "new-branch" or strategy == "worktree":
             try:
-                # Validate project_path before git operations (#2963)
-                if not project_path:
-                    raise GitHubOpsError("project_path is not set for branch creation")
-                if not os.path.isdir(project_path):
-                    raise GitHubOpsError(f"project_path {project_path} does not exist")
-                if not os.path.isdir(os.path.join(project_path, ".git")):
-                    raise GitHubOpsError(f"{project_path} is not a valid git repository")
-
                 # Ensure we branch from latest origin/main
                 gh._run_git(["fetch", "origin", "main"])
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -92,6 +92,7 @@ from app.modules.workspace.autonomous.terminal_report_i18n import render_ci_repa
 from app.repositories.autonomous_repo import DEFAULT_CONTENT_LANGUAGE, AutonomousWorkflowRepository
 from app.repositories.database import Database
 from app.repositories.user_repo import UserRepository
+from app.utils.workspace import get_workspace_base_dir
 
 logger = logging.getLogger(__name__)
 
@@ -2826,6 +2827,24 @@ class AutonomousOrchestrator:
             return None
         user = UserRepository().get_user_by_id(user_id)
         return user.get("system_account") if user else None
+
+    @staticmethod
+    def _get_user_workspace(system_account: str | None) -> str:
+        """Return the user's workspace directory path.
+
+        Constructs the path as ``{base_dir}/{system_account}`` where base_dir
+        comes from WORKSPACE_BASE_DIR env (Docker) or home directory (Package).
+
+        Args:
+            system_account: The system account name for the user.
+
+        Returns:
+            The user's workspace directory path.
+        """
+        base_dir = get_workspace_base_dir()
+        if system_account:
+            return os.path.join(base_dir, system_account)
+        return base_dir
 
     @staticmethod
     def _resolve_isolated_agent_account() -> str:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10066,17 +10066,11 @@ class AutonomousOrchestrator:
             try:
                 # Validate project_path before git operations (#2963)
                 if not project_path:
-                    raise GitHubOpsError(
-                        "project_path is not set for branch creation"
-                    )
+                    raise GitHubOpsError("project_path is not set for branch creation")
                 if not os.path.isdir(project_path):
-                    raise GitHubOpsError(
-                        f"project_path {project_path} does not exist"
-                    )
+                    raise GitHubOpsError(f"project_path {project_path} does not exist")
                 if not os.path.isdir(os.path.join(project_path, ".git")):
-                    raise GitHubOpsError(
-                        f"{project_path} is not a valid git repository"
-                    )
+                    raise GitHubOpsError(f"{project_path} is not a valid git repository")
 
                 # Ensure we branch from latest origin/main
                 gh._run_git(["fetch", "origin", "main"])

--- a/tests/unit/test_new_project_local_repo_init_2963.py
+++ b/tests/unit/test_new_project_local_repo_init_2963.py
@@ -45,9 +45,7 @@ class TestSyncWfAfterCreateRepo:
         wf["project_path"] = str(tmp_path)
 
         # Mock the orchestrator
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.GitHubOps"
-        ) as mock_gh_class:
+        with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps") as mock_gh_class:
             mock_gh = MagicMock()
             mock_gh_class.return_value = mock_gh
             mock_gh.create_repo.return_value = {
@@ -58,9 +56,7 @@ class TestSyncWfAfterCreateRepo:
                 "number": 1,
                 "url": "https://github.com/owner/my-new-project/issues/1",
             }
-            mock_gh._run_git.return_value = MagicMock(
-                returncode=0, stdout="", stderr=""
-            )
+            mock_gh._run_git.return_value = MagicMock(returncode=0, stdout="", stderr="")
             mock_gh.get_repo_url.return_value = "https://github.com/owner/my-new-project"
             mock_gh.list_worktrees.return_value = []
             mock_gh.path_exists_as_user.return_value = False
@@ -113,9 +109,7 @@ class TestIssueRepoFromLocalVariable:
         issue_repo_url = local_repo_url or wf_stale_value
 
         # Extract owner/repo
-        match = re.search(
-            r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", issue_repo_url
-        )
+        match = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", issue_repo_url)
         issue_repo = match.group(1) if match else None
 
         assert issue_repo == "owner/new-project"
@@ -193,9 +187,7 @@ class TestCloneAfterCreateRepo:
         with pytest.raises(GitHubOpsError, match="different git repo"):
             if os.path.isdir(os.path.join(project_path, ".git")):
                 if mock_gh.get_repo_url() != repo_url:
-                    raise GitHubOpsError(
-                        f"Directory {project_path} is a different git repo"
-                    )
+                    raise GitHubOpsError(f"Directory {project_path} is a different git repo")
 
 
 class TestValidateProjectPath:
@@ -224,9 +216,7 @@ class TestValidateProjectPath:
 
         with pytest.raises(GitHubOpsError, match="not a valid git repository"):
             if not os.path.isdir(os.path.join(project_path, ".git")):
-                raise GitHubOpsError(
-                    f"{project_path} is not a valid git repository"
-                )
+                raise GitHubOpsError(f"{project_path} is not a valid git repository")
 
     def test_pass_if_valid_git_repository(self, tmp_path):
         """Verify validation passes for valid git repository."""

--- a/tests/unit/test_new_project_local_repo_init_2963.py
+++ b/tests/unit/test_new_project_local_repo_init_2963.py
@@ -1,0 +1,245 @@
+# tests/unit/test_new_project_local_repo_init_2963.py
+"""
+Issue #2963: AI 自主开发创建新项目时首次创建 Issue 失败，重试后因本地仓库未初始化导致分支创建失败
+
+测试修复点：
+1. create_repo 后同步内存中的 wf 字典
+2. create_issue 优先使用本地 repo_url 变量
+3. 新项目创建后克隆仓库到本地
+4. git 操作前验证目录有效性
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+
+def _make_test_workflow():
+    """Create a test workflow dict for new project scenario."""
+    return {
+        "id": "test-workflow-id-2963",
+        "current_phase": "preparation",
+        "status": "preparing",
+        "is_new_project": True,
+        "branch_strategy": "worktree",
+        "requirements_text": "Build a REST API service",
+        "github_issue_number": None,
+        "project_repo_url": "my-new-project",  # Input name, not URL yet
+        "project_path": None,
+        "title": "Test Project",
+        "is_private": True,
+    }
+
+
+class TestSyncWfAfterCreateRepo:
+    """测试点1：create_repo 后同步内存中的 wf 字典"""
+
+    def test_wf_synced_after_create_repo(self, tmp_path):
+        """Verify wf dict is synced immediately after create_repo."""
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        wf = _make_test_workflow()
+        wf["project_path"] = str(tmp_path)
+
+        # Mock the orchestrator
+        with patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps"
+        ) as mock_gh_class:
+            mock_gh = MagicMock()
+            mock_gh_class.return_value = mock_gh
+            mock_gh.create_repo.return_value = {
+                "name": "my-new-project",
+                "url": "https://github.com/owner/my-new-project",
+            }
+            mock_gh.create_issue.return_value = {
+                "number": 1,
+                "url": "https://github.com/owner/my-new-project/issues/1",
+            }
+            mock_gh._run_git.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            mock_gh.get_repo_url.return_value = "https://github.com/owner/my-new-project"
+            mock_gh.list_worktrees.return_value = []
+            mock_gh.path_exists_as_user.return_value = False
+
+            # Create a mock repo
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = wf
+            mock_repo.update_workflow.return_value = {"success": True}
+
+            # Track updates to verify wf sync
+            updates_applied = []
+
+            def capture_update(patch):
+                updates_applied.append(patch)
+                # Simulate in-memory update
+                wf.update(patch)
+                return {"success": True}
+
+            mock_repo.update_workflow.side_effect = capture_update
+
+            o = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+            o.repo = mock_repo
+            o._workflow_id = "test-workflow-id-2963"
+            o._gh = None
+            o._emit = MagicMock()
+
+            # Simulate the create_repo block
+            repo_url = "https://github.com/owner/my-new-project"
+            o._update_workflow({"project_repo_url": repo_url})
+
+            # Verify wf was synced (this is what the fix adds)
+            # In the actual code, this is done by: wf["project_repo_url"] = repo_url
+            assert (
+                wf.get("project_repo_url") == repo_url
+            ), "wf should be synced with repo_url after _update_workflow"
+
+
+class TestIssueRepoFromLocalVariable:
+    """测试点2：create_issue 优先使用本地 repo_url 变量"""
+
+    def test_issue_repo_uses_local_repo_url(self):
+        """Verify issue creation uses local repo_url, not stale wf value."""
+        import re
+
+        # Scenario: create_repo succeeded, but wf dict has stale value
+        local_repo_url = "https://github.com/owner/new-project"  # From create_repo
+        wf_stale_value = "my-new-project"  # Input name, not URL
+
+        # The fix: issue_repo_url = repo_url or wf.get("project_repo_url", "")
+        issue_repo_url = local_repo_url or wf_stale_value
+
+        # Extract owner/repo
+        match = re.search(
+            r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", issue_repo_url
+        )
+        issue_repo = match.group(1) if match else None
+
+        assert issue_repo == "owner/new-project"
+        assert issue_repo is not None, "Should extract repo from local repo_url"
+
+
+class TestCloneAfterCreateRepo:
+    """测试点3：新项目创建后克隆仓库到本地"""
+
+    def test_clone_called_for_new_project(self, tmp_path):
+        """Verify git clone is called after create_repo for new projects."""
+        repo_url = "https://github.com/owner/new-project"
+        project_path = str(tmp_path / "new-project")
+
+        # Simulate the clone logic from the fix
+        git_calls = []
+
+        def mock_run_git(args, **kw):
+            git_calls.append(args)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_gh = MagicMock()
+        mock_gh._run_git.side_effect = mock_run_git
+        mock_gh.get_repo_url.return_value = repo_url
+
+        # Directory doesn't exist → should create parent and clone
+        assert not os.path.exists(project_path)
+
+        # The fix logic
+        if not os.path.exists(project_path):
+            os.makedirs(os.path.dirname(project_path), exist_ok=True)
+
+        if not os.path.isdir(os.path.join(project_path, ".git")):
+            mock_gh._run_git(["clone", repo_url, project_path])
+
+        # Verify clone was called
+        assert ["clone", repo_url, project_path] in git_calls
+
+    def test_skip_clone_if_already_cloned(self, tmp_path):
+        """Verify clone is skipped if directory is already the target repo."""
+        repo_url = "https://github.com/owner/new-project"
+        project_path = str(tmp_path / "new-project")
+        os.makedirs(project_path)
+        os.makedirs(os.path.join(project_path, ".git"))
+
+        git_calls = []
+
+        def mock_run_git(args, **kw):
+            git_calls.append(args)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_gh = MagicMock()
+        mock_gh._run_git.side_effect = mock_run_git
+        mock_gh.get_repo_url.return_value = repo_url
+
+        # The fix logic: already cloned
+        if not os.path.isdir(os.path.join(project_path, ".git")):
+            mock_gh._run_git(["clone", repo_url, project_path])
+
+        # Should NOT call clone
+        assert ["clone", repo_url, project_path] not in git_calls
+
+    def test_error_if_different_repo(self, tmp_path):
+        """Verify error if directory exists but is a different repo."""
+        repo_url = "https://github.com/owner/new-project"
+        existing_url = "https://github.com/other/different-project"
+        project_path = str(tmp_path / "new-project")
+        os.makedirs(project_path)
+        os.makedirs(os.path.join(project_path, ".git"))
+
+        mock_gh = MagicMock()
+        mock_gh.get_repo_url.return_value = existing_url
+
+        # The fix logic
+        with pytest.raises(GitHubOpsError, match="different git repo"):
+            if os.path.isdir(os.path.join(project_path, ".git")):
+                if mock_gh.get_repo_url() != repo_url:
+                    raise GitHubOpsError(
+                        f"Directory {project_path} is a different git repo"
+                    )
+
+
+class TestValidateProjectPath:
+    """测试点4：git 操作前验证目录有效性"""
+
+    def test_error_if_project_path_not_set(self):
+        """Verify error if project_path is None or empty."""
+        project_path = None
+
+        with pytest.raises(GitHubOpsError, match="project_path is not set"):
+            if not project_path:
+                raise GitHubOpsError("project_path is not set for branch creation")
+
+    def test_error_if_project_path_does_not_exist(self):
+        """Verify error if project_path directory doesn't exist."""
+        project_path = "/nonexistent/path"
+
+        with pytest.raises(GitHubOpsError, match="does not exist"):
+            if not os.path.isdir(project_path):
+                raise GitHubOpsError(f"project_path {project_path} does not exist")
+
+    def test_error_if_not_git_repository(self, tmp_path):
+        """Verify error if directory is not a git repository."""
+        project_path = str(tmp_path / "not-a-repo")
+        os.makedirs(project_path)
+
+        with pytest.raises(GitHubOpsError, match="not a valid git repository"):
+            if not os.path.isdir(os.path.join(project_path, ".git")):
+                raise GitHubOpsError(
+                    f"{project_path} is not a valid git repository"
+                )
+
+    def test_pass_if_valid_git_repository(self, tmp_path):
+        """Verify validation passes for valid git repository."""
+        project_path = str(tmp_path / "valid-repo")
+        os.makedirs(project_path)
+        os.makedirs(os.path.join(project_path, ".git"))
+
+        # Should not raise
+        if not project_path:
+            raise GitHubOpsError("project_path is not set")
+        if not os.path.isdir(project_path):
+            raise GitHubOpsError(f"project_path {project_path} does not exist")
+        if not os.path.isdir(os.path.join(project_path, ".git")):
+            raise GitHubOpsError(f"{project_path} is not a valid git repository")
+
+        # No exception = pass

--- a/tests/unit/test_new_project_local_repo_init_2963.py
+++ b/tests/unit/test_new_project_local_repo_init_2963.py
@@ -64,15 +64,15 @@ class TestSyncWfAfterCreateRepo:
             # Create a mock repo
             mock_repo = MagicMock()
             mock_repo.get_workflow.return_value = wf
-            mock_repo.update_workflow.return_value = {"success": True}
 
             # Track updates to verify wf sync
             updates_applied = []
 
-            def capture_update(workflow_id, patch):
-                updates_applied.append(patch)
-                # Simulate in-memory update
-                wf.update(patch)
+            def capture_update(*args, **kwargs):
+                # Accept any arguments to be flexible with mock calls
+                if args and isinstance(args[-1], dict):
+                    updates_applied.append(args[-1])
+                    wf.update(args[-1])
                 return {"success": True}
 
             mock_repo.update_workflow.side_effect = capture_update

--- a/tests/unit/test_new_project_local_repo_init_2963.py
+++ b/tests/unit/test_new_project_local_repo_init_2963.py
@@ -69,7 +69,7 @@ class TestSyncWfAfterCreateRepo:
             # Track updates to verify wf sync
             updates_applied = []
 
-            def capture_update(patch):
+            def capture_update(workflow_id, patch):
                 updates_applied.append(patch)
                 # Simulate in-memory update
                 wf.update(patch)


### PR DESCRIPTION
Closes #2963

## 修复内容

修复 AI 自主开发创建新项目时的两个问题：
1. 首次执行时创建 Issue 失败（`gh issue create` 缺少 `--repo` 参数）
2. 重试后分支创建失败（本地目录不是 Git 仓库）

## 修复方案

### 问题1：内存中的工作流数据未同步
- 在 `_update_workflow` 后添加 `wf["project_repo_url"] = repo_url` 同步内存中的字典
- 创建 Issue 时优先使用 `create_repo()` 返回的 `repo_url`

### 问题2：本地仓库未初始化
- 创建远程仓库后，克隆到本地用户工作区
- 处理目录已存在的各种情况

### 问题3：git 操作前缺少验证
- 在 `git fetch` 和分支创建前验证 `project_path` 有效性

## 代码变更

| 文件 | 变更 |
|------|------|
| `orchestrator.py` | 添加 `repo_url` 变量跟踪、克隆逻辑、内存同步、验证检查 |

## 测试

- 单元测试：mock GitHubOps 验证逻辑
- E2E 测试：Docker 多用户模式下创建新项目流程