### PR TITLE
fix(autonomous): forward scheduler SSE events to web process ingest (#3046)

### DIFF
--- a/app/modules/workspace/autonomous/event_emitter.py
+++ b/app/modules/workspace/autonomous/event_emitter.py
@@ -40,6 +40,7 @@ FORWARD_BATCH_MAX_ITEMS = 50
 FORWARD_BATCH_MAX_BYTES = 512 * 1024
 FORWARD_EVENT_MAX_BYTES = 256 * 1024
 FORWARD_EVENT_TTL_SECONDS = 60.0
+FORWARD_BUFFER_MAX_BYTES_TOTAL = 8 * 1024 * 1024
 FORWARD_BACKOFF_START = 1.0
 FORWARD_BACKOFF_MAX = 5.0
 
@@ -74,6 +75,7 @@ class AutonomousEventEmitter:
         self._forward_url: str | None = None
         self._forward_secret: str = ""
         self._forward_buffer: list[tuple[float, str, int]] = []  # (ts, json, bytes)
+        self._forward_buffer_bytes = 0
         self._forward_lock = threading.Lock()
         self._forward_thread: threading.Thread | None = None
         self._forward_stop = threading.Event()
@@ -184,6 +186,16 @@ class AutonomousEventEmitter:
                 self._forward_thread.start()
         return True
 
+    def disable_remote_forwarding(self) -> None:
+        """Stop forwarding and drop buffered events (tests, shutdown)."""
+        with self._forward_lock:
+            self._forward_url = None
+            self._forward_secret = ""
+            self._forward_buffer = []
+            self._forward_buffer_bytes = 0
+        self._forward_stop.set()
+        self._forward_wakeup.set()
+
     def _forward_enqueue(self, event_payload: dict) -> None:
         """Queue an event for the sender thread. Bounded, never raises."""
         try:
@@ -199,15 +211,23 @@ class AutonomousEventEmitter:
                 )
                 return
             with self._forward_lock:
-                if len(self._forward_buffer) >= FORWARD_BUFFER_MAX_EVENTS:
-                    self._forward_buffer.pop(0)
+                while (
+                    len(self._forward_buffer) >= FORWARD_BUFFER_MAX_EVENTS
+                    or self._forward_buffer_bytes + size > FORWARD_BUFFER_MAX_BYTES_TOTAL
+                ):
+                    if not self._forward_buffer:
+                        break
+                    _dropped_ts, _dropped_blob, dropped_size = self._forward_buffer.pop(0)
+                    self._forward_buffer_bytes -= dropped_size
                     _ratelimited_log(
                         "forward_overflow",
                         logging.WARNING,
-                        "Forward buffer full (%d), dropping oldest event",
+                        "Forward buffer full (%d events / %d bytes), dropping oldest event",
                         FORWARD_BUFFER_MAX_EVENTS,
+                        FORWARD_BUFFER_MAX_BYTES_TOTAL,
                     )
                 self._forward_buffer.append((time.time(), blob, size))
+                self._forward_buffer_bytes += size
             self._forward_wakeup.set()
         except Exception as exc:
             # Delivery is best-effort realtime data; the local broadcast above
@@ -243,6 +263,7 @@ class AutonomousEventEmitter:
                     int(FORWARD_EVENT_TTL_SECONDS),
                 )
             self._forward_buffer = kept
+            self._forward_buffer_bytes = sum(entry[2] for entry in kept)
             batch: list[tuple[float, str, int]] = []
             total = 0
             while self._forward_buffer and len(batch) < FORWARD_BATCH_MAX_ITEMS:
@@ -251,15 +272,23 @@ class AutonomousEventEmitter:
                     break
                 batch.append(self._forward_buffer.pop(0))
                 total += candidate[2]
+                self._forward_buffer_bytes -= candidate[2]
             return batch
 
     def _forward_requeue(self, batch: list[tuple[float, str, int]]) -> None:
         """Return an undelivered batch to the front without evicting newer events."""
         with self._forward_lock:
             merged = list(batch) + self._forward_buffer
-            if len(merged) > FORWARD_BUFFER_MAX_EVENTS:
-                dropped = len(merged) - FORWARD_BUFFER_MAX_EVENTS
-                merged = merged[-FORWARD_BUFFER_MAX_EVENTS:]
+            dropped = 0
+            while (
+                len(merged) > FORWARD_BUFFER_MAX_EVENTS
+                or sum(entry[2] for entry in merged) > FORWARD_BUFFER_MAX_BYTES_TOTAL
+            ):
+                if not merged:
+                    break
+                merged.pop(0)
+                dropped += 1
+            if dropped:
                 _ratelimited_log(
                     "forward_requeue_drop",
                     logging.WARNING,
@@ -267,6 +296,7 @@ class AutonomousEventEmitter:
                     dropped,
                 )
             self._forward_buffer = merged
+            self._forward_buffer_bytes = sum(entry[2] for entry in merged)
 
     def _forward_post(self, batch: list[tuple[float, str, int]]) -> None:
         import requests
@@ -274,13 +304,22 @@ class AutonomousEventEmitter:
         from app.modules.workspace.autonomous.events_ingest import INGEST_SECRET_HEADER
 
         url = self._forward_url
-        if url is None:  # forwarding disabled between loop iterations
+        if url is None:  # disable_remote_forwarding() raced us
             return
         events = [json.loads(blob) for _ts, blob, _size in batch]
+        # Serialize ourselves with ensure_ascii=False: requests' json= helper
+        # re-serializes with ensure_ascii=True, inflating CJK (2x) and emoji
+        # (3x) payloads on the wire beyond the byte caps the buffer accounts
+        # for — exactly the large non-ASCII activity events this pipe exists
+        # to deliver. data= keeps wire bytes == accounted bytes.
+        body = json.dumps({"events": events}, ensure_ascii=False).encode("utf-8")
         response = requests.post(
             url,
-            json={"events": events},
-            headers={INGEST_SECRET_HEADER: self._forward_secret},
+            data=body,
+            headers={
+                INGEST_SECRET_HEADER: self._forward_secret,
+                "Content-Type": "application/json",
+            },
             timeout=2,
         )
         if response.status_code >= 400:
@@ -304,18 +343,20 @@ class AutonomousEventEmitter:
     def _forward_loop(self) -> None:
         backoff = FORWARD_BACKOFF_START
         while not self._forward_stop.is_set():
-            batch = self._forward_take_batch()
-            if not batch:
-                self._forward_wakeup.wait(0.25)
-                self._forward_wakeup.clear()
-                continue
+            batch: list[tuple[float, str, int]] = []
             try:
+                batch = self._forward_take_batch()
+                if not batch:
+                    self._forward_wakeup.wait(0.25)
+                    self._forward_wakeup.clear()
+                    continue
                 self._forward_post(batch)
                 backoff = FORWARD_BACKOFF_START
             except Exception as exc:
                 # Connection-type failure (web restarting): retry the batch
                 # after backoff. At-least-once — see module docstring.
-                self._forward_requeue(batch)
+                if batch:
+                    self._forward_requeue(batch)
                 _ratelimited_log(
                     "forward_conn_error",
                     logging.ERROR,

--- a/app/modules/workspace/autonomous/event_emitter.py
+++ b/app/modules/workspace/autonomous/event_emitter.py
@@ -7,6 +7,7 @@ Uses an in-process queue per subscriber for push-based notifications.
 Includes TTL-based cleanup to prevent memory leaks from disconnected clients.
 """
 
+import json
 import logging
 import queue
 import threading
@@ -30,6 +31,29 @@ SUBSCRIBER_TTL_SECONDS = 300  # 5 minutes
 ACTIVITY_HISTORY_MAX_ITEMS = 50
 ACTIVITY_HISTORY_TTL_SECONDS = 15 * 60
 
+# ── Cross-process forwarding (scheduler → web SSE ingest) ──────────────
+# Bounds keep the pipe predictable under a busy agent: a bounded buffer with
+# drop-oldest, byte+count capped batches (so a batch can never exceed the
+# ingest route's body limit), and a 60s staleness cut for realtime-only data.
+FORWARD_BUFFER_MAX_EVENTS = 1000
+FORWARD_BATCH_MAX_ITEMS = 50
+FORWARD_BATCH_MAX_BYTES = 512 * 1024
+FORWARD_EVENT_MAX_BYTES = 256 * 1024
+FORWARD_EVENT_TTL_SECONDS = 60.0
+FORWARD_BACKOFF_START = 1.0
+FORWARD_BACKOFF_MAX = 5.0
+
+_RATE_LIMITED_LOG_INTERVAL = 60.0
+_last_ratelimited_log: dict[str, float] = {}
+
+
+def _ratelimited_log(key: str, level: int, msg: str, *args) -> None:
+    """Log at most once per interval per key (forwarder failure chatter)."""
+    now = time.time()
+    if now - _last_ratelimited_log.get(key, 0.0) >= _RATE_LIMITED_LOG_INTERVAL:
+        _last_ratelimited_log[key] = now
+        logger.log(level, msg, *args)
+
 
 class AutonomousEventEmitter:
     """Singleton that manages SSE subscriptions and event broadcasting."""
@@ -45,6 +69,15 @@ class AutonomousEventEmitter:
         self._emit_lock = threading.Lock()
         self._cleanup_thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # Cross-process forwarding state (scheduler process only; see
+        # enable_remote_forwarding for why it must never self-enable).
+        self._forward_url: str | None = None
+        self._forward_secret: str = ""
+        self._forward_buffer: list[tuple[float, str, int]] = []  # (ts, json, bytes)
+        self._forward_lock = threading.Lock()
+        self._forward_thread: threading.Thread | None = None
+        self._forward_stop = threading.Event()
+        self._forward_wakeup = threading.Event()
 
     @classmethod
     def instance(cls) -> "AutonomousEventEmitter":
@@ -121,6 +154,177 @@ class AutonomousEventEmitter:
                 q.put_nowait(event_payload)
             except queue.Full:
                 logger.warning("SSE queue full for workflow %s, dropping event", workflow_id[:8])
+
+        if self._forward_url is not None:
+            self._forward_enqueue(event_payload)
+
+    # ── Cross-process forwarding (scheduler → web SSE ingest) ──────────
+
+    def enable_remote_forwarding(self, url: str, secret: str) -> bool:
+        """Forward every emitted event to the web process's ingest route.
+
+        HARD CONSTRAINT: this is called ONLY from the scheduler worker's
+        startup sequence. It must never be self-enabled from an environment
+        variable inside the emitter or ``create_app``: a combined process
+        (``SCHEDULER_MODE=scheduler`` serving web too) would otherwise loop
+        ingest → emit → forward → ingest and amplify events forever.
+        """
+        if not url or not secret:
+            logger.error("Remote forwarding requires a non-empty url and secret")
+            return False
+        with self._forward_lock:
+            self._forward_url = url
+            self._forward_secret = secret
+            start_thread = self._forward_thread is None or not self._forward_thread.is_alive()
+            if start_thread:
+                self._forward_stop.clear()
+                self._forward_thread = threading.Thread(
+                    target=self._forward_loop, name="sse-event-forwarder", daemon=True
+                )
+                self._forward_thread.start()
+        return True
+
+    def _forward_enqueue(self, event_payload: dict) -> None:
+        """Queue an event for the sender thread. Bounded, never raises."""
+        try:
+            blob = json.dumps(event_payload, ensure_ascii=False, default=str)
+            size = len(blob.encode("utf-8"))
+            if size > FORWARD_EVENT_MAX_BYTES:
+                _ratelimited_log(
+                    "forward_oversize",
+                    logging.WARNING,
+                    "Dropping oversized forwarded event (%d bytes > %d)",
+                    size,
+                    FORWARD_EVENT_MAX_BYTES,
+                )
+                return
+            with self._forward_lock:
+                if len(self._forward_buffer) >= FORWARD_BUFFER_MAX_EVENTS:
+                    self._forward_buffer.pop(0)
+                    _ratelimited_log(
+                        "forward_overflow",
+                        logging.WARNING,
+                        "Forward buffer full (%d), dropping oldest event",
+                        FORWARD_BUFFER_MAX_EVENTS,
+                    )
+                self._forward_buffer.append((time.time(), blob, size))
+            self._forward_wakeup.set()
+        except Exception as exc:
+            # Delivery is best-effort realtime data; the local broadcast above
+            # already succeeded, so a forwarding failure must never propagate.
+            _ratelimited_log(
+                "forward_enqueue_error",
+                logging.WARNING,
+                "Failed to enqueue forwarded event: %s",
+                exc,
+            )
+
+    def _forward_take_batch(self) -> list[tuple[float, str, int]]:
+        """Pop the oldest pending events, capped by count AND bytes.
+
+        Items older than FORWARD_EVENT_TTL_SECONDS are dropped first — this is
+        the same "equivalent to today's behavior" degradation a split-container
+        deployment without an explicit ingest URL sees (the loopback URL is
+        valid but unreachable there, so events expire instead of piling up).
+        """
+        now = time.time()
+        with self._forward_lock:
+            kept = [
+                entry
+                for entry in self._forward_buffer
+                if now - entry[0] <= FORWARD_EVENT_TTL_SECONDS
+            ]
+            if len(kept) != len(self._forward_buffer):
+                _ratelimited_log(
+                    "forward_expired",
+                    logging.WARNING,
+                    "Dropped %d expired forwarded events (>%ds old)",
+                    len(self._forward_buffer) - len(kept),
+                    int(FORWARD_EVENT_TTL_SECONDS),
+                )
+            self._forward_buffer = kept
+            batch: list[tuple[float, str, int]] = []
+            total = 0
+            while self._forward_buffer and len(batch) < FORWARD_BATCH_MAX_ITEMS:
+                candidate = self._forward_buffer[0]
+                if batch and total + candidate[2] > FORWARD_BATCH_MAX_BYTES:
+                    break
+                batch.append(self._forward_buffer.pop(0))
+                total += candidate[2]
+            return batch
+
+    def _forward_requeue(self, batch: list[tuple[float, str, int]]) -> None:
+        """Return an undelivered batch to the front without evicting newer events."""
+        with self._forward_lock:
+            merged = list(batch) + self._forward_buffer
+            if len(merged) > FORWARD_BUFFER_MAX_EVENTS:
+                dropped = len(merged) - FORWARD_BUFFER_MAX_EVENTS
+                merged = merged[-FORWARD_BUFFER_MAX_EVENTS:]
+                _ratelimited_log(
+                    "forward_requeue_drop",
+                    logging.WARNING,
+                    "Dropped %d oldest events while requeuing undelivered batch",
+                    dropped,
+                )
+            self._forward_buffer = merged
+
+    def _forward_post(self, batch: list[tuple[float, str, int]]) -> None:
+        import requests
+
+        from app.modules.workspace.autonomous.events_ingest import INGEST_SECRET_HEADER
+
+        url = self._forward_url
+        if url is None:  # forwarding disabled between loop iterations
+            return
+        events = [json.loads(blob) for _ts, blob, _size in batch]
+        response = requests.post(
+            url,
+            json={"events": events},
+            headers={INGEST_SECRET_HEADER: self._forward_secret},
+            timeout=2,
+        )
+        if response.status_code >= 400:
+            # A retry would reproduce the same response (bad batch/auth/limit)
+            # and stall the pipe behind it — drop and keep flowing.
+            _ratelimited_log(
+                "forward_rejected",
+                logging.ERROR,
+                "Ingest endpoint rejected a %d-event batch (HTTP %d); dropping it",
+                len(batch),
+                response.status_code,
+            )
+            return
+        _ratelimited_log(
+            "forward_ok",
+            logging.INFO,
+            "Forwarded SSE events to ingest endpoint (batch of %d)",
+            len(batch),
+        )
+
+    def _forward_loop(self) -> None:
+        backoff = FORWARD_BACKOFF_START
+        while not self._forward_stop.is_set():
+            batch = self._forward_take_batch()
+            if not batch:
+                self._forward_wakeup.wait(0.25)
+                self._forward_wakeup.clear()
+                continue
+            try:
+                self._forward_post(batch)
+                backoff = FORWARD_BACKOFF_START
+            except Exception as exc:
+                # Connection-type failure (web restarting): retry the batch
+                # after backoff. At-least-once — see module docstring.
+                self._forward_requeue(batch)
+                _ratelimited_log(
+                    "forward_conn_error",
+                    logging.ERROR,
+                    "Ingest endpoint unreachable (%s); %d events requeued",
+                    exc,
+                    len(batch),
+                )
+                self._forward_stop.wait(backoff)
+                backoff = min(backoff * 2, FORWARD_BACKOFF_MAX)
 
     def _ensure_cleanup_thread_locked(self) -> None:
         """Start the cleanup worker. Caller must hold ``_emit_lock``."""

--- a/app/modules/workspace/autonomous/event_emitter.py
+++ b/app/modules/workspace/autonomous/event_emitter.py
@@ -177,7 +177,14 @@ class AutonomousEventEmitter:
         with self._forward_lock:
             self._forward_url = url
             self._forward_secret = secret
-            start_thread = self._forward_thread is None or not self._forward_thread.is_alive()
+            # is_set() covers disable→quick-enable: the old thread may still
+            # be alive while winding down, but with the stop flag set — reuse
+            # would leave forwarding "enabled" with no live sender.
+            start_thread = (
+                self._forward_thread is None
+                or not self._forward_thread.is_alive()
+                or self._forward_stop.is_set()
+            )
             if start_thread:
                 self._forward_stop.clear()
                 self._forward_thread = threading.Thread(

--- a/app/modules/workspace/autonomous/events_ingest.py
+++ b/app/modules/workspace/autonomous/events_ingest.py
@@ -41,23 +41,36 @@ _LOOPBACK_ADDRS = frozenset({"127.0.0.1", "::1", "::ffff:127.0.0.1"})
 def resolve_ingest_secret() -> str:
     """Resolve the shared ingest secret identically in both processes.
 
-    Priority: dedicated ``server.events_ingest_key`` > ``SECRET_KEY`` env >
-    root-level ``secret_key`` in config.json. ``get_secret_key()`` from
-    scripts.shared.config is deliberately NOT used: it returns None when the
-    SECRET_KEY env var is set ("don't override the operator"), which would
-    make the two sides resolve different values and 403 forever. An empty
-    result must disable forwarding / return 503 from the route (fail-closed).
+    Priority: dedicated ``server.events_ingest_key`` (must be ≥32 chars — an
+    ingest key is the only defense on a LAN-reachable port, so a weak one is
+    rejected with an error and the chain falls through to the strong keys) >
+    ``SECRET_KEY`` env > root-level ``secret_key`` in config.json.
+
+    ``get_secret_key()`` from scripts.shared.config is deliberately NOT used:
+    it returns None when the SECRET_KEY env var is set ("don't override the
+    operator"), which would make the two sides resolve different values and
+    403 forever. The env and config reads intentionally do NOT strip: the web
+    process consumes those same values unstripped, and asymmetric stripping
+    would desync the two sides.
+
+    An empty result must disable forwarding / return 503 from the route
+    (fail-closed).
     """
     dedicated = str(get_config_value("server", "events_ingest_key", "") or "").strip()
-    if dedicated:
+    if len(dedicated) >= 32:
         return dedicated
-    env_secret = (os.environ.get("SECRET_KEY") or "").strip()
+    if dedicated:
+        logger.error(
+            "server.events_ingest_key is shorter than 32 characters; ignoring it "
+            "and falling back to SECRET_KEY/secret_key"
+        )
+    env_secret = os.environ.get("SECRET_KEY") or ""
     if env_secret:
         return env_secret
     try:
         from scripts.shared.config import _load_user_config
 
-        root_secret = str(_load_user_config().get("secret_key") or "").strip()
+        root_secret = str(_load_user_config().get("secret_key") or "")
     except Exception:  # pragma: no cover - scripts/ always deployed with app
         root_secret = ""
     return root_secret

--- a/app/modules/workspace/autonomous/events_ingest.py
+++ b/app/modules/workspace/autonomous/events_ingest.py
@@ -1,0 +1,141 @@
+"""Cross-process SSE ingest plumbing (scheduler → web, same-host deployments).
+
+#2187 split the scheduler into its own process, but ``AutonomousEventEmitter``
+is an in-process singleton: events emitted by the scheduler never reach the
+web process's SSE subscribers, so the AI activity panel shows an eternal
+"waiting" state in split-process production. The scheduler-side emitter
+forwards events over a loopback HTTP POST to the web process's ingest route,
+which re-broadcasts through its own emitter.
+
+Resolution helpers live here so both processes derive the SAME values from the
+SAME shared ``~/.open-ace/config.json`` (both services run as one user on one
+host and read one deployed tree).
+
+Delivery semantics: at-least-once. A POST that times out after the web side
+already broadcast produces a duplicate; this is tolerated because the frontend
+dedups ``agent_activity`` by ``activity_id``, ``emit()``'s ``setdefault`` is
+idempotent, and a duplicate ``milestone_updated`` only invalidates a query
+cache one extra time.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+from functools import lru_cache
+
+from app.utils.config import get_config_value
+
+logger = logging.getLogger(__name__)
+
+INGEST_SECRET_HEADER = "X-OpenACE-Events-Key"
+DEFAULT_WEB_PORT = 19888  # mirrors scripts/shared/config.py's fallback
+
+# remote_addr values that are always trusted. Under an nginx reverse proxy
+# every external request arrives as 127.0.0.1, which is why the shared secret
+# — not this check — is the primary control for the ingest route.
+_LOOPBACK_ADDRS = frozenset({"127.0.0.1", "::1", "::ffff:127.0.0.1"})
+
+
+def resolve_ingest_secret() -> str:
+    """Resolve the shared ingest secret identically in both processes.
+
+    Priority: dedicated ``server.events_ingest_key`` > ``SECRET_KEY`` env >
+    root-level ``secret_key`` in config.json. ``get_secret_key()`` from
+    scripts.shared.config is deliberately NOT used: it returns None when the
+    SECRET_KEY env var is set ("don't override the operator"), which would
+    make the two sides resolve different values and 403 forever. An empty
+    result must disable forwarding / return 503 from the route (fail-closed).
+    """
+    dedicated = str(get_config_value("server", "events_ingest_key", "") or "").strip()
+    if dedicated:
+        return dedicated
+    env_secret = (os.environ.get("SECRET_KEY") or "").strip()
+    if env_secret:
+        return env_secret
+    try:
+        from scripts.shared.config import _load_user_config
+
+        root_secret = str(_load_user_config().get("secret_key") or "").strip()
+    except Exception:  # pragma: no cover - scripts/ always deployed with app
+        root_secret = ""
+    return root_secret
+
+
+def resolve_ingest_url() -> str | None:
+    """Resolve the ingest endpoint URL: explicit override > loopback + web port.
+
+    The port reuses the exact derivation the web server binds to, so the two
+    can never drift: both processes call the same function on the same config
+    file. No port is ever hardcoded at a call site.
+    """
+    explicit = str(get_config_value("server", "events_ingest_url", "") or "").strip()
+    if explicit:
+        return explicit
+    port = _configured_web_port()
+    if port is None:
+        return None
+    return f"http://127.0.0.1:{port}"
+
+
+def _configured_web_port() -> int | None:
+    """The web port exactly as server.py resolves it (config > default)."""
+    try:
+        from scripts.shared.config import _get_web_port
+
+        return int(_get_web_port())
+    except Exception:  # pragma: no cover - defensive; scripts/ ships with app
+        raw = get_config_value("server", "web_port", DEFAULT_WEB_PORT)
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            logger.error("Invalid server.web_port value: %r", raw)
+            return None
+
+
+@lru_cache(maxsize=8)
+def _parse_trusted_sources(raw: tuple) -> tuple:
+    """Parse IP/CIDR entries; malformed entries are logged and skipped."""
+    networks = []
+    for entry in raw:
+        try:
+            networks.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            logger.error(
+                "Ignoring malformed server.events_ingest_trusted_sources entry: %r",
+                entry,
+            )
+    return tuple(networks)
+
+
+def trusted_source_networks() -> tuple:
+    """Configured extra trusted sources (for split-host/container topologies)."""
+    raw = get_config_value("server", "events_ingest_trusted_sources", [])
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        entries = tuple(part.strip() for part in raw.split(",") if part.strip())
+    elif isinstance(raw, list):
+        entries = tuple(str(part).strip() for part in raw if str(part).strip())
+    else:
+        logger.error("server.events_ingest_trusted_sources must be a list, ignoring")
+        return ()
+    return _parse_trusted_sources(entries)
+
+
+def is_trusted_source(remote_addr: str | None) -> bool:
+    """Loopback addresses plus any configured trusted networks.
+
+    ``remote_addr`` is the socket-level peer address; X-Forwarded-For is
+    intentionally ignored (it is client-controlled).
+    """
+    if not remote_addr:
+        return False
+    if remote_addr in _LOOPBACK_ADDRS:
+        return True
+    try:
+        addr = ipaddress.ip_address(remote_addr)
+    except ValueError:
+        return False
+    return any(addr in network for network in trusted_source_networks())

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -7,6 +7,7 @@ API routes for AI autonomous development workflow management.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
@@ -26,6 +27,7 @@ from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 from app.auth.decorators import (
     auth_required,
     check_machine_admin_permission,
+    public_endpoint,
     validate_session_token,
 )
 from app.models.user import User
@@ -1997,6 +1999,79 @@ def get_workflow_pr_stats(workflow_id):
 
 
 # ── Real-Time Events (SSE) ─────────────────────────────────────────
+
+
+INGEST_MAX_BODY_BYTES = 1024 * 1024
+INGEST_MAX_EVENTS = 100
+_ingest_log_state = {"last": 0.0}
+
+
+@autonomous_bp.route("/internal/events/ingest", methods=["POST"])
+@public_endpoint
+def ingest_internal_events():
+    """Cross-process SSE ingest: scheduler process → this web process.
+
+    #2187 split the scheduler into its own process; the emitter is an
+    in-process singleton, so scheduler-side events must be handed over here to
+    reach SSE subscribers. Delivery is at-least-once (a timed-out POST may be
+    retried after we already broadcast).
+
+    Security model — the shared secret is the PRIMARY control, fail-closed:
+    an unconfigured/empty secret returns 503 (never a no-auth fallback),
+    mirroring require_upload_auth. The loopback/trusted-source check is
+    defense-in-depth: it does NOT help under an nginx reverse proxy, where
+    every external request arrives as 127.0.0.1 — hence the secret
+    requirement. X-Forwarded-For is intentionally ignored (client-controlled).
+    """
+    from app.modules.workspace.autonomous.events_ingest import (
+        INGEST_SECRET_HEADER,
+        is_trusted_source,
+        resolve_ingest_secret,
+    )
+
+    secret = resolve_ingest_secret()
+    if not secret:
+        logger.error(
+            "Events ingest rejected: no shared secret configured "
+            "(server.events_ingest_key / SECRET_KEY / config secret_key)"
+        )
+        return jsonify({"error": "Events ingest not configured"}), 503
+
+    provided = request.headers.get(INGEST_SECRET_HEADER, "")
+    if (
+        not provided
+        or not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8"))
+        or not is_trusted_source(request.remote_addr)
+    ):
+        return jsonify({"error": "Access denied"}), 403
+
+    content_length = request.content_length
+    if content_length is None or content_length <= 0 or content_length > INGEST_MAX_BODY_BYTES:
+        return jsonify({"error": "Payload too large"}), 413
+
+    payload = request.get_json(silent=True) or {}
+    events = payload.get("events")
+    if not isinstance(events, list) or not events or len(events) > INGEST_MAX_EVENTS:
+        return jsonify({"error": "Payload too large"}), 413
+
+    emitter = _get_event_emitter()
+    accepted = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        workflow_id = event.get("workflow_id") or ""
+        event_type = event.get("event_type") or ""
+        data = event.get("data")
+        if not workflow_id or not event_type or not isinstance(data, dict):
+            continue
+        emitter.emit(workflow_id, event_type, data)
+        accepted += 1
+
+    now = time.time()
+    if now - _ingest_log_state["last"] >= 60.0:
+        _ingest_log_state["last"] = now
+        logger.info("Events ingest accepted %d event(s)", accepted)
+    return jsonify({"success": True, "accepted": accepted})
 
 
 @autonomous_bp.route("/workflows/<workflow_id>/events/stream", methods=["GET"])

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -2046,12 +2046,16 @@ def ingest_internal_events():
         return jsonify({"error": "Access denied"}), 403
 
     content_length = request.content_length
-    if content_length is None or content_length <= 0 or content_length > INGEST_MAX_BODY_BYTES:
+    if content_length is None or content_length <= 0:
+        return jsonify({"error": "Empty or missing request body"}), 400
+    if content_length > INGEST_MAX_BODY_BYTES:
         return jsonify({"error": "Payload too large"}), 413
 
     payload = request.get_json(silent=True) or {}
     events = payload.get("events")
-    if not isinstance(events, list) or not events or len(events) > INGEST_MAX_EVENTS:
+    if not isinstance(events, list) or not events:
+        return jsonify({"error": "Invalid events payload"}), 400
+    if len(events) > INGEST_MAX_EVENTS:
         return jsonify({"error": "Payload too large"}), 413
 
     emitter = _get_event_emitter()

--- a/app/scheduler_worker.py
+++ b/app/scheduler_worker.py
@@ -398,6 +398,34 @@ class SchedulerWorker:
 
                 init_autonomous_scheduler()
                 logger.info("Autonomous scheduler initialized")
+
+                # Cross-process SSE forwarding (scheduler → web ingest). The
+                # emitter is an in-process singleton (#2187 split), so without
+                # this the web process's SSE subscribers never see scheduler
+                # events and the AI activity panel stays in "waiting". Enabled
+                # HERE ONLY — never from an env check inside the emitter or
+                # create_app: a combined process (SCHEDULER_MODE=scheduler
+                # serving web too) would loop ingest → emit → forward → ingest.
+                from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
+                from app.modules.workspace.autonomous.events_ingest import (
+                    resolve_ingest_secret,
+                    resolve_ingest_url,
+                )
+
+                ingest_url = resolve_ingest_url()
+                ingest_secret = resolve_ingest_secret()
+                if ingest_url and ingest_secret:
+                    if AutonomousEventEmitter.instance().enable_remote_forwarding(
+                        ingest_url, ingest_secret
+                    ):
+                        logger.info("SSE event forwarding enabled → %s", ingest_url)
+                else:
+                    logger.error(
+                        "SSE event forwarding disabled (url=%s, secret=%s); "
+                        "AI activity SSE will stay in waiting state",
+                        "resolved" if ingest_url else "missing",
+                        "resolved" if ingest_secret else "missing",
+                    )
             else:
                 logger.info("Autonomous scheduler disabled by configuration")
         except Exception as e:

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -9,6 +9,9 @@
     "upload_auth_key": "<UPLOAD_AUTH_KEY>",
     "server_url": "http://localhost:19888",
     "web_port": 19888,
+    "events_ingest_key": "",
+    "events_ingest_url": "",
+    "events_ingest_trusted_sources": [],
     "web_host": "0.0.0.0"
   },
   "workspace": {

--- a/docs/cn/NGINX.md
+++ b/docs/cn/NGINX.md
@@ -119,6 +119,14 @@ server {
         sub_filter_once off;
     }
 
+    # ── 内部事件接收端点（拒绝外部访问） ──
+    # 调度器进程通过环回地址向 web 进程转发 SSE 事件（#3046）。反代拓扑下
+    # 所有外部请求的 remote_addr 都是 127.0.0.1，环回校验失效，该路径仅由
+    # 共享密钥保护——建议在反代层直接拒绝：
+    location /api/autonomous/internal/ {
+        return 403;
+    }
+
     # ── Open-ACE 主应用 ──
     location / {
         client_max_body_size 50m;      # Agent 会话同步数据可能超过默认的 1MB 限制

--- a/docs/en/NGINX.md
+++ b/docs/en/NGINX.md
@@ -111,6 +111,14 @@ server {
     }
 
     # Main Open ACE application.
+    # Internal SSE event ingest (deny externally). The scheduler
+    # forwards events to the web process over loopback (#3046); behind this
+    # proxy every external request arrives as 127.0.0.1, so the route is
+    # guarded only by its shared secret — deny it here as well:
+    location /api/autonomous/internal/ {
+        return 403;
+    }
+
     location / {
         client_max_body_size 50m;      # Agent session sync payloads can exceed the 1MB default.
         proxy_pass         http://127.0.0.1:19888;

--- a/docs/en/NGINX.md
+++ b/docs/en/NGINX.md
@@ -110,7 +110,6 @@ server {
         sub_filter_once off;
     }
 
-    # Main Open ACE application.
     # Internal SSE event ingest (deny externally). The scheduler
     # forwards events to the web process over loopback (#3046); behind this
     # proxy every external request arrives as 127.0.0.1, so the route is
@@ -119,6 +118,7 @@ server {
         return 403;
     }
 
+    # Main Open ACE application.
     location / {
         client_max_body_size 50m;      # Agent session sync payloads can exceed the 1MB default.
         proxy_pass         http://127.0.0.1:19888;

--- a/tests/unit/test_event_forwarder.py
+++ b/tests/unit/test_event_forwarder.py
@@ -1,0 +1,217 @@
+"""#3046: scheduler-side SSE event forwarder (emitter → web ingest route).
+
+#2187 split the scheduler into its own process while AutonomousEventEmitter
+stayed an in-process singleton. These tests pin the forwarder half of the fix:
+bounded buffer semantics, count+byte batch caps, drop rules (oldest, expired,
+oversized, HTTP-rejected), retry-without-evicting-newest on connection
+failures, and the hard rule that a disabled forwarder never touches HTTP.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+import time
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from app.modules.workspace.autonomous import event_emitter as em_mod
+from app.modules.workspace.autonomous.event_emitter import (
+    FORWARD_BATCH_MAX_BYTES,
+    FORWARD_BUFFER_MAX_EVENTS,
+    FORWARD_EVENT_MAX_BYTES,
+    FORWARD_EVENT_TTL_SECONDS,
+    AutonomousEventEmitter,
+)
+
+pytestmark = [pytest.mark.issue(3046)]
+
+URL = "http://127.0.0.1:19888/api/autonomous/internal/events/ingest"
+SECRET = "test-ingest-secret"
+
+
+@pytest.fixture
+def emitter():
+    em = AutonomousEventEmitter()
+    yield em
+    em._forward_stop.set()
+
+
+def _wait_for(condition, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if condition():
+            return True
+        time.sleep(0.02)
+    return condition()
+
+
+def _enqueue(em, payload):
+    em._forward_enqueue(payload)
+
+
+def _buffer_len(em):
+    with em._forward_lock:
+        return len(em._forward_buffer)
+
+
+def test_disabled_forwarder_never_posts(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("requests.post must not be called when forwarding is disabled")
+
+    monkeypatch.setattr(requests, "post", _boom)
+    em = AutonomousEventEmitter()
+    try:
+        em.emit("wf-1", "status_change", {"status": "planning"})
+    finally:
+        em._forward_stop.set()
+    assert em._forward_url is None
+    assert _buffer_len(em) == 0
+
+
+def test_enabled_emit_forwards_event_with_defaults(monkeypatch, emitter):
+    posted = []
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda url, **kwargs: (posted.append((url, kwargs)), MagicMock(status_code=200))[1],
+    )
+    assert emitter.enable_remote_forwarding(URL, SECRET)
+    emitter.emit("wf-1", "agent_activity", {"activity_type": "tool_use", "text": "x"})
+    assert _wait_for(lambda: len(posted) >= 1)
+    url, kwargs = posted[0]
+    assert url == URL
+    assert kwargs["headers"]["X-OpenACE-Events-Key"] == SECRET
+    events = kwargs["json"]["events"]
+    assert len(events) == 1
+    assert events[0]["workflow_id"] == "wf-1"
+    assert events[0]["event_type"] == "agent_activity"
+    # setdefault ran before enqueue, so the forwarded copy keeps one identity.
+    assert events[0]["data"]["activity_id"]
+    assert events[0]["data"]["timestamp"]
+
+
+def test_enable_requires_url_and_secret():
+    em = AutonomousEventEmitter()
+    try:
+        assert em.enable_remote_forwarding("", SECRET) is False
+        assert em.enable_remote_forwarding(URL, "") is False
+        assert em._forward_thread is None
+    finally:
+        em._forward_stop.set()
+
+
+def test_double_enable_reuses_single_thread():
+    em = AutonomousEventEmitter()
+    try:
+        assert em.enable_remote_forwarding(URL, SECRET)
+        first = em._forward_thread
+        assert em.enable_remote_forwarding(URL, SECRET)
+        assert em._forward_thread is first
+    finally:
+        em._forward_stop.set()
+
+
+def test_oversized_event_is_skipped(emitter):
+    emitter._forward_url = URL  # unit-level: exercise enqueue without the thread
+    _enqueue(
+        emitter,
+        {
+            "workflow_id": "wf-1",
+            "event_type": "agent_activity",
+            "data": {"text": "x" * (FORWARD_EVENT_MAX_BYTES + 1)},
+        },
+    )
+    assert _buffer_len(emitter) == 0
+
+
+def test_buffer_overflow_drops_oldest(emitter):
+    emitter._forward_url = URL
+    for i in range(FORWARD_BUFFER_MAX_EVENTS + 5):
+        _enqueue(emitter, {"workflow_id": f"wf-{i}", "event_type": "e", "data": {}})
+    assert _buffer_len(emitter) == FORWARD_BUFFER_MAX_EVENTS
+    with emitter._forward_lock:
+        first = emitter._forward_buffer[0]
+    assert jsonlib.loads(first[1])["workflow_id"] == "wf-5"  # oldest five dropped
+
+
+def test_take_batch_respects_byte_cap(emitter):
+    emitter._forward_url = URL
+    # Each event is under FORWARD_EVENT_MAX_BYTES, but three together exceed
+    # FORWARD_BATCH_MAX_BYTES — the batch must stop at two and leave the third.
+    big = "y" * 200_001
+    for wf in ("wf-a", "wf-b", "wf-c"):
+        _enqueue(emitter, {"workflow_id": wf, "event_type": "e", "data": {"text": big}})
+    batch = emitter._forward_take_batch()
+    assert len(batch) == 2
+    assert jsonlib.loads(batch[0][1])["workflow_id"] == "wf-a"
+    assert jsonlib.loads(batch[1][1])["workflow_id"] == "wf-b"
+    assert _buffer_len(emitter) == 1
+
+
+def test_take_batch_drops_expired_entries(emitter):
+    emitter._forward_url = URL
+    emitter._forward_buffer.append(
+        (time.time() - FORWARD_EVENT_TTL_SECONDS - 30, '{"workflow_id": "old"}', 22)
+    )
+    _enqueue(emitter, {"workflow_id": "wf-new", "event_type": "e", "data": {}})
+    batch = emitter._forward_take_batch()
+    assert [jsonlib.loads(blob)["workflow_id"] for _ts, blob, _size in batch] == ["wf-new"]
+
+
+def test_requeue_keeps_newest_events(emitter):
+    # Buffer one short of full; requeuing two undelivered entries overflows by
+    # one, and the overflow drops the OLDEST overall (a requeued entry), never
+    # a newer buffered event.
+    old_batch = [(time.time(), '{"i": "old-%d"}' % i, 12) for i in range(2)]
+    with emitter._forward_lock:
+        emitter._forward_buffer = [
+            (time.time(), '{"i": "new-%d"}' % i, 12) for i in range(FORWARD_BUFFER_MAX_EVENTS - 1)
+        ]
+    emitter._forward_requeue(old_batch)
+    assert _buffer_len(emitter) == FORWARD_BUFFER_MAX_EVENTS
+    with emitter._forward_lock:
+        first = jsonlib.loads(emitter._forward_buffer[0][1])
+        last = jsonlib.loads(emitter._forward_buffer[-1][1])
+    assert first["i"] == "old-1"  # the older requeued entry survived in order
+    assert last["i"] == "new-%d" % (FORWARD_BUFFER_MAX_EVENTS - 2)
+
+
+def test_http_error_drops_batch(monkeypatch, emitter):
+    posted = []
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda url, **kwargs: (posted.append(1), MagicMock(status_code=413))[1],
+    )
+    emitter.enable_remote_forwarding(URL, SECRET)
+    emitter.emit("wf-1", "status_change", {"status": "planning"})
+    assert _wait_for(lambda: len(posted) >= 1)
+    assert _wait_for(lambda: _buffer_len(emitter) == 0)  # dropped, not requeued
+
+
+def test_connection_failure_requeues(monkeypatch, emitter):
+    posted = []
+
+    def _fail(url, **kwargs):
+        posted.append(1)
+        raise requests.ConnectionError("web restarting")
+
+    monkeypatch.setattr(requests, "post", _fail)
+    emitter.enable_remote_forwarding(URL, SECRET)
+    emitter.emit("wf-1", "status_change", {"status": "planning"})
+    assert _wait_for(lambda: len(posted) >= 1)
+    # The batch came back to the buffer for retry (at-least-once).
+    assert _wait_for(lambda: _buffer_len(emitter) >= 1)
+
+
+def test_emit_never_raises_from_forwarding(monkeypatch, emitter):
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("enqueue must be reached to fail")
+
+    monkeypatch.setattr(em_mod, "json", _boom)  # break serialization inside enqueue
+    emitter._forward_url = URL
+    emitter.emit("wf-1", "status_change", {"status": "planning"})  # must not raise
+    monkeypatch.undo()
+    assert _buffer_len(emitter) == 0

--- a/tests/unit/test_event_forwarder.py
+++ b/tests/unit/test_event_forwarder.py
@@ -35,7 +35,9 @@ SECRET = "test-ingest-secret"
 def emitter():
     em = AutonomousEventEmitter()
     yield em
-    em._forward_stop.set()
+    em.disable_remote_forwarding()
+    if em._forward_thread is not None:
+        em._forward_thread.join(timeout=2)
 
 
 def _wait_for(condition, timeout=5.0):
@@ -65,9 +67,71 @@ def test_disabled_forwarder_never_posts(monkeypatch):
     try:
         em.emit("wf-1", "status_change", {"status": "planning"})
     finally:
-        em._forward_stop.set()
+        em.disable_remote_forwarding()
     assert em._forward_url is None
     assert _buffer_len(em) == 0
+
+
+def test_wire_body_is_not_ascii_escaped(monkeypatch, emitter):
+    # requests' json= helper re-serializes with ensure_ascii=True, inflating
+    # CJK/emoji payloads 2-3x past the byte caps the buffer accounts for. The
+    # sender must serialize with ensure_ascii=False so wire bytes == accounted
+    # bytes (review MAJOR on PR #3047).
+    posted = []
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda url, **kwargs: (posted.append((url, kwargs)), MagicMock(status_code=200))[1],
+    )
+    emitter.enable_remote_forwarding(URL, SECRET)
+    emitter.emit("wf-1", "agent_activity", {"text": "中文活动 ✓"})
+    assert _wait_for(lambda: len(posted) >= 1)
+    _url, kwargs = posted[0]
+    body = kwargs["data"]
+    assert "中文活动".encode() in body  # raw UTF-8, not \uXXXX escapes
+    assert b"\\u4e2d" not in body
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+def test_buffer_total_byte_cap_drops_oldest(emitter):
+    emitter._forward_url = URL
+    chunk = "z" * 100_000
+    # 100 events × ~100KB ≈ 10MB > 8MB total cap → oldest dropped along the way
+    for i in range(100):
+        _enqueue(emitter, {"workflow_id": f"wf-{i}", "event_type": "e", "data": {"text": chunk}})
+    with emitter._forward_lock:
+        total = emitter._forward_buffer_bytes
+        first = jsonlib.loads(emitter._forward_buffer[0][1])["workflow_id"]
+    assert total <= em_mod.FORWARD_BUFFER_MAX_BYTES_TOTAL
+    assert first != "wf-0"  # the very oldest entries were evicted
+
+
+def test_disable_clears_state_and_stops_thread(monkeypatch, emitter):
+    emitter.enable_remote_forwarding(URL, SECRET)
+    thread = emitter._forward_thread
+    emitter.disable_remote_forwarding()
+    assert emitter._forward_url is None
+    assert emitter._forward_buffer == []
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    # After disable, emit must not enqueue anything.
+    emitter.emit("wf-1", "status_change", {"status": "planning"})
+    assert _buffer_len(emitter) == 0
+
+
+def test_connection_failure_backs_off_between_attempts(monkeypatch, emitter):
+    timestamps = []
+
+    def _fail(url, **kwargs):
+        timestamps.append(time.time())
+        raise requests.ConnectionError("web restarting")
+
+    monkeypatch.setattr(requests, "post", _fail)
+    emitter.enable_remote_forwarding(URL, SECRET)
+    emitter.emit("wf-1", "status_change", {"status": "planning"})
+    assert _wait_for(lambda: len(timestamps) >= 2)
+    # The retry after a connection failure waits ≥ FORWARD_BACKOFF_START (1s).
+    assert timestamps[1] - timestamps[0] >= 0.9
 
 
 def test_enabled_emit_forwards_event_with_defaults(monkeypatch, emitter):
@@ -83,7 +147,7 @@ def test_enabled_emit_forwards_event_with_defaults(monkeypatch, emitter):
     url, kwargs = posted[0]
     assert url == URL
     assert kwargs["headers"]["X-OpenACE-Events-Key"] == SECRET
-    events = kwargs["json"]["events"]
+    events = jsonlib.loads(kwargs["data"])["events"]
     assert len(events) == 1
     assert events[0]["workflow_id"] == "wf-1"
     assert events[0]["event_type"] == "agent_activity"
@@ -99,7 +163,7 @@ def test_enable_requires_url_and_secret():
         assert em.enable_remote_forwarding(URL, "") is False
         assert em._forward_thread is None
     finally:
-        em._forward_stop.set()
+        em.disable_remote_forwarding()
 
 
 def test_double_enable_reuses_single_thread():
@@ -110,7 +174,7 @@ def test_double_enable_reuses_single_thread():
         assert em.enable_remote_forwarding(URL, SECRET)
         assert em._forward_thread is first
     finally:
-        em._forward_stop.set()
+        em.disable_remote_forwarding()
 
 
 def test_oversized_event_is_skipped(emitter):

--- a/tests/unit/test_event_ingest_route.py
+++ b/tests/unit/test_event_ingest_route.py
@@ -33,6 +33,9 @@ def client(monkeypatch, tmp_path):
     monkeypatch.delenv("SECRET_KEY", raising=False)
     monkeypatch.setattr("scripts.shared.config._load_user_config", lambda: {})
     events_ingest._parse_trusted_sources.cache_clear()
+    # The blueprint's before_request gate reads the REAL config on this
+    # machine; force it so the route tests are hermetic everywhere.
+    monkeypatch.setattr("app.utils.config.is_autonomous_enabled", lambda: True)
 
     # Fresh emitter singleton so subscriber state never leaks across tests.
     AutonomousEventEmitter._instance = None
@@ -134,8 +137,74 @@ def test_event_count_over_limit_rejected(client, monkeypatch):
 
 def test_malformed_events_rejected(client, monkeypatch):
     monkeypatch.setenv("SECRET_KEY", SECRET)
-    response = _post(client, [])
-    assert response.status_code == 413
+    assert _post(client, []).status_code == 400
+    assert _post(client, "not-a-list").status_code == 400
+
+
+def test_empty_body_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    response = client.post(
+        "/api/autonomous/internal/events/ingest",
+        headers={"X-OpenACE-Events-Key": SECRET},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert response.status_code == 400
+
+
+def test_ipv6_loopback_forms_accepted(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    for addr in ("::1", "::ffff:127.0.0.1"):
+        assert _post(client, [_event()], addr=addr).status_code == 200, addr
+
+
+def test_secret_priority_dedicated_key_wins(monkeypatch):
+    monkeypatch.setattr(
+        events_ingest,
+        "get_config_value",
+        lambda section, key, default=None: "k" * 40 if key == "events_ingest_key" else default,
+    )
+    monkeypatch.setenv("SECRET_KEY", "env-secret-should-lose")
+    assert events_ingest.resolve_ingest_secret() == "k" * 40
+
+
+def test_secret_priority_weak_dedicated_key_falls_through(monkeypatch):
+    monkeypatch.setattr(
+        events_ingest,
+        "get_config_value",
+        lambda section, key, default=None: "short" if key == "events_ingest_key" else default,
+    )
+    monkeypatch.setenv("SECRET_KEY", "env-secret-should-win")
+    assert events_ingest.resolve_ingest_secret() == "env-secret-should-win"
+
+
+def test_secret_priority_root_config_fallback(monkeypatch):
+    monkeypatch.setattr(
+        events_ingest, "get_config_value", lambda section, key, default=None: default
+    )
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.setattr("scripts.shared.config._load_user_config", lambda: {"secret_key": "root"})
+    assert events_ingest.resolve_ingest_secret() == "root"
+
+
+def test_ingest_url_explicit_override(monkeypatch):
+    monkeypatch.setattr(
+        events_ingest,
+        "get_config_value",
+        lambda section, key, default=None: (
+            "http://web:8000/ingest" if key == "events_ingest_url" else default
+        ),
+    )
+    assert events_ingest.resolve_ingest_url() == "http://web:8000/ingest"
+
+
+def test_ingest_url_default_uses_configured_web_port(monkeypatch):
+    monkeypatch.setattr(
+        events_ingest,
+        "get_config_value",
+        lambda section, key, default=None: 5000 if key == "web_port" else default,
+    )
+    monkeypatch.setattr("scripts.shared.config._get_web_port", lambda: 5000, raising=False)
+    assert events_ingest.resolve_ingest_url() == "http://127.0.0.1:5000"
 
 
 def test_route_is_marked_public_endpoint(client):

--- a/tests/unit/test_event_ingest_route.py
+++ b/tests/unit/test_event_ingest_route.py
@@ -1,0 +1,145 @@
+"""#3046: web-side SSE ingest route (scheduler → web handover).
+
+Pins the security model (shared secret as primary control, fail-closed 503
+when unconfigured; loopback/trusted-source check as defense-in-depth) and the
+functional contract (re-broadcast through the web emitter, activity replay
+window, size/count caps).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous import events_ingest
+from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
+
+pytestmark = [pytest.mark.issue(3046)]
+
+SECRET = "test-ingest-secret"
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'ingest.db'}")
+    from app import create_app
+
+    app = create_app({"TESTING": True})
+
+    # Deterministic secret resolution: dedicated key empty, no env var, no
+    # root-level config secret — each test opts into what it needs.
+    monkeypatch.setattr(
+        events_ingest, "get_config_value", lambda section, key, default=None: default
+    )
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.setattr("scripts.shared.config._load_user_config", lambda: {})
+    events_ingest._parse_trusted_sources.cache_clear()
+
+    # Fresh emitter singleton so subscriber state never leaks across tests.
+    AutonomousEventEmitter._instance = None
+
+    with app.test_client() as c:
+        yield c
+
+    AutonomousEventEmitter._instance = None
+
+
+def _post(client, events, *, secret=SECRET, addr="127.0.0.1"):
+    return client.post(
+        "/api/autonomous/internal/events/ingest",
+        json={"events": events},
+        headers={"X-OpenACE-Events-Key": secret} if secret is not None else {},
+        environ_base={"REMOTE_ADDR": addr},
+    )
+
+
+def _event(**overrides):
+    payload = {"workflow_id": "wf-1", "event_type": "status_change", "data": {"status": "planning"}}
+    payload.update(overrides)
+    return payload
+
+
+def test_no_secret_configured_fails_closed(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "")
+    monkeypatch.setattr("scripts.shared.config._load_user_config", lambda: {})
+    response = _post(client, [_event()], secret="")
+    assert response.status_code == 503
+
+
+def test_wrong_secret_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    assert _post(client, [_event()], secret="wrong").status_code == 403
+
+
+def test_missing_secret_header_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    assert _post(client, [_event()], secret=None).status_code == 403
+
+
+def test_non_loopback_rejected_without_trusted_sources(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    assert _post(client, [_event()], addr="192.168.1.50").status_code == 403
+
+
+def test_valid_loopback_secret_broadcasts(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    emitter = AutonomousEventEmitter.instance()
+    q = emitter.subscribe("wf-1")
+    response = _post(client, [_event()])
+    assert response.status_code == 200
+    assert response.get_json()["accepted"] == 1
+    received = q.get(timeout=2)
+    assert received["event_type"] == "status_change"
+    assert received["data"]["status"] == "planning"
+
+
+def test_agent_activity_ingested_into_replay_window(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    emitter = AutonomousEventEmitter.instance()
+    assert (
+        _post(client, [_event(event_type="agent_activity", data={"text": "tool"})]).status_code
+        == 200
+    )
+    # Subscribe AFTER the ingest: the replay window must serve the activity.
+    q = emitter.subscribe("wf-1")
+    replayed = q.get(timeout=2)
+    assert replayed["event_type"] == "agent_activity"
+
+
+def test_trusted_sources_with_malformed_entry(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+
+    def _cfg(section, key, default=None):
+        if key == "events_ingest_trusted_sources":
+            return ["10.1.0.0/16", "not-an-ip"]
+        return default
+
+    monkeypatch.setattr(events_ingest, "get_config_value", _cfg)
+    events_ingest._parse_trusted_sources.cache_clear()
+    assert _post(client, [_event()], addr="10.1.2.3").status_code == 200
+    assert _post(client, [_event()], addr="10.2.0.1").status_code == 403
+
+
+def test_body_over_limit_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    pad = "x" * (1024 * 1024 + 512)
+    response = _post(client, [_event(data={"status": pad})])
+    assert response.status_code == 413
+
+
+def test_event_count_over_limit_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    response = _post(client, [_event(workflow_id=f"wf-{i}") for i in range(101)])
+    assert response.status_code == 413
+
+
+def test_malformed_events_rejected(client, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", SECRET)
+    response = _post(client, [])
+    assert response.status_code == 413
+
+
+def test_route_is_marked_public_endpoint(client):
+    # The SEC001 API security scanner allows unauthenticated routes only when
+    # explicitly marked; the ingest route is process-to-process, not user-facing.
+    view = client.application.view_functions["autonomous.ingest_internal_events"]
+    assert getattr(view, "_is_public_endpoint", False) is True


### PR DESCRIPTION
Closes #3046.

## 问题

双进程部署(#2187 拆分)下 AI 活动面板永远"等待中":`AutonomousEventEmitter` 是进程内单例,调度器进程的事件到不了 web 进程的 SSE 订阅者;`milestone_updated` 即时刷新退化为轮询。开发单进程模式正常。

## 修复(方案 A,评审驱动至零剩余意见)

- **调度器侧**:emitter 增加 `enable_remote_forwarding`(仅 scheduler_worker 启动序列调用,防组合模式回环);有界缓冲(1000 丢最旧)+ 单 daemon 发送线程;批双上限(50 条 / 512KB,批不可能超 ingest 限制);单事件 256KB 上限;60s 过期;连接失败回队不挤新事件(at-least-once,前端按 activity_id 去重);4xx/5xx 丢批。
- **web 侧**:`POST /api/autonomous/internal/events/ingest`(@public_endpoint)。共享密钥为主防线、未配置 **503 fail-closed**;环回/trusted_sources 为纵深(NGINX 反代穿透场景明确不依赖);逐条 emitter.emit 扇出,15 分钟活动回放窗免费覆盖 SSE 重连;每路由 content_length(1MB/100 条 → 413)。
- **同源推导**(events_ingest.py):URL=显式覆盖 > `http://127.0.0.1:{web_port}`(复用 server.py 同一推导,无硬编码端口);密钥=events_ingest_key > SECRET_KEY env > 根级 secret_key(避开 get_secret_key 的 None 陷阱)。同主机开箱即用;compose/k8s 显式 URL+trusted_sources+密钥。

## 验证

- 新增 23 条测试(12 转发器 + 11 路由)全绿;相关回归 `tests/unit -k "emitter or event or scheduler or autonomous"` 461 passed。
- black/isort/ruff/mypy(改动文件)干净。
- 部署需同步 4 个 py 文件并**同时重启 open-ace 与 openace-scheduler**;验证:调度器日志 "SSE event forwarding enabled → …",web 日志 "Events ingest accepted",浏览器 AI 活动实时显示。

方案与两轮独立评审记录见下方评论。