### PR TITLE
fix(docker): enable scheduler by default in multi-user mode (#3128)

### DIFF
--- a/docker-compose.multi-user.yml
+++ b/docker-compose.multi-user.yml
@@ -62,6 +62,9 @@ services:
     extends:
       file: docker-compose.yml
       service: scheduler
+    # Issue #3128: Override inherited profiles: [scheduler] from docker-compose.yml
+    # Empty profiles list ensures scheduler starts by default in multi-user mode
+    profiles: []
     user: "0"
     environment:
       # Multi-user workspace mode (required)


### PR DESCRIPTION
Closes #3128

## 修复内容

Add `profiles: []` to scheduler service in docker-compose.multi-user.yml to override the inherited `profiles: [scheduler]` from docker-compose.yml.

## 问题原因

- `docker-compose.yml` sets `profiles: [scheduler]` for the scheduler service
- `docker-compose.multi-user.yml` uses `extends` to inherit scheduler config
- Without overriding `profiles`, the scheduler service won't start by default
- AI autonomous development workflows depend on scheduler and would stay in `pending` state

## 修复方案

Add `profiles: []` to scheduler in `docker-compose.multi-user.yml`:
- Empty profiles list means the service starts by default
- Single-user mode unchanged (still uses `profiles: [scheduler]`)
- Multi-user deployments now have scheduler running automatically

## 修复方案讨论

See Issue #3128 for detailed analysis and evaluation.