### PR TITLE
fix(scheduler): fall back to scheduler_runs for idle status between runs

### DIFF
--- a/app/services/scheduler_health_monitor.py
+++ b/app/services/scheduler_health_monitor.py
@@ -277,6 +277,7 @@ class SchedulerHealthMonitor:
         """Check individual scheduler health and create alert if needed.
 
         Issue #2820: Uses health status classification (healthy/stale/stopped/unknown).
+        Issue #3146: "idle" status treated like "healthy" — worker alive between runs.
 
         Args:
             name: Scheduler name.
@@ -299,8 +300,8 @@ class SchedulerHealthMonitor:
             # Clear the stopped alert flag if it exists
             self._alert_created_for.discard(name)
 
-        elif health_status == "healthy":
-            # Clear alert flags when scheduler is healthy again
+        elif health_status in ("healthy", "idle"):
+            # Clear alert flags when scheduler is healthy or idle
             self._alert_created_for.discard(name)
             self._alert_created_for.discard(f"{name}:stale")
 

--- a/app/services/scheduler_status_reader.py
+++ b/app/services/scheduler_status_reader.py
@@ -281,9 +281,7 @@ class SchedulerStatusReader:
                 last_run_age_seconds = (now - last_run_at).total_seconds()
 
         # Determine health status based on last run age
-        if last_run_age_seconds is None:
-            health_status = "stopped"
-        elif last_run_age_seconds >= threshold_stopped:
+        if last_run_age_seconds is None or last_run_age_seconds >= threshold_stopped:
             health_status = "stopped"
         elif last_run_age_seconds >= threshold_healthy:
             health_status = "stale"

--- a/app/services/scheduler_status_reader.py
+++ b/app/services/scheduler_status_reader.py
@@ -150,7 +150,12 @@ class SchedulerStatusReader:
         threshold_healthy: int,
         threshold_stopped: int,
     ) -> dict[str, Any]:
-        """Query scheduler_leaders table for status."""
+        """Query scheduler_leaders table for status.
+
+        When the leader row is absent (idle interval between runs),
+        falls back to scheduler_runs for last-run and worker info.
+        Issue #3146.
+        """
         from app.repositories.database import Database
 
         db = Database()
@@ -167,16 +172,13 @@ class SchedulerStatusReader:
         )
 
         if not result:
-            return {
-                "running": False,
-                "worker_id": None,
-                "heartbeat": None,
-                "heartbeat_age_seconds": None,
-                "last_run": None,
-                "next_run": None,
-                "health_status": "stopped",
-                "error": None,
-            }
+            # No active leader row — the scheduler is idle between runs
+            # (release_leadership deletes the row after each execution).
+            # Fall back to scheduler_runs for durable run history.
+            # Issue #3146.
+            return self._query_runs_fallback(
+                db, job_name, interval_seconds, threshold_healthy, threshold_stopped
+            )
 
         # Check if expired
         now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -219,6 +221,100 @@ class SchedulerStatusReader:
             "worker_id": leader_id,
             "heartbeat": heartbeat_str,
             "heartbeat_age_seconds": heartbeat_age_seconds,
+            "last_run": last_run_str,
+            "next_run": next_run_str,
+            "health_status": health_status,
+            "error": None,
+        }
+
+    def _query_runs_fallback(
+        self,
+        db: Any,
+        job_name: str,
+        interval_seconds: int,
+        threshold_healthy: int,
+        threshold_stopped: int,
+    ) -> dict[str, Any]:
+        """Query scheduler_runs for last-run info when no leader row exists.
+
+        Issue #3146: After release_leadership() deletes the scheduler_leaders
+        row, the scheduler is idle between runs.  We read the most recent
+        scheduler_runs record to determine last_run, worker_id, next_run,
+        and compute health based on the age of that record.
+        """
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        run = db.fetch_one(
+            """
+            SELECT leader_id, started_at, ended_at, status
+            FROM scheduler_runs
+            WHERE job_name = ?
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (job_name,),
+        )
+
+        if not run:
+            # No run history at all — scheduler has never executed
+            return {
+                "running": False,
+                "worker_id": None,
+                "heartbeat": None,
+                "heartbeat_age_seconds": None,
+                "last_run": None,
+                "next_run": None,
+                "health_status": "stopped",
+                "error": None,
+            }
+
+        # Use ended_at if available, otherwise started_at
+        last_run_at = run.get("ended_at") or run.get("started_at")
+        worker_id = run.get("leader_id")
+
+        # Calculate age of last run
+        last_run_age_seconds: float | None = None
+        if last_run_at:
+            if last_run_at.tzinfo is not None:
+                last_run_age_seconds = (now - last_run_at.replace(tzinfo=None)).total_seconds()
+            else:
+                last_run_age_seconds = (now - last_run_at).total_seconds()
+
+        # Determine health status based on last run age
+        if last_run_age_seconds is None:
+            health_status = "stopped"
+        elif last_run_age_seconds >= threshold_stopped:
+            health_status = "stopped"
+        elif last_run_age_seconds >= threshold_healthy:
+            health_status = "stale"
+        else:
+            # Last run was recent — worker is alive but idle between runs
+            health_status = "idle"
+
+        # running is True for idle and stale (worker may still be alive);
+        # False only for stopped
+        running = health_status in ("idle", "stale")
+
+        # Calculate next_run from last_run + interval
+        next_run = None
+        if last_run_at:
+            from datetime import timedelta
+
+            if last_run_at.tzinfo:
+                last_run_naive = last_run_at.replace(tzinfo=None)
+            else:
+                last_run_naive = last_run_at
+            next_run = last_run_naive + timedelta(seconds=interval_seconds)
+
+        # Format timestamps
+        last_run_str = last_run_at.isoformat() if last_run_at else None
+        next_run_str = next_run.isoformat() if next_run else None
+
+        return {
+            "running": running,
+            "worker_id": worker_id,
+            "heartbeat": None,  # No active heartbeat when idle
+            "heartbeat_age_seconds": last_run_age_seconds,
             "last_run": last_run_str,
             "next_run": next_run_str,
             "health_status": health_status,

--- a/tests/integration/test_scheduler_cross_process_status.py
+++ b/tests/integration/test_scheduler_cross_process_status.py
@@ -295,3 +295,30 @@ class TestHealthMonitorIntegration:
         # Test with unknown running
         status = {"running": "unknown"}
         assert monitor._get_scheduler_health_status(status) == "unknown"
+
+    def test_health_monitor_idle_does_not_create_alert(self):
+        """Test that idle status does not create alerts.
+
+        Issue #3146: idle status means worker is alive between runs.
+        """
+        from app.services.scheduler_health_monitor import SchedulerHealthMonitor
+
+        SchedulerHealthMonitor._instance = None
+        monitor = SchedulerHealthMonitor()
+
+        # Pre-set alert flags to simulate a previous stopped/stale alert
+        monitor._alert_created_for.add("data_fetch")
+        monitor._alert_created_for.add("data_fetch:stale")
+
+        # Simulate idle status
+        status = {"health_status": "idle", "running": True}
+
+        with patch.object(monitor, "_create_scheduler_alert") as mock_alert:
+            monitor._check_scheduler_health("data_fetch", status)
+
+            # Should NOT create any alert
+            mock_alert.assert_not_called()
+
+        # Should clear previous alert flags
+        assert "data_fetch" not in monitor._alert_created_for
+        assert "data_fetch:stale" not in monitor._alert_created_for

--- a/tests/unit/test_scheduler_status_reader.py
+++ b/tests/unit/test_scheduler_status_reader.py
@@ -318,3 +318,229 @@ class TestConvenienceFunctions:
         with patch.object(SchedulerStatusReader, "clear_cache") as mock_clear:
             clear_cache("test_job")
             mock_clear.assert_called_once_with("test_job")
+
+
+class TestSchedulerStatusReaderRunsFallback:
+    """Test scheduler_runs fallback when no leader row exists.
+
+    Issue #3146: After release_leadership() deletes the scheduler_leaders
+    row, the status reader should fall back to scheduler_runs for
+    durable run history instead of reporting "stopped".
+    """
+
+    def setup_method(self):
+        SchedulerStatusReader._instance = None
+
+    def test_fallback_to_runs_returns_idle(self):
+        """When leader row absent but recent run exists, return idle."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        recent_run = now - timedelta(seconds=30)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            {  # scheduler_runs fallback query
+                "leader_id": "worker-abc-123",
+                "started_at": recent_run,
+                "ended_at": recent_run,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["health_status"] == "idle"
+        assert result["running"] is True
+        assert result["worker_id"] == "worker-abc-123"
+        assert result["last_run"] is not None
+        assert result["next_run"] is not None
+        assert result["heartbeat"] is None
+        assert result["error"] is None
+
+    def test_fallback_to_runs_returns_stale(self):
+        """When last run is old but not too old, return stale."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        # threshold_healthy for interval=300 is 360, threshold_stopped is 720
+        old_run = now - timedelta(seconds=500)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            {  # scheduler_runs fallback query
+                "leader_id": "worker-abc-123",
+                "started_at": old_run,
+                "ended_at": old_run,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["health_status"] == "stale"
+        assert result["running"] is True
+        assert result["worker_id"] == "worker-abc-123"
+
+    def test_fallback_to_runs_returns_stopped_when_old(self):
+        """When last run is very old, return stopped."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        # threshold_stopped for interval=300 is 720
+        very_old_run = now - timedelta(seconds=800)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            {  # scheduler_runs fallback query
+                "leader_id": "worker-abc-123",
+                "started_at": very_old_run,
+                "ended_at": very_old_run,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["health_status"] == "stopped"
+        assert result["running"] is False
+        assert result["worker_id"] == "worker-abc-123"
+
+    def test_fallback_no_runs_returns_stopped(self):
+        """When no leader row and no run history, return stopped."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            None,  # scheduler_runs fallback query also returns nothing
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["health_status"] == "stopped"
+        assert result["running"] is False
+        assert result["worker_id"] is None
+        assert result["last_run"] is None
+        assert result["next_run"] is None
+
+    def test_fallback_next_run_calculated_from_last_run(self):
+        """next_run should be last_run + interval."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        recent_run = now - timedelta(seconds=60)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            {  # scheduler_runs fallback query
+                "leader_id": "worker-abc-123",
+                "started_at": recent_run,
+                "ended_at": recent_run,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["next_run"] is not None
+        next_run_dt = datetime.fromisoformat(result["next_run"])
+        expected = recent_run + timedelta(seconds=300)
+        assert abs((next_run_dt - expected).total_seconds()) < 1
+
+    def test_fallback_uses_ended_at_when_available(self):
+        """Fallback should prefer ended_at over started_at for last_run."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        started = now - timedelta(seconds=120)
+        ended = now - timedelta(seconds=30)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,  # scheduler_leaders query returns no row
+            {  # scheduler_runs fallback query
+                "leader_id": "worker-abc-123",
+                "started_at": started,
+                "ended_at": ended,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        # last_run should be ended_at, not started_at
+        last_run_dt = datetime.fromisoformat(result["last_run"])
+        assert abs((last_run_dt - ended).total_seconds()) < 1
+
+    def test_leader_row_takes_precedence_over_runs(self):
+        """When leader row exists, scheduler_runs is NOT queried."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.return_value = {
+            "job_name": "data_fetch",
+            "leader_id": "active-worker",
+            "owner_info": "host:123",
+            "acquired_at": now,
+            "expires_at": now + timedelta(seconds=1800),
+            "heartbeat_at": now,
+            "last_run_at": now,
+            "run_count": 5,
+            "skip_count": 0,
+            "fail_count": 0,
+        }
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        # Should return from leader row, not runs fallback
+        assert result["health_status"] == "healthy"
+        assert result["worker_id"] == "active-worker"
+        # fetch_one should be called only once (for scheduler_leaders)
+        assert mock_db.fetch_one.call_count == 1
+
+    def test_fallback_heartbeat_age_is_last_run_age(self):
+        """heartbeat_age_seconds should reflect last run age in fallback."""
+        reader = SchedulerStatusReader()
+        reader._cache = {}
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        recent_run = now - timedelta(seconds=45)
+
+        mock_db = MagicMock()
+        mock_db.fetch_one.side_effect = [
+            None,
+            {
+                "leader_id": "worker-abc-123",
+                "started_at": recent_run,
+                "ended_at": recent_run,
+                "status": "completed",
+            },
+        ]
+
+        with patch("app.repositories.database.Database", return_value=mock_db):
+            result = reader.get_status("data_fetch", 300)
+
+        assert result["heartbeat_age_seconds"] is not None
+        # Should be approximately 45 seconds
+        assert 40 < result["heartbeat_age_seconds"] < 55


### PR DESCRIPTION
## 修复说明

关联 Issue：#3146

## 根因

`SchedulerStatusReader._query_database()` 仅从 `scheduler_leaders` 表读取状态。该表用于短期分布式执行互斥（leader election），在每次执行结束后行被 `release_leadership()` 删除。因此在两次执行之间的空闲间隔（默认约 5 分钟），状态读取器找不到行，返回 `health_status: "stopped"` 且所有时间戳为 null，导致健康监控器产生虚假的 "Scheduler Stale: data_fetch" 告警。

`record_run()` 写入的持久化执行历史记录在 `scheduler_runs` 表中，但状态读取器在该 leader 行不存在时完全不查询此表。

## 修复方案

当 `scheduler_leaders` 表无行时，`SchedulerStatusReader._query_database()` 回退查询 `scheduler_runs` 表获取最近一次执行记录。根据最近运行的时间、状态和 leader_id 计算 `last_run`、`worker_id`、`next_run` 和健康状态：

- 最近运行时间距今 < `threshold_healthy`（interval + 60s）→ `health_status: "idle"`, `running: True`
- 距今 < `threshold_stopped`（threshold_healthy * 2）→ `health_status: "stale"`, `running: True`
- 距今 >= `threshold_stopped` → `health_status: "stopped"`, `running: False`

同时更新 `SchedulerHealthMonitor._check_scheduler_health()` 将 `"idle"` 状态与 `"healthy"` 同等处理——清除告警标记，不创建新告警。

## 主要变更

- `app/services/scheduler_status_reader.py`：新增 `_query_runs_fallback()` 方法，在无 leader 行时回退查询 `scheduler_runs` 表
- `app/services/scheduler_health_monitor.py`：`_check_scheduler_health()` 将 `"idle"` 与 `"healthy"` 同等处理
- `tests/unit/test_scheduler_status_reader.py`：新增 8 个单元测试覆盖回退路径
- `tests/integration/test_scheduler_cross_process_status.py`：新增 1 个集成测试验证 idle 状态不创建告警

## 测试

- 测试环境：开发环境
- 已运行测试：`tests/unit/test_scheduler_status_reader.py`（25 passed）、`tests/integration/test_scheduler_cross_process_status.py`（12 passed）、`tests/unit/test_distributed_scheduler.py`、`tests/unit/test_leader_election.py`（23 passed）
- 新增测试：8 个单元测试 + 1 个集成测试
- 测试结果：全部通过

## 风险

- **兼容性风险**：低。新增 `"idle"` 健康状态值。健康监控器已显式处理，API 消费者如依赖 `health_status` 字段需知晓新值。但 `"idle"` 语义清晰，且 `running: True` 与 `"healthy"` 一致。
- **性能风险**：无。`scheduler_runs` 表已有索引 `idx_scheduler_runs_job_time (job_name, started_at DESC)`，回退查询效率高。且有 5 秒缓存。
- **回归风险**：低。有 leader 行时的逻辑完全不变，仅在无行时触发回退。