### PR TITLE
fix: use regex to find any cache-bust parameter in patch script

### DIFF
--- a/scripts/patch-qwen-webui-local-permission.py
+++ b/scripts/patch-qwen-webui-local-permission.py
@@ -23,6 +23,7 @@ of silently shipping an unpatched bundle.
 """
 
 import sys
+import re
 
 BUNDLE = "/usr/lib/node_modules/qwen-code-webui/dist/static/assets/index-DO2hmkKX.js"
 INDEX_HTML = "/usr/lib/node_modules/qwen-code-webui/dist/static/index.html"
@@ -123,12 +124,11 @@ def main() -> int:
                 f.write(html)
             print("[patch-qwen-webui-local-permission] index.html cache-bust applied")
         else:
-            # Check for older cache-bust version
-            old_bust_pattern = f'src="/assets/{basename}?v=local-perm-'
-            idx = html.find(old_bust_pattern)
-            if idx >= 0:
-                end = html.find('"', idx)
-                html = html[:idx] + busted_src + html[end:]
+            # Use regex to find and update any existing cache-bust parameter
+            pattern = rf'src="/assets/{re.escape(basename)}\?[^"]*"'
+            match = re.search(pattern, html)
+            if match:
+                html = html.replace(match.group(0), busted_src + '"')
                 with open(INDEX_HTML, "w", encoding="utf-8") as f:
                     f.write(html)
                 print("[patch-qwen-webui-local-permission] index.html cache-bust bumped")

--- a/scripts/patch-qwen-webui-local-permission.py
+++ b/scripts/patch-qwen-webui-local-permission.py
@@ -22,8 +22,8 @@ bundle changes, this script exits non-zero so the build fails loudly instead
 of silently shipping an unpatched bundle.
 """
 
-import sys
 import re
+import sys
 
 BUNDLE = "/usr/lib/node_modules/qwen-code-webui/dist/static/assets/index-DO2hmkKX.js"
 INDEX_HTML = "/usr/lib/node_modules/qwen-code-webui/dist/static/index.html"


### PR DESCRIPTION
## Problem

Docker build failed with error:
```
[patch-qwen-webui-local-permission] script src 'src="/assets/index-DO2hmkKX.js"' not found in index.html
```

The patch script was failing when `index.html` had an existing cache-bust parameter in a format different from what the script expected.

## Root Cause

The script used hardcoded string patterns to find and update cache-bust parameters. When the existing cache-bust format didn't match the expected patterns (`v=local-perm-`), the script returned exit code 1.

## Solution

Changed from string search to regex pattern matching:
```python
pattern = rf'src="/assets/{re.escape(basename)}\?[^"]*"'
```

This handles any existing cache-bust parameter format.

## Testing

- ✅ Script syntax verified
- ✅ Regex pattern matches expected formats