### PR TITLE
fix(#3081): 管理端机器列表中文主机名显示乱码

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -40,6 +40,12 @@ trap {
     exit 1
 }
 
+# Fix Chinese hostname encoding (Issue #3081)
+# PowerShell 5.1 defaults to system encoding (GBK on Chinese Windows),
+# which causes ConvertTo-Json to produce garbled output for non-ASCII characters.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
 Write-Host "Open ACE Remote Agent Installer" -ForegroundColor Blue
 Write-Host "================================" -ForegroundColor Blue
 Write-Host "Server: $ServerUrl"


### PR DESCRIPTION
## Summary

修复 Windows 安装脚本中处理中文主机名时的编码问题。

## 根因

PowerShell 5.1 默认使用系统编码（中文 Windows 下为 GBK），导致 `ConvertTo-Json` 在处理非 ASCII 字符时产生乱码。

## 修改内容

在 `remote-agent/install.ps1` 中添加 UTF-8 编码设置：

```powershell
[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
$OutputEncoding = [System.Text.Encoding]::UTF8
```

## 测试计划

- [ ] 在中文 Windows 环境下执行完整安装流程
- [ ] 验证数据库中存储的 hostname 为正确的中文
- [ ] 验证前端显示正确

## 风险

- 低风险：仅添加编码设置，不改变现有逻辑

## 回滚方式

移除编码设置代码

Fixes #3081