### PR TITLE
fix: user management page tool account mapping shows no feedback

### DIFF
--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -111,10 +111,25 @@ export const toolAccountsApi = {
       tool_type?: string;
       description?: string;
     }>
-  ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
-    return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
-      `/api/tool-accounts/user/${userId}/batch`,
-      { tool_accounts: toolAccounts }
-    );
+  ): Promise<{
+    created_count: number;
+    failed_count: number;
+    created: ToolAccount[];
+    failed: Array<{
+      tool_account: string;
+      error: string;
+      existing_user_id?: number;
+    }>;
+  }> {
+    return apiClient.post<{
+      created_count: number;
+      failed_count: number;
+      created: ToolAccount[];
+      failed: Array<{
+        tool_account: string;
+        error: string;
+        existing_user_id?: number;
+      }>;
+    }>(`/api/tool-accounts/user/${userId}/batch`, { tool_accounts: toolAccounts });
   },
 };

--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -170,13 +170,36 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
         };
       });
 
-      await toolAccountsApi.batchCreate(userId, accounts);
+      const result = await toolAccountsApi.batchCreate(userId, accounts);
+
+      // Handle failures
+      if (result.failed_count > 0) {
+        const errorMessages = result.failed
+          .map((f) => `${f.tool_account}: ${f.error}`)
+          .join('\n');
+        toast.error(
+          language === 'zh'
+            ? `映射失败 ${result.failed_count} 个账号：\n${errorMessages}`
+            : `Failed to map ${result.failed_count} accounts:\n${errorMessages}`
+        );
+      }
+
+      // Show success message only when there are successes
+      if (result.created_count > 0) {
+        toast.success(
+          language === 'zh'
+            ? `成功映射 ${result.created_count} 个账号`
+            : `Successfully mapped ${result.created_count} accounts`
+        );
+      }
+
       setSelectedUnmapped([]);
       setShowUnmappedModal(false);
       loadData();
       onChange?.();
     } catch (err) {
       console.error('Failed to map accounts:', err);
+      toast.error(language === 'zh' ? '映射操作失败' : 'Failed to map accounts');
     }
   };
 

--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -174,9 +174,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
 
       // Handle failures
       if (result.failed_count > 0) {
-        const errorMessages = result.failed
-          .map((f) => `${f.tool_account}: ${f.error}`)
-          .join('\n');
+        const errorMessages = result.failed.map((f) => `${f.tool_account}: ${f.error}`).join('\n');
         toast.error(
           language === 'zh'
             ? `映射失败 ${result.failed_count} 个账号：\n${errorMessages}`


### PR DESCRIPTION
## Issue

Fixes #3052

## Root Cause

Two code defects in tool account mapping feature:

1. **API response type mismatch**: Frontend expected `mappings` field, but backend returns `created` and `failed` fields
2. **Missing failure handling**: Frontend doesn't check `failed_count` or `failed` array, no user error toast

## Fix

### 1. Update API type definition (`frontend/src/api/toolAccounts.ts`)

Changed `batchCreate` return type from:
```typescript
Promise<{ created_count: number; mappings: ToolAccount[] }>
```

To match backend actual response:
```typescript
Promise<{
  created_count: number;
  failed_count: number;
  created: ToolAccount[];
  failed: Array<{
    tool_account: string;
    error: string;
    existing_user_id?: number;
  }>;
}>
```

### 2. Add failure handling (`frontend/src/components/features/management/ToolAccountsEditor.tsx`)

- Check `failed_count` from API response
- Show toast.error with detailed error messages when mapping fails
- Show toast.success only when there are successful mappings
- Handle catch block with user-friendly error message

## Testing

- ✅ TypeScript typecheck passed
- ✅ Frontend build passed

## Impact

- Users will now see clear error messages when tool account mapping fails
- Bilingual support (zh/en) for all feedback messages