### PR TITLE
fix: pass DB_PASSWORD as standalone env var to container (#3095)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       # Database (Issue #1893): Development mode uses dev-password-change-in-production.
       # Production mode requires explicit strong password via DB_PASSWORD env var.
       - DATABASE_URL=postgresql://${DB_USER:-ace}:${DB_PASSWORD:-dev-password-change-in-production}@postgres:5432/${DB_NAME:-ace}
+      # Issue #3095: Pass DB_PASSWORD as standalone env var for security baseline check.
+      # The entrypoint check_security_baseline() reads DB_PASSWORD directly, not from DATABASE_URL.
+      - DB_PASSWORD=${DB_PASSWORD:-}
       # Multi-user Workspace
       - WORKSPACE_MULTI_USER_MODE=${WORKSPACE_MULTI_USER_MODE:-false}
       # Workspace base directory (users' projects stored under /workspace/<username>/)
@@ -160,6 +163,8 @@ services:
       - SECRET_KEY=${SECRET_KEY:-}
       - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:-}
       - DATABASE_URL=postgresql://${DB_USER:-ace}:${DB_PASSWORD:-dev-password-change-in-production}@postgres:5432/${DB_NAME:-ace}
+      # Issue #3095: Pass DB_PASSWORD as standalone env var for security baseline check.
+      - DB_PASSWORD=${DB_PASSWORD:-}
       - SCHEDULER_HEARTBEAT_INTERVAL=${SCHEDULER_HEARTBEAT_INTERVAL:-10}
       - SCHEDULER_HEARTBEAT_TIMEOUT=${SCHEDULER_HEARTBEAT_TIMEOUT:-60}
       - SCHEDULER_LOCK_TIMEOUT=${SCHEDULER_LOCK_TIMEOUT:-1800}


### PR DESCRIPTION
## 修复说明

关联 Issue：#3095

## 根因

Docker Compose 配置中，`open-ace` 和 `scheduler` 服务将 `DB_PASSWORD` 插值到 `DATABASE_URL` 字符串中，但未将其作为独立环境变量传入容器。而 `docker-entrypoint.sh` 的 `check_security_baseline()` 函数直接读取 `DB_PASSWORD` 环境变量，导致 production 模式下检查失败、容器退出并持续重启。

## 修复方案

在 `docker-compose.yml` 中为 `open-ace` 和 `scheduler` 服务的 `environment` 添加独立的 `DB_PASSWORD` 环境变量：

```yaml
- DB_PASSWORD=${DB_PASSWORD:-}
```

## 主要变更

- 在 `open-ace` 服务的 `environment` 中添加 `DB_PASSWORD=${DB_PASSWORD:-}`（第 97 行）
- 在 `scheduler` 服务的 `environment` 中添加 `DB_PASSWORD=${DB_PASSWORD:-}`（第 166 行）
- 添加注释说明修复原因（Issue #3095）

## 测试

- 验证 Docker Compose 配置文件语法正确
- production + 强密码：安全基线应通过数据库密码检查
- production + 空密码：仍按现有规则失败
- development + 空密码：保持零配置兼容行为
- 修改后容器不再因安全基线检查失败而重启

## 风险

- **兼容性**：无风险。新增环境变量不影响现有行为
- **性能**：无风险。仅增加一个环境变量传递
- **安全**：无风险。密码通过 Compose 标准方式传递，不会泄漏到日志
- **回归**：无风险。默认值为空，development 模式行为不变