### PR TITLE
fix: extend DingTalk connection test with org-sync permission checks

### DIFF
--- a/app/routes/notification_integrations.py
+++ b/app/routes/notification_integrations.py
@@ -204,11 +204,13 @@ def test_dingtalk_config():
         token = payload.get("accessToken") or payload.get("access_token")
         if not token:
             checks["access_token"] = {"status": "failed", "message": "No access token returned"}
-            return jsonify({
-                "success": False,
-                "message": "DingTalk did not return an access token",
-                "checks": checks,
-            })
+            return jsonify(
+                {
+                    "success": False,
+                    "message": "DingTalk did not return an access token",
+                    "checks": checks,
+                }
+            )
         checks["access_token"] = {"status": "passed", "message": "Access token obtained"}
     except OutboundUrlBlockedError as e:
         logger.error("DingTalk connection test blocked by SSRF protection: %s", e)
@@ -216,19 +218,29 @@ def test_dingtalk_config():
             "status": "failed",
             "message": f"Request blocked by security policy: {e}",
         }
-        return jsonify({
-            "success": False,
-            "message": f"Request blocked by security policy: {e}",
-            "checks": checks,
-        }), 403
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": f"Request blocked by security policy: {e}",
+                    "checks": checks,
+                }
+            ),
+            403,
+        )
     except Exception:
         logger.warning("DingTalk connection test failed", exc_info=True)
         checks["access_token"] = {"status": "failed", "message": "Failed to obtain access token"}
-        return jsonify({
-            "success": False,
-            "message": "DingTalk connection test failed",
-            "checks": checks,
-        }), 502
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": "DingTalk connection test failed",
+                    "checks": checks,
+                }
+            ),
+            502,
+        )
 
     # ---- 2. department_list check ----
     try:
@@ -277,13 +289,12 @@ def test_dingtalk_config():
     if all_passed:
         message = "DingTalk connection test successful"
     else:
-        message = (
-            "DingTalk connection test: some checks failed – "
-            + ", ".join(failed_checks)
-        )
+        message = "DingTalk connection test: some checks failed – " + ", ".join(failed_checks)
 
-    return jsonify({
-        "success": all_passed,
-        "message": message,
-        "checks": checks,
-    })
+    return jsonify(
+        {
+            "success": all_passed,
+            "message": message,
+            "checks": checks,
+        }
+    )

--- a/app/routes/notification_integrations.py
+++ b/app/routes/notification_integrations.py
@@ -144,16 +144,55 @@ def dingtalk_config():
     return jsonify({"success": True, "data": saved})
 
 
+def _dingtalk_oapi_request(token: str, url: str, json_payload: dict) -> dict:
+    """Call a DingTalk oapi endpoint via *safe_request* and return the payload.
+
+    Raises ``ValueError`` with a human-readable message when the API returns a
+    non-zero *errcode*.  The access token is passed as a query parameter per
+    DingTalk's oapi convention.
+    """
+    response = safe_request(
+        "POST",
+        url,
+        params={"access_token": token},
+        json=json_payload,
+        timeout=10,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    errcode = payload.get("errcode", 0)
+    if errcode == 0:
+        return payload
+    errmsg = payload.get("errmsg") or payload.get("message") or "unknown error"
+    raise ValueError(f"DingTalk API error (errcode={errcode}): {errmsg}")
+
+
 @notification_integrations_bp.post("/management/dingtalk-config/test")
 def test_dingtalk_config():
+    """Test DingTalk credentials **and** organisation-sync permissions.
+
+    The test performs the following checks sequentially:
+
+    1. **access_token** – exchange AppKey/AppSecret for an access token.
+    2. **department_list** – list child departments of the root department
+       (verifies the *通讯录部门读取* permission).
+    3. **user_list** – list one user from the root department (verifies the
+       *成员信息读取* permission).
+
+    The response keeps the legacy ``success`` / ``message`` fields for backward
+    compatibility and adds a ``checks`` dict with per-check details.
+    """
     data = request.get_json(silent=True) or {}
     saved = get_notification_settings_repository().get("dingtalk", include_secrets=True) or {}
     app_key = data.get("app_key") or saved.get("app_key")
     app_secret = data.get("app_secret") or saved.get("app_secret")
     if not app_key or not app_secret:
         return jsonify({"success": False, "message": "AppKey and AppSecret are required"}), 400
+
+    checks: dict[str, dict[str, str]] = {}
+
+    # ---- 1. access_token check ----
     try:
-        # Issue #2237: Use safe_request to avoid gevent RecursionError and get SSRF protection
         response = safe_request(
             "POST",
             "https://api.dingtalk.com/v1.0/oauth2/accessToken",
@@ -162,22 +201,89 @@ def test_dingtalk_config():
         )
         response.raise_for_status()
         payload = response.json()
-        return jsonify(
-            {
-                "success": bool(payload.get("accessToken")),
-                "message": (
-                    "DingTalk connection test successful"
-                    if payload.get("accessToken")
-                    else "DingTalk did not return an access token"
-                ),
-            }
-        )
+        token = payload.get("accessToken") or payload.get("access_token")
+        if not token:
+            checks["access_token"] = {"status": "failed", "message": "No access token returned"}
+            return jsonify({
+                "success": False,
+                "message": "DingTalk did not return an access token",
+                "checks": checks,
+            })
+        checks["access_token"] = {"status": "passed", "message": "Access token obtained"}
     except OutboundUrlBlockedError as e:
         logger.error("DingTalk connection test blocked by SSRF protection: %s", e)
-        return (
-            jsonify({"success": False, "message": f"Request blocked by security policy: {e}"}),
-            403,
-        )
+        checks["access_token"] = {
+            "status": "failed",
+            "message": f"Request blocked by security policy: {e}",
+        }
+        return jsonify({
+            "success": False,
+            "message": f"Request blocked by security policy: {e}",
+            "checks": checks,
+        }), 403
     except Exception:
         logger.warning("DingTalk connection test failed", exc_info=True)
-        return jsonify({"success": False, "message": "DingTalk connection test failed"}), 502
+        checks["access_token"] = {"status": "failed", "message": "Failed to obtain access token"}
+        return jsonify({
+            "success": False,
+            "message": "DingTalk connection test failed",
+            "checks": checks,
+        }), 502
+
+    # ---- 2. department_list check ----
+    try:
+        _dingtalk_oapi_request(
+            token,
+            "https://oapi.dingtalk.com/topapi/v2/department/listsub",
+            {"dept_id": 1},
+        )
+        checks["department_list"] = {"status": "passed", "message": "Department list accessible"}
+    except ValueError as exc:
+        checks["department_list"] = {
+            "status": "failed",
+            "message": f"Department read permission missing ({exc})",
+        }
+    except Exception:
+        logger.warning("DingTalk department list check failed", exc_info=True)
+        checks["department_list"] = {
+            "status": "failed",
+            "message": "Failed to query department list",
+        }
+
+    # ---- 3. user_list check ----
+    try:
+        _dingtalk_oapi_request(
+            token,
+            "https://oapi.dingtalk.com/topapi/v2/user/list",
+            {"dept_id": 1, "cursor": 0, "size": 1},
+        )
+        checks["user_list"] = {"status": "passed", "message": "User list accessible"}
+    except ValueError as exc:
+        checks["user_list"] = {
+            "status": "failed",
+            "message": f"Member read permission missing ({exc})",
+        }
+    except Exception:
+        logger.warning("DingTalk user list check failed", exc_info=True)
+        checks["user_list"] = {
+            "status": "failed",
+            "message": "Failed to query user list",
+        }
+
+    # ---- Overall result ----
+    all_passed = all(c["status"] == "passed" for c in checks.values())
+    failed_checks = [name for name, c in checks.items() if c["status"] != "passed"]
+
+    if all_passed:
+        message = "DingTalk connection test successful"
+    else:
+        message = (
+            "DingTalk connection test: some checks failed – "
+            + ", ".join(failed_checks)
+        )
+
+    return jsonify({
+        "success": all_passed,
+        "message": message,
+        "checks": checks,
+    })

--- a/frontend/src/api/notificationChannels.ts
+++ b/frontend/src/api/notificationChannels.ts
@@ -57,10 +57,11 @@ export const notificationChannelsApi = {
     ).data;
   },
   async testDingTalk(data: { app_key?: string; app_secret?: string }) {
-    return await apiClient.post<{ success: boolean; message: string }>(
-      '/api/management/dingtalk-config/test',
-      data
-    );
+    return await apiClient.post<{
+      success: boolean;
+      message: string;
+      checks?: Record<string, { status: string; message: string }>;
+    }>('/api/management/dingtalk-config/test', data);
   },
   async syncDingTalk(tenantId: number) {
     return await apiClient.post<{ success: boolean; result: Record<string, unknown> }>(

--- a/frontend/src/components/features/settings/NotificationIntegration.tsx
+++ b/frontend/src/components/features/settings/NotificationIntegration.tsx
@@ -57,6 +57,9 @@ export const NotificationIntegration: React.FC = () => {
   const [status, setStatus] = useState<ChannelStatus>({});
   const [syncResult, setSyncResult] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [dingtalkTestChecks, setDingtalkTestChecks] = useState<
+    Record<string, { status: string; message: string }> | null
+  >(null);
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [webhookTestUrl, setWebhookTestUrl] = useState('');
   const [dingtalkTestUrl, setDingtalkTestUrl] = useState('');
@@ -145,11 +148,13 @@ export const NotificationIntegration: React.FC = () => {
 
   const testDingTalk = async () => {
     setBusy('test');
+    setDingtalkTestChecks(null);
     try {
       const result = await notificationChannelsApi.testDingTalk({
         app_key: dingtalk.app_key || undefined,
         app_secret: dingtalk.app_secret || undefined,
       });
+      setDingtalkTestChecks(result.checks ?? null);
       if (result.success) {
         toast.success(t('integrationTestSuccess', language), result.message);
       } else {
@@ -701,6 +706,49 @@ export const NotificationIntegration: React.FC = () => {
                   {t('testConnection', language)}
                 </Button>
               </div>
+
+              {dingtalkTestChecks && (
+                <div
+                  className="alert mt-3 mb-0"
+                  style={{
+                    borderLeftWidth: 3,
+                    borderLeftColor: Object.values(dingtalkTestChecks).every(
+                      (c) => c.status === 'passed'
+                    )
+                      ? '#639922'
+                      : '#EF9F27',
+                  }}
+                >
+                  <div style={{ fontWeight: 500, marginBottom: 8 }}>
+                    {t('integrationTestCheckResults', language)}
+                  </div>
+                  {Object.entries(dingtalkTestChecks).map(([key, check]) => (
+                    <div key={key} className="d-flex align-items-center gap-2 mb-1">
+                      <span
+                        style={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: '50%',
+                          background: check.status === 'passed' ? '#639922' : '#EF9F27',
+                          flexShrink: 0,
+                        }}
+                      />
+                      <strong style={{ fontSize: 13 }}>
+                        {key === 'access_token'
+                          ? t('integrationCheckAccessToken', language)
+                          : key === 'department_list'
+                            ? t('integrationCheckDeptList', language)
+                            : key === 'user_list'
+                              ? t('integrationCheckUserList', language)
+                              : key}
+                      </strong>
+                      <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                        — {check.message}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
 
               <div className="ni-section">{t('integrationSyncSettings', language)}</div>
               <div className="row g-3">

--- a/frontend/src/components/features/settings/NotificationIntegration.tsx
+++ b/frontend/src/components/features/settings/NotificationIntegration.tsx
@@ -57,9 +57,10 @@ export const NotificationIntegration: React.FC = () => {
   const [status, setStatus] = useState<ChannelStatus>({});
   const [syncResult, setSyncResult] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
-  const [dingtalkTestChecks, setDingtalkTestChecks] = useState<
-    Record<string, { status: string; message: string }> | null
-  >(null);
+  const [dingtalkTestChecks, setDingtalkTestChecks] = useState<Record<
+    string,
+    { status: string; message: string }
+  > | null>(null);
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [webhookTestUrl, setWebhookTestUrl] = useState('');
   const [dingtalkTestUrl, setDingtalkTestUrl] = useState('');

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -93,6 +93,10 @@ export const translations: Record<Language, Translations> = {
       'Recommended to configure keys per user/tenant; system-level keys serve only as compatibility fallback for legacy setups. Prefer tenant-level keys for new configurations.',
     integrationTestSendHint:
       'Test send: temporary URL input, single-use only, does not alter user notification preferences, operations logged',
+    integrationTestCheckResults: 'Connection test details',
+    integrationCheckAccessToken: 'Credential authentication',
+    integrationCheckDeptList: 'Department read',
+    integrationCheckUserList: 'Member read',
     integrationConfigureAlertTarget: 'Configure your alert targets and personal preferences',
     integrationFeishuBotSubtitle:
       'Feishu bot has no required system-level parameters; target addresses are set per user/tenant',
@@ -2201,6 +2205,10 @@ export const translations: Record<Language, Translations> = {
       '推荐按用户/租户配置密钥；系统级密钥仅作为旧配置的兼容回退，新配置请优先使用租户级密钥',
     integrationTestSendHint:
       '测试发送：临时输入 URL，仅本次使用、不保存、不改变用户通知偏好，操作写审计',
+    integrationTestCheckResults: '连接测试详情',
+    integrationCheckAccessToken: '凭证认证',
+    integrationCheckDeptList: '通讯录部门读取',
+    integrationCheckUserList: '成员信息读取',
     integrationConfigureAlertTarget: '配置你的告警目标与个人偏好',
     integrationFeishuBotSubtitle: '飞书机器人无系统级必填参数，目标地址按用户/租户设置',
     integrationFeishuBotNoConfigDetail:
@@ -4244,6 +4252,10 @@ export const translations: Record<Language, Translations> = {
       'ユーザー/テナントごとにキーを設定することを推奨；システムレベルのキーはレガシー設定の互換フォールバックのみ。新設定はテナントレベルキーを優先。',
     integrationTestSendHint:
       'テスト送信：一時的URL入力、1回のみ、ユーザー通知設定は変更しません、操作は監査ログに記録',
+    integrationTestCheckResults: '接続テスト詳細',
+    integrationCheckAccessToken: 'クレデンシャル認証',
+    integrationCheckDeptList: '部門読み取り',
+    integrationCheckUserList: 'メンバー読み取り',
     integrationConfigureAlertTarget: 'アラート宛先と個人設定を構成',
     integrationFeishuBotSubtitle:
       'Feishuボットにシステムレベルの必須パラメータはありません；宛先アドレスはユーザー/テナントごとに設定',
@@ -6178,6 +6190,10 @@ export const translations: Record<Language, Translations> = {
       '사용자/테넌트별로 키를 구성하는 것을 권장; 시스템 수준 키는 레거시 설정에 대한 호환 폴백 역할만 합니다. 새 설정은 테넌트 수준 키를 우선 사용하세요.',
     integrationTestSendHint:
       '테스트 발송: 일시적 URL 입력, 1회만 사용, 사용자 알림 환경설정을 변경하지 않음, 작업 감사 기록',
+    integrationTestCheckResults: '연결 테스트 상세',
+    integrationCheckAccessToken: '자격 증명 인증',
+    integrationCheckDeptList: '부서 읽기',
+    integrationCheckUserList: '멤버 읽기',
     integrationConfigureAlertTarget: '알림 대상 및 개인 환경설정 구성',
     integrationFeishuBotSubtitle:
       'Feishu 봇은 시스템 수준 필수 매개변수가 없습니다; 대상 주소는 사용자/테넌트별로 설정',

--- a/tests/issues/3022/test_dingtalk_permission_check.py
+++ b/tests/issues/3022/test_dingtalk_permission_check.py
@@ -1,0 +1,430 @@
+"""Tests for DingTalk connection test with org-sync permission checks (Issue #3022).
+
+The ``/management/dingtalk-config/test`` endpoint must now verify not only that
+AppKey/AppSecret can obtain an access token, but also that the app has the
+necessary permissions for organisation sync (department read and member read).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app():
+    """Create a minimal Flask app with the notification-integrations blueprint."""
+    from flask import Flask
+
+    from app.routes.notification_integrations import notification_integrations_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(notification_integrations_bp, url_prefix="/api")
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret-key"
+    return app
+
+
+@pytest.fixture()
+def admin_client(app):
+    """A test client that bypasses admin authentication."""
+
+    class _AuthenticatedClient:
+        def __init__(self, client):
+            self._client = client
+
+        def post(self, *args, **kwargs):
+            with patch("app.auth.decorators._extract_session_token", return_value="tok"):
+                with patch(
+                    "app.auth.decorators._load_user_from_token",
+                    return_value={"id": 1, "role": "admin", "username": "admin"},
+                ):
+                    return self._client.post(*args, **kwargs)
+
+    return _AuthenticatedClient(app.test_client())
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock responses
+# ---------------------------------------------------------------------------
+
+
+def _mock_token_response(token="fake-token"):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"accessToken": token, "expireIn": 7200}
+    return resp
+
+
+def _mock_oapi_success():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"errcode": 0, "errmsg": "ok", "result": []}
+    return resp
+
+
+def _mock_oapi_error(errcode, errmsg):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"errcode": errcode, "errmsg": errmsg}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDingTalkPermissionCheck:
+    """Verify that the connection test now checks org-sync permissions."""
+
+    def test_missing_credentials_returns_400(self, admin_client):
+        """Without AppKey/AppSecret the endpoint should reject immediately."""
+        with patch(
+            "app.routes.notification_integrations.get_notification_settings_repository",
+            return_value=MagicMock(get=MagicMock(return_value={})),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={},
+            )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["success"] is False
+        assert "required" in data["message"].lower()
+
+    def test_all_checks_pass(self, admin_client):
+        """When all checks succeed, success=True and all checks are 'passed'."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert "checks" in data
+        assert data["checks"]["access_token"]["status"] == "passed"
+        assert data["checks"]["department_list"]["status"] == "passed"
+        assert data["checks"]["user_list"]["status"] == "passed"
+
+    def test_token_failure_short_circuits(self, admin_client):
+        """When token exchange fails, dept/user checks should NOT be attempted."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {}  # No accessToken
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                return_value=resp,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is False
+        assert "checks" in data
+        assert data["checks"]["access_token"]["status"] == "failed"
+        # department_list and user_list should NOT be present (short-circuited)
+        assert "department_list" not in data["checks"]
+        assert "user_list" not in data["checks"]
+
+    def test_department_permission_missing(self, admin_client):
+        """When department API returns permission error, department_list fails."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            if "department/listsub" in url:
+                return _mock_oapi_error(60011, "no permission for this API")
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        data = response.get_json()
+        assert data["success"] is False
+        assert data["checks"]["access_token"]["status"] == "passed"
+        assert data["checks"]["department_list"]["status"] == "failed"
+        assert "permission" in data["checks"]["department_list"]["message"].lower()
+        # user_list should still have been attempted
+        assert "user_list" in data["checks"]
+        assert data["checks"]["user_list"]["status"] == "passed"
+
+    def test_user_permission_missing(self, admin_client):
+        """When user list API returns permission error, user_list fails."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            if "user/list" in url:
+                return _mock_oapi_error(60011, "no permission for this API")
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        data = response.get_json()
+        assert data["success"] is False
+        assert data["checks"]["access_token"]["status"] == "passed"
+        assert data["checks"]["department_list"]["status"] == "passed"
+        assert data["checks"]["user_list"]["status"] == "failed"
+        assert "permission" in data["checks"]["user_list"]["message"].lower()
+
+    def test_both_permissions_missing(self, admin_client):
+        """When both dept and user APIs fail, both checks report failure."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            return _mock_oapi_error(60011, "no permission for this API")
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        data = response.get_json()
+        assert data["success"] is False
+        assert data["checks"]["department_list"]["status"] == "failed"
+        assert data["checks"]["user_list"]["status"] == "failed"
+
+    def test_network_error_on_token(self, admin_client):
+        """A network error during token exchange should return 502."""
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=ConnectionError("network down"),
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        assert response.status_code == 502
+        data = response.get_json()
+        assert data["success"] is False
+        assert data["checks"]["access_token"]["status"] == "failed"
+
+    def test_ssrf_blocked_returns_403(self, admin_client):
+        """An SSRF-blocked token request should return 403."""
+        from app.utils.outbound_url_guard import OutboundUrlBlockedError
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=OutboundUrlBlockedError("blocked"),
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        assert response.status_code == 403
+        data = response.get_json()
+        assert data["success"] is False
+
+    def test_response_does_not_leak_secrets(self, admin_client):
+        """Response must never contain AppSecret or access token values."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response("super-secret-token-xyz")
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "my-key", "app_secret": "my-secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "my-key", "app_secret": "my-secret"},
+            )
+
+        body = response.get_data(as_text=True)
+        assert "my-secret" not in body
+        assert "super-secret-token-xyz" not in body
+
+    def test_network_error_on_dept_check_does_not_crash(self, admin_client):
+        """A transport error during dept check should degrade gracefully."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            if "department/listsub" in url:
+                raise ConnectionError("timeout")
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={"app_key": "key", "app_secret": "secret"},
+            )
+
+        data = response.get_json()
+        assert data["checks"]["department_list"]["status"] == "failed"
+        # user_list should still be attempted despite dept failure
+        assert data["checks"]["user_list"]["status"] == "passed"
+
+    def test_legacy_fields_still_present(self, admin_client):
+        """Backward compatibility: 'success' and 'message' fields must be present."""
+
+        def fake_safe_request(method, url, **kwargs):
+            if "oauth2/accessToken" in url:
+                return _mock_token_response()
+            return _mock_oapi_success()
+
+        with (
+            patch(
+                "app.routes.notification_integrations.get_notification_settings_repository",
+                return_value=MagicMock(
+                    get=MagicMock(
+                        return_value={"app_key": "key", "app_secret": "secret"}
+                    )
+                ),
+            ),
+            patch(
+                "app.routes.notification_integrations.safe_request",
+                side_effect=fake_safe_request,
+            ),
+        ):
+            response = admin_client.post(
+                "/api/management/dingtalk-config/test",
+                json={},
+            )
+
+        data = response.get_json()
+        assert "success" in data
+        assert "message" in data
+        assert isinstance(data["success"], bool)
+        assert isinstance(data["message"], str)

--- a/tests/unit/test_dingtalk_permission_check.py
+++ b/tests/unit/test_dingtalk_permission_check.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -114,9 +113,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -148,9 +145,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -186,9 +181,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -224,9 +217,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -258,9 +249,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -284,9 +273,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -312,9 +299,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -343,9 +328,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "my-key", "app_secret": "my-secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "my-key", "app_secret": "my-secret"})
                 ),
             ),
             patch(
@@ -376,9 +359,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(
@@ -408,9 +389,7 @@ class TestDingTalkPermissionCheck:
             patch(
                 "app.routes.notification_integrations.get_notification_settings_repository",
                 return_value=MagicMock(
-                    get=MagicMock(
-                        return_value={"app_key": "key", "app_secret": "secret"}
-                    )
+                    get=MagicMock(return_value={"app_key": "key", "app_secret": "secret"})
                 ),
             ),
             patch(


### PR DESCRIPTION
## 修复说明

关联 Issue：#3022

## 根因

`/management/dingtalk-config/test` 端点只调用 DingTalk OAuth2 access token 接口验证凭证有效性，返回"连接测试成功"。但它未验证组织同步所需的通讯录部门读取和成员信息读取权限，导致管理员在权限缺失时仍看到成功提示，实际同步时立即因权限不足失败。

## 修复方案

将连接测试扩展为组织同步前置检查，顺序执行以下三项验证：

1. **凭证认证** - 获取 access token（现有行为）
2. **通讯录部门读取** - 调用 `/topapi/v2/department/listsub`（验证部门权限）
3. **成员信息读取** - 调用 `/topapi/v2/user/list`（验证成员权限）

每项检查独立执行，单项失败不阻断后续检查。响应保留向后兼容的 `success`/`message` 字段，新增 `checks` 字典展示各项检查详情。

## 主要变更

- `app/routes/notification_integrations.py` — 扩展 `test_dingtalk_config()` 新增权限检查逻辑和 `_dingtalk_oapi_request()` 辅助函数
- `frontend/src/api/notificationChannels.ts` — 更新 API 类型定义，包含 `checks` 字段
- `frontend/src/components/features/settings/NotificationIntegration.tsx` — 新增测试结果详情展示区域
- `frontend/src/i18n/index.ts` — 新增 4 种语言的检查项翻译（凭证认证、通讯录部门读取、成员信息读取、连接测试详情）
- `tests/issues/3022/test_dingtalk_permission_check.py` — 新增 11 个测试用例

## 测试

- 已运行测试：`tests/issues/3022/test_dingtalk_permission_check.py`（11 个用例全部通过）
- 已运行回归测试：`tests/unit/test_dingtalk_org_sync.py`、`test_dingtalk_org_sync_hardening.py`、`test_dingtalk_sync_snapshot_protection.py`（19 个用例全部通过）
- 新增测试覆盖场景：
  1. 凭证缺失返回 400
  2. 所有检查通过
  3. Token 获取失败短路（不执行后续检查）
  4. 部门权限缺失
  5. 成员权限缺失
  6. 两项权限均缺失
  7. 网络错误（token 阶段）返回 502
  8. SSRF 拦截返回 403
  9. 响应不泄露 AppSecret 或 access token
  10. 部门检查网络错误优雅降级（不阻断成员检查）
  11. 向后兼容性（`success`/`message` 字段保留）

## 风险

- **兼容性**：低风险。新增 `checks` 字段向后兼容，旧客户端仅读取 `success`/`message` 不受影响
- **性能**：新增 2 个轻量只读 API 调用，预计增加 1-3 秒延迟
- **安全**：使用现有 `safe_request` SSRF 防护，响应中不暴露凭证或 token
- **回归**：不影响现有同步流程，仅扩展测试端点