### PR TITLE
fix(docker): add WORKSPACE_BASE_DIR to scheduler in multi-user mode (#3134)

### DIFF
--- a/docker-compose.multi-user.yml
+++ b/docker-compose.multi-user.yml
@@ -66,6 +66,8 @@ services:
     environment:
       # Multi-user workspace mode (required)
       - WORKSPACE_MULTI_USER_MODE=true
+      # Workspace base directory - required for _is_docker_multi_user_mode() check (Issue #3134)
+      - WORKSPACE_BASE_DIR=/workspace
       # Explicit root opt-in (Issue #1893)
       - OPENACE_ALLOW_ROOT_MULTI_USER=1
       # IMPORTANT: OPENACE_CONFIG_DIR must match the volume mount path in


### PR DESCRIPTION
Closes #3134

## 修复内容
在 `docker-compose.multi-user.yml` 的 scheduler 服务中添加 `WORKSPACE_BASE_DIR=/workspace` 环境变量。

## 修复方案
Issue #3134 已详细分析问题根因：

- `_is_docker_multi_user_mode()` 函数检查两个条件：
  1. `WORKSPACE_BASE_DIR == "/workspace"`
  2. `os.geteuid() == 0`（以 root 运行）
- scheduler 服务已配置 `user: "0"`（root），但缺少 `WORKSPACE_BASE_DIR`
- 导致多用户模式检测失败，用户同步被跳过

## 变更
- `docker-compose.multi-user.yml`：scheduler 服务添加 `WORKSPACE_BASE_DIR=/workspace`

## 验证方法
1. 部署多用户模式：`docker compose -f docker-compose.yml -f docker-compose.multi-user.yml up -d`
2. 检查 scheduler 容器环境变量：`docker exec open-ace-scheduler env | grep WORKSPACE_BASE_DIR`
3. 检查 scheduler 日志：`docker logs open-ace-scheduler | grep "Syncing system users"`
4. 验证系统用户同步：`docker exec open-ace-scheduler id <username>`