### PR TITLE
fix: add loading state for tool account mapping to prevent duplicate POST (#3057)

### DIFF
--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -83,6 +83,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   const [showUnmappedModal, setShowUnmappedModal] = useState(false);
   const [selectedUnmapped, setSelectedUnmapped] = useState<string[]>([]);
   const [isAdding, setIsAdding] = useState(false);
+  const [isMapping, setIsMapping] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
   const [showPredeclaredConfirm, setShowPredeclaredConfirm] = useState(false);
   const toast = useToast();
@@ -159,8 +160,9 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   };
 
   const handleMapUnmapped = async () => {
-    if (selectedUnmapped.length === 0) return;
+    if (isMapping || selectedUnmapped.length === 0) return;
 
+    setIsMapping(true);
     try {
       const accounts = selectedUnmapped.map((name) => {
         const account = unmappedAccounts.find((a) => a.sender_name === name);
@@ -198,6 +200,8 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
     } catch (err) {
       console.error('Failed to map accounts:', err);
       toast.error(language === 'zh' ? '映射操作失败' : 'Failed to map accounts');
+    } finally {
+      setIsMapping(false);
     }
   };
 
@@ -414,7 +418,8 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
             <Button
               variant="primary"
               onClick={handleMapUnmapped}
-              disabled={selectedUnmapped.length === 0}
+              loading={isMapping}
+              disabled={isMapping || selectedUnmapped.length === 0}
             >
               {t('mapToUser', language)} ({selectedUnmapped.length})
             </Button>


### PR DESCRIPTION
## Summary

Fixes #3057

The batch mapping button in the user management page was not disabled during submission, allowing duplicate POST requests when users clicked multiple times rapidly.

## Root Cause

`handleMapUnmapped` function was an async function without independent submission state:
- No `isMapping` state
- No re-entry guard at handler entry
- No `loading` prop on button
- No `disabled` check during request

## Changes

1. Added `isMapping` state to track submission status
2. Added re-entry guard: `if (isMapping || selectedUnmapped.length === 0) return;`
3. Added `loading={isMapping}` prop to button
4. Updated `disabled` condition to include `isMapping`
5. Added `finally` block to ensure state recovery

## Verification

- ✅ Frontend build passed
- ✅ Lint check passed (0 errors)
- ✅ Deployed to test environment

## Acceptance Criteria

- Click submit button, button enters loading state immediately and cannot be clicked again
- During request, triggering handler again will not produce a second POST
- Loading state recovers after success or failure
- Error toast and success toast behavior unchanged