### PR TITLE
fix: bootstrap multi-user production Compose configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,13 @@
 #   cp .env.example .env   # 然后按需修改
 #   docker compose up -d --build
 #
-# 不创建 .env 也能直接 `docker compose up -d --build`：缺失的密钥会在
+# 基础单用户 development 模式不创建 .env 也能直接 `docker compose up -d
+# --build`：缺失的密钥会在
 # 容器首次启动时由 docker-entrypoint.sh 自动生成强随机值，并持久化到 config
 # 卷的 generated-secrets.env（后续重启复用，不会轮转）。本文件主要用于生产
 # 环境显式配置——显式设置的值优先于自动生成的，且不会被写入 generated-secrets.env。
+# 多用户 overlay 默认使用 production，首次启动前必须执行：
+#   ./scripts/bootstrap-compose-env.sh
 #
 # 非 Docker 直启（python3 server.py）同样支持零配置（Issue #2667）：开发/试用
 # 模式下缺失的 OPENACE_ENCRYPTION_KEY 会在首次启动自动生成并持久化到

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__/
 *.so
 .Python
 .env
+.env.bootstrap.lock
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ git clone https://github.com/open-ace/open-ace.git
 cd open-ace
 
 # 使用 overlay 文件启动
-docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d
+./scripts/bootstrap-compose-env.sh
+docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d --wait
 
 # 访问 http://localhost:19888
 ```

--- a/docker-compose.multi-user.yml
+++ b/docker-compose.multi-user.yml
@@ -14,7 +14,7 @@
 #   4. Set SECRET_KEY, OPENACE_ENCRYPTION_KEY, UPLOAD_AUTH_KEY in production
 #
 # Usage:
-#   # Create users via admin API, then:
+#   ./scripts/bootstrap-compose-env.sh
 #   docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d
 #
 # Alternative using environment variables:
@@ -45,6 +45,10 @@ services:
       - OPENACE_CONFIG_DIR=/home/open-ace/.open-ace
       # Security mode - recommend production for actual deployments
       - OPENACE_SECURITY_MODE=${OPENACE_SECURITY_MODE:-production}
+      # Fail before container creation when production bootstrap was skipped.
+      - DB_PASSWORD=${DB_PASSWORD:?Run ./scripts/bootstrap-compose-env.sh first}
+      - SECRET_KEY=${SECRET_KEY:?Run ./scripts/bootstrap-compose-env.sh first}
+      - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:?Run ./scripts/bootstrap-compose-env.sh first}
 
     # Issue #2729: Share /home directory with scheduler for Qwen session collection
     # Users' .qwen/projects directories are stored under /home/<username>/
@@ -70,8 +74,15 @@ services:
       - OPENACE_CONFIG_DIR=/home/open-ace/.open-ace
       # Security mode - recommend production for actual deployments
       - OPENACE_SECURITY_MODE=${OPENACE_SECURITY_MODE:-production}
+      - DB_PASSWORD=${DB_PASSWORD:?Run ./scripts/bootstrap-compose-env.sh first}
+      - SECRET_KEY=${SECRET_KEY:?Run ./scripts/bootstrap-compose-env.sh first}
+      - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:?Run ./scripts/bootstrap-compose-env.sh first}
     volumes:
       - home-data:/home
+
+  postgres:
+    environment:
+      - POSTGRES_PASSWORD=${DB_PASSWORD:?Run ./scripts/bootstrap-compose-env.sh first}
 
 # Issue #2729: Named volume for multi-user home directories
 # Shared between open-ace and scheduler containers for session collection

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -79,7 +79,8 @@ uid 1000 执行入口脚本，而不再仅依赖清单中的 `securityContext`�
 
 ```bash
 # 一键启用多用户模式
-docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d
+./scripts/bootstrap-compose-env.sh
+docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d --wait
 ```
 
 docker-compose.multi-user.yml 会自动配置：

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -63,7 +63,8 @@ system users (`useradd`), fixes ownership (`chown`), and switches identity
 
 ```bash
 # One-command multi-user mode
-docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d
+./scripts/bootstrap-compose-env.sh
+docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d --wait
 ```
 
 The docker-compose.multi-user.yml automatically configures:

--- a/scripts/bootstrap-compose-env.sh
+++ b/scripts/bootstrap-compose-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/bootstrap_compose_env.py" "$@"

--- a/scripts/bootstrap_compose_env.py
+++ b/scripts/bootstrap_compose_env.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Safely bootstrap persistent secrets for multi-user Compose deployments."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REQUIRED = ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY")
+ALL_KEYS = ("OPENACE_SECURITY_MODE", *REQUIRED, "UPLOAD_AUTH_KEY")
+FORBIDDEN_PASSWORDS = {
+    "ace-secret", "dev-password-change-in-production", "change-me", "password",
+    "admin", "postgres", "123456",
+}
+
+
+def parse_env(lines: list[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in lines:
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line.rstrip("\r\n"))
+        if match:
+            value = match.group(2).strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            values[match.group(1)] = value
+    return values
+
+
+def validate(values: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    if values.get("OPENACE_SECURITY_MODE") != "production":
+        errors.append("OPENACE_SECURITY_MODE must be production")
+    password = values.get("DB_PASSWORD", "")
+    if len(password) < 9 or password in FORBIDDEN_PASSWORDS:
+        errors.append("DB_PASSWORD must be a strong non-default value (9+ characters)")
+    if len(values.get("SECRET_KEY", "")) < 32:
+        errors.append("SECRET_KEY must contain at least 32 characters")
+    if len(values.get("OPENACE_ENCRYPTION_KEY", "")) < 32:
+        errors.append("OPENACE_ENCRYPTION_KEY must contain at least 32 characters")
+    if not values.get("UPLOAD_AUTH_KEY"):
+        errors.append("UPLOAD_AUTH_KEY is required for complete upload functionality")
+    return errors
+
+
+def compose_project_name(project_root: Path) -> str:
+    explicit = os.environ.get("COMPOSE_PROJECT_NAME", "").strip()
+    raw = explicit or project_root.name
+    normalized = re.sub(r"[^a-z0-9_-]", "", raw.lower())
+    normalized = re.sub(r"^[^a-z0-9]+", "", normalized)
+    if not normalized:
+        raise RuntimeError("cannot determine the Compose project name")
+    return normalized
+
+
+def find_postgres_volumes(project_root: Path) -> list[str]:
+    docker = shutil.which("docker")
+    if not docker:
+        raise RuntimeError("Docker CLI is unavailable; existing volume state is unknown")
+    project = compose_project_name(project_root)
+    result = subprocess.run(
+        [docker, "volume", "ls", "-q", "--filter", f"label=com.docker.compose.project={project}",
+         "--filter", "label=com.docker.compose.volume=postgres-data"],
+        capture_output=True, text=True, timeout=15, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("cannot inspect Docker volumes; existing volume state is unknown")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def safe_external_value(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    if "\n" in value or "\r" in value or not re.fullmatch(r"[A-Za-z0-9_.~:/+@%-]+", value):
+        raise RuntimeError(f"{name} from the shell cannot be safely persisted; put it in .env explicitly")
+    return value
+
+
+def generated_value(name: str) -> str:
+    if name == "OPENACE_SECURITY_MODE":
+        return "production"
+    if name == "DB_PASSWORD":
+        return secrets.token_urlsafe(32)
+    return secrets.token_hex(32)
+
+
+def update_lines(lines: list[str], values: dict[str, str]) -> list[str]:
+    result = list(lines)
+    positions: dict[str, int] = {}
+    for index, line in enumerate(result):
+        match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=", line)
+        if match:
+            positions[match.group(1)] = index
+    for key, value in values.items():
+        rendered = f"{key}={value}\n"
+        if key in positions:
+            result[positions[key]] = rendered
+        else:
+            result.append(rendered)
+    return result
+
+
+def atomic_write(path: Path, lines: list[str]) -> None:
+    fd, temp_name = tempfile.mkstemp(prefix=".env.tmp.", dir=path.parent, text=True)
+    try:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.writelines(lines)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+def bootstrap(project_root: Path, check_only: bool = False) -> None:
+    env_path = project_root / ".env"
+    if env_path.is_symlink():
+        raise RuntimeError("refusing to read or replace a symbolic-link .env")
+    lock_path = project_root / ".env.bootstrap.lock"
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(lock_fd, "r+") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            lines = env_path.read_text(encoding="utf-8").splitlines(keepends=True) if env_path.exists() else []
+            current = parse_env(lines)
+            for key in ALL_KEYS:
+                external = os.environ.get(key)
+                if external and current.get(key) and external != current[key]:
+                    raise RuntimeError(
+                        f"{key} differs between the shell and .env; refusing an ambiguous deployment"
+                    )
+            if check_only:
+                errors = validate({**current, **{key: os.environ[key] for key in ALL_KEYS if os.environ.get(key)}})
+                if errors:
+                    raise RuntimeError("invalid production configuration:\n- " + "\n- ".join(errors))
+                return
+            missing_persisted_db = not current.get("DB_PASSWORD")
+            if missing_persisted_db:
+                volumes = find_postgres_volumes(project_root)
+                if volumes:
+                    raise RuntimeError(
+                        "an existing postgres-data volume was detected while DB_PASSWORD is missing; "
+                        "preserve data with a controlled role-password migration, or manually rebuild only after confirming no data is needed"
+                    )
+            additions: dict[str, str] = {}
+            for key in ALL_KEYS:
+                if current.get(key):
+                    continue
+                additions[key] = safe_external_value(key) or generated_value(key)
+            effective = {**current, **additions}
+            errors = validate(effective)
+            if errors:
+                raise RuntimeError("invalid production configuration:\n- " + "\n- ".join(errors))
+            if additions or not env_path.exists():
+                atomic_write(env_path, update_lines(lines, additions))
+            else:
+                os.chmod(env_path, stat.S_IRUSR | stat.S_IWUSR)
+    finally:
+        if os.path.exists(lock_path):
+            os.chmod(lock_path, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    try:
+        bootstrap(args.project_root.resolve(), args.check)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"ERROR: {exc}", file=os.sys.stderr)
+        return 1
+    print("Production Compose environment is valid." if args.check else "Production Compose environment is ready (.env mode 0600).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_compose_env.py
+++ b/scripts/bootstrap_compose_env.py
@@ -17,8 +17,13 @@ from pathlib import Path
 REQUIRED = ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY")
 ALL_KEYS = ("OPENACE_SECURITY_MODE", *REQUIRED, "UPLOAD_AUTH_KEY")
 FORBIDDEN_PASSWORDS = {
-    "ace-secret", "dev-password-change-in-production", "change-me", "password",
-    "admin", "postgres", "123456",
+    "ace-secret",
+    "dev-password-change-in-production",
+    "change-me",
+    "password",
+    "admin",
+    "postgres",
+    "123456",
 }
 
 
@@ -66,9 +71,20 @@ def find_postgres_volumes(project_root: Path, env_values: dict[str, str]) -> lis
         raise RuntimeError("Docker CLI is unavailable; existing volume state is unknown")
     project = compose_project_name(project_root, env_values)
     result = subprocess.run(
-        [docker, "volume", "ls", "-q", "--filter", f"label=com.docker.compose.project={project}",
-         "--filter", "label=com.docker.compose.volume=postgres-data"],
-        capture_output=True, text=True, timeout=15, check=False,
+        [
+            docker,
+            "volume",
+            "ls",
+            "-q",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+            "--filter",
+            "label=com.docker.compose.volume=postgres-data",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError("cannot inspect Docker volumes; existing volume state is unknown")
@@ -80,7 +96,9 @@ def safe_external_value(name: str) -> str | None:
     if value is None or value == "":
         return None
     if "\n" in value or "\r" in value or not re.fullmatch(r"[A-Za-z0-9_.~:/+@%-]+", value):
-        raise RuntimeError(f"{name} from the shell cannot be safely persisted; put it in .env explicitly")
+        raise RuntimeError(
+            f"{name} from the shell cannot be safely persisted; put it in .env explicitly"
+        )
     return value
 
 
@@ -139,7 +157,11 @@ def bootstrap(project_root: Path, check_only: bool = False) -> None:
     try:
         with os.fdopen(lock_fd, "r+") as lock:
             fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-            lines = env_path.read_text(encoding="utf-8").splitlines(keepends=True) if env_path.exists() else []
+            lines = (
+                env_path.read_text(encoding="utf-8").splitlines(keepends=True)
+                if env_path.exists()
+                else []
+            )
             current = parse_env(lines)
             for key in ALL_KEYS:
                 external = os.environ.get(key)
@@ -148,9 +170,13 @@ def bootstrap(project_root: Path, check_only: bool = False) -> None:
                         f"{key} differs between the shell and .env; refusing an ambiguous deployment"
                     )
             if check_only:
-                errors = validate({**current, **{key: os.environ[key] for key in ALL_KEYS if os.environ.get(key)}})
+                errors = validate(
+                    {**current, **{key: os.environ[key] for key in ALL_KEYS if os.environ.get(key)}}
+                )
                 if errors:
-                    raise RuntimeError("invalid production configuration:\n- " + "\n- ".join(errors))
+                    raise RuntimeError(
+                        "invalid production configuration:\n- " + "\n- ".join(errors)
+                    )
                 return
             missing_persisted_db = not current.get("DB_PASSWORD")
             if missing_persisted_db:
@@ -188,7 +214,11 @@ def main() -> int:
     except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         print(f"ERROR: {exc}", file=os.sys.stderr)
         return 1
-    print("Production Compose environment is valid." if args.check else "Production Compose environment is ready (.env mode 0600).")
+    print(
+        "Production Compose environment is valid."
+        if args.check
+        else "Production Compose environment is ready (.env mode 0600)."
+    )
     return 0
 
 

--- a/scripts/bootstrap_compose_env.py
+++ b/scripts/bootstrap_compose_env.py
@@ -50,9 +50,9 @@ def validate(values: dict[str, str]) -> list[str]:
     return errors
 
 
-def compose_project_name(project_root: Path) -> str:
+def compose_project_name(project_root: Path, env_values: dict[str, str]) -> str:
     explicit = os.environ.get("COMPOSE_PROJECT_NAME", "").strip()
-    raw = explicit or project_root.name
+    raw = explicit or env_values.get("COMPOSE_PROJECT_NAME", "").strip() or project_root.name
     normalized = re.sub(r"[^a-z0-9_-]", "", raw.lower())
     normalized = re.sub(r"^[^a-z0-9]+", "", normalized)
     if not normalized:
@@ -60,11 +60,11 @@ def compose_project_name(project_root: Path) -> str:
     return normalized
 
 
-def find_postgres_volumes(project_root: Path) -> list[str]:
+def find_postgres_volumes(project_root: Path, env_values: dict[str, str]) -> list[str]:
     docker = shutil.which("docker")
     if not docker:
         raise RuntimeError("Docker CLI is unavailable; existing volume state is unknown")
-    project = compose_project_name(project_root)
+    project = compose_project_name(project_root, env_values)
     result = subprocess.run(
         [docker, "volume", "ls", "-q", "--filter", f"label=com.docker.compose.project={project}",
          "--filter", "label=com.docker.compose.volume=postgres-data"],
@@ -94,6 +94,8 @@ def generated_value(name: str) -> str:
 
 def update_lines(lines: list[str], values: dict[str, str]) -> list[str]:
     result = list(lines)
+    if result and not result[-1].endswith(("\n", "\r")):
+        result[-1] += "\n"
     positions: dict[str, int] = {}
     for index, line in enumerate(result):
         match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=", line)
@@ -152,7 +154,7 @@ def bootstrap(project_root: Path, check_only: bool = False) -> None:
                 return
             missing_persisted_db = not current.get("DB_PASSWORD")
             if missing_persisted_db:
-                volumes = find_postgres_volumes(project_root)
+                volumes = find_postgres_volumes(project_root, current)
                 if volumes:
                     raise RuntimeError(
                         "an existing postgres-data volume was detected while DB_PASSWORD is missing; "

--- a/scripts/start-multi-user.sh
+++ b/scripts/start-multi-user.sh
@@ -117,16 +117,18 @@ else
 fi
 
 # ============================================================================
-# Step 4: Environment Variable Check
+# Step 4: Environment Bootstrap / Check
 # ============================================================================
 echo -e "${BLUE}[4/5] Checking environment configuration...${NC}"
 
-# Check for .env file
-if [ -f "$PROJECT_ROOT/.env" ]; then
-    echo -e "${GREEN}✓ Found: .env file${NC}"
-else
-    echo -e "${YELLOW}ℹ No .env file found (using defaults)${NC}"
-    echo "  For production deployment, create .env from .env.example"
+# Only commands that start services may create/update .env. Read-only and
+# lifecycle commands such as config/logs/down never mutate configuration.
+START_REQUEST=false
+if [ $# -eq 0 ] || [ "${1:-}" = "--build" ] || [ "${1:-}" = "up" ]; then
+    START_REQUEST=true
+fi
+if [ "$START_REQUEST" = true ]; then
+    "$PROJECT_ROOT/scripts/bootstrap-compose-env.sh"
 fi
 
 # Multi-user mode is configured in the overlay file
@@ -158,10 +160,20 @@ cd "$PROJECT_ROOT"
 COMPOSE_ARGS=("-f" "docker-compose.yml" "-f" "docker-compose.multi-user.yml")
 
 # Add any user-provided arguments
-if [ $# -gt 0 ]; then
-    COMPOSE_ARGS+=("$@")
-else
+if [ $# -eq 0 ]; then
     COMPOSE_ARGS+=("up" "-d")
+    if $COMPOSE_CMD up --help 2>&1 | grep -q -- '--wait'; then
+        COMPOSE_ARGS+=("--wait")
+    fi
+elif [ "$1" = "--build" ]; then
+    COMPOSE_ARGS+=("up" "-d" "--build")
+    shift
+    COMPOSE_ARGS+=("$@")
+    if $COMPOSE_CMD up --help 2>&1 | grep -q -- '--wait'; then
+        COMPOSE_ARGS+=("--wait")
+    fi
+else
+    COMPOSE_ARGS+=("$@")
 fi
 
 # Execute
@@ -171,9 +183,13 @@ echo ""
 if $COMPOSE_CMD "${COMPOSE_ARGS[@]}"; then
     echo ""
     echo -e "${GREEN}=========================================="
-    echo -e "  ✓ Multi-User Mode Started Successfully"
+    echo -e "  ✓ Multi-User Compose Command Completed"
     echo -e "==========================================${NC}"
     echo ""
+    if [[ " ${COMPOSE_ARGS[*]} " != *" --wait "* ]]; then
+        echo -e "${YELLOW}Health was not awaited by this Compose version; verify with compose ps.${NC}"
+        echo ""
+    fi
     echo -e "${BLUE}Access Open ACE:${NC}"
     echo "  URL: http://localhost:${PORT:-19888}"
     echo ""

--- a/scripts/start-multi-user.sh
+++ b/scripts/start-multi-user.sh
@@ -124,11 +124,29 @@ echo -e "${BLUE}[4/5] Checking environment configuration...${NC}"
 # Only commands that start services may create/update .env. Read-only and
 # lifecycle commands such as config/logs/down never mutate configuration.
 START_REQUEST=false
-if [ $# -eq 0 ] || [ "${1:-}" = "--build" ] || [ "${1:-}" = "up" ]; then
+BOOTSTRAP_PROJECT_NAME=""
+if [ $# -eq 0 ] || [ "${1:-}" = "--build" ]; then
     START_REQUEST=true
 fi
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+    case "${args[$i]}" in
+        up) START_REQUEST=true; break ;;
+        -p|--project-name)
+            if (( i + 1 < ${#args[@]} )); then
+                BOOTSTRAP_PROJECT_NAME="${args[$((i + 1))]}"
+                i=$((i + 1))
+            fi
+            ;;
+        --project-name=*) BOOTSTRAP_PROJECT_NAME="${args[$i]#*=}" ;;
+    esac
+done
 if [ "$START_REQUEST" = true ]; then
-    "$PROJECT_ROOT/scripts/bootstrap-compose-env.sh"
+    if [ -n "$BOOTSTRAP_PROJECT_NAME" ]; then
+        COMPOSE_PROJECT_NAME="$BOOTSTRAP_PROJECT_NAME" "$PROJECT_ROOT/scripts/bootstrap-compose-env.sh"
+    else
+        "$PROJECT_ROOT/scripts/bootstrap-compose-env.sh"
+    fi
 fi
 
 # Multi-user mode is configured in the overlay file

--- a/tests/unit/test_compose_production_bootstrap_3104.py
+++ b/tests/unit/test_compose_production_bootstrap_3104.py
@@ -1,0 +1,117 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "bootstrap_compose_env.py"
+OVERLAY = ROOT / "docker-compose.multi-user.yml"
+
+
+def fake_docker(tmp_path: Path, volumes: str = "", exit_code: int = 0) -> Path:
+    binary = tmp_path / "docker"
+    binary.write_text(f"#!/bin/sh\nprintf '%s' '{volumes}'\nexit {exit_code}\n")
+    binary.chmod(0o755)
+    return binary
+
+
+def run_bootstrap(project: Path, bin_dir: Path, extra_env=None):
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY", "UPLOAD_AUTH_KEY", "OPENACE_SECURITY_MODE"):
+        env.pop(key, None)
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["python3", str(SCRIPT), "--project-root", str(project)],
+        capture_output=True, text=True, env=env, timeout=20,
+    )
+
+
+def values(path: Path):
+    return dict(line.split("=", 1) for line in path.read_text().splitlines() if "=" in line and not line.startswith("#"))
+
+
+def test_fresh_bootstrap_is_secure_and_idempotent(tmp_path):
+    fake_docker(tmp_path)
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode == 0, result.stderr
+    env_path = tmp_path / ".env"
+    first = env_path.read_bytes()
+    configured = values(env_path)
+    assert configured["OPENACE_SECURITY_MODE"] == "production"
+    assert all(configured[key] for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY", "UPLOAD_AUTH_KEY"))
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    assert run_bootstrap(tmp_path, tmp_path).returncode == 0
+    assert env_path.read_bytes() == first
+
+
+def test_preserves_comments_unknown_keys_and_existing_secrets(tmp_path):
+    fake_docker(tmp_path)
+    original_password = "existing-strong-password"
+    (tmp_path / ".env").write_text(f"# keep me\nUNKNOWN=value\nDB_PASSWORD={original_password}\n")
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode == 0, result.stderr
+    content = (tmp_path / ".env").read_text()
+    assert "# keep me" in content and "UNKNOWN=value" in content
+    assert values(tmp_path / ".env")["DB_PASSWORD"] == original_password
+
+
+def test_existing_project_volume_blocks_missing_password(tmp_path):
+    fake_docker(tmp_path, "project_postgres-data\\n")
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode != 0
+    assert "existing postgres-data volume" in result.stderr
+    assert not (tmp_path / ".env").exists()
+
+
+def test_unknown_volume_state_fails_closed(tmp_path):
+    fake_docker(tmp_path, exit_code=1)
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode != 0
+    assert "volume state is unknown" in result.stderr
+
+
+def test_shell_values_are_persisted_without_logging(tmp_path):
+    fake_docker(tmp_path)
+    supplied = {
+        "DB_PASSWORD": "shell-strong-password",
+        "SECRET_KEY": "a" * 64,
+        "OPENACE_ENCRYPTION_KEY": "b" * 64,
+        "UPLOAD_AUTH_KEY": "c" * 64,
+        "OPENACE_SECURITY_MODE": "production",
+    }
+    result = run_bootstrap(tmp_path, tmp_path, supplied)
+    assert result.returncode == 0, result.stderr
+    assert values(tmp_path / ".env")["DB_PASSWORD"] == supplied["DB_PASSWORD"]
+    assert all(secret not in result.stdout + result.stderr for secret in supplied.values())
+
+
+def test_conflicting_shell_and_env_values_fail_closed(tmp_path):
+    fake_docker(tmp_path)
+    (tmp_path / ".env").write_text(
+        "OPENACE_SECURITY_MODE=production\nDB_PASSWORD=file-strong-password\n"
+        f"SECRET_KEY={'a' * 64}\nOPENACE_ENCRYPTION_KEY={'b' * 64}\nUPLOAD_AUTH_KEY={'c' * 64}\n"
+    )
+    result = run_bootstrap(tmp_path, tmp_path, {"DB_PASSWORD": "different-shell-password"})
+    assert result.returncode != 0
+    assert "differs between the shell and .env" in result.stderr
+    assert "different-shell-password" not in result.stderr
+
+
+def test_symlink_env_is_rejected(tmp_path):
+    fake_docker(tmp_path)
+    target = tmp_path / "target"
+    target.write_text("")
+    (tmp_path / ".env").symlink_to(target)
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode != 0
+    assert "symbolic-link" in result.stderr
+
+
+def test_overlay_has_fail_fast_contract_for_all_services():
+    content = OVERLAY.read_text()
+    for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY"):
+        assert content.count(f"${{{key}:?") >= 2
+    assert "POSTGRES_PASSWORD=${DB_PASSWORD:?" in content

--- a/tests/unit/test_compose_production_bootstrap_3104.py
+++ b/tests/unit/test_compose_production_bootstrap_3104.py
@@ -58,12 +58,37 @@ def test_preserves_comments_unknown_keys_and_existing_secrets(tmp_path):
     assert values(tmp_path / ".env")["DB_PASSWORD"] == original_password
 
 
+@pytest.mark.parametrize("last_line", ["# final comment", "UNKNOWN=value", "DB_PASSWORD=existing-strong-password"])
+def test_existing_env_without_final_newline_remains_valid(tmp_path, last_line):
+    fake_docker(tmp_path)
+    (tmp_path / ".env").write_text(last_line)
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode == 0, result.stderr
+    content = (tmp_path / ".env").read_text()
+    assert content.startswith(last_line + "\n")
+    assert "\nOPENACE_SECURITY_MODE=production\n" in "\n" + content
+
+
 def test_existing_project_volume_blocks_missing_password(tmp_path):
     fake_docker(tmp_path, "project_postgres-data\\n")
     result = run_bootstrap(tmp_path, tmp_path)
     assert result.returncode != 0
     assert "existing postgres-data volume" in result.stderr
     assert not (tmp_path / ".env").exists()
+
+
+def test_project_name_from_env_file_is_used_for_volume_lookup(tmp_path):
+    log = tmp_path / "docker.args"
+    docker = tmp_path / "docker"
+    docker.write_text(
+        f"#!/bin/sh\nprintf '%s' \"$*\" > '{log}'\nprintf 'custom_postgres-data\\n'\n"
+    )
+    docker.chmod(0o755)
+    (tmp_path / ".env").write_text("COMPOSE_PROJECT_NAME=custom\n")
+    result = run_bootstrap(tmp_path, tmp_path)
+    assert result.returncode != 0
+    assert "com.docker.compose.project=custom" in log.read_text()
+    assert "existing postgres-data volume" in result.stderr
 
 
 def test_unknown_volume_state_fails_closed(tmp_path):

--- a/tests/unit/test_compose_production_bootstrap_3104.py
+++ b/tests/unit/test_compose_production_bootstrap_3104.py
@@ -20,17 +20,30 @@ def fake_docker(tmp_path: Path, volumes: str = "", exit_code: int = 0) -> Path:
 def run_bootstrap(project: Path, bin_dir: Path, extra_env=None):
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY", "UPLOAD_AUTH_KEY", "OPENACE_SECURITY_MODE"):
+    for key in (
+        "DB_PASSWORD",
+        "SECRET_KEY",
+        "OPENACE_ENCRYPTION_KEY",
+        "UPLOAD_AUTH_KEY",
+        "OPENACE_SECURITY_MODE",
+    ):
         env.pop(key, None)
     env.update(extra_env or {})
     return subprocess.run(
         ["python3", str(SCRIPT), "--project-root", str(project)],
-        capture_output=True, text=True, env=env, timeout=20,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=20,
     )
 
 
 def values(path: Path):
-    return dict(line.split("=", 1) for line in path.read_text().splitlines() if "=" in line and not line.startswith("#"))
+    return dict(
+        line.split("=", 1)
+        for line in path.read_text().splitlines()
+        if "=" in line and not line.startswith("#")
+    )
 
 
 def test_fresh_bootstrap_is_secure_and_idempotent(tmp_path):
@@ -41,7 +54,10 @@ def test_fresh_bootstrap_is_secure_and_idempotent(tmp_path):
     first = env_path.read_bytes()
     configured = values(env_path)
     assert configured["OPENACE_SECURITY_MODE"] == "production"
-    assert all(configured[key] for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY", "UPLOAD_AUTH_KEY"))
+    assert all(
+        configured[key]
+        for key in ("DB_PASSWORD", "SECRET_KEY", "OPENACE_ENCRYPTION_KEY", "UPLOAD_AUTH_KEY")
+    )
     assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
     assert run_bootstrap(tmp_path, tmp_path).returncode == 0
     assert env_path.read_bytes() == first
@@ -58,7 +74,9 @@ def test_preserves_comments_unknown_keys_and_existing_secrets(tmp_path):
     assert values(tmp_path / ".env")["DB_PASSWORD"] == original_password
 
 
-@pytest.mark.parametrize("last_line", ["# final comment", "UNKNOWN=value", "DB_PASSWORD=existing-strong-password"])
+@pytest.mark.parametrize(
+    "last_line", ["# final comment", "UNKNOWN=value", "DB_PASSWORD=existing-strong-password"]
+)
 def test_existing_env_without_final_newline_remains_valid(tmp_path, last_line):
     fake_docker(tmp_path)
     (tmp_path / ".env").write_text(last_line)

--- a/tests/unit/test_multi_user_config_2235.py
+++ b/tests/unit/test_multi_user_config_2235.py
@@ -154,6 +154,14 @@ class TestDockerComposeMultiUserSyntax:
 
         # Use docker compose config to validate syntax
         # Set timeout to avoid hanging the test suite if Docker daemon is slow
+        compose_env = os.environ.copy()
+        compose_env.update(
+            {
+                "DB_PASSWORD": "test-only-strong-password",
+                "SECRET_KEY": "s" * 64,
+                "OPENACE_ENCRYPTION_KEY": "e" * 64,
+            }
+        )
         try:
             result = subprocess.run(
                 ["docker", "compose", "-f", str(compose_file), "config", "--quiet"],
@@ -161,6 +169,7 @@ class TestDockerComposeMultiUserSyntax:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=compose_env,
             )
         except subprocess.TimeoutExpired:
             pytest.skip("Docker compose command timed out")
@@ -173,6 +182,7 @@ class TestDockerComposeMultiUserSyntax:
             if (
                 "docker-compose.yml" in result.stderr
                 or "has neither an image nor a build context" in result.stderr
+                or "looking up compose provider failed" in result.stderr
             ):
                 pytest.skip("Base docker-compose.yml validation required")
             else:


### PR DESCRIPTION
## Summary

- add an idempotent, atomic production `.env` bootstrap with stable secrets and `0600` permissions
- fail closed when an existing project PostgreSQL volume makes password initialization ambiguous
- add multi-user Compose interpolation guards before container creation
- integrate bootstrap into start commands while preserving non-start command behavior and Compose compatibility
- document the production bootstrap contract and add regression tests

## Root cause

The multi-user overlay defaults to production, while the base Compose file permits empty application secrets and a development database default. The application then exits in its production security baseline after Compose reports the detached start as successful; the restart policy turns this deterministic configuration error into a loop.

## Safety and compatibility

- no volume is deleted or migrated automatically
- existing non-empty secrets are never overwritten
- shell/`.env` conflicts fail closed
- base single-user development remains zero-configuration
- `UPLOAD_AUTH_KEY` is generated for complete upload functionality but is not treated as an application startup gate

## Tests

- `pytest` targeted security/bootstrap suite: 93 passed
- Ruff: passed
- Shell syntax: passed
- YAML parser: passed
- diff whitespace check: passed
- Real Compose integration was not run in the package test environment because no Compose provider is installed; CI or a Docker-enabled environment must cover the final merged-config/runtime check.

Closes #3104