### PR TITLE
fix(#3081): use Windows API for Unicode hostname retrieval

### DIFF
--- a/remote-agent/config.py
+++ b/remote-agent/config.py
@@ -46,7 +46,9 @@ def _get_hostname() -> str:
         if kernel32.GetComputerNameW(buffer, ctypes.byref(size)):
             return buffer.value
     except Exception as e:
-        logger.debug("Windows API GetComputerNameW failed: %s, falling back to socket.gethostname()", e)
+        logger.debug(
+            "Windows API GetComputerNameW failed: %s, falling back to socket.gethostname()", e
+        )
 
     # Fallback to socket.gethostname() if Windows API fails
     hostname = socket.gethostname()
@@ -59,7 +61,9 @@ def _get_hostname() -> str:
             cp = ctypes.windll.kernel32.GetACP()
             encoding = f"cp{cp}"
             try:
-                fixed = hostname.encode(encoding, errors="replace").decode("utf-8", errors="replace")
+                fixed = hostname.encode(encoding, errors="replace").decode(
+                    "utf-8", errors="replace"
+                )
                 if fixed and fixed != hostname:
                     logger.info("Fixed hostname encoding: %s -> %s", repr(hostname), repr(fixed))
                     return fixed
@@ -69,6 +73,7 @@ def _get_hostname() -> str:
         pass
 
     return hostname
+
 
 # Default configuration values
 DEFAULTS = {

--- a/remote-agent/config.py
+++ b/remote-agent/config.py
@@ -20,6 +20,56 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+
+def _get_hostname() -> str:
+    """
+    Get the system hostname with proper Unicode handling.
+
+    Issue #3081: On Windows with Chinese hostnames, socket.gethostname() may
+    return incorrectly encoded strings. Use Windows API GetComputerNameW
+    to ensure correct Unicode hostname retrieval.
+
+    Returns:
+        The hostname as a Unicode string.
+    """
+    if os.name != "nt":
+        return socket.gethostname()
+
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+
+        # GetComputerNameW returns the NetBIOS name as Unicode
+        size = ctypes.c_ulong(256)
+        buffer = ctypes.create_unicode_buffer(size.value)
+        if kernel32.GetComputerNameW(buffer, ctypes.byref(size)):
+            return buffer.value
+    except Exception as e:
+        logger.debug("Windows API GetComputerNameW failed: %s, falling back to socket.gethostname()", e)
+
+    # Fallback to socket.gethostname() if Windows API fails
+    hostname = socket.gethostname()
+
+    # Try to fix encoding if it looks like corrupted bytes
+    try:
+        if "?" in hostname or any(ord(c) > 65535 for c in hostname):
+            import ctypes
+
+            cp = ctypes.windll.kernel32.GetACP()
+            encoding = f"cp{cp}"
+            try:
+                fixed = hostname.encode(encoding, errors="replace").decode("utf-8", errors="replace")
+                if fixed and fixed != hostname:
+                    logger.info("Fixed hostname encoding: %s -> %s", repr(hostname), repr(fixed))
+                    return fixed
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    return hostname
+
 # Default configuration values
 DEFAULTS = {
     "server_url": "http://localhost:19888",
@@ -291,12 +341,12 @@ class AgentConfig:
     @property
     def machine_name(self) -> str:
         """Human-readable machine name."""
-        return self._data.get("machine_name", socket.gethostname())
+        return self._data.get("machine_name", _get_hostname())
 
     @property
     def hostname(self) -> str:
         """Machine hostname."""
-        return self._data.get("hostname", socket.gethostname())
+        return self._data.get("hostname", _get_hostname())
 
     # --- Persistence helpers ---
 

--- a/remote-agent/system_info.py
+++ b/remote-agent/system_info.py
@@ -15,6 +15,62 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+
+def _get_hostname() -> str:
+    """
+    Get the system hostname with proper Unicode handling.
+
+    Issue #3081: On Windows with Chinese hostnames, platform.node() may
+    return incorrectly encoded strings. Use Windows API GetComputerNameW
+    to ensure correct Unicode hostname retrieval.
+
+    Returns:
+        The hostname as a Unicode string.
+    """
+    if os.name != "nt":
+        return platform.node()
+
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+
+        # GetComputerNameW returns the NetBIOS name as Unicode
+        # https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcomputernameW
+        size = ctypes.c_ulong(256)
+        buffer = ctypes.create_unicode_buffer(size.value)
+        if kernel32.GetComputerNameW(buffer, ctypes.byref(size)):
+            return buffer.value
+    except Exception as e:
+        logger.debug("Windows API GetComputerNameW failed: %s, falling back to platform.node()", e)
+
+    # Fallback to platform.node() if Windows API fails
+    hostname = platform.node()
+
+    # Try to fix encoding if it looks like corrupted bytes
+    # This handles the case where the hostname was decoded incorrectly
+    try:
+        # If the hostname contains replacement characters or looks wrong,
+        # try to re-encode it correctly
+        if "?" in hostname or any(ord(c) > 65535 for c in hostname):
+            # Try encoding as the Windows system code page and re-decoding as UTF-8
+            import ctypes
+
+            cp = ctypes.windll.kernel32.GetACP()
+            encoding = f"cp{cp}"
+            # This is a best-effort fix for already-corrupted strings
+            try:
+                fixed = hostname.encode(encoding, errors="replace").decode("utf-8", errors="replace")
+                if fixed and fixed != hostname:
+                    logger.info("Fixed hostname encoding: %s -> %s", repr(hostname), repr(fixed))
+                    return fixed
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    return hostname
+
 # CLI tools the agent can manage
 KNOWN_CLI_TOOLS = [
     "qwen-code-cli",
@@ -38,7 +94,7 @@ def get_system_info() -> dict[str, Any]:
         "os_type": platform.system(),
         "os_version": platform.release(),
         "os_platform": platform.platform(),
-        "hostname": platform.node(),
+        "hostname": _get_hostname(),
         "architecture": platform.machine(),
         "python_version": platform.python_version(),
     }

--- a/remote-agent/system_info.py
+++ b/remote-agent/system_info.py
@@ -60,7 +60,9 @@ def _get_hostname() -> str:
             encoding = f"cp{cp}"
             # This is a best-effort fix for already-corrupted strings
             try:
-                fixed = hostname.encode(encoding, errors="replace").decode("utf-8", errors="replace")
+                fixed = hostname.encode(encoding, errors="replace").decode(
+                    "utf-8", errors="replace"
+                )
                 if fixed and fixed != hostname:
                     logger.info("Fixed hostname encoding: %s -> %s", repr(hostname), repr(fixed))
                     return fixed
@@ -70,6 +72,7 @@ def _get_hostname() -> str:
         pass
 
     return hostname
+
 
 # CLI tools the agent can manage
 KNOWN_CLI_TOOLS = [


### PR DESCRIPTION
## Problem

On Windows with Chinese hostnames, `socket.gethostname()` and `platform.node()` may return incorrectly encoded strings due to encoding mismatches between the Windows system code page (GBK/CP936) and Python's expected UTF-8.

This causes Chinese hostnames to display as garbled characters (e.g., `??????O`) in the management machine list.

## Root Cause

- Windows computer names are stored using the system local encoding (GBK/CP936 for Simplified Chinese Windows)
- Python's `socket.gethostname()` and `platform.node()` may not correctly decode non-ASCII hostnames in some environments
- This results in corrupted strings being sent to the server and stored in the database

## Solution

Added `_get_hostname()` function that:
1. On Windows: Uses Windows API `GetComputerNameW` to retrieve the hostname as proper Unicode
2. On other systems: Continues using the original `socket.gethostname()` or `platform.node()`
3. Includes fallback encoding fix for already-corrupted hostnames

## Modified Files

- `remote-agent/config.py`: Updated `hostname` and `machine_name` properties
- `remote-agent/system_info.py`: Updated `get_system_info()` function

## Testing

- All existing unit tests pass
- Tested on Linux (non-Windows path still works correctly)
- Windows-specific API calls only execute on `os.name == "nt"`

## Related

- Fixes #3081
- Related to #2602 (Windows terminal encoding issues)