### PR TITLE
fix: prevent mass deactivation on incomplete DingTalk directory snapshot

### DIFF
--- a/app/services/dingtalk_org_sync.py
+++ b/app/services/dingtalk_org_sync.py
@@ -119,6 +119,7 @@ class DingTalkOrgSyncResult:
     started_at: str | None = None
     finished_at: str | None = None
     warnings: list[str] = field(default_factory=list)
+    snapshot_complete: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         """Convert result to a JSON-friendly dictionary."""
@@ -136,6 +137,7 @@ class DingTalkOrgSyncResult:
             "started_at": self.started_at,
             "finished_at": self.finished_at,
             "warnings": list(self.warnings),
+            "snapshot_complete": self.snapshot_complete,
         }
 
 
@@ -221,11 +223,19 @@ class DingTalkOrgSyncService:
                 try:
                     self._ensure_supporting_tables()
                     token = self._get_access_token(app_key, app_secret)
-                    departments, users = self._fetch_directory_snapshot(
+                    departments, users, snapshot_complete = self._fetch_directory_snapshot(
                         token, root_department_id, warnings=result.warnings
                     )
                     result.departments_seen = len(departments)
                     result.users_seen = len(users)
+                    result.snapshot_complete = snapshot_complete
+                    if not snapshot_complete:
+                        result.warnings.append(
+                            "Directory snapshot is incomplete due to one or more "
+                            "department user fetch failures; departed-user cleanup "
+                            "will be skipped to avoid accidentally deactivating "
+                            "valid users."
+                        )
 
                     # Cache the synced-team index once per run instead of re-scanning
                     # the whole teams table per department (WP-1). Newly created teams
@@ -274,10 +284,14 @@ class DingTalkOrgSyncService:
                     # Deactivate/unlink DingTalk users that were synced previously but are no
                     # longer in the directory. DingTalk recycles userids, so leaving a stale
                     # SSO identity row would let a recycled id re-resolve to the old account.
+                    # Issue #3020: Skip destructive cleanup when the directory snapshot is
+                    # incomplete (API failures) or empty (no users seen), to prevent mass
+                    # deactivation of valid synced users.
                     self._deactivate_departed_users(
                         tenant_id=effective_tenant_id,
                         seen_provider_user_ids=seen_provider_user_ids,
                         result=result,
+                        snapshot_complete=snapshot_complete,
                     )
 
                     result.finished_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
@@ -565,10 +579,17 @@ class DingTalkOrgSyncService:
         token: str,
         root_department_id: str,
         warnings: list[str] | None = None,
-    ) -> tuple[list[DingTalkDepartment], list[DingTalkUser]]:
-        """Recursively fetch departments and users starting from the configured root."""
+    ) -> tuple[list[DingTalkDepartment], list[DingTalkUser], bool]:
+        """Recursively fetch departments and users starting from the configured root.
+
+        Returns a ``(departments, users, snapshot_complete)`` tuple.
+        ``snapshot_complete`` is False when any department's user page fetch
+        failed, meaning the user set may be incomplete. Callers must check this
+        flag before running destructive reconciliation (departed-user cleanup).
+        """
         departments: dict[str, DingTalkDepartment] = {}
         users: dict[str, DingTalkUser] = {}
+        snapshot_complete = True
 
         queue: deque[str] = deque([root_department_id])
         visited: set[str] = set()
@@ -585,9 +606,11 @@ class DingTalkOrgSyncService:
                     departments[department.department_id] = department
                     queue.append(department.department_id)
 
-            direct_users = self._fetch_department_users(
+            direct_users, dept_complete = self._fetch_department_users(
                 token, current_department_id, warnings=warnings
             )
+            if not dept_complete:
+                snapshot_complete = False
             for user in direct_users:
                 existing = users.get(user.user_id)
                 if existing is None:
@@ -613,7 +636,7 @@ class DingTalkOrgSyncService:
             ),
         )
         sorted_users = sorted(users.values(), key=lambda u: (u.name.lower(), u.user_id))
-        return sorted_departments, sorted_users
+        return sorted_departments, sorted_users, snapshot_complete
 
     def _fetch_child_departments(self, token: str, department_id: str) -> list[DingTalkDepartment]:
         """Fetch immediate child departments for a DingTalk department."""
@@ -651,7 +674,7 @@ class DingTalkOrgSyncService:
         token: str,
         department_id: str,
         warnings: list[str] | None = None,
-    ) -> list[DingTalkUser]:
+    ) -> tuple[list[DingTalkUser], bool]:
         """Fetch users directly under a DingTalk department.
 
         Uses the batched ``topapi/v2/user/list`` endpoint (one call per page of up
@@ -660,6 +683,10 @@ class DingTalkOrgSyncService:
         follow-up per-user call is needed. Page-level transient errors (rate-limit
         ``errcode -1``) are retried with bounded backoff; a non-transient error on
         a page warns and stops paging that department without aborting the run.
+
+        Returns a ``(users, complete)`` tuple. ``complete`` is False when any page
+        fetch failed (partial results may be present); callers can use this to
+        decide whether destructive reconciliation is safe.
         """
         users: list[DingTalkUser] = []
         cursor = 0
@@ -668,7 +695,8 @@ class DingTalkOrgSyncService:
             if data is None:
                 # Page failed (non-transient errcode or retries exhausted): keep
                 # whatever users were already collected and stop paging this dept.
-                return users
+                # Signal incompleteness so the caller can skip destructive cleanup.
+                return users, False
             result = data.get("result") if isinstance(data.get("result"), dict) else data
             if not isinstance(result, dict):
                 result = {}
@@ -686,7 +714,7 @@ class DingTalkOrgSyncService:
             if next_cursor is None:
                 break
             cursor = int(next_cursor)
-        return users
+        return users, True
 
     def _fetch_user_page(
         self,
@@ -1211,6 +1239,7 @@ class DingTalkOrgSyncService:
         tenant_id: int,
         seen_provider_user_ids: set[str],
         result: DingTalkOrgSyncResult,
+        snapshot_complete: bool = True,
     ) -> None:
         """Deactivate and unlink DingTalk-synced users absent from the current snapshot.
 
@@ -1224,7 +1253,21 @@ class DingTalkOrgSyncService:
         whose linked local user belongs to this tenant) are eligible. Without this
         filter a multi-tenant deployment would let tenant A's sync deactivate tenant
         B's DingTalk identities.
+
+        Issue #3020: If the snapshot is incomplete (API failures during directory
+        fetch) or empty (no users seen at all), the cleanup is skipped entirely to
+        prevent mass deactivation of valid synced users. This matches the Feishu
+        implementation's ``if not seen_provider_user_ids: return`` guard.
         """
+        if not snapshot_complete:
+            # Incomplete snapshot: some department user fetches failed. We cannot
+            # trust the seen set, so skip destructive cleanup to avoid false
+            # deactivations.
+            return
+        if not seen_provider_user_ids:
+            # Nothing was seen this run; do not mass-deactivate on an empty
+            # snapshot (likely an API outage) to avoid a destructive blunder.
+            return
         rows = self.db.fetch_all(
             """
             SELECT user_id, provider_user_id, provider_data

--- a/tests/issues/3020/test_dingtalk_sync_snapshot_protection.py
+++ b/tests/issues/3020/test_dingtalk_sync_snapshot_protection.py
@@ -241,7 +241,9 @@ def test_mid_pagination_failure_does_not_deactivate(sync_env):
 
     # Existing user should not be deactivated
     existing = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (existing_user_id,))
-    assert bool(existing["is_active"]), "Existing user should remain active after partial pagination"
+    assert bool(
+        existing["is_active"]
+    ), "Existing user should remain active after partial pagination"
 
     # SSO identity preserved
     identities = db.fetch_all(
@@ -310,7 +312,11 @@ def test_complete_snapshot_still_deactivates_departed_users(sync_env):
 
     # Leaver should be deactivated
     leaver_after = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (leaving_id,))
-    is_active = bool(leaver_after["is_active"]) if isinstance(leaver_after["is_active"], int) else leaver_after["is_active"]
+    is_active = (
+        bool(leaver_after["is_active"])
+        if isinstance(leaver_after["is_active"], int)
+        else leaver_after["is_active"]
+    )
     assert not is_active, "Departed user should be deactivated with complete snapshot"
 
     # Leaver's SSO identity should be deleted
@@ -356,9 +362,9 @@ def test_complete_empty_directory_does_not_deactivate(sync_env):
 
     # Defensive guard: even with complete snapshot, empty seen-set skips cleanup
     existing_after = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (existing_id,))
-    assert bool(existing_after["is_active"]), (
-        "Empty complete snapshot should NOT deactivate users (defensive guard)"
-    )
+    assert bool(
+        existing_after["is_active"]
+    ), "Empty complete snapshot should NOT deactivate users (defensive guard)"
 
     identities = db.fetch_all(
         "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (existing_id,)
@@ -428,13 +434,15 @@ def test_fetch_department_users_returns_completeness_tuple(monkeypatch):
     # Test successful fetch returns (users, True)
     class OkHttp:
         def post(self, url, **kwargs):
-            return FakeResponse({
-                "errcode": 0,
-                "result": {
-                    "has_more": False,
-                    "list": [{"userid": "u1", "name": "User 1", "dept_id_list": [100]}],
-                },
-            })
+            return FakeResponse(
+                {
+                    "errcode": 0,
+                    "result": {
+                        "has_more": False,
+                        "list": [{"userid": "u1", "name": "User 1", "dept_id_list": [100]}],
+                    },
+                }
+            )
 
     service_ok = DingTalkOrgSyncService(
         config_override={"dingtalk": {"app_key": "k", "app_secret": "s"}},

--- a/tests/issues/3020/test_dingtalk_sync_snapshot_protection.py
+++ b/tests/issues/3020/test_dingtalk_sync_snapshot_protection.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Tests for Issue #3020: DingTalk directory read failure empty-snapshot protection.
+
+When the DingTalk directory read fails (all departments, some departments, or
+mid-pagination), the sync must NOT proceed with destructive departed-user
+cleanup (deactivation + SSO identity deletion) on existing synced users.
+
+Test cases:
+1. All departments user fetch fails + existing synced users -> no deactivation
+2. Partial department failure -> no deactivation (incomplete snapshot)
+3. Mid-pagination failure -> no deactivation
+4. Complete snapshot with departed user -> deactivation proceeds normally
+5. Complete but empty directory (no users at all) -> no deactivation (defensive)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import app.utils.smtp_crypto as smtp_crypto
+from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+from app.repositories.user_repo import UserRepository
+from app.services.dingtalk_org_sync import (
+    DINGTALK_PROVIDER_NAME,
+    DingTalkDepartment,
+    DingTalkOrgSyncService,
+    DingTalkUser,
+)
+
+
+class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):
+    """Deterministic DingTalk sync service for tests."""
+
+    def __init__(self, *args, departments=None, users=None, snapshot_complete=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._departments = list(departments or [])
+        self._users = list(users or [])
+        self._snapshot_complete = snapshot_complete
+
+    def _get_access_token(self, app_key: str, app_secret: str) -> str:
+        return "test-token"
+
+    def _fetch_directory_snapshot(self, token: str, root_department_id: str, **kwargs):
+        return self._departments, self._users, self._snapshot_complete
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Create an isolated SQLite-backed sync environment."""
+    from app.utils.encryption_key_registry import reset_registry
+
+    reset_registry()
+    monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "test-issue-3020-key")
+    smtp_crypto._password_manager_instance = None
+
+    monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
+    # Patch is_postgresql in collaboration module too (imported at module load time)
+    monkeypatch.setattr("app.modules.workspace.collaboration.is_postgresql", lambda: False)
+
+    db = Database(db_url=f"sqlite:///{tmp_path / 'issue3020-sync.db'}")
+    load_schema_from_file(db_url=db.db_url, dialect="sqlite")
+
+    db.execute(
+        "INSERT INTO tenants (id, name, slug, quota) VALUES (?, ?, ?, ?)",
+        (8, "Issue 3020 Test Tenant", "issue3020-test", '{"max_users": 100}'),
+    )
+
+    config = {
+        "dingtalk": {
+            "app_key": "test-app-key",
+            "app_secret": "test-app-secret",
+            "org_sync_enabled": True,
+            "org_sync_tenant_id": 8,
+            "org_sync_interval_minutes": 60,
+            "org_sync_root_dept_id": "1",
+        }
+    }
+
+    try:
+        yield db, config
+    finally:
+        smtp_crypto._password_manager_instance = None
+        reset_registry()
+
+
+def _seed_synced_user(db, user_repo, provider_user_id, username, tenant_id=8):
+    """Create a local user + DingTalk SSO identity to simulate a prior sync."""
+    user_id = user_repo.create_user(
+        username=username,
+        email=f"{provider_user_id}@dingtalk.local",
+        password_hash="!",
+        role="user",
+        is_active=True,
+        tenant_id=tenant_id,
+    )
+    assert user_id is not None
+
+    provider_data = {
+        "user_id": provider_user_id,
+        "name": username,
+        "email": f"{provider_user_id}@dingtalk.local",
+        "department_ids": ["100"],
+        "status": {"active": True},
+        "synced_by": "dingtalk_org_sync",
+        "tenant_id": tenant_id,
+    }
+
+    from app.modules.sso.manager import SSOManager
+
+    sso_manager = SSOManager(db=db)
+    sso_manager.link_identity(
+        user_id=user_id,
+        provider_name=DINGTALK_PROVIDER_NAME,
+        provider_user_id=provider_user_id,
+        provider_data=provider_data,
+    )
+    return user_id
+
+
+# ---- Test Case 1: All departments user fetch fails ----
+
+
+def test_all_departments_fail_does_not_deactivate_existing_users(sync_env):
+    """When all department user fetches fail (empty snapshot, incomplete), existing
+    synced users must NOT be deactivated or unlinked.
+    """
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    # Seed two users from a prior sync
+    alice_id = _seed_synced_user(db, user_repo, "dt_alice", "alice_synced")
+    bob_id = _seed_synced_user(db, user_repo, "dt_bob", "bob_synced")
+
+    # Simulate a sync where all user fetches failed (incomplete, empty)
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[DingTalkDepartment(department_id="100", name="Engineering")],
+        users=[],  # No users fetched
+        snapshot_complete=False,  # Snapshot is incomplete
+    )
+    result = service.sync_org()
+
+    # Verify: users are still active
+    alice = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (alice_id,))
+    bob = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (bob_id,))
+    assert bool(alice["is_active"]), "Alice should remain active after incomplete snapshot"
+    assert bool(bob["is_active"]), "Bob should remain active after incomplete snapshot"
+
+    # Verify: SSO identities are preserved
+    alice_identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (alice_id,)
+    )
+    bob_identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (bob_id,)
+    )
+    assert len(alice_identities) == 1, "Alice's SSO identity should be preserved"
+    assert len(bob_identities) == 1, "Bob's SSO identity should be preserved"
+
+    # Verify: result has the snapshot_complete flag and warning
+    assert result.snapshot_complete is False
+    assert any("incomplete" in w.lower() for w in result.warnings)
+
+
+# ---- Test Case 2: Partial department failure ----
+
+
+def test_partial_department_failure_does_not_deactivate(sync_env):
+    """When some departments succeed but others fail (non-empty but incomplete
+    snapshot), departed-user cleanup must NOT run.
+    """
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    # Seed users: one in dept 100 (succeeds), one in dept 200 (fails)
+    dept100_user_id = _seed_synced_user(db, user_repo, "dt_dept100", "user_dept100")
+    dept200_user_id = _seed_synced_user(db, user_repo, "dt_dept200", "user_dept200")
+
+    # Simulate: only dept 100's users fetched, dept 200 failed
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[
+            DingTalkDepartment(department_id="100", name="Dept 100"),
+            DingTalkDepartment(department_id="200", name="Dept 200"),
+        ],
+        users=[
+            DingTalkUser(
+                user_id="dt_dept100",
+                name="User Dept 100",
+                department_ids=["100"],
+            ),
+        ],  # Only partial users
+        snapshot_complete=False,  # Incomplete due to dept 200 failure
+    )
+    result = service.sync_org()
+
+    # Both users should remain active
+    user_100 = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (dept100_user_id,))
+    user_200 = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (dept200_user_id,))
+    assert bool(user_100["is_active"]), "Dept 100 user should remain active"
+    assert bool(user_200["is_active"]), "Dept 200 user should remain active (not falsely cleaned)"
+
+    assert result.snapshot_complete is False
+
+
+# ---- Test Case 3: Mid-pagination failure ----
+
+
+def test_mid_pagination_failure_does_not_deactivate(sync_env):
+    """When pagination succeeds for some pages but fails mid-way (incomplete
+    snapshot), departed-user cleanup must NOT run.
+    """
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    # Seed users
+    existing_user_id = _seed_synced_user(db, user_repo, "dt_existing", "existing_user")
+
+    # Simulate: some users fetched before pagination failure
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[DingTalkDepartment(department_id="100", name="Engineering")],
+        users=[
+            DingTalkUser(
+                user_id="dt_newuser1",
+                name="New User 1",
+                department_ids=["100"],
+            ),
+        ],  # Some users, but pagination didn't complete
+        snapshot_complete=False,
+    )
+    result = service.sync_org()
+
+    # Existing user should not be deactivated
+    existing = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (existing_user_id,))
+    assert bool(existing["is_active"]), "Existing user should remain active after partial pagination"
+
+    # SSO identity preserved
+    identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (existing_user_id,)
+    )
+    assert len(identities) == 1, "SSO identity should be preserved"
+
+    assert result.snapshot_complete is False
+
+
+# ---- Test Case 4: Complete snapshot with departed user ----
+
+
+def test_complete_snapshot_still_deactivates_departed_users(sync_env):
+    """When the snapshot is complete and a user is genuinely absent, deactivation
+    should proceed normally.
+    """
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+    dept = DingTalkDepartment(department_id="100", name="Engineering")
+
+    # First sync: two users
+    service1 = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[dept],
+        users=[
+            DingTalkUser(
+                user_id="dt_staying",
+                name="Staying User",
+                department_ids=["100"],
+            ),
+            DingTalkUser(
+                user_id="dt_leaving",
+                name="Leaving User",
+                department_ids=["100"],
+            ),
+        ],
+        snapshot_complete=True,
+    )
+    result1 = service1.sync_org()
+    assert result1.users_created == 2
+
+    # Find the leaving user's local ID
+    leaving = db.fetch_one("SELECT id FROM users WHERE username LIKE 'leaving%'")
+    assert leaving is not None
+    leaving_id = int(leaving["id"])
+
+    # Second sync: only one user remains (complete snapshot)
+    service2 = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[dept],
+        users=[
+            DingTalkUser(
+                user_id="dt_staying",
+                name="Staying User",
+                department_ids=["100"],
+            ),
+        ],
+        snapshot_complete=True,  # Complete snapshot
+    )
+    result2 = service2.sync_org()
+
+    # Leaver should be deactivated
+    leaver_after = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (leaving_id,))
+    is_active = bool(leaver_after["is_active"]) if isinstance(leaver_after["is_active"], int) else leaver_after["is_active"]
+    assert not is_active, "Departed user should be deactivated with complete snapshot"
+
+    # Leaver's SSO identity should be deleted
+    leaver_identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (leaving_id,)
+    )
+    assert len(leaver_identities) == 0, "Departed user's SSO identity should be deleted"
+
+    # Staying user's SSO identity should be preserved (not deactivated)
+    staying = db.fetch_one("SELECT id FROM users WHERE username LIKE 'staying%'")
+    staying_identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (int(staying["id"]),)
+    )
+    assert len(staying_identities) == 1, "Staying user's SSO identity should be preserved"
+
+    assert result2.snapshot_complete is True
+
+
+# ---- Test Case 5: Complete but empty directory ----
+
+
+def test_complete_empty_directory_does_not_deactivate(sync_env):
+    """When the snapshot is complete but empty (genuinely no users), the defensive
+    empty-set guard prevents mass deactivation. This is a safe default: a truly
+    empty org is rare, and it's safer to not mass-deactivate.
+    """
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    # Seed a user from a prior sync
+    existing_id = _seed_synced_user(db, user_repo, "dt_existing", "existing_user")
+
+    # Simulate a complete but empty snapshot (org was emptied)
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[DingTalkDepartment(department_id="100", name="Empty Dept")],
+        users=[],  # No users at all
+        snapshot_complete=True,  # But the snapshot IS complete
+    )
+    result = service.sync_org()
+
+    # Defensive guard: even with complete snapshot, empty seen-set skips cleanup
+    existing_after = db.fetch_one("SELECT is_active FROM users WHERE id = ?", (existing_id,))
+    assert bool(existing_after["is_active"]), (
+        "Empty complete snapshot should NOT deactivate users (defensive guard)"
+    )
+
+    identities = db.fetch_all(
+        "SELECT provider_user_id FROM sso_identities WHERE user_id = ?", (existing_id,)
+    )
+    assert len(identities) == 1, "SSO identity should be preserved with empty snapshot"
+
+    assert result.snapshot_complete is True
+
+
+# ---- Test: snapshot_complete field in result ----
+
+
+def test_result_includes_snapshot_complete_field(sync_env):
+    """The sync result should expose the snapshot_complete flag for API consumers."""
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    # Complete sync
+    service_ok = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[DingTalkDepartment(department_id="100", name="Eng")],
+        users=[DingTalkUser(user_id="u1", name="User", department_ids=["100"])],
+        snapshot_complete=True,
+    )
+    result_ok = service_ok.sync_org()
+    assert result_ok.snapshot_complete is True
+    result_dict = result_ok.to_dict()
+    assert "snapshot_complete" in result_dict
+    assert result_dict["snapshot_complete"] is True
+
+    # Incomplete sync
+    service_fail = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[],
+        users=[],
+        snapshot_complete=False,
+    )
+    result_fail = service_fail.sync_org()
+    assert result_fail.snapshot_complete is False
+    result_fail_dict = result_fail.to_dict()
+    assert result_fail_dict["snapshot_complete"] is False
+
+
+# ---- Test: _fetch_department_users returns completeness tuple ----
+
+
+def test_fetch_department_users_returns_completeness_tuple(monkeypatch):
+    """_fetch_department_users should return (users, complete) tuple."""
+    import app.services.dingtalk_org_sync as dt_module
+
+    monkeypatch.setattr(dt_module, "_TRANSIENT_SLEEP", lambda _s: None)
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    # Test successful fetch returns (users, True)
+    class OkHttp:
+        def post(self, url, **kwargs):
+            return FakeResponse({
+                "errcode": 0,
+                "result": {
+                    "has_more": False,
+                    "list": [{"userid": "u1", "name": "User 1", "dept_id_list": [100]}],
+                },
+            })
+
+    service_ok = DingTalkOrgSyncService(
+        config_override={"dingtalk": {"app_key": "k", "app_secret": "s"}},
+        http_session=OkHttp(),
+    )
+    users, complete = service_ok._fetch_department_users("token", "100")
+    assert complete is True
+    assert len(users) == 1
+    assert users[0].user_id == "u1"
+
+    # Test failed fetch returns (users, False)
+    class FailHttp:
+        def post(self, url, **kwargs):
+            return FakeResponse({"errcode": 60011, "errmsg": "no permission"})
+
+    service_fail = DingTalkOrgSyncService(
+        config_override={"dingtalk": {"app_key": "k", "app_secret": "s"}},
+        http_session=FailHttp(),
+    )
+    warnings = []
+    users_fail, complete_fail = service_fail._fetch_department_users(
+        "token", "100", warnings=warnings
+    )
+    assert complete_fail is False
+    assert users_fail == []

--- a/tests/unit/test_dingtalk_org_sync.py
+++ b/tests/unit/test_dingtalk_org_sync.py
@@ -19,10 +19,11 @@ from app.services.dingtalk_org_sync import (
 class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):
     """Deterministic DingTalk sync service for tests."""
 
-    def __init__(self, *args, departments=None, users=None, **kwargs):
+    def __init__(self, *args, departments=None, users=None, snapshot_complete=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._departments = list(departments or [])
         self._users = list(users or [])
+        self._snapshot_complete = snapshot_complete
 
     def _get_access_token(self, app_key: str, app_secret: str) -> str:
         assert app_key == "test-app-key"
@@ -32,7 +33,7 @@ class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):
     def _fetch_directory_snapshot(self, token: str, root_department_id: str, **kwargs):
         assert token == "test-token"
         assert root_department_id == "1"
-        return self._departments, self._users
+        return self._departments, self._users, self._snapshot_complete
 
 
 @pytest.fixture
@@ -324,7 +325,8 @@ def test_fetch_directory_snapshot_uses_dingtalk_department_and_user_apis():
         http_session=FakeHttp(),
     )
 
-    departments, users = service._fetch_directory_snapshot("token", "1")
+    departments, users, snapshot_complete = service._fetch_directory_snapshot("token", "1")
+    assert snapshot_complete is True
 
     assert departments == [DingTalkDepartment(department_id="100", name="Engineering")]
     assert users == [

--- a/tests/unit/test_dingtalk_org_sync_hardening.py
+++ b/tests/unit/test_dingtalk_org_sync_hardening.py
@@ -26,16 +26,17 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(1787)]
 
 
 class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):
-    def __init__(self, *args, departments=None, users=None, **kwargs):
+    def __init__(self, *args, departments=None, users=None, snapshot_complete=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._departments = list(departments or [])
         self._users = list(users or [])
+        self._snapshot_complete = snapshot_complete
 
     def _get_access_token(self, app_key, app_secret):
         return "test-token"
 
     def _fetch_directory_snapshot(self, token, root_department_id, **kwargs):
-        return self._departments, self._users
+        return self._departments, self._users, self._snapshot_complete
 
 
 @pytest.fixture
@@ -238,6 +239,11 @@ def test_departed_users_are_deactivated(sync_env):
     """Users present in a prior sync but absent from the current snapshot must be
     deactivated (and their DingTalk SSO identity unlinked) so a recycled DingTalk
     userid cannot re-resolve to the previous local account.
+
+    Note: the second sync must have at least one user in the snapshot so that
+    ``seen_provider_user_ids`` is non-empty. Issue #3020 added an empty-set
+    guard to prevent mass-deactivation when the snapshot is empty (likely an
+    API outage).
     """
     db, config = sync_env
     user_repo = UserRepository(db=db)
@@ -253,7 +259,12 @@ def test_departed_users_are_deactivated(sync_env):
                 user_id="dt_dave",
                 name="Dave DingTalk",
                 department_ids=["100"],
-            )
+            ),
+            DingTalkUser(
+                user_id="dt_eve",
+                name="Eve DingTalk",
+                department_ids=["100"],
+            ),
         ],
     )
     service.sync_org()
@@ -265,13 +276,20 @@ def test_departed_users_are_deactivated(sync_env):
     )
     assert sso_before, "expected Dave to have a dingtalk SSO identity after first sync"
 
-    # Second sync: Dave is no longer in the directory.
+    # Second sync: Dave is no longer in the directory, but Eve is still present.
+    # The non-empty snapshot ensures the departed-user cleanup runs.
     service2 = FakeDingTalkOrgSyncService(
         db=db,
         user_repo=user_repo,
         config_override=config,
         departments=[dept],
-        users=[],
+        users=[
+            DingTalkUser(
+                user_id="dt_eve",
+                name="Eve DingTalk",
+                department_ids=["100"],
+            ),
+        ],
     )
     service2.sync_org()
 
@@ -331,8 +349,9 @@ def test_transient_user_lookup_errcode_warns_and_skips(monkeypatch):
 
     warnings: list[str] = []
     # Must NOT raise.
-    users = service._fetch_department_users("token", "100", warnings=warnings)
+    users, complete = service._fetch_department_users("token", "100", warnings=warnings)
     assert users == [], "expected the flaky department's users to be skipped, not returned"
+    assert complete is False, "expected incomplete snapshot when page fetch fails"
     assert any(
         "100" in w and "errcode=-1" in w for w in warnings
     ), f"expected a warning about the failed department; got {warnings}"

--- a/tests/unit/test_dingtalk_sync_snapshot_protection.py
+++ b/tests/unit/test_dingtalk_sync_snapshot_protection.py
@@ -15,8 +15,6 @@ Test cases:
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 import app.utils.smtp_crypto as smtp_crypto
@@ -29,6 +27,8 @@ from app.services.dingtalk_org_sync import (
     DingTalkOrgSyncService,
     DingTalkUser,
 )
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3020)]
 
 
 class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):


### PR DESCRIPTION
## 修复说明

关联 Issue：#3020

## 根因

`app/services/dingtalk_org_sync.py` 中存在两个协同缺陷：

1. `_fetch_directory_snapshot()` 不传递快照完整性信息 —— 当任何部门的用户分页获取失败时，调用方无法区分「完整但空的目录」和「因 API 失败而不完整的快照」
2. `_deactivate_departed_users()` 缺少空集合保护和完整性保护 —— 飞书的对应函数已有 `if not seen_provider_user_ids: return` 的保护，钉钉缺失

这导致当 API 权限被撤销、限流或网络失败时，同步流程继续以空/不完整快照执行离职用户清理，批量停用正常用户并删除其钉钉 SSO identity。

## 修复方案

- `_fetch_department_users()` 返回 `(users, complete)` 元组，标记该部门用户是否完整获取
- `_fetch_directory_snapshot()` 追踪完整性并返回 `(departments, users, snapshot_complete)` 三元组
- `_deactivate_departed_users()` 增加 `snapshot_complete` 参数和空集合保护：
  - `if not snapshot_complete: return` —— 不完整快照跳过清理
  - `if not seen_provider_user_ids: return` —— 空集合保护（与飞书一致）
- `DingTalkOrgSyncResult` 增加 `snapshot_complete: bool = True` 字段，`to_dict()` 同步更新
- 不完整快照时在 `result.warnings` 中附加明确的汇总警告

## 主要变更

- `app/services/dingtalk_org_sync.py`：核心修复（完整性追踪 + 防御性保护）
- `tests/unit/test_dingtalk_org_sync.py`：更新 FakeDingTalkOrgSyncService 返回三元组
- `tests/unit/test_dingtalk_org_sync_hardening.py`：更新 FakeDingTalkOrgSyncService 和测试断言
- `tests/issues/3020/test_dingtalk_sync_snapshot_protection.py`：新增 7 个测试用例

## 测试

- 测试环境：本地 SQLite + mock HTTP
- 已运行的测试：`tests/issues/3020/`（7 个新增）+`tests/unit/test_dingtalk_org_sync.py` + `tests/unit/test_dingtalk_org_sync_hardening.py`
- 新增测试覆盖：
  1. 所有部门用户读取失败 → 不得执行离职清理
  2. 部分部门成功、部分失败 → 不得执行离职清理
  3. 分页中途失败 → 不得执行离职清理
  4. 完整快照确实删除用户 → 应正常停用并解绑
  5. 完整但空的目录 → 防御性保护生效
  6. Result 暴露 snapshot_complete 字段
  7. _fetch_department_users 返回完整性元组

## 风险

- **兼容性风险**：无。`_fetch_directory_snapshot()` 的返回值变化是内部 API。
- **性能风险**：无。仅增加一个布尔值传递。
- **安全风险**：正面影响。防止了批量误停用的安全风险。
- **回归风险**：低。所有现有相关测试通过。