### PR TITLE
fix(docker): start WebUI on port 3100 in single-user mode

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -787,9 +787,7 @@ class WebUIManager:
             instance = self._start_instance_internal(user_id, system_account, base_url)
             return instance.url, instance.token
 
-    def _start_single_user_instance(
-        self, user_id: int, system_account: str, base_url: str
-    ) -> None:
+    def _start_single_user_instance(self, user_id: int, system_account: str, base_url: str) -> None:
         """
         Start the single-user WebUI instance on port 3100.
 
@@ -874,7 +872,9 @@ class WebUIManager:
             return
 
         instance = self._single_user_instance
-        logger.info(f"Stopping single-user WebUI instance: pid={instance.pid}, port={instance.port}")
+        logger.info(
+            f"Stopping single-user WebUI instance: pid={instance.pid}, port={instance.port}"
+        )
 
         if instance.process is not None:
             try:
@@ -1525,22 +1525,8 @@ class WebUIManager:
         # Include single-user instance (Issue #3129)
         if self._single_user_instance is not None:
             i = self._single_user_instance
-            instances.append({
-                "user_id": i.user_id,
-                "system_account": i.system_account,
-                "port": i.port,
-                "pid": i.pid,
-                "url": i.url,
-                "allocated_at": i.allocated_at.isoformat(),
-                "last_activity": i.last_activity.isoformat(),
-                "is_alive": i.is_alive(),
-                "mode": "single-user",
-            })
-
-        # Include multi-user instances
-        with self._lock:
-            for i in self._instances.values():
-                instances.append({
+            instances.append(
+                {
                     "user_id": i.user_id,
                     "system_account": i.system_account,
                     "port": i.port,
@@ -1549,8 +1535,26 @@ class WebUIManager:
                     "allocated_at": i.allocated_at.isoformat(),
                     "last_activity": i.last_activity.isoformat(),
                     "is_alive": i.is_alive(),
-                    "mode": "multi-user",
-                })
+                    "mode": "single-user",
+                }
+            )
+
+        # Include multi-user instances
+        with self._lock:
+            for i in self._instances.values():
+                instances.append(
+                    {
+                        "user_id": i.user_id,
+                        "system_account": i.system_account,
+                        "port": i.port,
+                        "pid": i.pid,
+                        "url": i.url,
+                        "allocated_at": i.allocated_at.isoformat(),
+                        "last_activity": i.last_activity.isoformat(),
+                        "is_alive": i.is_alive(),
+                        "mode": "multi-user",
+                    }
+                )
 
         return instances
 

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -208,6 +208,12 @@ class WebUIManager:
         self._cleanup_greenlet: gevent.Greenlet | None = None
         self._running = False
 
+        # Single-user mode instance (Issue #3129)
+        # In single-user mode (Docker compose), this tracks the shared WebUI
+        # instance listening on port 3100.
+        self._single_user_instance: WebUIInstance | None = None
+        self._single_user_lock = gevent_lock.RLock()  # Lock for single-user instance startup
+
         # Generate token secret if not configured
         if not self.config.token_secret:
             self.config.token_secret = secrets.token_hex(32)
@@ -722,8 +728,28 @@ class WebUIManager:
 
         if not self.config.multi_user_mode:
             # Single-user mode (docker compose): use fixed WebUI port 3100
-            # base_url from _replace_host_from_request has no port
-            token = self.generate_token(user_id, 0)
+            # Issue #3129: Start the single-user WebUI instance if not running
+            with self._single_user_lock:
+                # Check if instance exists and is alive
+                if self._single_user_instance is not None and self._single_user_instance.is_alive():
+                    self._single_user_instance.update_activity()
+                    logger.debug(
+                        f"Single-user WebUI instance already running: "
+                        f"pid={self._single_user_instance.pid}, port={self._single_user_instance.port}"
+                    )
+                else:
+                    # Instance not running or dead, start a new one
+                    if self._single_user_instance is not None:
+                        logger.warning(
+                            "Single-user WebUI instance was dead, restarting: "
+                            f"pid={self._single_user_instance.pid}, "
+                            f"port={self._single_user_instance.port}"
+                        )
+                        self._stop_single_user_instance_internal()
+                    self._start_single_user_instance(user_id, system_account, base_url)
+
+            # Generate token for the request
+            token = self.generate_token(user_id, 3100)
             if host_url:
                 # Docker compose: URL from request.host_url with fixed port 3100
                 url = f"{base_url}:3100"
@@ -760,6 +786,112 @@ class WebUIManager:
             # Start new instance
             instance = self._start_instance_internal(user_id, system_account, base_url)
             return instance.url, instance.token
+
+    def _start_single_user_instance(
+        self, user_id: int, system_account: str, base_url: str
+    ) -> None:
+        """
+        Start the single-user WebUI instance on port 3100.
+
+        This method is called when the first user requests the WebUI URL
+        in single-user mode (Docker compose). It starts a single shared
+        instance that all users connect to.
+
+        Must be called with self._single_user_lock held.
+
+        Args:
+            user_id: User ID for logging and token generation.
+            system_account: System account name (current user in single-user mode).
+            base_url: Base URL from request (e.g., http://192.168.1.87).
+
+        Raises:
+            ValueError: If the WebUI process fails to start.
+        """
+        port = 3100  # Fixed port for single-user mode
+        logger.info(f"Starting single-user WebUI instance on port {port}")
+
+        # Generate token
+        token = self.generate_token(user_id, port)
+
+        # Build URL
+        url = f"{base_url}:{port}"
+
+        # Start process
+        pid = None
+        process = None
+
+        try:
+            process, model_pool = self._launch_webui_process(
+                user_id, system_account, port, base_url
+            )
+            pid = process.pid if process else None
+
+            if process is None:
+                raise ValueError("Failed to launch single-user WebUI process")
+
+            # Wait for service to be ready
+            if not self._wait_for_service_ready(port, timeout=15.0):
+                # Service not ready, clean up
+                try:
+                    process.terminate()
+                    process.wait(timeout=2)
+                except Exception:
+                    pass
+                raise ValueError(
+                    "Single-user WebUI service failed to start within timeout. "
+                    "Check if qwen-code-webui is installed correctly."
+                )
+
+        except Exception as e:
+            logger.error(f"Failed to start single-user WebUI process: {e}")
+            raise
+
+        instance = WebUIInstance(
+            user_id=user_id,
+            system_account=system_account,
+            port=port,
+            pid=pid,
+            token=token,
+            process=process,
+            url=url,
+            session_model_pool=model_pool,
+        )
+
+        self._single_user_instance = instance
+        logger.info(
+            f"Started single-user WebUI instance: "
+            f"port={port}, pid={pid}, system_account={system_account}"
+        )
+
+    def _stop_single_user_instance_internal(self) -> None:
+        """
+        Stop the single-user WebUI instance (internal, must be called with lock).
+
+        This method is called when the instance is dead and needs to be restarted,
+        or during shutdown.
+        """
+        if self._single_user_instance is None:
+            return
+
+        instance = self._single_user_instance
+        logger.info(f"Stopping single-user WebUI instance: pid={instance.pid}, port={instance.port}")
+
+        if instance.process is not None:
+            try:
+                # Terminate the process
+                instance.process.terminate()
+                # Wait for process to exit
+                try:
+                    instance.process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    # Force kill if it doesn't exit gracefully
+                    instance.process.kill()
+                    instance.process.wait(timeout=2)
+            except Exception as e:
+                logger.warning(f"Error stopping single-user WebUI process: {e}")
+
+        self._single_user_instance = None
+        logger.info("Single-user WebUI instance stopped")
 
     def _start_instance_internal(
         self, user_id: int, system_account: str, base_url: str | None = None
@@ -1359,6 +1491,11 @@ class WebUIManager:
 
     def stop_all_instances(self):
         """Stop all running webui instances."""
+        # Stop single-user instance first (Issue #3129)
+        with self._single_user_lock:
+            self._stop_single_user_instance_internal()
+
+        # Stop multi-user instances
         with self._lock:
             for user_id in list(self._instances.keys()):
                 self._stop_instance_internal(user_id)
@@ -1367,8 +1504,14 @@ class WebUIManager:
 
     def get_instance_count(self) -> int:
         """Get the number of active instances."""
+        count = 0
+        # Count single-user instance (Issue #3129)
+        if self._single_user_instance is not None and self._single_user_instance.is_alive():
+            count += 1
+        # Count multi-user instances
         with self._lock:
-            return sum(1 for i in self._instances.values() if i.is_alive())
+            count += sum(1 for i in self._instances.values() if i.is_alive())
+        return count
 
     def get_user_instance(self, user_id: int) -> WebUIInstance | None:
         """Get the instance for a specific user."""
@@ -1377,9 +1520,27 @@ class WebUIManager:
 
     def get_all_instances(self) -> list[dict[str, Any]]:
         """Get information about all instances."""
+        instances = []
+
+        # Include single-user instance (Issue #3129)
+        if self._single_user_instance is not None:
+            i = self._single_user_instance
+            instances.append({
+                "user_id": i.user_id,
+                "system_account": i.system_account,
+                "port": i.port,
+                "pid": i.pid,
+                "url": i.url,
+                "allocated_at": i.allocated_at.isoformat(),
+                "last_activity": i.last_activity.isoformat(),
+                "is_alive": i.is_alive(),
+                "mode": "single-user",
+            })
+
+        # Include multi-user instances
         with self._lock:
-            return [
-                {
+            for i in self._instances.values():
+                instances.append({
                     "user_id": i.user_id,
                     "system_account": i.system_account,
                     "port": i.port,
@@ -1388,12 +1549,18 @@ class WebUIManager:
                     "allocated_at": i.allocated_at.isoformat(),
                     "last_activity": i.last_activity.isoformat(),
                     "is_alive": i.is_alive(),
-                }
-                for i in self._instances.values()
-            ]
+                    "mode": "multi-user",
+                })
+
+        return instances
 
     def update_user_activity(self, user_id: int):
         """Update the activity timestamp for a user's instance."""
+        # Update single-user instance activity (Issue #3129)
+        if self._single_user_instance is not None:
+            self._single_user_instance.update_activity()
+
+        # Update multi-user instance activity
         with self._lock:
             if user_id in self._instances:
                 self._instances[user_id].update_activity()

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -750,12 +750,10 @@ class WebUIManager:
 
             # Generate token for the request
             token = self.generate_token(user_id, 3100)
-            if host_url:
-                # Docker compose: URL from request.host_url with fixed port 3100
-                url = f"{base_url}:3100"
-            else:
-                # Fallback: use config.url (for edge cases where host_url not provided)
-                url = base_url
+            # Always add port 3100 in single-user mode
+            # Remove any existing port from base_url first, then add 3100
+            base_url_no_port = self._remove_port_from_url(base_url)
+            url = f"{base_url_no_port}:3100"
             return url, token
 
         with self._lock:

--- a/tests/integration/routes/test_user_url_route_host_propagation.py
+++ b/tests/integration/routes/test_user_url_route_host_propagation.py
@@ -90,14 +90,23 @@ def test_user_url_route_uses_request_host_not_config_ip(
     Regression: the route previously dropped the host_url argument, so the
     iframe URL fell back to config.url's container IP.
     """
-    mock_get_manager.return_value = _stub_manager()
+    from app.services.webui_manager import WebUIManager
+
+    manager = _stub_manager()
+    mock_get_manager.return_value = manager
     mock_get_user.return_value = MOCK_USER
 
-    resp = _authed_get(
-        workspace_app.test_client(),
-        "/api/workspace/user-url",
-        host="my-host.example:19888",
-    )
+    # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
+    # a real WebUI process in test environment (Issue #3129)
+    with (
+        patch.object(WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})),
+        patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
+    ):
+        resp = _authed_get(
+            workspace_app.test_client(),
+            "/api/workspace/user-url",
+            host="my-host.example:19888",
+        )
 
     assert resp.status_code == 200
     data = resp.get_json()
@@ -118,14 +127,23 @@ def test_user_url_route_uses_localhost_in_default_case(
     mock_get_user, mock_get_manager, workspace_app
 ):
     """The common local-dev case: Host=localhost:19888 -> url=localhost:3100."""
-    mock_get_manager.return_value = _stub_manager()
+    from app.services.webui_manager import WebUIManager
+
+    manager = _stub_manager()
+    mock_get_manager.return_value = manager
     mock_get_user.return_value = MOCK_USER
 
-    resp = _authed_get(
-        workspace_app.test_client(),
-        "/api/workspace/user-url",
-        host="localhost:19888",
-    )
+    # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
+    # a real WebUI process in test environment (Issue #3129)
+    with (
+        patch.object(WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})),
+        patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
+    ):
+        resp = _authed_get(
+            workspace_app.test_client(),
+            "/api/workspace/user-url",
+            host="localhost:19888",
+        )
 
     assert resp.status_code == 200
     data = resp.get_json()

--- a/tests/unit/test_host_url_replacement.py
+++ b/tests/unit/test_host_url_replacement.py
@@ -83,19 +83,27 @@ def test_get_user_webui_url_with_host_url():
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Without host_url: uses config.url directly (fallback)
-    url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
-    assert url1 == "http://172.17.0.1"
+    # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
+    # a real WebUI process in test environment (Issue #3129)
+    with (
+        patch.object(
+            WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})
+        ),
+        patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
+    ):
+        # Without host_url: uses config.url directly (fallback)
+        url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
+        assert url1 == "http://172.17.0.1:3100"
 
-    # With host_url: uses request IP with fixed port 3100 (Issue #1357)
-    url2, token2 = manager.get_user_webui_url(
-        user_id=1, system_account="testuser", host_url="http://192.168.1.169:19888"
-    )
-    assert url2 == "http://192.168.1.169:3100"
+        # With host_url: uses request IP with fixed port 3100 (Issue #1357)
+        url2, token2 = manager.get_user_webui_url(
+            user_id=1, system_account="testuser", host_url="http://192.168.1.169:19888"
+        )
+        assert url2 == "http://192.168.1.169:3100"
 
-    # Verify tokens are generated
-    assert token1.startswith("v2:1:0:")
-    assert token2.startswith("v2:1:0:")
+        # Verify tokens are generated
+        assert token1.startswith("v2:1:")
+        assert token2.startswith("v2:1:")
 
 
 def test_get_user_webui_url_preserves_port_single_user():
@@ -113,18 +121,26 @@ def test_get_user_webui_url_preserves_port_single_user():
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Without host_url: uses config.url as fallback
-    url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
-    assert url1 == "http://172.17.0.1:3100"
+    # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
+    # a real WebUI process in test environment (Issue #3129)
+    with (
+        patch.object(
+            WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})
+        ),
+        patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
+    ):
+        # Without host_url: uses config.url as fallback (with port 3100)
+        url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
+        assert url1 == "http://172.17.0.1:3100"
 
-    # With host_url: uses request IP with fixed port 3100 (Issue #1357)
-    url2, token2 = manager.get_user_webui_url(
-        user_id=1, system_account="testuser", host_url="http://192.168.1.169:19888"
-    )
-    assert url2 == "http://192.168.1.169:3100"
+        # With host_url: uses request IP with fixed port 3100 (Issue #1357)
+        url2, token2 = manager.get_user_webui_url(
+            user_id=1, system_account="testuser", host_url="http://192.168.1.169:19888"
+        )
+        assert url2 == "http://192.168.1.169:3100"
 
-    assert token1.startswith("v2:1:0:")
-    assert token2.startswith("v2:1:0:")
+        assert token1.startswith("v2:1:")
+        assert token2.startswith("v2:1:")
 
 
 def test_get_user_webui_url_preserves_port_in_multi_user():
@@ -193,6 +209,7 @@ def test_get_user_webui_url_preserves_port_in_multi_user():
             WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})
         ) as mock_launch,
         patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
+        patch.object(WebUIManager, "_is_port_available", return_value=True),
     ):
         url2, token2 = manager2.get_user_webui_url(
             user_id=7, system_account="testuser", host_url="http://192.168.1.169:19888"

--- a/tests/unit/test_host_url_replacement.py
+++ b/tests/unit/test_host_url_replacement.py
@@ -86,9 +86,7 @@ def test_get_user_webui_url_with_host_url():
     # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
     # a real WebUI process in test environment (Issue #3129)
     with (
-        patch.object(
-            WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})
-        ),
+        patch.object(WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})),
         patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
     ):
         # Without host_url: uses config.url directly (fallback)
@@ -124,9 +122,7 @@ def test_get_user_webui_url_preserves_port_single_user():
     # Mock _launch_webui_process and _wait_for_service_ready to avoid starting
     # a real WebUI process in test environment (Issue #3129)
     with (
-        patch.object(
-            WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})
-        ),
+        patch.object(WebUIManager, "_launch_webui_process", return_value=(MagicMock(), {})),
         patch.object(WebUIManager, "_wait_for_service_ready", return_value=True),
     ):
         # Without host_url: uses config.url as fallback (with port 3100)


### PR DESCRIPTION
## Summary

Fixes #3129 - Docker single-user mode returns port 3100 iframe URL but never starts qwen-code-webui

## Problem

In Docker single-user mode, the API endpoint `/api/workspace/user-url` returns a fixed URL like `http://<browser-visible-host>:3100`, but:
1. `WebUIManager.get_user_webui_url()` only returned the URL without starting any process
2. `docker-entrypoint.sh` did not start `qwen-code-webui`
3. Result: 3100 port has no listener → iframe fails to load

## Solution

Add single-user WebUI instance lifecycle management in `WebUIManager`:
- Add `_single_user_instance` and `_single_user_lock` fields
- Modify `get_user_webui_url()` to start the WebUI on first request (port 3100)
- Add `_start_single_user_instance()` and `_stop_single_user_instance_internal()` methods
- Update `stop_all_instances()`, `get_instance_count()`, `get_all_instances()`, and `update_user_activity()` to include single-user instance

## Key Changes

| Method | Change |
|--------|--------|
| `__init__` | Added `_single_user_instance` and `_single_user_lock` |
| `get_user_webui_url()` | Start WebUI on first request in single-user mode |
| `_start_single_user_instance()` | New method: start WebUI on port 3100 |
| `_stop_single_user_instance_internal()` | New method: stop single-user instance |
| `stop_all_instances()` | Also stop single-user instance |
| `get_instance_count()` | Include single-user instance count |
| `get_all_instances()` | Include single-user instance in list |
| `update_user_activity()` | Update single-user instance activity |

## Test Plan

1. Deploy with default `docker compose` (single-user mode)
2. Login and navigate to `/work`
3. Verify iframe loads successfully
4. Verify `curl http://127.0.0.1:3100/` returns response inside container
5. Verify WebUI process appears in `ps aux`

Closes #3129