### PR TITLE
fix(#3116): treat transient upstream DNS-resolution failure as retryable in LLM proxy

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -223,6 +223,38 @@ def _determine_target_url(
         # Standard SSRF validation
         result = validate_llm_proxy_url(target_url, tenant_id, provider)
         if not result.allowed:
+            if result.transient:
+                # A transient DNS-resolution failure (timeout / empty answer) is
+                # NOT a policy violation — no request is sent either way, but it
+                # is safe to retry. Surface a retryable 5xx whose body the
+                # orchestrator's transient-error classifier recognizes, instead
+                # of a permanent 403 that hard-fails the workflow. #3116.
+                logger.warning(
+                    "LLM proxy upstream DNS resolution failed for tenant %s provider %s: %s",
+                    tenant_id,
+                    provider,
+                    result.error,
+                )
+                audit_blocked_url(
+                    tenant_id=tenant_id,
+                    provider=provider,
+                    url=target_url,
+                    reason="dns_resolution_failed",
+                )
+                return (
+                    jsonify(
+                        {
+                            "error": {
+                                "message": (
+                                    "Upstream host DNS resolution failed (transient). "
+                                    "Service Unavailable — retry later."
+                                ),
+                                "type": "upstream_unavailable",
+                            }
+                        }
+                    ),
+                    503,
+                )
             sanitized_error = sanitize_error_message(result.error or "Invalid URL")
             logger.warning(
                 "LLM proxy URL blocked for tenant %s provider %s: %s",

--- a/app/utils/llm_proxy_url_validator.py
+++ b/app/utils/llm_proxy_url_validator.py
@@ -44,6 +44,9 @@ class LlmProxyValidationResult:
     error: str | None = None
     resolved_ips: tuple[IPAddress, ...] = ()
     is_allowlist_match: bool = False
+    # Mirrors OutboundUrlValidationResult.transient: True for a DNS-resolution
+    # failure (retryable) vs a policy block (permanent). #3116.
+    transient: bool = False
 
 
 @dataclass(frozen=True)
@@ -359,7 +362,7 @@ def validate_llm_proxy_url(
     # Standard SSRF validation
     result = validate_public_http_url(url, resolver=resolver)
     if not result.allowed:
-        return LlmProxyValidationResult(False, result.error)
+        return LlmProxyValidationResult(False, result.error, transient=result.transient)
 
     return LlmProxyValidationResult(True, resolved_ips=result.resolved_addresses)
 

--- a/app/utils/outbound_url_guard.py
+++ b/app/utils/outbound_url_guard.py
@@ -177,6 +177,11 @@ class OutboundUrlValidationResult:
     # before the request and by :class:`_PinnedIPAdapter` to re-check at
     # connect time.
     resolved_addresses: tuple[IPAddress, ...] = ()
+    # True when the failure is a *resolution* failure (DNS timeout / empty
+    # answer) rather than a policy determination. A transient failure sends no
+    # request but is safe to retry; callers may surface it as a retryable 5xx
+    # instead of a permanent 4xx. #3116.
+    transient: bool = False
 
 
 class OutboundUrlBlockedError(ValueError):
@@ -243,12 +248,16 @@ def validate_public_http_url(
     try:
         addresses = _resolve_addresses(ascii_host, parsed.port, resolver)
     except OSError as exc:
-        return OutboundUrlValidationResult(False, f"Host could not be resolved: {exc}")
+        return OutboundUrlValidationResult(
+            False, f"Host could not be resolved: {exc}", transient=True
+        )
     except ValueError as exc:
         return OutboundUrlValidationResult(False, str(exc))
 
     if not addresses:
-        return OutboundUrlValidationResult(False, "Host did not resolve to an IP address")
+        return OutboundUrlValidationResult(
+            False, "Host did not resolve to an IP address", transient=True
+        )
 
     public_addresses = [addr for addr in addresses if _is_public_address(addr)]
     if len(public_addresses) != len(addresses):

--- a/docs/superpowers/plans/2026-08-26-llm-proxy-dns-timeout-transient.md
+++ b/docs/superpowers/plans/2026-08-26-llm-proxy-dns-timeout-transient.md
@@ -1,0 +1,458 @@
+# LLM Proxy Transient-DNS-Failure Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the workspace LLM proxy return a retryable 5xx (not a permanent 403) when an upstream host's DNS resolution fails transiently, so autonomous workflows retry a brief DNS blip instead of hard-failing.
+
+**Architecture:** Carry a `transient` flag through the two validation result dataclasses; set it only on DNS-resolution-failure branches; the proxy handler maps `transient` → HTTP 503 with a message the orchestrator's existing transient-retry classifier recognizes. Genuine policy violations keep returning 403. No outbound request is sent on a resolution failure either way, so security posture is unchanged.
+
+**Tech Stack:** Python, Flask, pytest. Spec: `docs/superpowers/specs/2026-08-26-llm-proxy-dns-timeout-transient-design.md`. Issue: #3116.
+
+---
+
+## File Structure
+
+- `app/utils/outbound_url_guard.py` — add `transient` to `OutboundUrlValidationResult`; set it on the resolution-failure branches of `validate_public_http_url`.
+- `app/utils/llm_proxy_url_validator.py` — add `transient` to `LlmProxyValidationResult`; propagate it from the standard-SSRF path in `validate_llm_proxy_url`.
+- `app/modules/workspace/llm_proxy_handler.py` — in `_determine_target_url`, return 503 for a transient validation failure, 403 otherwise.
+- `tests/unit/test_outbound_url_guard.py` — extend (Task 1).
+- `tests/unit/test_llm_proxy_url_validator.py` — extend (Task 2).
+- `tests/unit/test_llm_proxy_dns_transient.py` — new handler + contract tests (Task 3).
+
+All new tests carry `pytest.mark.issue(3116)` and `pytest.mark.regression`.
+
+---
+
+## Task 1: `transient` flag on the outbound guard
+
+**Files:**
+- Modify: `app/utils/outbound_url_guard.py` (dataclass `OutboundUrlValidationResult` ~line 169; `validate_public_http_url` ~lines 244-251)
+- Test: `tests/unit/test_outbound_url_guard.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_outbound_url_guard.py`:
+
+```python
+import socket as _socket
+
+
+def _raising_resolver(host, port, type=_socket.SOCK_STREAM):
+    raise OSError("temporary failure in name resolution")
+
+
+def _empty_resolver(host, port, type=_socket.SOCK_STREAM):
+    return []
+
+
+def test_dns_resolution_timeout_is_transient():
+    result = validate_public_http_url(
+        "https://coding.example.com/v1/messages",
+        resolver=_raising_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_empty_resolution_is_transient():
+    result = validate_public_http_url(
+        "https://coding.example.com/v1/messages",
+        resolver=_empty_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_private_address_block_is_not_transient():
+    result = validate_public_http_url(
+        "https://sso.example.com/token",
+        resolver=_resolver("10.1.2.3"),
+    )
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_bad_scheme_block_is_not_transient():
+    result = validate_public_http_url("ftp://example.com/file")
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_allowed_url_is_not_transient():
+    result = validate_public_http_url(
+        "https://login.example.com/oauth/token",
+        resolver=_resolver("93.184.216.34"),
+    )
+    assert result.allowed
+    assert result.transient is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_outbound_url_guard.py -k "transient" -v`
+Expected: FAIL — `AttributeError: 'OutboundUrlValidationResult' object has no attribute 'transient'`.
+
+- [ ] **Step 3: Add the field**
+
+In `app/utils/outbound_url_guard.py`, extend the dataclass (currently ends with `resolved_addresses`):
+
+```python
+@dataclass(frozen=True)
+class OutboundUrlValidationResult:
+    """Result for an outbound URL security validation."""
+
+    allowed: bool
+    error: str | None = None
+    # The public IP addresses that were verified for this URL. Populated only
+    # when ``allowed`` is True. Used by :func:`safe_request` to pre-validate
+    # before the request and by :class:`_PinnedIPAdapter` to re-check at
+    # connect time.
+    resolved_addresses: tuple[IPAddress, ...] = ()
+    # True when the failure is a *resolution* failure (DNS timeout / empty
+    # answer) rather than a policy determination. A transient failure sends no
+    # request but is safe to retry; callers may surface it as a retryable 5xx
+    # instead of a permanent 4xx. #3116.
+    transient: bool = False
+```
+
+- [ ] **Step 4: Set `transient` on the resolution-failure branches**
+
+In `validate_public_http_url`, the two resolution branches become:
+
+```python
+    try:
+        addresses = _resolve_addresses(ascii_host, parsed.port, resolver)
+    except OSError as exc:
+        return OutboundUrlValidationResult(
+            False, f"Host could not be resolved: {exc}", transient=True
+        )
+    except ValueError as exc:
+        return OutboundUrlValidationResult(False, str(exc))
+
+    if not addresses:
+        return OutboundUrlValidationResult(
+            False, "Host did not resolve to an IP address", transient=True
+        )
+```
+
+(Leave every other `OutboundUrlValidationResult(False, ...)` in the function untouched — they default `transient=False`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_outbound_url_guard.py -v`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/utils/outbound_url_guard.py tests/unit/test_outbound_url_guard.py
+git commit -m "fix(#3116): flag DNS-resolution failures as transient in outbound guard"
+```
+
+---
+
+## Task 2: Propagate `transient` through the LLM-proxy validator
+
+**Files:**
+- Modify: `app/utils/llm_proxy_url_validator.py` (dataclass `LlmProxyValidationResult` ~line 39; `validate_llm_proxy_url` return at ~line 361)
+- Test: `tests/unit/test_llm_proxy_url_validator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_llm_proxy_url_validator.py` (match the file's existing imports; add these if missing):
+
+```python
+import socket as _socket
+
+from app.utils.llm_proxy_url_validator import validate_llm_proxy_url
+
+
+def _raising_resolver(host, port, type=_socket.SOCK_STREAM):
+    raise OSError("temporary failure in name resolution")
+
+
+def _public_resolver(host, port, type=_socket.SOCK_STREAM):
+    return [(_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+
+
+def _private_resolver(host, port, type=_socket.SOCK_STREAM):
+    return [(_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("10.1.2.3", port))]
+
+
+def test_validate_llm_proxy_url_marks_dns_failure_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_raising_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_validate_llm_proxy_url_private_block_not_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_private_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_validate_llm_proxy_url_allowed_not_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_public_resolver,
+    )
+    assert result.allowed
+    assert result.transient is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_llm_proxy_url_validator.py -k transient -v`
+Expected: FAIL — `AttributeError: 'LlmProxyValidationResult' object has no attribute 'transient'`.
+
+- [ ] **Step 3: Add the field**
+
+In `app/utils/llm_proxy_url_validator.py`:
+
+```python
+@dataclass(frozen=True)
+class LlmProxyValidationResult:
+    """Result for LLM proxy URL validation."""
+
+    allowed: bool
+    error: str | None = None
+    resolved_ips: tuple[IPAddress, ...] = ()
+    is_allowlist_match: bool = False
+    # Mirrors OutboundUrlValidationResult.transient: True for a DNS-resolution
+    # failure (retryable) vs a policy block (permanent). #3116.
+    transient: bool = False
+```
+
+- [ ] **Step 4: Propagate from the standard-SSRF path**
+
+In `validate_llm_proxy_url`, the standard-SSRF failure return (currently `return LlmProxyValidationResult(False, result.error)`) becomes:
+
+```python
+    # Standard SSRF validation
+    result = validate_public_http_url(url, resolver=resolver)
+    if not result.allowed:
+        return LlmProxyValidationResult(False, result.error, transient=result.transient)
+
+    return LlmProxyValidationResult(True, resolved_ips=result.resolved_addresses)
+```
+
+(The allowlist branch and the parse/host-normalization guards stay `transient=False` by default — a malformed URL is a permanent client error, not a transient one.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_llm_proxy_url_validator.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/utils/llm_proxy_url_validator.py tests/unit/test_llm_proxy_url_validator.py
+git commit -m "fix(#3116): propagate transient DNS-failure flag through proxy validator"
+```
+
+---
+
+## Task 3: Handler returns 503 for transient failures + retry-contract test
+
+**Files:**
+- Modify: `app/modules/workspace/llm_proxy_handler.py` (`_determine_target_url`, the `if not result.allowed:` block ~lines 225-251)
+- Test: `tests/unit/test_llm_proxy_dns_transient.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_llm_proxy_dns_transient.py`:
+
+```python
+"""LLM proxy returns a retryable 5xx for transient DNS-resolution failures
+instead of a permanent 403, so autonomous workflows retry a brief DNS blip
+rather than hard-failing. Issue #3116.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from app.modules.workspace.llm_proxy_handler import _determine_target_url
+from app.utils.llm_proxy_url_validator import LlmProxyValidationResult
+
+pytestmark = [pytest.mark.issue(3116), pytest.mark.regression]
+
+_APP = Flask(__name__)
+
+
+def _call_determine(validation_result):
+    with patch(
+        "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
+        return_value=validation_result,
+    ):
+        with _APP.test_request_context("/api/remote/llm-proxy/v1/messages"):
+            return _determine_target_url(
+                provider="anthropic",
+                base_url="https://coding.example.com",
+                path="v1/messages",
+                tenant_id=1,
+            )
+
+
+def test_transient_validation_failure_returns_503():
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Host could not be resolved: timeout", transient=True)
+    )
+    assert isinstance(out, tuple)
+    _response, status = out
+    assert status == 503
+
+
+def test_policy_violation_still_returns_403():
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Blocked non-public address: 10.1.2.3", transient=False)
+    )
+    assert isinstance(out, tuple)
+    _response, status = out
+    assert status == 403
+
+
+def test_transient_503_message_matches_orchestrator_retry_classifier():
+    """Linchpin: the 503 body the handler emits must be recognized as transient
+    by the orchestrator's retry regex, otherwise the workflow won't retry."""
+    from app.modules.workspace.autonomous.orchestrator import _TRANSIENT_API_ERROR_RE
+
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Host could not be resolved: timeout", transient=True)
+    )
+    response, status = out
+    assert status == 503
+    message = response.get_json()["error"]["message"]
+    assert _TRANSIENT_API_ERROR_RE.search(message), (
+        f"503 message not recognized as transient by orchestrator: {message!r}"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_llm_proxy_dns_transient.py -v`
+Expected: FAIL — `test_transient_validation_failure_returns_503` and the contract test get `403` (current behavior).
+
+- [ ] **Step 3: Add the transient branch in the handler**
+
+In `app/modules/workspace/llm_proxy_handler.py`, replace the `if not result.allowed:` block (the one that logs "LLM proxy URL blocked", records `ssrf_blocked`, audits, and returns 403) with a branch that splits transient from policy:
+
+```python
+        # Standard SSRF validation
+        result = validate_llm_proxy_url(target_url, tenant_id, provider)
+        if not result.allowed:
+            if result.transient:
+                # A transient DNS-resolution failure (timeout / empty answer) is
+                # NOT a policy violation — no request is sent either way, but it
+                # is safe to retry. Surface a retryable 5xx whose body the
+                # orchestrator's transient-error classifier recognizes, instead
+                # of a permanent 403 that hard-fails the workflow. #3116.
+                logger.warning(
+                    "LLM proxy upstream DNS resolution failed for tenant %s provider %s: %s",
+                    tenant_id,
+                    provider,
+                    result.error,
+                )
+                audit_blocked_url(
+                    tenant_id=tenant_id,
+                    provider=provider,
+                    url=target_url,
+                    reason="dns_resolution_failed",
+                )
+                return (
+                    jsonify(
+                        {
+                            "error": {
+                                "message": (
+                                    "Upstream host DNS resolution failed (transient). "
+                                    "Service Unavailable — retry later."
+                                ),
+                                "type": "upstream_unavailable",
+                            }
+                        }
+                    ),
+                    503,
+                )
+            sanitized_error = sanitize_error_message(result.error or "Invalid URL")
+            logger.warning(
+                "LLM proxy URL blocked for tenant %s provider %s: %s",
+                tenant_id,
+                provider,
+                sanitized_error,
+            )
+            record_ssrf_blocked(tenant_id, provider, "ssrf_violation")
+            audit_blocked_url(
+                tenant_id=tenant_id,
+                provider=provider,
+                url=target_url,
+                reason=result.error or "ssrf_violation",
+            )
+            return (
+                jsonify(
+                    {
+                        "error": {
+                            "message": sanitized_error,
+                            "type": "ssrf_blocked",
+                            "blocked_host_hash": hash_host_for_audit(target_url),
+                        }
+                    }
+                ),
+                403,
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_llm_proxy_dns_transient.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full affected suites**
+
+Run: `python -m pytest tests/unit/test_outbound_url_guard.py tests/unit/test_llm_proxy_url_validator.py tests/unit/test_llm_proxy_dns_transient.py tests/unit/test_llm_proxy_handler_audit_username.py -v`
+Expected: PASS (all, no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/modules/workspace/llm_proxy_handler.py tests/unit/test_llm_proxy_dns_transient.py
+git commit -m "fix(#3116): return retryable 503 for transient upstream DNS failure in LLM proxy"
+```
+
+---
+
+## Task 4: Mutation checks (verify each guard clause bites)
+
+- [ ] **Step 1: Mutation — revert the OSError `transient=True`**
+
+Temporarily change Task 1 Step 4's `except OSError` return back to `transient` default (drop `transient=True`).
+Run: `python -m pytest tests/unit/test_outbound_url_guard.py::test_dns_resolution_timeout_is_transient tests/unit/test_llm_proxy_dns_transient.py -v`
+Expected: FAIL (the transient/503/contract tests fail). Restore the change; re-run → PASS.
+
+- [ ] **Step 2: Mutation — make the handler always 403**
+
+Temporarily force the handler's `if result.transient:` to `if False:`.
+Run: `python -m pytest tests/unit/test_llm_proxy_dns_transient.py -v`
+Expected: FAIL (`test_transient_validation_failure_returns_503` + contract test). Restore; re-run → PASS.
+
+(No commit — mutation checks are verification only. Confirm the tree is clean and matches Task 3's committed state afterward.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** dataclass fields (Tasks 1-2), resolution-failure branches (Task 1), propagation (Task 2), handler 503-vs-403 (Task 3), linchpin contract test (Task 3 Step 1), mutation checks (Task 4). All spec test-strategy items are covered.
+- **Type consistency:** field name `transient: bool` identical across both dataclasses and the handler read `result.transient`.
+- **No security change:** every non-resolution `OutboundUrlValidationResult(False, ...)` keeps `transient=False`; the DNS-rebinding branch in the handler is untouched (still 403).

--- a/docs/superpowers/specs/2026-08-26-llm-proxy-dns-timeout-transient-design.md
+++ b/docs/superpowers/specs/2026-08-26-llm-proxy-dns-timeout-transient-design.md
@@ -1,0 +1,154 @@
+# Design: LLM proxy — treat transient upstream DNS-resolution failure as retryable, not a 403 policy violation
+
+- **Issue:** #3116
+- **Date:** 2026-08-26
+- **Origin:** autonomous-workflow monitoring (class-2), workflow `23db89b3` / issue #3083
+
+## Problem
+
+The workspace LLM proxy validates the upstream target URL for SSRF on every
+call. For a **public, non-allowlisted** host the path is:
+
+```
+llm_proxy_handler._handle...                      (app/modules/workspace/llm_proxy_handler.py:224)
+  -> validate_llm_proxy_url                        (app/utils/llm_proxy_url_validator.py:360)
+    -> validate_public_http_url                    (app/utils/outbound_url_guard.py:244)
+      -> _resolve_addresses(host, 443, getaddrinfo)  (live DNS lookup)
+```
+
+When DNS resolution **times out transiently**, `getaddrinfo` raises `OSError`;
+`validate_public_http_url` returns
+`OutboundUrlValidationResult(allowed=False, error="Host could not be resolved: ...")`.
+The handler runs that through `sanitize_error_message`, whose fall-through
+collapses it to the generic **`"Blocked outbound URL: security policy
+violation"`** and returns **HTTP 403**.
+
+The autonomous orchestrator's transient-retry classifier
+(`_TRANSIENT_API_ERROR_RE`, `orchestrator.py:2094`) intentionally treats **all
+4xx except 429 as permanent** ("400/401/403/404/422 are permanent client errors
+and must NOT trigger retry") and matches `5\d{2}`, `service unavailable`,
+`bad gateway`, etc. as transient. So a **403 is never retried**: a ~1-minute DNS
+blip on a known upstream endpoint **hard-fails the entire workflow** with a
+misleading, security-sounding error.
+
+### Evidence (prod, ai-lab, 2026-08-26)
+
+- Test-phase agent calls to `https://coding.dashscope.aliyuncs.com/.../messages`
+  (glm-5) returned **403** after a fixed **~20.0 s** stall (getaddrinfo timeout)
+  at 14:48–14:49 local; dozens of calls to the same upstream returned 200 in the
+  minutes before and after.
+- Only **5** such blocked warnings in 3 days, all inside that single minute — an
+  isolated transient.
+- Downstream symptom: workflow reported *"Tests were not actually run — agent
+  could not execute any test framework"* (the agent got 403 on its first call
+  and ran nothing).
+
+## Root cause
+
+A transient **DNS-resolution failure** is conflated with a permanent **policy
+violation** and surfaced as a non-retryable **403**. The allowlist path already
+tolerates DNS failure ("Allow on DNS failure, will be caught by safe_request",
+`llm_proxy_url_validator.py:350`); the public-host path fail-closes hard and,
+worse, mislabels the reason.
+
+## Chosen approach — Distinguish "transient" at the proxy boundary
+
+Carry a `transient` flag through the validation results and let the handler map
+it to a **5xx** (retryable) response instead of the generic 403.
+
+**Security posture is unchanged.** On a resolution failure **no outbound request
+is sent** in any case — the request is still blocked. The only thing that
+changes is the HTTP status/message returned to the *caller* (the agent), which
+is what decides retry-vs-hard-fail in the orchestrator. **403 remains** for
+genuine policy determinations (non-public IP, blocked host, bad scheme, bad
+port, credentials-in-URL, DNS rebinding).
+
+### Components & changes
+
+1. **`app/utils/outbound_url_guard.py`**
+   - Add `transient: bool = False` to the frozen dataclass
+     `OutboundUrlValidationResult` (default keeps every existing construction
+     valid).
+   - In `validate_public_http_url`, set `transient=True` on the two
+     **resolution-failure** branches only:
+     - `except OSError` (getaddrinfo failure/timeout) — line ~245.
+     - "Host did not resolve to an IP address" (empty result) — line ~250.
+   - All **policy** branches (blocked host, non-public address, port, scheme,
+     credentials, invalid host) keep `transient=False` (the default).
+
+2. **`app/utils/llm_proxy_url_validator.py`**
+   - Add `transient: bool = False` to `LlmProxyValidationResult`.
+   - In `validate_llm_proxy_url`, when the standard-SSRF path returns
+     `not allowed`, propagate `transient=result.transient` (line ~361).
+   - The allowlist branch and the parse/host-normalization guards remain
+     `transient=False`.
+
+3. **`app/modules/workspace/llm_proxy_handler.py`** (call-site ~224)
+   - When `validate_llm_proxy_url` returns `not allowed`:
+     - If `result.transient`: return **HTTP 503** with
+       `type="upstream_unavailable"` and a message that contains both the
+       numeric and phrase cues the retry classifier recognizes, e.g.
+       `"Upstream host DNS resolution failed (transient). Service Unavailable — retry later."`
+       Log at WARNING as an upstream/transient event; audit with a
+       `dns_resolution_failed` reason (distinct from `ssrf_violation`).
+     - Else: unchanged — sanitized **403** `ssrf_blocked`.
+   - The DNS-rebinding branch (line ~194) is a genuine policy block and stays
+     **403** (`"DNS resolution changed"`).
+
+### Why 503 + this message
+
+The orchestrator matches on the agent's surfaced **response text**, not the raw
+HTTP code. The agent renders proxy failures as `"API Error: <status>-... <body>"`
+(observed: `"API Error: 403-***-**** Blocked outbound URL: ..."`). A **503** body
+gives the classifier two independent matches — `api\s*error:?\s*5\d{2}` (status)
+and `service\s+unavailable` (phrase in the body) — so retry fires even if the
+agent's formatting of one cue changes.
+
+## Blast radius
+
+- `OutboundUrlValidationResult` / `LlmProxyValidationResult` each gain one
+  optional field defaulting to `False`; `assert_public_http_url`, `safe_request`,
+  and all existing callers are unaffected (they only read `allowed` / `error` /
+  `resolved_addresses`).
+- Handler adds one status branch. Every genuine-policy-violation 403 is
+  byte-for-byte unchanged.
+
+## Alternatives rejected
+
+- **B — Let the request proceed on public-host DNS failure (mirror the allowlist
+  path).** Public hosts have no pinned IPs, so the handler's non-pinned branch
+  (`http_requests.request`, line ~1676) performs **no** SSRF check → a real
+  security hole; and it does not help when DNS is genuinely down (the request
+  fails anyway).
+- **C — Retry DNS inside the validator.** A ~1-minute outage outlasts any
+  in-request retry budget, adds request latency, and duplicates the
+  orchestrator's existing, well-tested retry loop.
+
+## Test strategy (TDD, `tests/unit/`, marked `issue(3116)` + `regression`)
+
+1. `validate_public_http_url`:
+   - resolver raising `OSError` → `allowed False`, **`transient True`**.
+   - resolver returning a **private** IP → `allowed False`, **`transient False`**
+     (policy).
+   - resolver returning **empty** → `allowed False`, **`transient True`**.
+   - a blocked scheme/port → `allowed False`, `transient False`.
+2. `validate_llm_proxy_url` propagates `transient` from the standard-SSRF path;
+   allowlist and parse-guard failures stay `transient False`.
+3. Handler:
+   - transient validation failure → **503**, body message present.
+   - genuine policy violation → **403** (unchanged).
+4. **Linchpin contract test:** the exact 503 message string the handler emits is
+   matched by `orchestrator._TRANSIENT_API_ERROR_RE` — proving the cross-module
+   coupling that makes retry actually fire.
+
+## Deployment & rollout
+
+- Pure logic change, no migration, no schema. CI gates via `tests/unit/`
+  (`python-core`).
+- Deploy: hot-patch `app/utils/outbound_url_guard.py`,
+  `app/utils/llm_proxy_url_validator.py`,
+  `app/modules/workspace/llm_proxy_handler.py` to prod; the proxy runs in
+  `open-ace.service` (web app) — restart it (not the scheduler) so the new
+  validation takes effect.
+- Then reset workflow `23db89b3` (#3083) so it re-runs; it will now retry the
+  transient DNS failure instead of hard-failing.

--- a/tests/unit/test_llm_proxy_dns_transient.py
+++ b/tests/unit/test_llm_proxy_dns_transient.py
@@ -1,0 +1,64 @@
+"""LLM proxy returns a retryable 5xx for transient DNS-resolution failures
+instead of a permanent 403, so autonomous workflows retry a brief DNS blip
+rather than hard-failing. Issue #3116.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from app.modules.workspace.llm_proxy_handler import _determine_target_url
+from app.utils.llm_proxy_url_validator import LlmProxyValidationResult
+
+pytestmark = [pytest.mark.issue(3116), pytest.mark.regression]
+
+_APP = Flask(__name__)
+
+
+def _call_determine(validation_result):
+    with patch(
+        "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
+        return_value=validation_result,
+    ):
+        with _APP.test_request_context("/api/remote/llm-proxy/v1/messages"):
+            return _determine_target_url(
+                provider="anthropic",
+                base_url="https://coding.example.com",
+                path="v1/messages",
+                tenant_id=1,
+            )
+
+
+def test_transient_validation_failure_returns_503():
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Host could not be resolved: timeout", transient=True)
+    )
+    assert isinstance(out, tuple)
+    _response, status = out
+    assert status == 503
+
+
+def test_policy_violation_still_returns_403():
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Blocked non-public address: 10.1.2.3", transient=False)
+    )
+    assert isinstance(out, tuple)
+    _response, status = out
+    assert status == 403
+
+
+def test_transient_503_message_matches_orchestrator_retry_classifier():
+    """Linchpin: the 503 body the handler emits must be recognized as transient
+    by the orchestrator's retry regex, otherwise the workflow won't retry."""
+    from app.modules.workspace.autonomous.orchestrator import _TRANSIENT_API_ERROR_RE
+
+    out = _call_determine(
+        LlmProxyValidationResult(False, "Host could not be resolved: timeout", transient=True)
+    )
+    response, status = out
+    assert status == 503
+    message = response.get_json()["error"]["message"]
+    assert _TRANSIENT_API_ERROR_RE.search(
+        message
+    ), f"503 message not recognized as transient by orchestrator: {message!r}"

--- a/tests/unit/test_llm_proxy_url_validator.py
+++ b/tests/unit/test_llm_proxy_url_validator.py
@@ -400,3 +400,43 @@ class TestIsAllowedHost:
             tenant_id=1,
         )
         assert not is_allowed
+
+
+# --- Issue #3116: transient DNS-resolution failures ---
+
+
+def _raising_resolver(host, port, type=socket.SOCK_STREAM):
+    raise OSError("temporary failure in name resolution")
+
+
+def test_validate_llm_proxy_url_marks_dns_failure_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_raising_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_validate_llm_proxy_url_private_block_not_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_resolver("10.1.2.3"),
+    )
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_validate_llm_proxy_url_allowed_not_transient():
+    result = validate_llm_proxy_url(
+        "https://coding.example.com/v1/messages",
+        tenant_id=1,
+        provider="anthropic",
+        resolver=_resolver("93.184.216.34"),
+    )
+    assert result.allowed
+    assert result.transient is False

--- a/tests/unit/test_outbound_url_guard.py
+++ b/tests/unit/test_outbound_url_guard.py
@@ -628,3 +628,56 @@ def test_ip_literal_url_validation():
     # Test with a private IP literal URL (should raise, but still not call resolver)
     with pytest.raises(OutboundUrlBlockedError, match="non-public IP"):
         adapter._check_resolved_ip("https://10.0.0.1/test")
+
+
+# --- Issue #3116: transient DNS-resolution failures ---
+
+
+def _raising_resolver(host, port, type=socket.SOCK_STREAM):
+    raise OSError("temporary failure in name resolution")
+
+
+def _empty_resolver(host, port, type=socket.SOCK_STREAM):
+    return []
+
+
+def test_dns_resolution_timeout_is_transient():
+    result = validate_public_http_url(
+        "https://coding.example.com/v1/messages",
+        resolver=_raising_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_empty_resolution_is_transient():
+    result = validate_public_http_url(
+        "https://coding.example.com/v1/messages",
+        resolver=_empty_resolver,
+    )
+    assert not result.allowed
+    assert result.transient is True
+
+
+def test_private_address_block_is_not_transient():
+    result = validate_public_http_url(
+        "https://sso.example.com/token",
+        resolver=_resolver("10.1.2.3"),
+    )
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_bad_scheme_block_is_not_transient():
+    result = validate_public_http_url("ftp://example.com/file")
+    assert not result.allowed
+    assert result.transient is False
+
+
+def test_allowed_url_is_not_transient():
+    result = validate_public_http_url(
+        "https://login.example.com/oauth/token",
+        resolver=_resolver("93.184.216.34"),
+    )
+    assert result.allowed
+    assert result.transient is False


### PR DESCRIPTION
## Problem

The workspace LLM proxy validates the upstream target URL for SSRF on every call. For a **public, non-allowlisted** host it does a live `getaddrinfo` (`validate_public_http_url` → `_resolve_addresses`). When DNS resolution **times out transiently**, the validator returns `allowed=False, "Host could not be resolved"`, which the handler collapses to a generic **HTTP 403 "Blocked outbound URL: security policy violation"**.

The autonomous orchestrator's transient-retry classifier (`_TRANSIENT_API_ERROR_RE`) intentionally treats **all 4xx except 429 as permanent** and does not retry them. So a ~1-minute DNS blip on a known upstream endpoint **hard-fails the entire workflow** with a misleading, security-sounding error — even though a retry seconds later would succeed.

### Evidence (prod, ai-lab, 2026-08-26)
- A test-phase agent's calls to `https://coding.dashscope.aliyuncs.com/.../messages` (glm-5) returned **403** after a fixed **~20.0 s** stall (getaddrinfo timeout) at 14:48–14:49 local; dozens of calls to the same upstream returned 200 in the minutes before and after.
- Only **5** blocked warnings in 3 days, all inside that single minute — an isolated transient.
- Downstream symptom: workflow `23db89b3` (#3083) reported *"Tests were not actually run — agent could not execute any test framework"* (the agent got 403 on its first call and ran nothing).

## Root cause

A transient **DNS-resolution failure** is conflated with a permanent **policy violation** and surfaced as a non-retryable **403**.

## Fix

Carry a `transient` flag through the two validation-result dataclasses and set it **only** on the resolution-failure branches (`getaddrinfo` `OSError`; empty answer). The proxy handler maps `transient` → a retryable **503** whose body (`"…Service Unavailable — retry later."`) is recognized by the orchestrator's existing transient classifier; genuine policy violations (non-public IP, blocked host, bad scheme/port, credentials, DNS rebinding) still return **403**.

**Security posture is unchanged** — on a resolution failure **no outbound request is sent** either way; only the status/message the agent sees changes, which is what decides retry-vs-hard-fail. The retry loop is bounded (`API_RETRY_TOTAL_TIMEOUT = 1800`s with backoff), so a persistently-failing 503 is not an infinite loop.

## Changes
- `app/utils/outbound_url_guard.py` — `OutboundUrlValidationResult.transient`; set on the two resolution-failure branches of `validate_public_http_url`.
- `app/utils/llm_proxy_url_validator.py` — `LlmProxyValidationResult.transient`; propagate from the standard-SSRF path.
- `app/modules/workspace/llm_proxy_handler.py` — `_determine_target_url` returns 503 for transient failures, 403 otherwise.

## Process (class-2, autonomous-workflow monitoring)
- Root cause found with primary evidence (`systematic-debugging`): fixed ~20 s stall = `getaddrinfo` timeout; confirmed the 4xx-non-retryable classifier at `orchestrator.py:2094`.
- Spec + plan written; **independent agent plan review → APPROVE** (0 blocking; anchors, linchpin contract, security, bounded-retry all verified against source).
- TDD: tests written first, watched red, minimal impl, green. **Mutation-verified** — dropping the guard's `transient=True` fails the guard/propagation tests; forcing the handler branch off fails the 503/contract tests.
- Linchpin **contract test** asserts the exact 503 body matches `_TRANSIENT_API_ERROR_RE`.
- Affected suites: **85 passed** (`test_outbound_url_guard`, `test_llm_proxy_url_validator`, `test_llm_proxy_dns_transient`, `test_llm_proxy_handler_audit_username`).

Pure logic change; no migration/schema. Spec: `docs/superpowers/specs/2026-08-26-llm-proxy-dns-timeout-transient-design.md`. Plan: `docs/superpowers/plans/2026-08-26-llm-proxy-dns-timeout-transient.md`.

Closes #3116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
