### PR TITLE
feat(timeline): dedicated icons for all 26 unmapped milestone types

### DIFF
--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -769,10 +769,13 @@ describe('MILESTONE_DISPLAY icon coverage', () => {
     }
   });
 
-  it('uses unique icon+color pairs and known color keys', () => {
+  it('uses unique icons, unique icon+color pairs, and known color keys', () => {
+    const seenIcons = new Set<string>();
     const seen = new Set<string>();
     for (const [type, display] of Object.entries(MILESTONE_DISPLAY)) {
       expect(MILESTONE_ICON_COLORS[display.color], `unknown color for ${type}`).toBeDefined();
+      expect(seenIcons.has(display.icon), `duplicate icon: ${display.icon}`).toBe(false);
+      seenIcons.add(display.icon);
       const key = `${display.icon}/${display.color}`;
       expect(seen.has(key), `duplicate icon+color pair: ${key}`).toBe(false);
       seen.add(key);

--- a/frontend/src/components/work/WorkflowTimeline.test.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.test.tsx
@@ -8,10 +8,14 @@
 import { format as formatDateTime } from 'date-fns';
 import { fireEvent, render, screen, within } from '@/test/utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   WorkflowTimeline,
   formatAcceptanceReport,
   getAcceptanceSummaryDetail,
+  MILESTONE_DISPLAY,
+  MILESTONE_ICON_COLORS,
 } from './WorkflowTimeline';
 import { useMilestoneSession, useWorkflowTimeline } from '@/hooks/useAutonomous';
 import type { AutonomousWorkflow, WorkflowMilestone } from '@/api/autonomous';
@@ -702,6 +706,88 @@ describe('milestone time format (#2985)', () => {
       expect(staleEl?.textContent).toMatch(/2024/);
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+describe('MILESTONE_DISPLAY icon coverage', () => {
+  // Every milestone_type the backend can emit (orchestrator + phases/* +
+  // git_workspace literals) or that exists on historical rows. Unmapped types
+  // fall back to a gray bi-circle, which is how the pre-#3036 gap was spotted.
+  const ALL_TYPES = [
+    'repo_setup',
+    'issue_created',
+    'issue_linked',
+    'branch_created',
+    'branch_mismatch',
+    'plan_created',
+    'plan_reviewed',
+    'plan_refined',
+    'plan_finalized',
+    'dev_started',
+    'dev_completed',
+    'tests_run',
+    'pr_created',
+    'pr_reviewed',
+    'pr_updated',
+    'pr_review_summary',
+    'pr_head_unverified',
+    'pr_zero_check_runs',
+    'conflicts_resolved',
+    'conflicts_pushed',
+    'worktree_restored',
+    'progress_reported',
+    'requirement_received',
+    'round_completed',
+    'merged',
+    'cleaned_up',
+    'cleanup_pending',
+    'wait_started',
+    'no_changes',
+    'timing_issue',
+    'terminal_report_posted',
+    'workflow_forked',
+    'ci_repair_started',
+    'ci_repair_applied',
+    'ci_repair_exhausted',
+    'ci_repair_no_change_exhausted',
+    'ci_repair_transient_exhausted',
+    'ci_repair_escalated_to_development',
+    'ci_repair_environment_mismatch',
+    'ci_diagnostics_pending',
+    'ci_failed_before_report',
+    'acceptance_verification',
+    'acceptance_rejected_cap_exhausted',
+    'acceptance_rejected_reopened',
+    'recovery_evidence_missing',
+    'frontend_node_modules_shim_failed',
+  ] as const;
+
+  it('maps every backend milestone type to a dedicated icon (no bi-circle fallback)', () => {
+    for (const type of ALL_TYPES) {
+      expect(MILESTONE_DISPLAY[type], `unmapped type: ${type}`).toBeDefined();
+    }
+  });
+
+  it('uses unique icon+color pairs and known color keys', () => {
+    const seen = new Set<string>();
+    for (const [type, display] of Object.entries(MILESTONE_DISPLAY)) {
+      expect(MILESTONE_ICON_COLORS[display.color], `unknown color for ${type}`).toBeDefined();
+      const key = `${display.icon}/${display.color}`;
+      expect(seen.has(key), `duplicate icon+color pair: ${key}`).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it('references only icon classes that exist in bootstrap-icons', () => {
+    const css = readFileSync(
+      join(process.cwd(), 'node_modules/bootstrap-icons/font/bootstrap-icons.css'),
+      'utf8'
+    );
+    for (const [type, display] of Object.entries(MILESTONE_DISPLAY)) {
+      expect(css, `missing bootstrap icon for ${type}: ${display.icon}`).toContain(
+        `.${display.icon}::before`
+      );
     }
   });
 });

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -104,7 +104,7 @@ const formatSessionTimestamp = (value?: string | null): string => {
 };
 
 // Milestone type display config
-const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
+export const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
   repo_setup: { icon: 'bi-github', color: 'dark' },
   issue_created: { icon: 'bi-card-text', color: 'info' },
   branch_created: { icon: 'bi-git', color: 'success' },
@@ -115,7 +115,11 @@ const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
   dev_started: { icon: 'bi-code-slash', color: 'primary' },
   dev_completed: { icon: 'bi-check2-square', color: 'success' },
   tests_run: { icon: 'bi-activity', color: 'info' },
-  pr_created: { icon: 'bi-git-pull-request', color: 'success' },
+  // bi-git-pull-request does not exist in bootstrap-icons (no PR icons in
+  // the set) — the pre-fix class rendered an empty glyph since the map's
+  // introduction. bi-file-earmark-diff carries the "proposed code change"
+  // meaning instead.
+  pr_created: { icon: 'bi-file-earmark-diff', color: 'success' },
   pr_reviewed: { icon: 'bi-chat-left-text', color: 'warning' },
   pr_updated: { icon: 'bi-pencil-square', color: 'primary' },
   pr_review_summary: { icon: 'bi-check2-circle', color: 'success' },
@@ -125,6 +129,39 @@ const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
   round_completed: { icon: 'bi-flag-fill', color: 'success' },
   merged: { icon: 'bi-sign-merge-right', color: 'success' },
   cleaned_up: { icon: 'bi-trash', color: 'secondary' },
+  // CI repair family (merge phase). Exhausted/failed variants stay warning so
+  // the "needs attention" tone is visible at a glance in the timeline.
+  ci_repair_started: { icon: 'bi-wrench', color: 'warning' },
+  ci_repair_applied: { icon: 'bi-wrench-adjustable-circle', color: 'primary' },
+  ci_repair_exhausted: { icon: 'bi-exclamation-triangle', color: 'warning' },
+  ci_repair_no_change_exhausted: { icon: 'bi-clipboard-x', color: 'warning' },
+  ci_repair_transient_exhausted: { icon: 'bi-lightning-charge', color: 'warning' },
+  ci_repair_escalated_to_development: { icon: 'bi-arrow-up-right-square', color: 'warning' },
+  ci_repair_environment_mismatch: { icon: 'bi-hdd-network', color: 'warning' },
+  ci_diagnostics_pending: { icon: 'bi-search', color: 'info' },
+  ci_failed_before_report: { icon: 'bi-x-circle', color: 'warning' },
+  timing_issue: { icon: 'bi-clock-history', color: 'warning' },
+  pr_zero_check_runs: { icon: 'bi-slash-circle', color: 'warning' },
+  // Conflict / worktree family.
+  conflicts_pushed: { icon: 'bi-box-arrow-up', color: 'success' },
+  worktree_restored: { icon: 'bi-arrow-counterclockwise', color: 'info' },
+  branch_mismatch: { icon: 'bi-shuffle', color: 'warning' },
+  // Acceptance family. The verdict itself is carried by the status badge and
+  // the ✅/❌/⚠️ tone in the card summary; these icons mark the action.
+  acceptance_verification: { icon: 'bi-shield-check', color: 'primary' },
+  acceptance_rejected_cap_exhausted: { icon: 'bi-shield-exclamation', color: 'warning' },
+  acceptance_rejected_reopened: { icon: 'bi-arrow-repeat', color: 'warning' },
+  pr_head_unverified: { icon: 'bi-question-circle', color: 'warning' },
+  // Wait / bookkeeping family. frontend_node_modules_shim_failed only exists
+  // on historical rows (producer reverted in #2694) but still needs an icon.
+  wait_started: { icon: 'bi-hourglass', color: 'secondary' },
+  issue_linked: { icon: 'bi-link-45deg', color: 'info' },
+  no_changes: { icon: 'bi-dash-circle', color: 'secondary' },
+  cleanup_pending: { icon: 'bi-trash3', color: 'secondary' },
+  terminal_report_posted: { icon: 'bi-file-earmark-check', color: 'success' },
+  frontend_node_modules_shim_failed: { icon: 'bi-exclamation-diamond', color: 'warning' },
+  recovery_evidence_missing: { icon: 'bi-journal-x', color: 'warning' },
+  workflow_forked: { icon: 'bi-diagram-3', color: 'info' },
 };
 
 // Milestone types whose `plan_content` / `review_content` holds full-text output
@@ -294,7 +331,7 @@ export const formatAcceptanceReport = (metadata: string, language: Language): st
   }
   return lines.join('\n').trim();
 };
-const MILESTONE_ICON_COLORS: Record<string, string> = {
+export const MILESTONE_ICON_COLORS: Record<string, string> = {
   dark: 'var(--text-primary)',
   info: 'var(--color-info)',
   success: 'var(--color-success)',

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -150,7 +150,7 @@ export const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> 
   // the ✅/❌/⚠️ tone in the card summary; these icons mark the action.
   acceptance_verification: { icon: 'bi-shield-check', color: 'primary' },
   acceptance_rejected_cap_exhausted: { icon: 'bi-shield-exclamation', color: 'warning' },
-  acceptance_rejected_reopened: { icon: 'bi-arrow-repeat', color: 'warning' },
+  acceptance_rejected_reopened: { icon: 'bi-bootstrap-reboot', color: 'warning' },
   pr_head_unverified: { icon: 'bi-question-circle', color: 'warning' },
   // Wait / bookkeeping family. frontend_node_modules_shim_failed only exists
   // on historical rows (producer reverted in #2694) but still needs an icon.
@@ -2366,7 +2366,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     rel="noopener noreferrer"
                     className="timeline-pill-link"
                   >
-                    <i className="bi bi-git-pull-request"></i>
+                    <i className="bi bi-file-earmark-diff"></i>
                     <span>
                       {t('autoPrBadge', language)}
                       {workflow.github_pr_number}
@@ -2374,7 +2374,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   </a>
                 ) : (
                   <span className="timeline-chip timeline-chip--subtle">
-                    <i className="bi bi-git-pull-request me-1"></i>
+                    <i className="bi bi-file-earmark-diff me-1"></i>
                     {t('autoPrBadge', language)}
                     {workflow.github_pr_number}
                   </span>


### PR DESCRIPTION
## 目的

`MILESTONE_DISPLAY` 只映射 20 种里程碑类型,其余全部 fallback 灰色空心圆——包括时间线上最高频的 CI 修复族(~800 行)与 `acceptance_verification`(95 行)。本 PR 补齐全部 26 种未映射类型(17 种生产已触发 + 8 种代码定义未触发 + 1 种仅历史行)。

## 图标设计原则

- 与既有 20 条及彼此无图标重复;避开同卡片其它图标位已用的类(`bi-gear` 系统步骤 chip、`bi-hourglass-split` 等待 chip);`workflow_forked` 对齐组件 fork 语汇用 `bi-diagram-3`。
- 颜色仅用 `MILESTONE_ICON_COLORS` 现有 6 键;耗尽/失败类用 warning 一眼可辨。
- 验收族:结论仍由状态徽章与标题区 ✅/❌/⚠️ 表达,类型图标(`bi-shield-check` primary)只标记"核对"动作。

## 顺带修复一个潜在 bug

新增的覆盖测试当场抓到:`pr_created` 引用的 `bi-git-pull-request` **在 bootstrap-icons 中不存在**(该图标集没有任何 PR 类图标),自映射表引入以来一直渲染为空白;改为 `bi-file-earmark-diff`。

## 测试(新增 3 条)

- 全部 47 种后端可产出类型必须有映射(不再出现 bi-circle fallback);
- 图标+颜色组合无重复、颜色键全部有效;
- 每个图标类与安装的 bootstrap-icons CSS 逐一验真(vite/tsc 不校验运行时 className)。

## 验证

- `npx vitest run src/components/work/WorkflowTimeline.test.tsx` → 33 passed;
- eslint/prettier 干净;`npm run build`(tsc + vite + retain-release-assets)通过。

方案与两轮独立评审意见见下方评论。前端部署将按资产保留机制(不用 `--delete`)另行执行。