### PR TITLE
fix(3047): default ingest URL must include the route path

### DIFF
--- a/app/modules/workspace/autonomous/events_ingest.py
+++ b/app/modules/workspace/autonomous/events_ingest.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 INGEST_SECRET_HEADER = "X-OpenACE-Events-Key"
 DEFAULT_WEB_PORT = 19888  # mirrors scripts/shared/config.py's fallback
+DEFAULT_INGEST_PATH = "/api/autonomous/internal/events/ingest"
 
 # remote_addr values that are always trusted. Under an nginx reverse proxy
 # every external request arrives as 127.0.0.1, which is why the shared secret
@@ -89,7 +90,9 @@ def resolve_ingest_url() -> str | None:
     port = _configured_web_port()
     if port is None:
         return None
-    return f"http://127.0.0.1:{port}"
+    # Origin + path: a bare origin would hit the SPA catch-all (GET-only) and
+    # come back 405 — caught by production verification of the first deploy.
+    return f"http://127.0.0.1:{port}{DEFAULT_INGEST_PATH}"
 
 
 def _configured_web_port() -> int | None:

--- a/tests/unit/test_event_ingest_route.py
+++ b/tests/unit/test_event_ingest_route.py
@@ -204,7 +204,13 @@ def test_ingest_url_default_uses_configured_web_port(monkeypatch):
         lambda section, key, default=None: 5000 if key == "web_port" else default,
     )
     monkeypatch.setattr("scripts.shared.config._get_web_port", lambda: 5000, raising=False)
-    assert events_ingest.resolve_ingest_url() == "http://127.0.0.1:5000"
+    # The default URL must carry the ingest PATH — a bare origin POSTs to "/"
+    # and hits the GET-only SPA catch-all (405), as the first production
+    # deploy of #3047 demonstrated.
+    assert (
+        events_ingest.resolve_ingest_url()
+        == "http://127.0.0.1:5000/api/autonomous/internal/events/ingest"
+    )
 
 
 def test_route_is_marked_public_endpoint(client):


### PR DESCRIPTION
Follow-up to #3047 found in production verification: the derived default URL was a bare origin (`http://127.0.0.1:5000`), so the forwarder POSTed to `/`, hit the GET-only SPA catch-all, and every batch came back 405 (scheduler log "Ingest endpoint rejected (HTTP 405)"; the ingest route never saw a request; a curl with the full path returned 403 correctly).

Fix: the default branch now appends `DEFAULT_INGEST_PATH` (char-identical to the registered route, verified by the quick review). Explicit `events_ingest_url` overrides pass through unchanged. Test asserts the full URL.

独立快评结论"可合并"(2 NIT:路径字面量多处存在——已有双测试断言钉住;注释重复——可接受)。