### PR TITLE
fix(#3096): use npm ci to sync frontend deps instead of checking node_modules existence

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2262,10 +2262,26 @@ build_docker_image() {
             # Build frontend
             print_info "构建前端..."
             cd "$source_dir/frontend"
-            if [ ! -d "node_modules" ]; then
-                print_info "安装前端依赖..."
-                npm install
-                if [ $? -ne 0 ]; then
+
+            # Install/sync frontend dependencies based on lockfile (Issue #3096)
+            # Use npm ci to ensure dependencies match package-lock.json exactly.
+            # Fallback: if npm ci fails (e.g. offline) and node_modules already
+            # exists, warn and continue; if node_modules is missing, abort.
+            if [ -f "package-lock.json" ]; then
+                print_info "同步前端依赖 (npm ci)..."
+                if npm ci; then
+                    :
+                else
+                    if [ -d "node_modules" ]; then
+                        print_warning "npm ci 失败，将使用现有 node_modules 继续构建"
+                    else
+                        print_error "前端依赖安装失败且 node_modules 不存在"
+                        return 1
+                    fi
+                fi
+            else
+                print_info "安装前端依赖 (npm install)..."
+                if ! npm install; then
                     print_error "前端依赖安装失败"
                     return 1
                 fi
@@ -2587,10 +2603,30 @@ upgrade_deployment() {
             return 1
         fi
 
-        # Install dependencies if needed
-        if [ ! -d "node_modules" ]; then
-            print_info "安装前端依赖..."
-            npm install
+        # Install/sync dependencies based on lockfile (Issue #3096)
+        # Use npm ci to ensure dependencies match package-lock.json exactly.
+        # Fallback: if npm ci fails (e.g. offline) and node_modules already
+        # exists, warn and continue; if node_modules is missing, abort.
+        if [ -f "package-lock.json" ]; then
+            print_info "同步前端依赖 (npm ci)..."
+            if npm ci; then
+                :
+            else
+                if [ -d "node_modules" ]; then
+                    print_warning "npm ci 失败，将使用现有 node_modules 继续构建"
+                else
+                    print_error "前端依赖安装失败且 node_modules 不存在"
+                    print_info "旧服务未受影响，继续运行"
+                    return 1
+                fi
+            fi
+        else
+            print_info "安装前端依赖 (npm install)..."
+            if ! npm install; then
+                print_error "前端依赖安装失败"
+                print_info "旧服务未受影响，继续运行"
+                return 1
+            fi
         fi
 
         # Build frontend

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -368,11 +368,31 @@ if [ -d "$FRONTEND_DIR" ]; then
 
     cd "$FRONTEND_DIR"
 
-    # Install dependencies if node_modules doesn't exist or package.json changed
+    # Install/sync dependencies based on lockfile (Issue #3096)
+    # Use npm ci to ensure dependencies match package-lock.json exactly.
+    # Fallback: if npm ci fails (e.g. offline) and node_modules already
+    # exists, warn and continue; if node_modules is missing, abort.
     # Set HUSKY=0 to skip git hooks setup (package directory is not a git repo)
-    if [ ! -d "node_modules" ] || [ "$(find package.json -newer node_modules 2>/dev/null | head -1)" ]; then
-        echo -e "${BLUE}Installing frontend dependencies...${NC}"
-        HUSKY=0 npm install --silent 2>/dev/null || HUSKY=0 npm install
+    if [ -f "package-lock.json" ]; then
+        echo -e "${BLUE}Syncing frontend dependencies (npm ci)...${NC}"
+        if HUSKY=0 npm ci --silent 2>/dev/null || HUSKY=0 npm ci; then
+            :
+        else
+            if [ -d "node_modules" ]; then
+                echo -e "${YELLOW}Warning: npm ci failed, continuing with existing node_modules${NC}"
+            else
+                echo -e "${RED}Error: Frontend dependency installation failed and node_modules is missing${NC}"
+                exit 1
+            fi
+        fi
+    else
+        echo -e "${BLUE}Installing frontend dependencies (npm install)...${NC}"
+        if HUSKY=0 npm install --silent 2>/dev/null || HUSKY=0 npm install; then
+            :
+        else
+            echo -e "${RED}Error: Frontend dependency installation failed${NC}"
+            exit 1
+        fi
     fi
 
     # Build frontend


### PR DESCRIPTION
## 修复说明

关联 Issue：#3096

## 根因

三个前端构建路径均以 `node_modules` 目录是否存在作为依赖有效性判据，不与 `package-lock.json` 同步。当旧 `node_modules` 缺少新锁文件声明的依赖（如 `react-datepicker`）时，脚本跳过安装直接执行 `npm run build`，TypeScript 编译因找不到模块而失败。

## 修复方案

在所有前端构建路径中，当 `package-lock.json` 存在时执行 `npm ci`（严格按锁文件安装），否则 fallback 到 `npm install`。如果 `npm ci` 失败（如离线环境）且 `node_modules` 已存在，给出警告并继续构建；如果 `node_modules` 不存在，则报错退出。

所有错误处理使用 `if/then/else` 模式，兼容 `set -e`。

## 主要变更

- `scripts/install-central/docker-method/install.sh` - `build_docker_image()` 函数（本地构建镜像路径）
- `scripts/install-central/docker-method/install.sh` - `upgrade_deployment()` 函数（升级路径，适配新版 phase 结构）
- `scripts/install-central/package-method/package.sh` - 前端构建路径

## 测试

- `npm ci` 在 `frontend/` 目录执行成功
- bash 语法检查通过（`bash -n`）
- 确认无其他 `[ ! -d "node_modules" ]` 残留实例
- Dockerfile 已使用 `npm ci`，无需修改

## 风险

- 兼容性：离线环境 `npm ci` 失败时有 fallback（`node_modules` 存在则继续构建）
- 性能：每次构建重新执行 `npm ci`，耗时增加但可接受（安装/升级脚本频率低）
- 回归：首次安装不受影响（无 `node_modules` 时 `npm ci` 等效于全新安装）