### PR TITLE
fix(workspace): remove active-session fallback for webui:* tokens (#3025)

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -1248,36 +1248,26 @@ def handle_llm_proxy_request(
     else:
         session_id = token_session_id
 
-        # Issue #2464: If using webui aggregate session, check for user's active session
-        # When user creates a session via /work, route WebUI messages to that session
+        # Issue #3025: Remove active-session fallback for webui:* tokens.
+        # Previously, when a webui:* aggregate token lacked X-Session-Id, the code
+        # queried the user's active sessions and picked the most recently updated
+        # non-webui session. This caused cross-session data contamination: requests
+        # from one workspace were written into an unrelated session, inflating its
+        # message/request/token counts while the intended session remained empty.
+        #
+        # Now, the session_id stays as the webui:* aggregate session. The existing
+        # auto-create logic in _record_llm_usage (lines ~464-479) handles creating
+        # the aggregate session if needed. When upstream sends X-Session-Id, the
+        # header-based routing above (lines ~1128-1247) takes precedence.
         if session_id.startswith("webui:"):
-            # Issue #2727: Log WARNING for webui:* fallback behavior
             logger.warning(
-                "Using webui aggregate session without X-Session-Id header, "
-                "fallback to user's active session (user_id=%s, tenant_id=%s)",
+                "Using webui aggregate session without X-Session-Id header; "
+                "requests will be recorded to the aggregate session "
+                "(user_id=%s, tenant_id=%s). "
+                "Upstream should send X-Session-Id to route to a specific session.",
                 user_id,
                 tenant_id,
             )
-            try:
-                from app.modules.workspace.session_manager import get_session_manager
-
-                sm = get_session_manager()
-                active_sessions = sm.get_active_sessions(user_id=user_id, tenant_id=tenant_id)
-                # Filter out webui aggregate sessions, get the most recent non-webui session
-                # get_active_sessions already returns sessions sorted by updated_at DESC
-                non_webui_sessions = [
-                    s for s in active_sessions if not s.session_id.startswith("webui:")
-                ]
-                if non_webui_sessions:
-                    # First result is the most recently updated (SQL ORDER BY updated_at DESC)
-                    session_id = non_webui_sessions[0].session_id
-                    logger.debug(
-                        "Using user's active session %s instead of webui aggregate",
-                        session_id[:8],
-                    )
-            except Exception as e:
-                # On any error, fall back to webui aggregate session
-                logger.warning("Failed to get active sessions, using webui aggregate: %s", e)
 
     # Issue #2547: Circuit breaking for stopped sessions
     # Reject requests from orphan processes that may still be retrying

--- a/tests/unit/issues/test_webui_active_session_2464.py
+++ b/tests/unit/issues/test_webui_active_session_2464.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """
-Tests for Issue #2464: WebUI 会话消息记录与历史会话显示分离
+Tests for Issue #2464 / #3025: WebUI aggregate session fallback behavior.
 
-Test coverage:
-1. LLM proxy uses webui aggregate session when no active non-webui session exists
-2. LLM proxy uses user's active non-webui session when available
-3. LLM proxy uses most recently updated session when multiple active sessions exist
+Issue #2464 originally added fallback from webui:* aggregate to user's active session.
+Issue #3025 removed that fallback because it caused cross-session data contamination.
+
+Test coverage (post #3025 fix):
+1. LLM proxy uses webui aggregate session directly (no active-session lookup)
+2. LLM proxy does NOT call get_active_sessions for webui:* tokens without X-Session-Id
+3. X-Session-Id header still takes precedence (ownership validation unchanged)
+4. webui:* aggregate sessions are used as-is, never replaced by regular sessions
 """
 
 import json
@@ -90,16 +94,29 @@ _PROXY_PATH = "app.routes.workspace.get_api_key_proxy_service"
 _QUOTA_PATH = "app.modules.governance.quota_manager.QuotaManager"
 _HTTP_PATH = "requests.request"
 _SESSION_MGR_PATH = "app.modules.workspace.session_manager.get_session_manager"
+_GATEWAY_PATH = "app.modules.workspace.llm_proxy_handler.get_gateway_planner"
+
+
+def _make_noop_gateway():
+    """Return a mock gateway planner with is_noop=True (direct-provider mode)."""
+    gw = MagicMock()
+    gw.is_noop = True
+    return gw
 
 
 # ===================================================================
-# A. No active non-webui session → use webui aggregate
+# A. No X-Session-Id → use webui aggregate directly (no fallback)
 # ===================================================================
 
 
 class TestNoActiveNonWebuiSession:
-    """Test LLM proxy behavior when user has no active non-webui session."""
+    """Test LLM proxy behavior when webui:* token has no X-Session-Id header.
 
+    Issue #3025: The old fallback to active sessions was removed.
+    Now, requests always use the webui:* aggregate session directly.
+    """
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_SESSION_MGR_PATH)
@@ -114,9 +131,10 @@ class TestNoActiveNonWebuiSession:
         mock_session_mgr,
         mock_quota_cls,
         mock_http,
+        mock_gateway,
         workspace_app,
     ):
-        """Should use webui aggregate session when user has no active non-webui session."""
+        """Should use webui aggregate session directly without calling get_active_sessions."""
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.get_tool_model_pool.return_value = {
@@ -133,9 +151,7 @@ class TestNoActiveNonWebuiSession:
         )
         mock_get_proxy.return_value = mock_proxy
 
-        # No active sessions
         mock_sm = MagicMock()
-        mock_sm.get_active_sessions.return_value = []
         mock_session_mgr.return_value = mock_sm
 
         mock_quota_cls.return_value = _make_quota_ok()
@@ -148,16 +164,23 @@ class TestNoActiveNonWebuiSession:
             headers={"Authorization": "Bearer tok"},
         )
         assert resp.status_code == 200
+        # Issue #3025: get_active_sessions must NOT be called (fallback removed)
+        mock_sm.get_active_sessions.assert_not_called()
 
 
 # ===================================================================
-# B. Active non-webui session → use that session
+# B. Active non-webui session exists → still use webui aggregate (no fallback)
 # ===================================================================
 
 
 class TestActiveNonWebuiSession:
-    """Test LLM proxy behavior when user has an active non-webui session."""
+    """Test LLM proxy behavior when user has an active non-webui session.
 
+    Issue #3025: Even when active sessions exist, webui:* tokens without
+    X-Session-Id must NOT route to them. The old fallback was removed.
+    """
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_SESSION_MGR_PATH)
@@ -166,15 +189,16 @@ class TestActiveNonWebuiSession:
         "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
         _mock_validate_llm_proxy_url,
     )
-    def test_uses_active_session_when_available(
+    def test_does_not_fallback_to_active_session(
         self,
         mock_get_proxy,
         mock_session_mgr,
         mock_quota_cls,
         mock_http,
+        mock_gateway,
         workspace_app,
     ):
-        """Should use user's active non-webui session when available."""
+        """Should NOT call get_active_sessions; must use webui aggregate directly."""
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.get_tool_model_pool.return_value = {
@@ -191,7 +215,7 @@ class TestActiveNonWebuiSession:
         )
         mock_get_proxy.return_value = mock_proxy
 
-        # User has one active non-webui session
+        # User has one active non-webui session (but it must be ignored)
         active_session = _mock_session("uuid-session-123")
         mock_sm = MagicMock()
         mock_sm.get_active_sessions.return_value = [active_session]
@@ -207,18 +231,23 @@ class TestActiveNonWebuiSession:
             headers={"Authorization": "Bearer tok"},
         )
         assert resp.status_code == 200
-        # Verify get_active_sessions was called
-        mock_sm.get_active_sessions.assert_called_once()
+        # Issue #3025: get_active_sessions must NOT be called (fallback removed)
+        mock_sm.get_active_sessions.assert_not_called()
 
 
 # ===================================================================
-# C. Multiple active sessions → use most recently updated
+# C. Multiple active sessions → still use webui aggregate (no fallback)
 # ===================================================================
 
 
 class TestMultipleActiveSessions:
-    """Test LLM proxy behavior when user has multiple active non-webui sessions."""
+    """Test LLM proxy behavior when user has multiple active non-webui sessions.
 
+    Issue #3025: Multiple active sessions must NOT trigger fallback selection.
+    The old behavior of picking the most recently updated session was removed.
+    """
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_SESSION_MGR_PATH)
@@ -227,15 +256,16 @@ class TestMultipleActiveSessions:
         "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
         _mock_validate_llm_proxy_url,
     )
-    def test_uses_most_recently_updated_session(
+    def test_does_not_select_from_multiple_sessions(
         self,
         mock_get_proxy,
         mock_session_mgr,
         mock_quota_cls,
         mock_http,
+        mock_gateway,
         workspace_app,
     ):
-        """Should use the most recently updated session when multiple active sessions exist."""
+        """Should NOT call get_active_sessions even when multiple sessions exist."""
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.get_tool_model_pool.return_value = {
@@ -252,10 +282,9 @@ class TestMultipleActiveSessions:
         )
         mock_get_proxy.return_value = mock_proxy
 
-        # User has multiple active non-webui sessions
+        # User has multiple active non-webui sessions (all must be ignored)
         now = datetime.now(timezone.utc)
         older_session = _mock_session("uuid-session-old", updated_at=now)
-        # Newer session: 1 minute later
         from datetime import timedelta
 
         newer_time = now + timedelta(minutes=1)
@@ -274,6 +303,8 @@ class TestMultipleActiveSessions:
             headers={"Authorization": "Bearer tok"},
         )
         assert resp.status_code == 200
+        # Issue #3025: get_active_sessions must NOT be called (fallback removed)
+        mock_sm.get_active_sessions.assert_not_called()
 
 
 # ===================================================================
@@ -284,6 +315,7 @@ class TestMultipleActiveSessions:
 class TestXSessionIdHeaderOverride:
     """Test that X-Session-Id header still takes precedence."""
 
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_SESSION_MGR_PATH)
@@ -298,6 +330,7 @@ class TestXSessionIdHeaderOverride:
         mock_session_mgr,
         mock_quota_cls,
         mock_http,
+        mock_gateway,
         workspace_app,
     ):
         """X-Session-Id header should take precedence over active session lookup."""
@@ -344,13 +377,17 @@ class TestXSessionIdHeaderOverride:
 
 
 # ===================================================================
-# E. Webui session filter
+# E. Webui aggregate used directly (no session lookup)
 # ===================================================================
 
 
 class TestWebuiSessionFilter:
-    """Test that webui aggregate sessions are filtered from active session lookup."""
+    """Test that webui:* tokens without X-Session-Id use aggregate session directly.
 
+    Issue #3025: No active-session lookup is performed for webui:* tokens.
+    """
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_SESSION_MGR_PATH)
@@ -359,15 +396,16 @@ class TestWebuiSessionFilter:
         "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
         _mock_validate_llm_proxy_url,
     )
-    def test_filters_webui_sessions_from_lookup(
+    def test_no_session_lookup_for_webui_aggregate(
         self,
         mock_get_proxy,
         mock_session_mgr,
         mock_quota_cls,
         mock_http,
+        mock_gateway,
         workspace_app,
     ):
-        """Webui aggregate sessions should be filtered from active session lookup."""
+        """Webui:* tokens without X-Session-Id must not trigger session lookup."""
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.get_tool_model_pool.return_value = {
@@ -384,11 +422,7 @@ class TestWebuiSessionFilter:
         )
         mock_get_proxy.return_value = mock_proxy
 
-        # User has both webui and non-webui sessions
-        webui_session = _mock_session("webui:1")
-        non_webui_session = _mock_session("uuid-session-123")
         mock_sm = MagicMock()
-        mock_sm.get_active_sessions.return_value = [webui_session, non_webui_session]
         mock_session_mgr.return_value = mock_sm
 
         mock_quota_cls.return_value = _make_quota_ok()
@@ -401,3 +435,5 @@ class TestWebuiSessionFilter:
             headers={"Authorization": "Bearer tok"},
         )
         assert resp.status_code == 200
+        # Issue #3025: No session lookup for webui:* tokens without X-Session-Id
+        mock_sm.get_active_sessions.assert_not_called()


### PR DESCRIPTION
## 修复说明

关联 Issue：#3025

## 根因

`llm_proxy_handler.py` 在 `webui:*` 聚合令牌缺少 `X-Session-Id` 时，通过 `get_active_sessions()` 查询用户所有 active 会话，按 `updated_at DESC` 选择第一条普通会话，将请求数据写入其中。这导致：

- 工作区 B 的请求被写入工作区 A
- 工作区 B 显示 0 请求、0 消息、0 tokens
- 工作区 A 的计数器虚增
- 错误粘连自我强化（更新 A 的 updated_at 使其继续被选中）

## 修复方案

删除 active-session fallback 逻辑。`webui:*` 令牌缺少 `X-Session-Id` 时，`session_id` 保持为 `webui:*` 聚合会话。`_record_llm_usage` 已有的自动创建逻辑会处理聚合会话的创建。`X-Session-Id` header 路由不受影响。

## 主要变更

- `app/modules/workspace/llm_proxy_handler.py`：删除 `get_active_sessions` fallback 代码块，保留 WARNING 日志并更新消息
- `tests/unit/issues/test_webui_active_session_2464.py`：更新测试验证 `get_active_sessions` 不再被调用，添加 gateway planner mock

## 测试

- 测试环境：Package 测试环境
- 已运行测试：
  - `tests/unit/issues/test_webui_active_session_2464.py`（5/5 通过）
  - `tests/unit/test_llm_proxy_handler_audit_username.py`（9/9 通过）
  - `tests/unit/test_llm_proxy_autonomous_exempt.py`（3/3 通过）
  - `tests/unit/test_llm_proxy_ssrf_protection.py`（15/15 通过）
- 共 32 个相关测试全部通过
- `test_llm_proxy_failover.py` 的 14 个失败是预先存在的 gateway mock 问题，与本次修改无关

## 风险

- 兼容性：低。`_record_llm_usage` 已有 `webui:*` 会话自动创建逻辑
- 性能：微升（删除了一次数据库查询）
- 安全：无影响
- 回归：低。X-Session-Id header 路由逻辑不变