### PR TITLE
fix: add global unread alert badge to Header (#3060)

### DIFF
--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Header Component Tests - Notification Bell & Unread Alert Badge
+ *
+ * Tests cover:
+ * - Notification bell renders when authenticated
+ * - Notification bell hidden when not authenticated
+ * - Clicking bell navigates to /manage/quota
+ * - Polling fetches unread count on mount and every 30s
+ * - Polling cleans up on unmount
+ * - API error handled gracefully
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+// Mutable mock state
+let mockIsAuthenticated = true;
+const mockGetUnreadCount = vi.fn();
+const mockNavigate = vi.fn();
+
+// Mock hooks
+vi.mock('@/hooks', () => ({
+  useAuth: () => ({
+    user: { username: 'testuser', email: 'test@test.com', avatar_url: null },
+    isAuthenticated: mockIsAuthenticated,
+    logout: vi.fn(),
+  }),
+  useTheme: () => 'light',
+  useLanguage: () => 'en',
+}));
+
+// Mock store
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      setTheme: vi.fn(),
+      setLanguage: vi.fn(),
+      toggleMobileSidebar: vi.fn(),
+    }),
+  },
+}));
+
+// Mock i18n
+vi.mock('@/i18n', () => ({
+  t: (key: string) => {
+    const translations: Record<string, string> = {
+      unreadAlerts: 'Unread Alerts',
+      help: 'Help',
+      toggleTheme: 'Toggle Theme',
+      settings: 'Settings',
+      logout: 'Logout',
+      login: 'Login',
+      english: 'English',
+      chinese: 'Chinese',
+      japanese: 'Japanese',
+      korean: 'Korean',
+    };
+    return translations[key] || key;
+  },
+  setLanguage: vi.fn(),
+}));
+
+// Mock API
+vi.mock('@/api', () => ({
+  alertsApi: {
+    getUnreadCount: (...args: unknown[]) => mockGetUnreadCount(...args),
+  },
+}));
+
+// Mock common components (pass-through for CountBadge)
+vi.mock('@/components/common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/components/common');
+  return {
+    ...actual,
+    UserSettingsModal: () => null,
+    Avatar: ({ name }: { name: string }) => <span>{name}</span>,
+  };
+});
+
+// Mock DocumentViewer
+vi.mock('@/components/work/DocumentViewer', () => ({
+  DocumentViewer: () => null,
+  helpDocs: [],
+  getDocTitle: () => '',
+}));
+
+// Mock react-router-dom navigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { Header } from './Header';
+
+describe('Header - Notification Bell', () => {
+  beforeEach(() => {
+    mockIsAuthenticated = true;
+    mockGetUnreadCount.mockResolvedValue(5);
+    mockNavigate.mockClear();
+    mockGetUnreadCount.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderHeader = (compact = false) =>
+    render(
+      <MemoryRouter>
+        <Header compact={compact} />
+      </MemoryRouter>
+    );
+
+  it('renders notification bell when authenticated', async () => {
+    renderHeader();
+    await waitFor(() => {
+      expect(screen.getByTitle('Unread Alerts')).toBeInTheDocument();
+    });
+  });
+
+  it('hides notification bell when not authenticated', async () => {
+    mockIsAuthenticated = false;
+    renderHeader();
+    // Give time for any async effects to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+    expect(screen.queryByTitle('Unread Alerts')).not.toBeInTheDocument();
+  });
+
+  it('calls getUnreadCount on mount', async () => {
+    renderHeader();
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalled();
+    });
+  });
+
+  it('navigates to /manage/quota when bell is clicked', async () => {
+    renderHeader();
+    await waitFor(() => {
+      expect(screen.getByTitle('Unread Alerts')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTitle('Unread Alerts'));
+    expect(mockNavigate).toHaveBeenCalledWith('/manage/quota');
+  });
+
+  it('handles API error gracefully without crashing', async () => {
+    mockGetUnreadCount.mockRejectedValue(new Error('Network error'));
+    renderHeader();
+
+    // Wait for the fetch attempt
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    // Bell should still be visible
+    expect(screen.getByTitle('Unread Alerts')).toBeInTheDocument();
+  });
+
+  it('renders bell in compact mode when authenticated', async () => {
+    renderHeader(true);
+    await waitFor(() => {
+      expect(screen.getByTitle('Unread Alerts')).toBeInTheDocument();
+    });
+  });
+
+  it('polls every 30 seconds using fake timers', async () => {
+    vi.useFakeTimers();
+    mockGetUnreadCount.mockClear();
+
+    renderHeader();
+
+    // Initial fetch
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+
+    const initialCallCount = mockGetUnreadCount.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThanOrEqual(1);
+
+    // Advance 30 seconds
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(mockGetUnreadCount.mock.calls.length).toBeGreaterThan(initialCallCount);
+
+    vi.useRealTimers();
+  });
+
+  it('cleans up polling on unmount', async () => {
+    vi.useFakeTimers();
+
+    const { unmount } = renderHeader();
+
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+
+    const callsBeforeUnmount = mockGetUnreadCount.mock.calls.length;
+
+    unmount();
+
+    // Advance time after unmount
+    await act(async () => {
+      vi.advanceTimersByTime(60000);
+    });
+
+    // Should not have been called again after unmount
+    expect(mockGetUnreadCount.mock.calls.length).toBe(callsBeforeUnmount);
+
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,13 +2,14 @@
  * Header Component - Top navigation header
  */
 
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { cn } from '@/utils';
 import { useAuth, useTheme, useLanguage } from '@/hooks';
 import { useAppStore } from '@/store';
 import { t, setLanguage as setI18nLanguage } from '@/i18n';
-import { UserSettingsModal, Avatar } from '@/components/common';
+import { alertsApi } from '@/api';
+import { UserSettingsModal, Avatar, CountBadge } from '@/components/common';
 import { DocumentViewer, helpDocs, getDocTitle } from '@/components/work/DocumentViewer';
 
 interface HeaderProps {
@@ -19,8 +20,47 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
   const { user, isAuthenticated, logout } = useAuth();
   const theme = useTheme();
   const language = useLanguage();
+  const navigate = useNavigate();
   const [showSettings, setShowSettings] = useState(false);
   const [helpDocId, setHelpDocId] = useState<string>('');
+  const [unreadAlertCount, setUnreadAlertCount] = useState(0);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Fetch unread alert count
+  const fetchUnreadCount = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      const count = await alertsApi.getUnreadCount();
+      setUnreadAlertCount(count);
+    } catch {
+      // Graceful degradation: keep previous count on error
+    }
+  }, [isAuthenticated]);
+
+  // Poll unread alert count every 30 seconds
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setUnreadAlertCount(0);
+      return;
+    }
+
+    // Initial fetch
+    fetchUnreadCount();
+
+    // Start polling
+    pollingRef.current = setInterval(fetchUnreadCount, 30000);
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [isAuthenticated, fetchUnreadCount]);
+
+  const handleNotificationClick = () => {
+    navigate('/manage/quota');
+  };
 
   const handleThemeToggle = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
@@ -40,6 +80,19 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
   // Content for right side (help, language, theme, user menu)
   const rightContent = (
     <div className="d-flex align-items-center gap-2">
+      {/* Notification bell with unread count badge */}
+      {isAuthenticated && (
+        <button
+          className="btn btn-link header-icon-btn p-0 position-relative"
+          onClick={handleNotificationClick}
+          title={t('unreadAlerts', language)}
+          aria-label={t('unreadAlerts', language)}
+        >
+          <i className="bi bi-bell" />
+          <CountBadge count={unreadAlertCount} />
+        </button>
+      )}
+
       {/* Help menu */}
       <div className="dropdown">
         <button


### PR DESCRIPTION
## 修复说明

关联 Issue：#3060

## 根因

Header 组件（`frontend/src/components/layout/Header.tsx`）缺少全局未读告警角标实现。后端 API `GET /api/alerts/unread-count` 和前端 API 客户端 `alertsApi.getUnreadCount()` 已就绪，但 Header UI 层未集成通知铃铛图标和未读角标。

## 修复方案

在 Header 右侧区域（help 菜单之前）添加通知铃铛图标 + CountBadge：
- 使用 `bi-bell` 图标 + 已有的 `CountBadge` 组件
- 每 30 秒轮询 `alertsApi.getUnreadCount()` 更新未读数
- 点击铃铛跳转到 `/manage/quota` 告警管理页面
- 仅登录用户显示铃铛
- API 错误时优雅降级（保持之前显示的数量）
- 角标 >99 时显示 "99+"，为 0 时隐藏角标

## 主要变更

- `frontend/src/components/layout/Header.tsx`：添加通知铃铛、未读数轮询、点击跳转逻辑
- `frontend/src/components/layout/Header.test.tsx`：新增 8 个测试覆盖铃铛渲染/轮询/导航/错误处理

## 测试

- 测试环境：Package 测试环境
- 已运行的测试：全部 1142 个前端单元测试（含 8 个新增）
- 新增测试：
  - 认证用户显示铃铛
  - 未认证用户隐藏铃铛
  - 挂载时调用 getUnreadCount
  - 点击铃铛导航到 /manage/quota
  - API 错误时优雅降级
  - compact 模式下显示铃铛
  - 30 秒轮询行为验证
  - 卸载时清理定时器

## 风险

- 兼容性风险：无 — 仅新增 UI 元素
- 性能风险：极低 — 30 秒一次轻量 API 调用
- 安全风险：无 — 使用现有认证 API
- 回归风险：极低 — 不修改任何现有组件行为