### PR TITLE
fix: Token趋势图表选择7天时无数据 (#3030)

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1009,6 +1009,166 @@ class UsageRepository:
             logger.warning("Failed to get session summary by tool: %s", e)
             return {}
 
+    def get_session_trend_by_tool(
+        self,
+        start_date: str,
+        end_date: str,
+        host_name: str | None = None,
+        tenant_id: int | None = None,
+    ) -> list[dict]:
+        """Get trend data from agent_sessions for WebUI sessions.
+
+        Issue #3030: /api/trend only queries daily_stats, missing WebUI
+        session data (local/remote/terminal). This method aggregates
+        agent_sessions grouped by date + tool to supplement the trend data.
+
+        Args:
+            start_date: Start date filter (YYYY-MM-DD).
+            end_date: End date filter (YYYY-MM-DD).
+            host_name: Optional host name filter.
+            tenant_id: Optional tenant ID filter.
+
+        Returns:
+            List[Dict]: Trend data with date, tool_name, tokens fields.
+        """
+        try:
+            conditions = ["workspace_type IN ('local', 'remote', 'terminal')"]
+            params: list[Any] = []
+            normalized_tenant_id = self._normalize_tenant_id(tenant_id)
+
+            conditions.append("CAST(created_at AS DATE) >= ?")
+            params.append(start_date)
+
+            conditions.append("CAST(created_at AS DATE) <= ?")
+            params.append(end_date)
+
+            if normalized_tenant_id is not None:
+                conditions.append("tenant_id = ?")
+                params.append(normalized_tenant_id)
+
+            if host_name:
+                conditions.append("host_name = ?")
+                params.append(host_name)
+
+            where_clause = " AND ".join(conditions)
+
+            query = f"""
+                SELECT
+                    CAST(created_at AS DATE) as date,
+                    COALESCE(tool_name, 'unknown') as tool_name,
+                    SUM(COALESCE(total_tokens, 0)) as tokens
+                FROM agent_sessions
+                WHERE {where_clause}
+                GROUP BY CAST(created_at AS DATE), COALESCE(tool_name, 'unknown')
+                ORDER BY date ASC, tool_name ASC
+            """
+
+            rows = self.db.fetch_all(query, tuple(params))
+
+            # Normalize tool names and merge duplicates
+            merged: dict[tuple, dict] = {}
+            for row in rows:
+                key = (row["date"], normalize_tool_name(row["tool_name"]))
+                if key in merged:
+                    merged[key]["tokens"] += row["tokens"] or 0
+                else:
+                    merged[key] = {
+                        "date": row["date"],
+                        "tool_name": key[1],
+                        "tokens": row["tokens"] or 0,
+                    }
+
+            return list(merged.values())
+        except Exception as e:
+            logger.warning("Failed to get session trend by tool: %s", e)
+            return []
+
+    def get_session_key_metrics(
+        self,
+        start_date: str,
+        end_date: str,
+        host_name: str | None = None,
+        tenant_id: int | None = None,
+    ) -> dict:
+        """Get key metrics from agent_sessions for WebUI sessions.
+
+        Issue #3030: /api/analysis/batch key_metrics only queries daily_messages,
+        missing WebUI session data. This method aggregates agent_sessions
+        to supplement the key_metrics.
+
+        Args:
+            start_date: Start date filter (YYYY-MM-DD).
+            end_date: End date filter (YYYY-MM-DD).
+            host_name: Optional host name filter.
+            tenant_id: Optional tenant ID filter.
+
+        Returns:
+            Dict: Key metrics with total_tokens, total_input_tokens,
+                  total_output_tokens, total_requests, unique_tools, unique_hosts.
+        """
+        try:
+            conditions = ["workspace_type IN ('local', 'remote', 'terminal')"]
+            params: list[Any] = []
+            normalized_tenant_id = self._normalize_tenant_id(tenant_id)
+
+            conditions.append("CAST(created_at AS DATE) >= ?")
+            params.append(start_date)
+
+            conditions.append("CAST(created_at AS DATE) <= ?")
+            params.append(end_date)
+
+            if normalized_tenant_id is not None:
+                conditions.append("tenant_id = ?")
+                params.append(normalized_tenant_id)
+
+            if host_name:
+                conditions.append("host_name = ?")
+                params.append(host_name)
+
+            where_clause = " AND ".join(conditions)
+
+            query = f"""
+                SELECT
+                    SUM(COALESCE(total_tokens, 0)) as total_tokens,
+                    SUM(COALESCE(total_input_tokens, 0)) as total_input_tokens,
+                    SUM(COALESCE(total_output_tokens, 0)) as total_output_tokens,
+                    SUM(COALESCE(request_count, 0)) as total_requests,
+                    COUNT(DISTINCT tool_name) as unique_tools,
+                    COUNT(DISTINCT host_name) as unique_hosts
+                FROM agent_sessions
+                WHERE {where_clause}
+            """
+
+            row = self.db.fetch_one(query, tuple(params))
+            if not row:
+                return {
+                    "total_tokens": 0,
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "total_requests": 0,
+                    "unique_tools": 0,
+                    "unique_hosts": 0,
+                }
+
+            return {
+                "total_tokens": row["total_tokens"] or 0,
+                "total_input_tokens": row["total_input_tokens"] or 0,
+                "total_output_tokens": row["total_output_tokens"] or 0,
+                "total_requests": row["total_requests"] or 0,
+                "unique_tools": row["unique_tools"] or 0,
+                "unique_hosts": row["unique_hosts"] or 0,
+            }
+        except Exception as e:
+            logger.warning("Failed to get session key metrics: %s", e)
+            return {
+                "total_tokens": 0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_requests": 0,
+                "unique_tools": 0,
+                "unique_hosts": 0,
+            }
+
     def get_all_tools(self, tenant_id: int | None = None) -> list[str]:
         """
         Get list of all tools.

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -388,6 +388,8 @@ class AnalysisService:
         Get key metrics for the dashboard.
 
         Issue #1852: Added tenant_id for tenant isolation.
+        Issue #3030: Merge agent_sessions data with daily_messages to include
+        WebUI local/remote/terminal sessions.
 
         Args:
             start_date: Optional start date filter.
@@ -423,6 +425,20 @@ class AnalysisService:
             total_input = sum(u.get("total_input_tokens", 0) for u in user_tokens)
             total_output = sum(u.get("total_output_tokens", 0) for u in user_tokens)
 
+        # Issue #3030: Also get session data from agent_sessions
+        session_metrics = self.usage_repo.get_session_key_metrics(
+            start_date=start_date,
+            end_date=end_date,
+            host_name=host_name,
+            tenant_id=tenant_id,
+        )
+
+        # Merge session data into totals
+        total_tokens += session_metrics.get("total_tokens", 0)
+        total_input += session_metrics.get("total_input_tokens", 0)
+        total_output += session_metrics.get("total_output_tokens", 0)
+        total_requests += session_metrics.get("total_requests", 0)
+
         # Get unique tools and hosts (normalize tool names)
         tools = set()
         hosts = set()
@@ -431,6 +447,10 @@ class AnalysisService:
                 tools.add(normalize_tool_name(u["tool_name"]))
             if u.get("host_name"):
                 hosts.add(u["host_name"])
+
+        # Issue #3030: Include unique tools/hosts from session metrics
+        tools_count = max(len(tools), session_metrics.get("unique_tools", 0))
+        hosts_count = max(len(hosts), session_metrics.get("unique_hosts", 0))
 
         # Get top tools by token usage from messages (has real token data)
         tool_stats = self.message_repo.get_tool_token_totals(
@@ -490,8 +510,8 @@ class AnalysisService:
             "total_output_tokens": total_output,
             "total_requests": total_requests,
             "total_messages": total_messages,
-            "unique_tools": len(tools) if tools else 1,
-            "unique_hosts": len(hosts) if hosts else 1,
+            "unique_tools": tools_count if tools_count > 0 else 1,
+            "unique_hosts": hosts_count if hosts_count > 0 else 1,
             "top_tools": top_tools,
             "top_hosts": [{"host": h, "count": 0} for h in hosts][:5] if hosts else [],
             "total_sessions": total_sessions,

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -324,9 +324,7 @@ class UsageService:
             List[Dict]: List of usage records by date and tool.
         """
         # 1. Get trend data from daily_stats (CLI fetch scripts data)
-        dm_trend = self.usage_repo.get_daily_by_tool(
-            start_date, end_date, host_name, tenant_id
-        )
+        dm_trend = self.usage_repo.get_daily_by_tool(start_date, end_date, host_name, tenant_id)
 
         # 2. Get trend data from agent_sessions (WebUI local/remote/terminal sessions)
         session_trend = self.usage_repo.get_session_trend_by_tool(

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -311,12 +311,52 @@ class UsageService:
         """
         Get usage trend data aggregated by date and tool.
 
+        Issue #3030: Merge daily_stats (CLI data) with agent_sessions (WebUI data)
+        to ensure trend charts include all session types.
+
         Args:
             start_date: Start date string (YYYY-MM-DD).
             end_date: End date string (YYYY-MM-DD).
             host_name: Optional host name filter.
+            tenant_id: Optional tenant ID filter.
 
         Returns:
             List[Dict]: List of usage records by date and tool.
         """
-        return self.usage_repo.get_daily_by_tool(start_date, end_date, host_name, tenant_id)
+        # 1. Get trend data from daily_stats (CLI fetch scripts data)
+        dm_trend = self.usage_repo.get_daily_by_tool(
+            start_date, end_date, host_name, tenant_id
+        )
+
+        # 2. Get trend data from agent_sessions (WebUI local/remote/terminal sessions)
+        session_trend = self.usage_repo.get_session_trend_by_tool(
+            start_date, end_date, host_name, tenant_id
+        )
+
+        # 3. Merge both data sources
+        merged: dict[tuple, dict] = {}
+        for entry in dm_trend:
+            key = (entry["date"], entry["tool_name"])
+            if key in merged:
+                merged[key]["tokens"] += entry.get("tokens", 0)
+            else:
+                merged[key] = {
+                    "date": entry["date"],
+                    "tool_name": entry["tool_name"],
+                    "tokens": entry.get("tokens", 0),
+                }
+
+        for entry in session_trend:
+            key = (entry["date"], entry["tool_name"])
+            if key in merged:
+                merged[key]["tokens"] += entry.get("tokens", 0)
+            else:
+                merged[key] = {
+                    "date": entry["date"],
+                    "tool_name": entry["tool_name"],
+                    "tokens": entry.get("tokens", 0),
+                }
+
+        # Sort by date, then by tool_name
+        result = sorted(merged.values(), key=lambda x: (x["date"], x["tool_name"]))
+        return result

--- a/tests/unit/test_analysis_batch.py
+++ b/tests/unit/test_analysis_batch.py
@@ -392,6 +392,15 @@ class TestSameSourceConsistency:
         self.usage_repo.get_daily_range.return_value = []
         self.message_repo.get_user_token_totals.return_value = []
         self.message_repo.get_tool_token_totals.return_value = []
+        # Issue #3030: Mock get_session_key_metrics for key_metrics
+        self.usage_repo.get_session_key_metrics.return_value = {
+            "total_tokens": 0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_requests": 0,
+            "unique_tools": 0,
+            "unique_hosts": 0,
+        }
 
         batch = self.service.get_batch_analysis("2026-05-01", "2026-05-23")
         conv = self.service.get_conversation_stats("2026-05-01", "2026-05-23")

--- a/tests/unit/test_analysis_service.py
+++ b/tests/unit/test_analysis_service.py
@@ -38,6 +38,15 @@ class TestAnalysisService:
                 "host_name": "h1",
             }
         ]
+        # Issue #3030: Mock the new session metrics method
+        mock_usage.get_session_key_metrics.return_value = {
+            "total_tokens": 0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_requests": 0,
+            "unique_tools": 0,
+            "unique_hosts": 0,
+        }
         mock_msg.get_user_token_totals.return_value = [
             {
                 "total_tokens": 1000,
@@ -62,6 +71,15 @@ class TestAnalysisService:
     def test_get_key_metrics_no_data(self):
         svc, mock_usage, mock_msg, _ = self._make_service()
         mock_usage.get_daily_range.return_value = []
+        # Issue #3030: Mock the new session metrics method
+        mock_usage.get_session_key_metrics.return_value = {
+            "total_tokens": 0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_requests": 0,
+            "unique_tools": 0,
+            "unique_hosts": 0,
+        }
         mock_msg.get_user_token_totals.return_value = []
         mock_msg.get_tool_token_totals.return_value = []
         mock_msg.get_conversation_stats_summary.return_value = {

--- a/tests/unit/test_issue_3030_trend_webui_sessions.py
+++ b/tests/unit/test_issue_3030_trend_webui_sessions.py
@@ -316,7 +316,12 @@ class TestGetKeyMetricsMerge:
         """Key metrics should include session tokens in totals."""
         svc, mock_usage_repo, mock_message_repo = self._make_service()
         mock_usage_repo.get_daily_range.return_value = [
-            {"tokens_used": 10000, "input_tokens": 8000, "output_tokens": 2000, "request_count": 50},
+            {
+                "tokens_used": 10000,
+                "input_tokens": 8000,
+                "output_tokens": 2000,
+                "request_count": 50,
+            },
         ]
         mock_message_repo.get_user_token_totals.return_value = []
         mock_message_repo.get_tool_token_totals.return_value = []

--- a/tests/unit/test_issue_3030_trend_webui_sessions.py
+++ b/tests/unit/test_issue_3030_trend_webui_sessions.py
@@ -1,0 +1,390 @@
+"""Tests for Issue #3030: Token趋势图表选择7天时无数据，但汇总数据显示正常
+
+Verifies that:
+1. get_session_trend_by_tool() queries agent_sessions with workspace_type filter
+2. get_session_key_metrics() queries agent_sessions for key metrics
+3. get_trend_data() merges both daily_stats and agent_sessions
+4. get_key_metrics() merges session data into totals
+5. Edge cases: empty data, host_name filter, tenant_id filter, date filters
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.repositories.usage_repo import UsageRepository
+from app.services.analysis_service import AnalysisService
+from app.services.usage_service import UsageService
+from app.utils.cache import get_cache
+
+
+def _make_repo(db):
+    repo = UsageRepository()
+    repo.db = db
+    return repo
+
+
+class TestGetSessionTrendByTool:
+    """Test the new get_session_trend_by_tool method."""
+
+    def test_queries_agent_sessions_table(self):
+        """Must query agent_sessions, not daily_stats."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "FROM agent_sessions" in sql
+        assert "daily_stats" not in sql
+
+    def test_filters_workspace_type(self):
+        """Must filter to workspace_type IN ('local', 'remote', 'terminal')."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+
+        sql = db.fetch_all.call_args[0][0]
+        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
+
+    def test_returns_empty_on_exception(self):
+        """Should return empty list on error, not raise."""
+        db = MagicMock()
+        db.fetch_all.side_effect = Exception("DB error")
+        repo = _make_repo(db)
+
+        result = repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+        assert result == []
+
+    def test_normalizes_tool_name(self):
+        """Results should be keyed by normalized tool name."""
+        db = MagicMock()
+        db.fetch_all.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen-code", "tokens": 5000},
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+
+        assert len(result) == 1
+        assert result[0]["tool_name"] == "qwen"  # normalize_tool_name("qwen-code") -> "qwen"
+        assert result[0]["tokens"] == 5000
+
+    def test_merges_duplicate_tool_names(self):
+        """Multiple rows with different tool_name variants should merge after normalization."""
+        db = MagicMock()
+        db.fetch_all.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen-code", "tokens": 1000},
+            {"date": "2026-08-01", "tool_name": "qwen-code-cli", "tokens": 2000},
+        ]
+        repo = _make_repo(db)
+
+        result = repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+
+        # Both normalize to "qwen", same date, should merge
+        assert len(result) == 1
+        assert result[0]["tokens"] == 3000
+
+    def test_date_filters_applied(self):
+        """start_date and end_date should be applied to CAST(created_at AS DATE)."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_trend_by_tool("2026-08-01", "2026-08-31")
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "CAST(created_at AS DATE) >= ?" in sql
+        assert "CAST(created_at AS DATE) <= ?" in sql
+        assert "2026-08-01" in params
+        assert "2026-08-31" in params
+
+    def test_host_name_filter_applied(self):
+        """host_name should be applied as a filter."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_trend_by_tool("2026-08-01", "2026-08-31", host_name="my-host")
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "host_name = ?" in sql
+        assert "my-host" in params
+
+    def test_tenant_id_filter_applied(self):
+        """tenant_id should be applied as a filter."""
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        repo = _make_repo(db)
+
+        repo.get_session_trend_by_tool("2026-08-01", "2026-08-31", tenant_id=42)
+
+        sql = db.fetch_all.call_args[0][0]
+        params = db.fetch_all.call_args[0][1]
+        assert "tenant_id = ?" in sql
+        assert 42 in params
+
+
+class TestGetSessionKeyMetrics:
+    """Test the new get_session_key_metrics method."""
+
+    def test_queries_agent_sessions_table(self):
+        """Must query agent_sessions, not daily_messages."""
+        db = MagicMock()
+        db.fetch_one.return_value = {
+            "total_tokens": 10000,
+            "total_input_tokens": 8000,
+            "total_output_tokens": 2000,
+            "total_requests": 100,
+            "unique_tools": 3,
+            "unique_hosts": 2,
+        }
+        repo = _make_repo(db)
+
+        repo.get_session_key_metrics("2026-08-01", "2026-08-31")
+
+        sql = db.fetch_one.call_args[0][0]
+        assert "FROM agent_sessions" in sql
+        assert "daily_messages" not in sql
+
+    def test_filters_workspace_type(self):
+        """Must filter to workspace_type IN ('local', 'remote', 'terminal')."""
+        db = MagicMock()
+        db.fetch_one.return_value = {}
+        repo = _make_repo(db)
+
+        repo.get_session_key_metrics("2026-08-01", "2026-08-31")
+
+        sql = db.fetch_one.call_args[0][0]
+        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
+
+    def test_returns_empty_on_exception(self):
+        """Should return empty dict on error, not raise."""
+        db = MagicMock()
+        db.fetch_one.side_effect = Exception("DB error")
+        repo = _make_repo(db)
+
+        result = repo.get_session_key_metrics("2026-08-01", "2026-08-31")
+        assert result["total_tokens"] == 0
+        assert result["total_requests"] == 0
+
+    def test_aggregates_tokens_and_requests(self):
+        """Should aggregate total_tokens, input/output, and requests."""
+        db = MagicMock()
+        db.fetch_one.return_value = {
+            "total_tokens": 15000,
+            "total_input_tokens": 12000,
+            "total_output_tokens": 3000,
+            "total_requests": 150,
+            "unique_tools": 5,
+            "unique_hosts": 3,
+        }
+        repo = _make_repo(db)
+
+        result = repo.get_session_key_metrics("2026-08-01", "2026-08-31")
+
+        assert result["total_tokens"] == 15000
+        assert result["total_input_tokens"] == 12000
+        assert result["total_output_tokens"] == 3000
+        assert result["total_requests"] == 150
+        assert result["unique_tools"] == 5
+        assert result["unique_hosts"] == 3
+
+
+class TestGetTrendDataMerge:
+    """Test that get_trend_data merges both data sources."""
+
+    def _make_service(self):
+        mock_repo = MagicMock()
+        svc = UsageService(usage_repo=mock_repo)
+        return svc, mock_repo
+
+    def setup_method(self):
+        get_cache().clear()
+
+    def test_merges_daily_stats_and_session_data(self):
+        """Trend should include data from both daily_stats and agent_sessions."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "claude", "tokens": 10000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 2
+        tools = {r["tool_name"] for r in result}
+        assert "claude" in tools
+        assert "qwen" in tools
+
+    def test_merges_same_tool_from_both_sources(self):
+        """When the same tool appears in both sources, tokens should be summed."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 10000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 1
+        assert result[0]["tokens"] == 15000
+
+    def test_empty_both_sources(self):
+        """When both sources return empty, result should be empty list."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = []
+        mock_repo.get_session_trend_by_tool.return_value = []
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+        assert result == []
+
+    def test_only_daily_stats_data(self):
+        """When agent_sessions has no data, result should be daily_stats only."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 10000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = []
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 1
+        assert result[0]["tokens"] == 10000
+
+    def test_only_session_data(self):
+        """When daily_stats has no data, result should be session data only."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = []
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 1
+        assert result[0]["tokens"] == 5000
+
+    def test_passes_filters_to_both_repos(self):
+        """All filter parameters should be passed to both repo methods."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = []
+        mock_repo.get_session_trend_by_tool.return_value = []
+
+        svc.get_trend_data(
+            "2026-08-01",
+            "2026-08-31",
+            host_name="my-host",
+            tenant_id=42,
+        )
+
+        mock_repo.get_daily_by_tool.assert_called_once_with(
+            "2026-08-01", "2026-08-31", "my-host", 42
+        )
+        mock_repo.get_session_trend_by_tool.assert_called_once_with(
+            "2026-08-01", "2026-08-31", "my-host", 42
+        )
+
+
+class TestGetKeyMetricsMerge:
+    """Test that get_key_metrics merges session data into totals."""
+
+    def _make_service(self):
+        mock_usage_repo = MagicMock()
+        mock_message_repo = MagicMock()
+        mock_daily_stats_repo = MagicMock()
+        svc = AnalysisService(
+            usage_repo=mock_usage_repo,
+            message_repo=mock_message_repo,
+            daily_stats_repo=mock_daily_stats_repo,
+        )
+        return svc, mock_usage_repo, mock_message_repo
+
+    def setup_method(self):
+        get_cache().clear()
+
+    def test_merges_session_tokens_into_totals(self):
+        """Key metrics should include session tokens in totals."""
+        svc, mock_usage_repo, mock_message_repo = self._make_service()
+        mock_usage_repo.get_daily_range.return_value = [
+            {"tokens_used": 10000, "input_tokens": 8000, "output_tokens": 2000, "request_count": 50},
+        ]
+        mock_message_repo.get_user_token_totals.return_value = []
+        mock_message_repo.get_tool_token_totals.return_value = []
+        mock_message_repo.get_conversation_stats_summary.return_value = {}
+        mock_usage_repo.get_session_key_metrics.return_value = {
+            "total_tokens": 5000,
+            "total_input_tokens": 4000,
+            "total_output_tokens": 1000,
+            "total_requests": 20,
+            "unique_tools": 3,
+            "unique_hosts": 2,
+        }
+
+        result = svc.get_key_metrics("2026-08-01", "2026-08-31")
+
+        # 10000 + 5000 = 15000
+        assert result["total_tokens"] == 15000
+        assert result["total_input_tokens"] == 12000
+        assert result["total_output_tokens"] == 3000
+        assert result["total_requests"] == 70
+
+    def test_session_data_only(self):
+        """When daily_messages is empty, session data should still be included."""
+        svc, mock_usage_repo, mock_message_repo = self._make_service()
+        mock_usage_repo.get_daily_range.return_value = []
+        mock_message_repo.get_user_token_totals.return_value = []
+        mock_message_repo.get_tool_token_totals.return_value = []
+        mock_message_repo.get_conversation_stats_summary.return_value = {}
+        mock_usage_repo.get_session_key_metrics.return_value = {
+            "total_tokens": 5000,
+            "total_input_tokens": 4000,
+            "total_output_tokens": 1000,
+            "total_requests": 20,
+            "unique_tools": 3,
+            "unique_hosts": 2,
+        }
+
+        result = svc.get_key_metrics("2026-08-01", "2026-08-31")
+
+        assert result["total_tokens"] == 5000
+        assert result["total_requests"] == 20
+
+    def test_passes_filters_to_session_repo(self):
+        """All filter parameters should be passed to get_session_key_metrics."""
+        svc, mock_usage_repo, mock_message_repo = self._make_service()
+        mock_usage_repo.get_daily_range.return_value = []
+        mock_message_repo.get_user_token_totals.return_value = []
+        mock_message_repo.get_tool_token_totals.return_value = []
+        mock_message_repo.get_conversation_stats_summary.return_value = {}
+        mock_usage_repo.get_session_key_metrics.return_value = {
+            "total_tokens": 0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_requests": 0,
+            "unique_tools": 0,
+            "unique_hosts": 0,
+        }
+
+        svc.get_key_metrics(
+            start_date="2026-08-01",
+            end_date="2026-08-31",
+            host_name="my-host",
+            tenant_id=42,
+        )
+
+        mock_usage_repo.get_session_key_metrics.assert_called_once_with(
+            start_date="2026-08-01",
+            end_date="2026-08-31",
+            host_name="my-host",
+            tenant_id=42,
+        )


### PR DESCRIPTION
Closes #3030

## 问题分析

Issue #2938 修复了 `/api/summary` 合并 `agent_sessions` 数据，但 `/api/trend` 和 `/api/analysis/batch` (key_metrics) 未同步修复，导致：

1. Dashboard 趋势图表缺失 WebUI 会话数据
2. TrendAnalysis 页面 key_metrics 缺失 WebUI 会话数据
3. 用户看到不同页面数据不一致

## 修复内容

| API | 数据来源 | 修复前 | 修复后 |
|-----|----------|--------|--------|
| `/api/trend` | `daily_stats` + `agent_sessions` | ❌ 缺失 | ✅ 包含 |
| `/api/analysis/batch` (key_metrics) | `daily_messages` + `agent_sessions` | ❌ 缺失 | ✅ 包含 |

## 代码变更

- `app/repositories/usage_repo.py`：新增 `get_session_trend_by_tool()`, `get_session_key_metrics()`
- `app/services/usage_service.py`：修改 `get_trend_data()` 合并数据源
- `app/services/analysis_service.py`：修改 `get_key_metrics()` 合并数据源
- `tests/unit/test_issue_3030_trend_webui_sessions.py`：新增单元测试

## 测试覆盖

- 21 个单元测试全部通过
- 参考 `test_issue_2938_summary_webui_sessions.py` 的测试模式

## 修复方案

详见 Issue 评论中的方案协作记录。

Generated with Qwen Code