### PR TITLE
fix: use dict access for RealDictRow in tool account routes (#3055)

### DIFF
--- a/app/routes/tool_accounts.py
+++ b/app/routes/tool_accounts.py
@@ -580,7 +580,7 @@ def batch_create_user_tool_accounts(user_id: int):
             mapping_source=mapping_source,
             mapping_status=mapping_status,
             created_by=created_by,
-            tenant_id=target_user.tenant_id if target_user else None,
+            tenant_id=target_user.get("tenant_id") if target_user else None,
         )
 
         if mapping:
@@ -743,7 +743,7 @@ def resolve_conflict(id: int):
 
         # Get the owner user to check tenant
         owner_user = user_repo.get_user_by_id(mapping.user_id)
-        if not owner_user or owner_user.tenant_id != user_tenant_id:
+        if not owner_user or owner_user.get("tenant_id") != user_tenant_id:
             return jsonify({"error": "Mapping not found"}), 404
 
     data = request.get_json()
@@ -802,7 +802,7 @@ def touch_mapping_activity(id: int):
 
         # Get the owner user to check tenant
         owner_user = user_repo.get_user_by_id(mapping.user_id)
-        if not owner_user or owner_user.tenant_id != user_tenant_id:
+        if not owner_user or owner_user.get("tenant_id") != user_tenant_id:
             return jsonify({"error": "Mapping not found"}), 404
 
     success = tool_account_repo.touch_activity(id)

--- a/tests/integration/test_tool_accounts_auth_2759.py
+++ b/tests/integration/test_tool_accounts_auth_2759.py
@@ -5,8 +5,8 @@ Issue #2759: Verifies authorization and tenant isolation for tool account APIs.
 Issue #3055: Tests for RealDictRow-compatible dict access in batch endpoint.
 """
 
-from unittest.mock import MagicMock, patch
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -495,13 +495,15 @@ class TestBatchEndpointWithDictLikeRow:
 
         # Create a DictLikeRow that mimics RealDictRow behavior
         # It supports .get() but NOT attribute access like .tenant_id
-        target_user_row = DictLikeRow({
-            "id": 2,
-            "tenant_id": 1,
-            "role": "user",
-            "username": "target_user",
-            "email": "target@example.com",
-        })
+        target_user_row = DictLikeRow(
+            {
+                "id": 2,
+                "tenant_id": 1,
+                "role": "user",
+                "username": "target_user",
+                "email": "target@example.com",
+            }
+        )
 
         with patch("app.auth.decorators._load_user_from_token", return_value=user):
             from app.routes.tool_accounts import tool_accounts_bp

--- a/tests/integration/test_tool_accounts_auth_2759.py
+++ b/tests/integration/test_tool_accounts_auth_2759.py
@@ -2,9 +2,11 @@
 Integration tests for tool account management authorization.
 
 Issue #2759: Verifies authorization and tenant isolation for tool account APIs.
+Issue #3055: Tests for RealDictRow-compatible dict access in batch endpoint.
 """
 
 from unittest.mock import MagicMock, patch
+from typing import Any
 
 import pytest
 from flask import Flask
@@ -15,6 +17,40 @@ from app.auth.tool_account_auth import (
     validate_target_user_for_write,
     validate_user_in_tenant,
 )
+
+
+class DictLikeRow:
+    """A dict-like object that mimics psycopg2.extras.RealDictRow behavior.
+
+    This class supports dict-style access (get, __getitem__) but NOT attribute
+    access. This matches the behavior of RealDictRow in PostgreSQL environment.
+
+    Issue #3055: Used to test that code uses .get() instead of attribute access.
+    """
+
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-style get method."""
+        return self._data.get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        """Dict-style item access."""
+        return self._data[key]
+
+    def __contains__(self, key: str) -> bool:
+        """Support 'in' operator."""
+        return key in self._data
+
+    def __bool__(self) -> bool:
+        """Truthiness - non-empty dict is truthy."""
+        return bool(self._data)
+
+    def __repr__(self) -> str:
+        return f"DictLikeRow({self._data})"
+
+    # Intentionally NOT implementing __getattr__ to ensure .tenant_id fails
 
 
 class TestValidateUserInTenant:
@@ -434,3 +470,90 @@ class TestBatchEndpointAuthorization:
                 )
                 # Should be forbidden (403)
                 assert response.status_code == 403
+
+
+class TestBatchEndpointWithDictLikeRow:
+    """Tests for batch endpoint with RealDictRow-like dict objects.
+
+    Issue #3055: Ensures code uses .get() instead of attribute access,
+    matching PostgreSQL RealDictRow behavior.
+    """
+
+    def test_batch_create_with_dict_like_row_succeeds(self):
+        """Batch create should succeed with dict-like row (no attribute access).
+
+        This test would FAIL on the old code that used target_user.tenant_id
+        because DictLikeRow does not support attribute access.
+        """
+        user = {
+            "id": 1,
+            "role": "platform_admin",
+            "tenant_id": None,
+            "username": "admin",
+            "email": "admin@example.com",
+        }
+
+        # Create a DictLikeRow that mimics RealDictRow behavior
+        # It supports .get() but NOT attribute access like .tenant_id
+        target_user_row = DictLikeRow({
+            "id": 2,
+            "tenant_id": 1,
+            "role": "user",
+            "username": "target_user",
+            "email": "target@example.com",
+        })
+
+        with patch("app.auth.decorators._load_user_from_token", return_value=user):
+            from app.routes.tool_accounts import tool_accounts_bp
+
+            app = Flask(__name__)
+            app.config["TESTING"] = True
+            app.register_blueprint(tool_accounts_bp)
+
+            with patch("app.routes.tool_accounts.user_repo") as mock_user_repo:
+                with patch("app.routes.tool_accounts.tool_account_repo") as mock_tool_repo:
+                    # Return DictLikeRow instead of plain dict
+                    mock_user_repo.get_user_by_id.return_value = target_user_row
+                    mock_tool_repo.get_by_tool_account.return_value = None  # No existing mapping
+
+                    # Mock the created mapping
+                    mock_mapping = MagicMock()
+                    mock_mapping.id = 1
+                    mock_mapping.user_id = 2
+                    mock_mapping.tool_account = "test-sender"
+                    mock_mapping.to_dict.return_value = {
+                        "id": 1,
+                        "user_id": 2,
+                        "tool_account": "test-sender",
+                    }
+                    mock_tool_repo.create.return_value = mock_mapping
+                    mock_tool_repo.update_daily_messages_user_id.return_value = 0
+
+                    client = app.test_client()
+                    response = client.post(
+                        "/tool-accounts/user/2/batch",
+                        json={"tool_accounts": [{"tool_account": "test-sender"}]},
+                        headers={"Authorization": "Bearer token"},
+                    )
+
+                    # Should succeed (200), not throw AttributeError (500)
+                    assert response.status_code == 200
+                    data = response.json
+                    assert data["created_count"] == 1
+                    assert data["failed_count"] == 0
+
+    def test_dict_like_row_attribute_access_raises_attributeerror(self):
+        """Verify DictLikeRow does NOT support attribute access.
+
+        This documents the key difference from regular dict that causes
+        the bug in the old code.
+        """
+        row = DictLikeRow({"tenant_id": 1})
+
+        # Dict access works
+        assert row.get("tenant_id") == 1
+        assert row["tenant_id"] == 1
+
+        # Attribute access raises AttributeError - this is what the bug was
+        with pytest.raises(AttributeError):
+            _ = row.tenant_id  # noqa: B018


### PR DESCRIPTION
## Summary

Fixes #3055

PostgreSQL's `RealDictRow` does not support attribute access. Code in `tool_accounts.py` used `target_user.tenant_id` and `owner_user.tenant_id`, which throws `AttributeError` when the user object is a `RealDictRow` from PostgreSQL.

## Root Cause

`UserRepository.get_user_by_id()` returns `dict | None`. In PostgreSQL, this is `psycopg2.extras.RealDictRow` which supports dict-style access (`.get("tenant_id")`) but not attribute access (`.tenant_id`).

## Fix

Replace 3 occurrences of attribute access with dict access:

| Line | Function | Change |
|---|---|---|
| 583 | `batch_create_user_tool_accounts()` | `target_user.tenant_id` → `target_user.get("tenant_id")` |
| 746 | `resolve_conflict()` | `owner_user.tenant_id` → `owner_user.get("tenant_id")` |
| 805 | `touch_mapping_activity()` | `owner_user.tenant_id` → `owner_user.get("tenant_id")` |

## Changes

- `app/routes/tool_accounts.py`: 3 lines fixed
- `tests/integration/test_tool_accounts_auth_2759.py`: Added `DictLikeRow` test helper and 2 new tests

## Test Evidence

```text
$ pytest tests/integration/test_tool_accounts_auth_2759.py -v
================================ 25 passed in 0.52s ================================
```

New tests:
- `test_batch_create_with_dict_like_row_succeeds`: Verifies batch endpoint succeeds with dict-like objects
- `test_dict_like_row_attribute_access_raises_attributeerror`: Documents why the old code fails

## Risk Assessment

- **Low risk**: Only 3 lines changed, logic unchanged
- **Backward compatible**: `.get()` works on both `dict` and `RealDictRow`
- **No breaking changes**: No API or database schema changes

## Checklist

- [x] Code follows project conventions
- [x] Tests added and passing
- [x] No sensitive information in changes