### PR TITLE
fix(#3124): don't blame a cross-user isolated agent for shared-clone main drift

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3355,6 +3355,32 @@ class AutonomousOrchestrator:
                 and before_main.get("branch") == after_main.get("branch")
                 and before_effective.get("head") == after_effective.get("head")
             ):
+                # #3124: on multi-user hosts the agent runs under the cross-user
+                # isolated launcher — a credentialless principal with a scoped
+                # ACL to ONLY its worktree — and CANNOT touch the shared project
+                # clone. So a main-HEAD move it could not have caused is external
+                # (a sibling workflow's merge/prep or the developer); project
+                # clones are shared across concurrent workflows, so blaming the
+                # agent is a false positive. This mirrors the branch-switch skip
+                # below and relies on the same isolation assumption, keyed on the
+                # SAME predicate that gates the isolated launch (_is_cross_user).
+                # We reason via the repo-owner ``system_account`` here (the
+                # isolated launch uses a distinct credentialless account), but on
+                # a multi-user host both differ from the service process user, so
+                # the answer is identical. Short-circuit before the benign-pull
+                # probe, which itself runs git on the contended shared clone and
+                # can fail closed under concurrency. Same-user (dev/macOS) mode
+                # has no isolation and keeps the fail-closed probe below.
+                if AutonomousAgentRunner._is_cross_user(system_account):
+                    logger.warning(
+                        "Workflow %s: main repo HEAD moved %s..%s during agent run, "
+                        "but the agent ran cross-user (isolated launcher; cannot touch "
+                        "the shared project clone). Treating as external drift and allowing.",
+                        self._workflow_id,
+                        before_main.get("head", "")[:8],
+                        after_main.get("head", "")[:8],
+                    )
+                    return ""
                 # main HEAD moved but the worktree did not. This is either an
                 # agent operating on the main repo, or an external `git pull`
                 # moving HEAD to a remote commit during the agent run. Allow

--- a/docs/superpowers/plans/2026-08-26-main-drift-guard-shared-clone.md
+++ b/docs/superpowers/plans/2026-08-26-main-drift-guard-shared-clone.md
@@ -1,0 +1,215 @@
+# Main-HEAD-drift Guard Shared-Clone Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the autonomous main-HEAD-drift guard from failing a workflow when the *shared* project clone's main HEAD is moved by a sibling workflow or the developer, in the case where the agent ran cross-user (isolated launcher) and therefore provably could not have moved it.
+
+**Architecture:** In the same-branch main-drift block of `_validate_repo_context_after_run`, short-circuit to "allow (external drift)" with a WARNING when `AutonomousAgentRunner._is_cross_user(system_account)` is True — the same predicate that decided the agent was launched credentialless with a scoped ACL to only its worktree. Same-user mode keeps today's benign-pull probe + fail-closed behavior.
+
+**Tech Stack:** Python, pytest. Spec: `docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md`. Issue: #3124.
+
+---
+
+## File Structure
+
+- `app/modules/workspace/autonomous/orchestrator.py` — one added branch in the same-branch main-drift block of `_validate_repo_context_after_run` (currently the fail-closed `return "Detected commits on the main repository…"` at ~line 3378).
+- `tests/autonomous/test_repo_drift_validation.py` — extend with cross-user cases (reuses the file's existing `_make_orchestrator`, `_before_state`, `_install_fake_gh` helpers).
+
+`AutonomousAgentRunner` is already imported in `orchestrator.py` (`from app.modules.workspace.autonomous.agent_runner import ... AutonomousAgentRunner`), so no new import.
+
+---
+
+## Task 1: Cross-user allow in the main-drift block
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/orchestrator.py` (same-branch main-drift block; the benign-pull `if`/`return ""` and the fail-closed `return (...)` at ~3364-3382)
+- Test: `tests/autonomous/test_repo_drift_validation.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/autonomous/test_repo_drift_validation.py`. First ensure `import pytest` is present near the top (add it if missing, after `import os`). Then append this class at end of file:
+
+```python
+class TestSharedCloneCrossUser:
+    """#3124: a cross-user isolated agent cannot touch the shared project
+    clone, so a main-HEAD move during its run is external (a sibling workflow
+    or the developer) and must not fail the workflow. Same-user mode, where an
+    escape is possible, stays fail-closed."""
+
+    pytestmark = [pytest.mark.issue(3124), pytest.mark.regression]
+
+    def test_cross_user_agent_allows_nonbenign_main_drift(self, monkeypatch):
+        # #2739: main moved forward but NOT onto origin/main (benign-pull probe
+        # would return False → today this blocks). Under the cross-user isolated
+        # launcher the agent could not have done it → allow.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(
+            AutonomousAgentRunner, "_is_cross_user", return_value=True
+        ):
+            assert o._validate_repo_context_after_run(before, system_account="dwu") == ""
+
+    def test_cross_user_agent_allows_even_when_probe_indeterminate(self, monkeypatch):
+        # #2739 exact shape: the benign-pull probe hits a git error under shared-
+        # clone contention (indeterminate → fail-closed today). Cross-user must
+        # still allow, and must not depend on the probe outcome.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            git_error=True,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(
+            AutonomousAgentRunner, "_is_cross_user", return_value=True
+        ):
+            assert o._validate_repo_context_after_run(before, system_account="dwu") == ""
+
+    def test_same_user_nonbenign_main_drift_still_blocks(self, monkeypatch):
+        # Same-user host (no isolation): an escape is possible, so a non-benign
+        # main move stays fail-closed.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(
+            AutonomousAgentRunner, "_is_cross_user", return_value=False
+        ):
+            err = o._validate_repo_context_after_run(before, system_account="alice")
+            assert "Detected commits on the main repository" in err
+
+    def test_cross_user_does_not_suppress_repo_root_escape(self, monkeypatch):
+        # The cross-user allow is scoped to the main-drift block only. A genuine
+        # worktree-integrity violation (repo root changed) still blocks.
+        def factory(repo_path, system_account=None):
+            gh = MagicMock()
+            gh.get_path_identity.return_value = "1:1"
+            gh.get_current_branch.return_value = "auto-dev/wf-drift"
+            gh.get_current_commit.return_value = WORKTREE_HEAD
+
+            def run_git(args, check=True):
+                if args == ["rev-parse", "--show-toplevel"]:
+                    return MagicMock(stdout="/srv/somewhere-else")
+                return MagicMock(stdout=repo_path, returncode=0)
+
+            gh._run_git.side_effect = run_git
+            return gh
+
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps", factory
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(
+            AutonomousAgentRunner, "_is_cross_user", return_value=True
+        ):
+            err = o._validate_repo_context_after_run(before, system_account="dwu")
+            assert "Agent escaped the workflow repository" in err
+```
+
+Add the import the tests need (top of file, with the other imports):
+
+```python
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/autonomous/test_repo_drift_validation.py::TestSharedCloneCrossUser -v`
+Expected: `test_cross_user_agent_allows_nonbenign_main_drift` and `test_cross_user_agent_allows_even_when_probe_indeterminate` FAIL (they get the "Detected commits on the main repository" block instead of ""). The same-user and repo-root tests pass (existing behavior).
+
+- [ ] **Step 3: Add the cross-user allow (minimal implementation)**
+
+In `app/modules/workspace/autonomous/orchestrator.py`, inside the same-branch main-drift block, insert the cross-user short-circuit **before** the benign-pull probe. The block currently reads (starting at the `# main HEAD moved but the worktree did not.` comment):
+
+```python
+                # main HEAD moved but the worktree did not. This is either an
+                # agent operating on the main repo, or an external `git pull`
+                # moving HEAD to a remote commit during the agent run. Allow
+                # only when the move is a forward update to a remote-sourced
+                # commit (a benign pull); a local escape commit (not pushed),
+                # a reset/rollback, or a non-fast-forward rewrite is blocked.
+                if self._main_drift_is_benign_pull(
+```
+
+Insert immediately after that comment block and before `if self._main_drift_is_benign_pull(`:
+
+```python
+                # #3124: on multi-user hosts the agent runs under the cross-user
+                # isolated launcher — a credentialless principal with a scoped
+                # ACL to ONLY its worktree — and CANNOT touch the shared project
+                # clone. So a main-HEAD move it could not have caused is external
+                # (a sibling workflow's merge/prep or the developer). Attributing
+                # it to the agent is a false positive; project clones are shared
+                # across concurrent workflows. This mirrors the branch-switch
+                # skip below and relies on the same isolation assumption. It
+                # short-circuits before the benign-pull probe, which itself runs
+                # git on the contended shared clone and can fail closed under
+                # concurrency. Same-user (dev/macOS) mode has no isolation and
+                # keeps the fail-closed probe.
+                if AutonomousAgentRunner._is_cross_user(system_account):
+                    logger.warning(
+                        "Workflow %s: main repo HEAD moved %s..%s during agent run, "
+                        "but the agent ran cross-user (isolated launcher; cannot touch "
+                        "the shared project clone). Treating as external drift and allowing.",
+                        self._workflow_id,
+                        before_main.get("head", "")[:8],
+                        after_main.get("head", "")[:8],
+                    )
+                    return ""
+                # main HEAD moved but the worktree did not. This is either an
+                # agent operating on the main repo, or an external `git pull`
+                # moving HEAD to a remote commit during the agent run. Allow
+                # only when the move is a forward update to a remote-sourced
+                # commit (a benign pull); a local escape commit (not pushed),
+                # a reset/rollback, or a non-fast-forward rewrite is blocked.
+                if self._main_drift_is_benign_pull(
+```
+
+(This duplicates the existing comment so the benign-pull path keeps its rationale; the net effect is the new `if` block inserted above the existing comment. Implement it as: add the new comment + `if` + `return ""` directly before the existing `# main HEAD moved but the worktree did not.` comment.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/autonomous/test_repo_drift_validation.py -v`
+Expected: PASS (all — the 4 new plus every pre-existing drift test unchanged, since they use `system_account=None` → `_is_cross_user(None)` is False → same-user path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/orchestrator.py tests/autonomous/test_repo_drift_validation.py
+git commit -m "fix(#3124): allow shared-clone main drift when agent ran cross-user (isolated)"
+```
+
+---
+
+## Task 2: Mutation check (verify the guard clause bites)
+
+- [ ] **Step 1: Mutation — force the cross-user check off**
+
+Temporarily change `if AutonomousAgentRunner._is_cross_user(system_account):` to `if False:`.
+Run: `python -m pytest tests/autonomous/test_repo_drift_validation.py::TestSharedCloneCrossUser -v`
+Expected: FAIL — `test_cross_user_agent_allows_nonbenign_main_drift` and `test_cross_user_agent_allows_even_when_probe_indeterminate` block instead of allow. Restore; re-run → PASS.
+
+(No commit — verification only. Confirm the tree matches Task 1's committed state afterward.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** cross-user allow (Task 1 Step 3); tests for cross-user-allow (#2739 shape, incl. indeterminate probe), same-user-still-blocks, scoped-not-suppressing-other-violations (Task 1 Step 1); mutation (Task 2). All spec test-strategy items covered.
+- **Type/name consistency:** predicate `AutonomousAgentRunner._is_cross_user(system_account)` matches the imported class and its staticmethod signature; tests patch it via `patch.object(AutonomousAgentRunner, "_is_cross_user", ...)`.
+- **No behavior change for same-user:** every existing drift test uses `system_account=None` → `_is_cross_user` False → unchanged path.
+- **Scope:** only the same-branch main-drift block changes; the auto-dev/*-branch-switch block and all worktree-integrity checks are untouched.

--- a/docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md
+++ b/docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md
@@ -63,7 +63,7 @@ becomes: keep the benign-pull allow; then, before the fail-closed `return`, add 
 - **Harden the benign-pull probe** (retry fetch, tolerate lock-contention git errors). More complex, does not fix the stale-`origin/main` sub-case, and still *guesses* attribution instead of using the definitive cross-user signal.
 - **Skip the main-drift check entirely.** Removes real protection on same-user dev hosts where an escape is possible; the cross-user gate is strictly better (keeps that protection).
 
-## Test strategy (TDD, `tests/unit/`, marked `issue(3124)` + `regression`)
+## Test strategy (TDD, extend `tests/autonomous/test_repo_drift_validation.py` — reusing its `_make_orchestrator`/`_before_state`/`_install_fake_gh` harness; marked `issue(3124)` + `regression`)
 
 Drive `_validate_repo_context_after_run` with a crafted `before_state` (worktree "effective" head unchanged; "main" head moved, same branch) and patch `_capture_repo_state` for the after-snapshots and `AutonomousAgentRunner._is_cross_user` for the mode.
 

--- a/docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md
+++ b/docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md
@@ -1,0 +1,77 @@
+# Design: main-HEAD-drift guard must not blame a cross-user isolated agent for shared-clone drift
+
+- **Issue:** #3124
+- **Date:** 2026-08-26
+- **Origin:** autonomous-workflow monitoring (class-2); workflow `10a24081` / #2739
+
+## Problem
+
+`_validate_repo_context_after_run` (`app/modules/workspace/autonomous/orchestrator.py`) snapshots the **project clone's** main HEAD before a local agent phase and re-checks it after. Its same-branch main-drift block fails the workflow with:
+
+> "Detected commits on the main repository while the workflow worktree HEAD did not move; the agent likely executed git commands outside the workflow worktree."
+
+when, during the agent run: the project clone's main HEAD moved · the clone stayed on the same branch · the workflow's **worktree HEAD did not move** · and `_main_drift_is_benign_pull` returned False (the move was not provably a forward update to an `origin/main` commit).
+
+Project clones are **shared across many concurrent workflows** (and with the human developer). So that HEAD move is routinely caused by a sibling workflow's merge/prep or the developer — not the agent. The benign-pull probe runs its own `fetch origin main` + `merge-base` on the **same contended clone**; under concurrent sibling git activity (lock contention → git error → indeterminate → fail closed) or a stale/racing `origin/main` fetch (`after` not yet on the local `origin/main` ref), it cannot prove the move benign and blocks.
+
+### Evidence (workflow `10a24081` / #2739, prod ai-lab, 2026-08-20)
+
+- The agent was a **read-only plan-refine run** — system prompt: *"只进行分析、阅读代码、输出方案文本，不要修改任何文件或执行写操作"*. Across both agent sessions every tool call was Read/Grep/Glob inside its own worktree; **zero** `git commit/add/checkout/reset/pull`. It could not have moved main.
+- `/home/dwu/open-ace-01/open-ace` is shared by **10 workflows**; at the exact failure second (`01:54:27`) three siblings — #2740, #2754, #2756 — were at `acceptance_verification` on the same clone.
+- Only 2 workflows ever hit this guard (#2565, #2739), but every project clone is shared (68/41/30/29/25/22/10/…), so the whole fleet is susceptible to the timing race.
+
+## Root cause
+
+The guard assumes **single-tenant ownership** of the project clone, but the clone is **shared**, so an external main-HEAD move during the agent run trips a fail-closed guard that misattributes it to the agent.
+
+## Chosen approach — allow the drift when the agent provably could not have caused it
+
+The codebase **already relies on** this assumption in the adjacent branch-switch skip (orchestrator.py, the `else` branch of the branch-changed case):
+
+> "On multi-user Linux hosts with the launcher, the agent runs as a credentialless principal and CANNOT touch the main repo, so this tradeoff is dev-host-only."
+
+`AutonomousAgentRunner._is_cross_user(system_account)` (`agent_runner.py`) is the **authoritative predicate that decides how the agent was actually launched**: True ⇒ the agent ran under the cross-user isolated `openace-run-as` launcher (a credentialless principal with a scoped ACL to only its worktree) and cannot touch the shared main clone. It returns True when `system_account` is set and differs from the service-process user (and, fail-safe, True when the current user's passwd entry can't be resolved — the same default the launch path uses, so it stays consistent with how the agent was actually isolated).
+
+**Fix:** in the same-branch main-drift block, before failing closed, if `AutonomousAgentRunner._is_cross_user(system_account)` is True, allow the drift and log a WARNING (external move; the isolated agent could not have caused it), mirroring the branch-switch skip. **Same-user mode is unchanged** — it keeps the current `_main_drift_is_benign_pull` probe and fail-closed behavior, because on a same-user host an agent escape is genuinely possible.
+
+Because `_is_cross_user` is the same predicate the launcher used, matching the guard's allow-decision to it is semantically exact: if the agent was launched isolated, it demonstrably could not move main, so the drift is external by construction.
+
+### Where the change goes
+
+Exactly one place: the same-branch main-drift block. Currently:
+
+```python
+                if self._main_drift_is_benign_pull(...):
+                    logger.info(... "benign external pull"); return ""
+                return (
+                    "Detected commits on the main repository while the workflow worktree "
+                    "HEAD did not move; the agent likely executed git commands outside "
+                    "the workflow worktree."
+                )
+```
+
+becomes: keep the benign-pull allow; then, before the fail-closed `return`, add a cross-user allow that logs a WARNING and returns "" (no violation).
+
+## Blast radius
+
+- One added condition + WARNING log in one block. Same-user behavior byte-for-byte unchanged.
+- The auto-dev/*-branch-switch block (the branch-*changed*-to-`auto-dev/*` case) is a stronger escape signal and is **not** #2739's path — left strict, out of scope.
+- No dataclass/schema/migration changes.
+
+## Alternatives rejected
+
+- **Harden the benign-pull probe** (retry fetch, tolerate lock-contention git errors). More complex, does not fix the stale-`origin/main` sub-case, and still *guesses* attribution instead of using the definitive cross-user signal.
+- **Skip the main-drift check entirely.** Removes real protection on same-user dev hosts where an escape is possible; the cross-user gate is strictly better (keeps that protection).
+
+## Test strategy (TDD, `tests/unit/`, marked `issue(3124)` + `regression`)
+
+Drive `_validate_repo_context_after_run` with a crafted `before_state` (worktree "effective" head unchanged; "main" head moved, same branch) and patch `_capture_repo_state` for the after-snapshots and `AutonomousAgentRunner._is_cross_user` for the mode.
+
+1. **Cross-user isolated agent → allowed.** main HEAD moved + same branch + worktree HEAD unchanged + `_is_cross_user` True → returns "" (no violation), and `_main_drift_is_benign_pull` is **not** relied on (patch it to return False to prove the cross-user path wins). Mutation anchor: this is #2739.
+2. **Same-user + non-benign move → still blocks.** `_is_cross_user` False + `_main_drift_is_benign_pull` False → returns the "Detected commits on the main repository…" violation (fail-closed preserved).
+3. **Benign pull still allowed** regardless of mode (`_main_drift_is_benign_pull` True → "").
+4. **Regression:** an actual worktree-integrity violation (e.g. branch changed) still returns its violation — the cross-user allow only covers the main-drift block, not the other checks.
+
+## Deployment & rollout
+
+Pure logic change; no migration/schema. The guard runs in the scheduler (`openace-scheduler.service`) — deploy = hot-patch `orchestrator.py`, restart that unit. #2739's issue is **CLOSED** (resolved elsewhere), so **no workflow reset is needed**; the fix prevents future recurrences fleet-wide.

--- a/tests/autonomous/test_repo_drift_validation.py
+++ b/tests/autonomous/test_repo_drift_validation.py
@@ -25,6 +25,9 @@ Covers:
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
 MAIN_REPO = "/srv/open-ace"
@@ -369,3 +372,83 @@ class TestRepoDriftValidation:
 
         err = o._validate_repo_context_after_run(before, system_account=None)
         assert err == ""
+
+
+class TestSharedCloneCrossUser:
+    """#3124: a cross-user isolated agent cannot touch the shared project
+    clone, so a main-HEAD move during its run is external (a sibling workflow
+    or the developer) and must not fail the workflow. Same-user mode, where an
+    escape is possible, stays fail-closed."""
+
+    pytestmark = [pytest.mark.issue(3124), pytest.mark.regression]
+
+    def test_cross_user_agent_allows_nonbenign_main_drift(self, monkeypatch):
+        # #2739: main moved forward but NOT onto origin/main (benign-pull probe
+        # would return False -> today this blocks). Under the cross-user isolated
+        # launcher the agent could not have done it -> allow.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=True):
+            assert o._validate_repo_context_after_run(before, system_account="dwu") == ""
+
+    def test_cross_user_agent_allows_even_when_probe_indeterminate(self, monkeypatch):
+        # #2739 exact shape: the benign-pull probe hits a git error under shared-
+        # clone contention (indeterminate -> fail-closed today). Cross-user must
+        # still allow, and must not depend on the probe outcome.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            git_error=True,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=True):
+            assert o._validate_repo_context_after_run(before, system_account="dwu") == ""
+
+    def test_same_user_nonbenign_main_drift_still_blocks(self, monkeypatch):
+        # Same-user host (no isolation): an escape is possible, so a non-benign
+        # main move stays fail-closed.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=False):
+            err = o._validate_repo_context_after_run(before, system_account="alice")
+            assert "Detected commits on the main repository" in err
+
+    def test_cross_user_does_not_suppress_repo_root_escape(self, monkeypatch):
+        # The cross-user allow is scoped to the main-drift block only. A genuine
+        # worktree-integrity violation (repo root changed) still blocks.
+        def factory(repo_path, system_account=None):
+            gh = MagicMock()
+            gh.get_path_identity.return_value = "1:1"
+            gh.get_current_branch.return_value = "auto-dev/wf-drift"
+            gh.get_current_commit.return_value = WORKTREE_HEAD
+
+            def run_git(args, check=True):
+                if args == ["rev-parse", "--show-toplevel"]:
+                    return MagicMock(stdout="/srv/somewhere-else")
+                return MagicMock(stdout=repo_path, returncode=0)
+
+            gh._run_git.side_effect = run_git
+            return gh
+
+        monkeypatch.setattr("app.modules.workspace.autonomous.orchestrator.GitHubOps", factory)
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+        with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=True):
+            err = o._validate_repo_context_after_run(before, system_account="dwu")
+            assert "Agent escaped the workflow repository" in err


### PR DESCRIPTION
## Problem

The autonomous main-HEAD-drift guard (`_validate_repo_context_after_run`, `app/modules/workspace/autonomous/orchestrator.py`) fails a workflow with *"Detected commits on the main repository while the workflow worktree HEAD did not move; the agent likely executed git commands outside the workflow worktree"* when the **project clone's** main HEAD moves during the agent run and `_main_drift_is_benign_pull` can't prove the move was a forward pull to an `origin/main` commit.

Project clones are **shared across many concurrent workflows** (and with the developer), so that HEAD move is routinely a **sibling workflow's merge/prep or the developer** — not the agent. The benign-pull probe runs its own `fetch`+`merge-base` on the *same contended clone* and fails closed under concurrent git activity or a stale/racing `origin/main` fetch.

### Evidence (workflow `10a24081` / #2739, prod ai-lab, 2026-08-20)
- The agent was a **read-only plan-refine run** (system prompt: analyze/read only, no writes). Every tool call was Read/Grep/Glob inside its own worktree; **zero** git commit/add/checkout/reset/pull — it could not have moved main.
- `/home/dwu/open-ace-01/open-ace` is shared by **10 workflows**; at the exact failure second three siblings (#2740/#2754/#2756) were at `acceptance_verification` on the same clone.
- Only 2 workflows ever hit this guard (#2565, #2739), but *every* project clone is shared (68/41/30/29/25/22/10/…), so the whole fleet is susceptible to the timing race.

## Root cause
The guard assumes **single-tenant ownership** of the project clone, but the clone is **shared**, so an external main-HEAD move during the agent run trips a fail-closed guard that misattributes it to the agent.

## Fix
The codebase already relies on this assumption in the adjacent branch-switch skip: *"the agent runs as a credentialless principal and CANNOT touch the main repo."* `AutonomousAgentRunner._is_cross_user(system_account)` is the **same predicate that gates the isolated launch** (`_wrap_agent_cmd` wraps with `openace-run-as --isolated` exactly when it is True). In the same-branch main-drift block, when the agent ran **cross-user**, short-circuit to allow the drift with a WARNING (external move; the isolated agent could not have caused it) — *before* the fragile benign-pull probe. **Same-user (dev/macOS) mode is unchanged** and keeps today's fail-closed probe, because there an escape is genuinely possible.

The change is strictly **safer than** the branch-switch skip it mirrors (that skip is unconditional; this one gates on `_is_cross_user`), and touches nothing on hosts where an escape is possible.

## Changes
- `app/modules/workspace/autonomous/orchestrator.py` — one added cross-user allow branch in the same-branch main-drift block.
- `tests/autonomous/test_repo_drift_validation.py` — 4 tests reusing the existing harness.

## Process (class-2, autonomous-workflow monitoring)
- Root cause established with primary evidence (`systematic-debugging`): the agent's own session shows read-only tool calls, zero git writes; the shared clone had 3 active siblings at the failure second.
- Spec + plan → **independent agent plan review → APPROVE** (0 blocking; anchors, `_is_cross_user` correspondence, security, scope, test-bite all verified against source at runtime).
- TDD: tests written first, watched red, minimal impl, green. **Mutation-verified** — forcing the cross-user clause off re-blocks the two #2739-shape tests. Same-user + repo-root-escape regression tests confirm scope.
- Suite: `tests/autonomous/test_repo_drift_validation.py` **16 passed** (12 existing unchanged + 4 new).

Pure logic change; no migration/schema. #2739's issue is **CLOSED**, so no workflow reset is needed — this prevents future fleet-wide recurrences. Spec: `docs/superpowers/specs/2026-08-26-main-drift-guard-shared-clone-design.md`. Plan: `docs/superpowers/plans/2026-08-26-main-drift-guard-shared-clone.md`.

Closes #3124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
