### PR TITLE
fix: 刷新页面后保持所有标签页状态 (#3071)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1085,31 +1085,50 @@ export const Workspace: React.FC = () => {
         // Issue #2953: Smart URL restore - check if session already exists in store
         const existingTab = safeStoredTabs.find((t) => t.sessionId === restoreSessionId);
         if (existingTab) {
-          // Session already exists in store, just activate it instead of creating new tab
-          console.log('[Workspace] Found existing tab for session, activating:', restoreSessionId);
-          initialActiveTabId = existingTab.id;
-          // Regenerate URL for existing tab
-          const remoteParams = existingTab.workspaceType
-            ? {
-                workspaceType: existingTab.workspaceType,
-                machineId: existingTab.machineId,
-                machineName: existingTab.machineName,
-              }
-            : undefined;
-          const effectiveUrl = getEffectiveUrl(
-            existingTab.sessionId,
-            existingTab.encodedProjectName,
-            existingTab.toolName,
-            existingTab.settings,
-            remoteParams
+          // Session already exists in store, restore ALL tabs and activate this one
+          console.log(
+            '[Workspace] Found existing tab for session, restoring all tabs and activating:',
+            restoreSessionId
           );
-          initialTabs = [
-            {
-              ...existingTab,
+          initialActiveTabId = existingTab.id;
+
+          // Issue #3071: Restore ALL tabs from localStorage, not just the matched one
+          initialTabs = safeStoredTabs.map((storedTab) => {
+            // Terminal tabs don't need URL regeneration
+            if (storedTab.tabType === 'terminal') {
+              return {
+                ...storedTab,
+                url: '',
+                token: '',
+                terminalWsUrl: '',
+                terminalToken: '',
+              };
+            }
+
+            // Regenerate URL for each tab
+            const remoteParams = storedTab.workspaceType
+              ? {
+                  workspaceType: storedTab.workspaceType,
+                  machineId: storedTab.machineId,
+                  machineName: storedTab.machineName,
+                }
+              : undefined;
+            const effectiveUrl = storedTab.sessionId
+              ? getEffectiveUrl(
+                  storedTab.sessionId,
+                  storedTab.encodedProjectName,
+                  storedTab.toolName,
+                  storedTab.settings,
+                  remoteParams
+                )
+              : getEffectiveUrl(undefined, undefined, undefined, undefined, remoteParams);
+
+            return {
+              ...storedTab,
               url: effectiveUrl ?? '',
               token: userWebUI?.token ?? '',
-            },
-          ];
+            };
+          });
         } else {
           // No existing tab, create new one
           // Build settings from URL params
@@ -1179,7 +1198,7 @@ export const Workspace: React.FC = () => {
               urlResumeHint
             );
             if (effectiveUrl) {
-              const tab: WorkspaceTab = {
+              const newTab: WorkspaceTab = {
                 id: generateTabId(),
                 title: t('restoredSession', language),
                 url: effectiveUrl,
@@ -1198,24 +1217,64 @@ export const Workspace: React.FC = () => {
                 waitingForUser: false,
                 waitingType: null,
               };
-              initialTabs = [tab];
-              initialActiveTabId = tab.id;
+
+              // Issue #3071: Restore ALL tabs from localStorage and APPEND the new tab
+              initialTabs = [
+                ...safeStoredTabs.map((storedTab) => {
+                  // Terminal tabs don't need URL regeneration
+                  if (storedTab.tabType === 'terminal') {
+                    return {
+                      ...storedTab,
+                      url: '',
+                      token: '',
+                      terminalWsUrl: '',
+                      terminalToken: '',
+                    };
+                  }
+
+                  // Regenerate URL for each tab
+                  const remoteParams = storedTab.workspaceType
+                    ? {
+                        workspaceType: storedTab.workspaceType,
+                        machineId: storedTab.machineId,
+                        machineName: storedTab.machineName,
+                      }
+                    : undefined;
+                  const effectiveUrl = storedTab.sessionId
+                    ? getEffectiveUrl(
+                        storedTab.sessionId,
+                        storedTab.encodedProjectName,
+                        storedTab.toolName,
+                        storedTab.settings,
+                        remoteParams
+                      )
+                    : getEffectiveUrl(undefined, undefined, undefined, undefined, remoteParams);
+
+                  return {
+                    ...storedTab,
+                    url: effectiveUrl ?? '',
+                    token: userWebUI?.token ?? '',
+                  };
+                }),
+                newTab, // Append new tab
+              ];
+              initialActiveTabId = newTab.id;
 
               // Save to store (append, don't clear existing tabs)
               // Issue #2953: Smart append instead of replacing all tabs
               addStoredTab({
-                id: tab.id,
-                title: tab.title,
-                sessionId: tab.sessionId,
-                encodedProjectName: tab.encodedProjectName,
-                toolName: tab.toolName,
-                settings: tab.settings,
-                workspaceType: tab.workspaceType,
-                machineId: tab.machineId,
-                machineName: tab.machineName,
-                createdAt: tab.createdAt,
-                waitingForUser: tab.waitingForUser,
-                waitingType: tab.waitingType,
+                id: newTab.id,
+                title: newTab.title,
+                sessionId: newTab.sessionId,
+                encodedProjectName: newTab.encodedProjectName,
+                toolName: newTab.toolName,
+                settings: newTab.settings,
+                workspaceType: newTab.workspaceType,
+                machineId: newTab.machineId,
+                machineName: newTab.machineName,
+                createdAt: newTab.createdAt,
+                waitingForUser: newTab.waitingForUser,
+                waitingType: newTab.waitingType,
               });
             }
           }


### PR DESCRIPTION
Closes #3071

## 问题描述

当用户在Work模式下有多个标签页时，点击其中一个标签页后刷新页面，工作区只显示当前标签页，其他标签页丢失了。

## 根本原因

Issue #2899（PR #2924）的修复方案存在缺陷：当URL有sessionId参数时，初始化逻辑只创建一个标签页数组，然后用setTabs覆盖React状态中的所有标签页，导致localStorage中的其他标签页丢失。

## 修复方案

### 找到标签页时
从 localStorage 恢复所有标签页（从 safeStoredTabs 恢复），只激活对应的标签页（设置 initialActiveTabId），不要用单个标签页数组覆盖所有标签页。

### 未找到标签页时
从 localStorage 恢复所有标签页，创建新标签页，将新标签页追加到恢复的标签页列表，激活新标签页。

## 代码变更

- 文件：frontend/src/components/features/Workspace.tsx
- 第 1091-1120 行：从 safeStoredTabs 恢复所有标签页
- 第 1182-1199 行：恢复所有标签页并追加新标签页

## 风险评估

- 重复恢复：现有代码已有 existingTab 检查，确保不会重复添加同一 session 的标签页
- URL 参数不一致：现有代码已有 session 验证逻辑（Issue #2892）
- 性能影响：标签页数量通常较少，性能影响可忽略
- 并发刷新：React 状态更新是同步的，不存在并发问题

## 测试场景

- 基础：打开多个标签页，刷新页面，验证所有标签页都存在
- 激活：切换到其中一个标签页，刷新页面，验证当前标签页被激活，其他标签页保留
- 边界：localStorage 为空或 URL 的 sessionId 不存在
- 回归：浏览器前进/后退功能（Issue #2899）正常