### PR TITLE
fix(#3139): auto-resume for loop detection aborts in autonomous modes

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -1714,7 +1714,14 @@ class RemoteSessionManager:
         reason: str = "user",
         message: str | None = None,
     ) -> None:
-        """Buffer a request lifecycle event for SSE delivery to the frontend."""
+        """Buffer a request lifecycle event for SSE delivery to the frontend.
+
+        Issue #3139: Auto-resume for loop detection aborts in autonomous modes.
+        When qwen-code-webui's loop detection triggers an abort (reason contains
+        "loop", "system", or "internal_abort"), and the session is in yolo or
+        auto-edit mode, automatically send a resume message to continue the
+        autonomous workflow without user intervention.
+        """
         if state not in self._allowed_request_states:
             logger.warning(
                 "Ignoring unsupported request_state for session %s: %s",
@@ -1722,6 +1729,36 @@ class RemoteSessionManager:
                 state,
             )
             return
+
+        # Issue #3139: Check for loop detection abort in autonomous mode
+        # Loop detection aborts have reason="loop", "system", or "internal_abort"
+        # and should auto-resume for yolo/auto-edit sessions.
+        permission_mode = self._session_permission_modes.get(session_id, "default")
+        is_autonomous = permission_mode in ("yolo", "auto-edit")
+        reason_lower = reason.lower() if reason else ""
+        is_loop_abort = (
+            state == "aborted"
+            and reason_lower in ("loop", "system", "internal_abort")
+        )
+
+        if is_loop_abort and is_autonomous:
+            logger.info(
+                "Auto-resuming session %s after loop detection abort "
+                "(permission_mode=%s, reason=%s)",
+                session_id[:8],
+                permission_mode,
+                reason,
+            )
+            # Use a timer to delay the resume slightly, giving the abort
+            # time to complete before resuming. This also avoids potential
+            # issues with nested call stacks.
+            timer = threading.Timer(
+                0.5,
+                self._auto_resume_after_loop_abort,
+                args=(session_id,),
+            )
+            timer.daemon = True
+            timer.start()
 
         payload: dict[str, Any] = {
             "type": state,
@@ -1745,6 +1782,61 @@ class RemoteSessionManager:
             state,
             reason,
         )
+
+    def _auto_resume_after_loop_abort(self, session_id: str) -> None:
+        """Auto-resume a session after a loop detection abort.
+
+        Called from a background thread after a short delay to allow the abort
+        to complete. Sends a "继续" message to the remote session to resume
+        the autonomous workflow.
+
+        Issue #3139: This enables autonomous workflows (fix_issue, etc.) to
+        continue without user intervention when qwen-code-webui's loop detection
+        triggers a false abort.
+        """
+        try:
+            # Check if session is still active before resuming
+            session = self._session_manager.get_session(session_id)
+            if not session:
+                logger.warning(
+                    "Session %s not found, skipping auto-resume",
+                    session_id[:8],
+                )
+                return
+
+            if session.status in ("stopped", "error"):
+                logger.info(
+                    "Session %s is %s, skipping auto-resume",
+                    session_id[:8],
+                    session.status,
+                )
+                return
+
+            # Send the resume message
+            success = self.send_message(session_id, "继续")
+            if success:
+                logger.info(
+                    "Auto-resumed session %s after loop detection abort",
+                    session_id[:8],
+                )
+                # Record the auto-resume event for audit
+                self._timeline(
+                    "record_event",
+                    session_id,
+                    "auto_resume",
+                    metadata={"reason": "loop_detection_abort"},
+                )
+            else:
+                logger.warning(
+                    "Failed to auto-resume session %s after loop detection abort",
+                    session_id[:8],
+                )
+        except Exception as e:
+            logger.exception(
+                "Error auto-resuming session %s after loop detection abort: %s",
+                session_id[:8],
+                e,
+            )
 
     def process_session_status_update(
         self,

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -1736,10 +1736,7 @@ class RemoteSessionManager:
         permission_mode = self._session_permission_modes.get(session_id, "default")
         is_autonomous = permission_mode in ("yolo", "auto-edit")
         reason_lower = reason.lower() if reason else ""
-        is_loop_abort = (
-            state == "aborted"
-            and reason_lower in ("loop", "system", "internal_abort")
-        )
+        is_loop_abort = state == "aborted" and reason_lower in ("loop", "system", "internal_abort")
 
         if is_loop_abort and is_autonomous:
             logger.info(

--- a/tests/unit/test_remote_session_manager.py
+++ b/tests/unit/test_remote_session_manager.py
@@ -75,6 +75,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
 
             # Wait for timer to execute
             import time
+
             time.sleep(0.6)
 
             # Verify send_message was called with "继续"
@@ -106,6 +107,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
             )
 
             import time
+
             time.sleep(0.6)
 
             mock_send.assert_called_once_with(session_id, "继续")
@@ -131,6 +133,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
             )
 
             import time
+
             time.sleep(0.6)
 
             # Should NOT auto-resume for user abort
@@ -158,6 +161,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
             )
 
             import time
+
             time.sleep(0.6)
 
             # Should NOT auto-resume for default mode
@@ -184,6 +188,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
             )
 
             import time
+
             time.sleep(0.6)
 
             # Should NOT auto-resume stopped session
@@ -211,6 +216,7 @@ class TestProcessRequestStateLoopAbortAutoResume:
             )
 
             import time
+
             time.sleep(0.6)
 
             mock_send.assert_called_once_with(session_id, "继续")

--- a/tests/unit/test_remote_session_manager.py
+++ b/tests/unit/test_remote_session_manager.py
@@ -2,11 +2,218 @@
 Unit tests for RemoteSessionManager.
 
 Issue #2597: Prevent zombie sessions during heartbeat tolerance window.
+Issue #3139: Auto-resume for loop detection aborts in autonomous modes.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+class TestProcessRequestStateLoopAbortAutoResume:
+    """Tests for auto-resume after loop detection abort (Issue #3139)."""
+
+    @pytest.fixture
+    def mock_agent_manager(self):
+        """Create a mock agent manager."""
+        mock = MagicMock()
+        mock.buffer_output = MagicMock()
+        return mock
+
+    @pytest.fixture
+    def mock_session_manager(self):
+        """Create a mock session manager."""
+        mock = MagicMock()
+        return mock
+
+    @pytest.fixture
+    def manager(self, mock_agent_manager, mock_session_manager):
+        """Create a RemoteSessionManager with mocked dependencies."""
+        with patch(
+            "app.modules.workspace.remote_session_manager.get_remote_agent_manager",
+            return_value=mock_agent_manager,
+        ):
+            with patch(
+                "app.modules.workspace.remote_session_manager.SessionManager",
+                return_value=mock_session_manager,
+            ):
+                with patch(
+                    "app.modules.workspace.remote_session_manager.APIKeyProxyService",
+                ):
+                    from app.modules.workspace.remote_session_manager import RemoteSessionManager
+
+                    mgr = RemoteSessionManager()
+                    mgr._agent_manager = mock_agent_manager
+                    mgr._session_manager = mock_session_manager
+                    yield mgr
+
+    def test_auto_resumes_yolo_mode_on_loop_abort(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should auto-resume when loop detection abort occurs
+        in yolo mode session.
+        """
+        session_id = "test-session-id"
+
+        # Set permission mode to yolo
+        manager._session_permission_modes[session_id] = "yolo"
+
+        # Mock session as active
+        mock_session = MagicMock()
+        mock_session.status = "active"
+        mock_session_manager.get_session.return_value = mock_session
+
+        # Mock send_message to capture the resume call
+        with patch.object(manager, "send_message") as mock_send:
+            mock_send.return_value = True
+
+            # Process loop detection abort
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="loop",
+            )
+
+            # Wait for timer to execute
+            import time
+            time.sleep(0.6)
+
+            # Verify send_message was called with "继续"
+            mock_send.assert_called_once_with(session_id, "继续")
+
+    def test_auto_resumes_auto_edit_mode_on_loop_abort(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should auto-resume when loop detection abort occurs
+        in auto-edit mode session.
+        """
+        session_id = "test-session-id"
+
+        # Set permission mode to auto-edit
+        manager._session_permission_modes[session_id] = "auto-edit"
+
+        # Mock session as active
+        mock_session = MagicMock()
+        mock_session.status = "active"
+        mock_session_manager.get_session.return_value = mock_session
+
+        # Mock send_message
+        with patch.object(manager, "send_message") as mock_send:
+            mock_send.return_value = True
+
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="system",
+            )
+
+            import time
+            time.sleep(0.6)
+
+            mock_send.assert_called_once_with(session_id, "继续")
+
+    def test_no_auto_resume_for_user_abort(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should NOT auto-resume for user-initiated abort
+        even in yolo mode.
+        """
+        session_id = "test-session-id"
+
+        manager._session_permission_modes[session_id] = "yolo"
+
+        mock_session = MagicMock()
+        mock_session.status = "active"
+        mock_session_manager.get_session.return_value = mock_session
+
+        with patch.object(manager, "send_message") as mock_send:
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="user",
+            )
+
+            import time
+            time.sleep(0.6)
+
+            # Should NOT auto-resume for user abort
+            mock_send.assert_not_called()
+
+    def test_no_auto_resume_for_default_mode(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should NOT auto-resume for default permission mode
+        even on loop detection abort.
+        """
+        session_id = "test-session-id"
+
+        # Default mode (no entry means default)
+        manager._session_permission_modes[session_id] = "default"
+
+        mock_session = MagicMock()
+        mock_session.status = "active"
+        mock_session_manager.get_session.return_value = mock_session
+
+        with patch.object(manager, "send_message") as mock_send:
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="loop",
+            )
+
+            import time
+            time.sleep(0.6)
+
+            # Should NOT auto-resume for default mode
+            mock_send.assert_not_called()
+
+    def test_no_auto_resume_for_stopped_session(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should NOT auto-resume if session is already stopped.
+        """
+        session_id = "test-session-id"
+
+        manager._session_permission_modes[session_id] = "yolo"
+
+        # Session is stopped
+        mock_session = MagicMock()
+        mock_session.status = "stopped"
+        mock_session_manager.get_session.return_value = mock_session
+
+        with patch.object(manager, "send_message") as mock_send:
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="loop",
+            )
+
+            import time
+            time.sleep(0.6)
+
+            # Should NOT auto-resume stopped session
+            mock_send.assert_not_called()
+
+    def test_auto_resume_handles_internal_abort_reason(self, manager, mock_session_manager):
+        """
+        Issue #3139: Should auto-resume for 'internal_abort' reason.
+        """
+        session_id = "test-session-id"
+
+        manager._session_permission_modes[session_id] = "yolo"
+
+        mock_session = MagicMock()
+        mock_session.status = "active"
+        mock_session_manager.get_session.return_value = mock_session
+
+        with patch.object(manager, "send_message") as mock_send:
+            mock_send.return_value = True
+
+            manager.process_request_state(
+                session_id=session_id,
+                state="aborted",
+                reason="internal_abort",
+            )
+
+            import time
+            time.sleep(0.6)
+
+            mock_send.assert_called_once_with(session_id, "继续")
 
 
 class TestCreateRemoteSessionDBStatusCheck:


### PR DESCRIPTION
## Summary

Fixes #3139

When qwen-code-webui's loop detection triggers an abort (reason contains "loop", "system", or "internal_abort"), and the session is in yolo or auto-edit mode, automatically send a resume message to continue the autonomous workflow without user intervention.

## Problem

Iterative skill workflows (e.g., `fix_issue`) running through qwen-code-webui sessions were being interrupted by loop detection even in YOLO mode. The user had to manually type "继续" to resume, breaking the autonomous workflow promise.

## Root Cause

Open-ACE's `process_request_state` method did not:
1. Check the `reason` field to distinguish user-initiated aborts from loop detection aborts
2. Check the session's `permission_mode` to determine if auto-resume is appropriate
3. Have any auto-resume mechanism for autonomous workflows

## Solution

Added auto-resume logic in `process_request_state()`:
- Detects loop detection aborts by checking if `state == "aborted"` and `reason.lower() in ("loop", "system", "internal_abort")`
- Checks if the session is in an autonomous mode (`yolo` or `auto-edit`)
- Uses a background timer to send "继续" after a short 0.5s delay
- Records the auto-resume event for audit purposes

## Changes

- `app/modules/workspace/remote_session_manager.py`:
  - Added auto-resume logic in `process_request_state()`
  - Added `_auto_resume_after_loop_abort()` helper method
- `tests/unit/test_remote_session_manager.py`:
  - Added `TestProcessRequestStateLoopAbortAutoResume` test class
  - 6 new test cases covering all edge cases

## Test Coverage

- ✅ Auto-resumes for yolo mode on loop abort
- ✅ Auto-resumes for auto-edit mode on loop abort
- ✅ No auto-resume for user-initiated abort
- ✅ No auto-resume for default permission mode
- ✅ No auto-resume for stopped sessions
- ✅ Handles "internal_abort" reason

## Checklist

- [x] Tests pass locally
- [x] Code follows project style guidelines
- [x] No sensitive information in comments/logs