### PR TITLE
fix: 修复 get_daily_by_tool 返回字段名不一致 (#3051)

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1329,7 +1329,7 @@ class UsageRepository:
             tenant_id: Optional tenant ID filter. If None, returns all tenants (admin).
 
         Returns:
-            List[Dict]: List of usage records by date and tool.
+            List[Dict]: Trend data with date, tool_name, tokens fields.
 
         Note:
             Issue #1852: Added tenant_id parameter for tenant filtering.

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1373,7 +1373,7 @@ class UsageRepository:
             else:
                 merged[key] = {
                     "date": row["date"],
-                    "tool": normalize_tool_name(row["tool_name"]),
+                    "tool_name": normalize_tool_name(row["tool_name"]),
                     "tokens": int(row["tokens"] or 0),
                 }
 

--- a/tests/integration/test_usage_repo_tenant_scope.py
+++ b/tests/integration/test_usage_repo_tenant_scope.py
@@ -315,13 +315,13 @@ def test_get_daily_by_tool_filters_by_tenant(tmp_db):
     # Query for tenant 1 - should only see tenant 1's data
     tenant_one_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=1)
     assert len(tenant_one_trend) == 1
-    assert tenant_one_trend[0]["tool"] == "codex"
+    assert tenant_one_trend[0]["tool_name"] == "codex"
     assert tenant_one_trend[0]["tokens"] == 100
 
     # Query for tenant 2 - should only see tenant 2's data
     tenant_two_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=2)
     assert len(tenant_two_trend) == 1
-    assert tenant_two_trend[0]["tool"] == "qwen"
+    assert tenant_two_trend[0]["tool_name"] == "qwen"
     assert tenant_two_trend[0]["tokens"] == 200
 
     # Query for admin (no tenant filter) - should see all


### PR DESCRIPTION
Closes #3051

## 修复内容
修复 `get_daily_by_tool` 方法返回的字段名不一致问题，将 `"tool"` 改为 `"tool_name"`，与 `get_session_trend_by_tool` 保持一致。

## 修复方案
参见 Issue #3051 中的修复方案2