### PR TITLE
fix: quota edit null fields and toast z-index (#2887)

### DIFF
--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -106,7 +106,7 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({
   return createPortal(
     <div
       className={cn('toast-container position-fixed p-3', positionClasses[position])}
-      style={{ zIndex: 9999 }}
+      style={{ zIndex: 10600 }}
     >
       {toasts.map((toast) => (
         <Toast key={toast.id} {...toast} onClose={onClose} />

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -158,7 +158,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
               position: 'fixed',
               top: position.top,
               left: position.left,
-              zIndex: 9999,
+              zIndex: 10600,
             }}
             role="tooltip"
           >

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -316,8 +316,8 @@ export const QuotaAlerts: React.FC = () => {
       const submitData: UpdateQuotaRequest = {
         daily_token_quota: formData.daily_token_quota ?? undefined,
         monthly_token_quota: formData.monthly_token_quota ?? undefined,
-        daily_request_quota: formData.daily_request_quota,
-        monthly_request_quota: formData.monthly_request_quota,
+        daily_request_quota: formData.daily_request_quota ?? undefined,
+        monthly_request_quota: formData.monthly_request_quota ?? undefined,
       };
       await updateQuota.mutateAsync({ userId: editingUser.id, data: submitData });
       toast.success(t('quotaUpdated', language), t('quotaUpdatedDesc', language));

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -736,7 +736,7 @@ pre code {
   align-items: center;
   justify-content: center;
   background-color: rgba(255, 255, 255, 0.8);
-  z-index: 9999;
+  z-index: 10600;
 }
 
 [data-theme='dark'] .loading-overlay {
@@ -2211,7 +2211,7 @@ table .latency-row:hover td {
 /* Tooltip Styles */
 .tooltip {
   position: fixed;
-  z-index: 9999;
+  z-index: 10600;
 }
 
 .tooltip-inner {


### PR DESCRIPTION
Closes #2887

## 修复内容

1. **QuotaAlerts.tsx** - 修复 null request 配额字段被误传为 EXPLICIT_NULL
   - `daily_request_quota: formData.daily_request_quota ?? undefined`
   - `monthly_request_quota: formData.monthly_request_quota ?? undefined`

2. **z-index 提升** - 将 Toast、Tooltip、loading-overlay 的 z-index 从 9999 提升至 10600
   - `Toast.tsx` - Toast 容器 z-index: 10600
   - `Tooltip.tsx` - Tooltip 组件 z-index: 10600
   - `main.css` - .loading-overlay 和 .tooltip z-index: 10600

## 修复方案

参考 Issue 中的修复方案2（已通过评估）：
- 问题1：null 值被当作 EXPLICIT_NULL 发送给后端 → 添加 `?? undefined` 过滤
- 问题2：Toast 被 Modal 遮挡（z-index 9999 < Modal 10050）→ 提升至 10600

## 测试验证

- [x] TypeScript 类型检查通过
- [ ] CI 检查通过
- [ ] 功能测试：编辑配额保存成功
- [ ] 边界测试：错误 toast 显示在 Modal 上层