### PR TITLE
fix(installer): install fetch wrapper and sudoers for privileged collection (#3145)

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -33,8 +33,31 @@ _fetch_status: dict[str, Any] = {
     "last_run": None,
     "last_result": None,
     "error": None,
+    "degraded": False,
+    "degraded_reason": None,
 }
 _fetch_lock = threading.Lock()
+
+
+def set_fetch_degraded(reason: str | None) -> None:
+    """Set or clear the fetch degraded state.
+
+    Issue #3145: When FETCH_USE_SUDO=true but the wrapper is missing or invalid,
+    the scheduler should not attempt to run fetch jobs that will fail.
+
+    Args:
+        reason: Description of why fetch is degraded, or None to clear.
+    """
+    global _fetch_status
+    with _fetch_lock:
+        if reason:
+            _fetch_status["degraded"] = True
+            _fetch_status["degraded_reason"] = reason
+            logger.error(f"Fetch set to degraded mode: {reason}")
+        else:
+            _fetch_status["degraded"] = False
+            _fetch_status["degraded_reason"] = None
+            logger.info("Fetch degraded mode cleared")
 
 
 def _parse_fetch_result(output: str) -> dict[str, Any]:
@@ -128,11 +151,19 @@ def run_fetch_scripts():
     Returns:
         dict or None: Per-tool results on success (e.g. {"qwen": {"success": True, ...}, ...}).
                       {"_skipped": True} if a concurrent fetch is already running.
+                      {"_degraded": True, "reason": str} if in degraded mode.
                       None if an unexpected error occurred in the outer handler.
     """
     global _fetch_status
 
     with _fetch_lock:
+        # Issue #3145: Check degraded state first
+        if _fetch_status.get("degraded"):
+            logger.error(
+                f"Fetch skipped due to degraded state: {_fetch_status.get('degraded_reason')}"
+            )
+            return {"_degraded": True, "reason": _fetch_status.get("degraded_reason")}
+
         if _fetch_status["is_running"]:
             return {"_skipped": True}
         _fetch_status["is_running"] = True
@@ -386,7 +417,14 @@ def api_fetch_status():
     # Add scheduler status
     scheduler_status = scheduler.get_status()
 
-    return jsonify({"success": True, "status": fetch_status, "scheduler": scheduler_status})
+    # Issue #3145: Include degraded state in response
+    return jsonify(
+        {
+            "success": True,
+            "status": fetch_status,
+            "scheduler": scheduler_status,
+        }
+    )
 
 
 @fetch_bp.route("/fetch")

--- a/app/scheduler_worker.py
+++ b/app/scheduler_worker.py
@@ -225,6 +225,9 @@ class SchedulerWorker:
         【Issue #2543】确保 scheduler 和 web 服务的 FETCH_USE_SUDO 配置一致，
         检查 wrapper 是否存在，sudoers 规则是否正确。
 
+        【Issue #3145】当 FETCH_USE_SUDO=true 且 wrapper 缺失时，设置 degraded 状态，
+        阻止 scheduler 执行注定失败的采集任务。
+
         漂移级别：
         - 警告级：记录日志，标记 degraded，继续运行
         - 错误级：记录日志，标记 failed，可能影响功能
@@ -315,6 +318,21 @@ class SchedulerWorker:
             for warning in warnings:
                 logger.warning(f"  WARNING: {warning}")
             logger.warning("=" * 60)
+
+        # Issue #3145: 设置 degraded 状态
+        # 当 FETCH_USE_SUDO=true 但有 critical issues 时，阻止采集任务运行
+        if scheduler_fetch_sudo and issues:
+            from app.routes.fetch import set_fetch_degraded
+
+            degraded_reason = "; ".join(issues)
+            set_fetch_degraded(degraded_reason)
+            logger.error(
+                f"Fetch set to degraded mode due to critical issues. "
+                f"Scheduler will not run data collection jobs until fixed."
+            )
+        elif scheduler_fetch_sudo and warnings:
+            # 警告级别不影响运行，但记录状态
+            logger.warning("Fetch has warnings but will continue to run")
 
         # 总结
         if not issues and not warnings:

--- a/app/scheduler_worker.py
+++ b/app/scheduler_worker.py
@@ -327,8 +327,8 @@ class SchedulerWorker:
             degraded_reason = "; ".join(issues)
             set_fetch_degraded(degraded_reason)
             logger.error(
-                f"Fetch set to degraded mode due to critical issues. "
-                f"Scheduler will not run data collection jobs until fixed."
+                "Fetch set to degraded mode due to critical issues. "
+                "Scheduler will not run data collection jobs until fixed."
             )
         elif scheduler_fetch_sudo and warnings:
             # 警告级别不影响运行，但记录状态

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -759,6 +759,40 @@ CONF_EOF
     return 0
 }
 
+# Install the privileged data fetch wrapper (Issue #3145).
+# This wrapper is required when FETCH_USE_SUDO=true in multi-user systemd deployments.
+# It allows the scheduler to run fetch scripts with root privileges to read
+# user home directories, then drops privileges to write to the database.
+install_fetch_wrapper() {
+    local src="${SCRIPT_DIR:-$(dirname "$(readlink -f "$0")")}/scripts/openace-fetch-wrapper"
+    local dst="/usr/local/bin/openace-fetch-wrapper"
+
+    # Resolve repo-relative source (install.sh lives in scripts/install-central/docker-method/)
+    if [ ! -f "$src" ]; then
+        local alt_src="$(dirname "$(dirname "$(readlink -f "$0")")")/../../scripts/openace-fetch-wrapper"
+        alt_src="$(readlink -f "$alt_src" 2>/dev/null || echo "$alt_src")"
+        if [ -f "$alt_src" ]; then
+            src="$alt_src"
+        fi
+    fi
+    if [ ! -f "$src" ]; then
+        print_warning "未找到 openace-fetch-wrapper（搜索 $src），跳过 wrapper 安装"
+        return 1
+    fi
+    if ! cp "$src" "$dst" 2>/dev/null; then
+        print_warning "拷贝 openace-fetch-wrapper 到 $dst 失败（需要 root？）"
+        return 1
+    fi
+    chown root:root "$dst" 2>/dev/null || true
+    chmod 755 "$dst"
+
+    # Create audit log directory
+    install -d -o root -g root -m 755 /var/log/openace 2>/dev/null || true
+
+    print_success "已安装 fetch wrapper 到 $dst"
+    return 0
+}
+
 install_git_gh_wrappers() {
     local script_dir
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -882,6 +916,10 @@ $RUN_USER ALL=(root) NOPASSWD: $wrapper_bin *"
 Cmnd_Alias GIT_SAFE = /usr/local/bin/openace-git *
 Cmnd_Alias GH_SAFE = /usr/local/bin/openace-gh *
 
+# Fetch wrapper for privileged data collection (Issue #3145).
+# Required for multi-user systemd deployments with FETCH_USE_SUDO=true.
+Cmnd_Alias FETCH_WRAPPER = /usr/local/bin/openace-fetch-wrapper *
+
 # 低风险工具（Issue #2181：移除 cat/chown/rm，改用 wrapper）
 Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr/bin/id *, /usr/bin/find *
 
@@ -897,6 +935,7 @@ $RUN_USER ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch * "$webui_path
 $RUN_USER ALL=(ALL) NOPASSWD: OPENACE_UTILS
 $RUN_USER ALL=(ALL) NOPASSWD: GIT_SAFE
 $RUN_USER ALL=(ALL) NOPASSWD: GH_SAFE
+$RUN_USER ALL=(ALL) NOPASSWD: FETCH_WRAPPER
 $RUN_USER ALL=(ALL) NOPASSWD: MKDIR_SAFE
 
 # 【Issue #2181】安全 wrapper 规则（替代原 cat/chown/useradd/rm 通配）
@@ -2766,6 +2805,7 @@ upgrade_deployment() {
         print_info "更新 sudoers 配置..."
         stop_webui_systemd_service
         install_run_as_wrapper || print_warning "run-as wrapper 安装失败，跨用户 agent 启动可能受限"
+        install_fetch_wrapper || print_warning "fetch wrapper 安装失败，特权数据采集可能受限"
         if ! install_git_gh_wrappers; then
             print_error "git/gh wrappers 安装失败，拒绝写入 wrapper-only sudoers"
         else
@@ -4182,6 +4222,7 @@ if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
     # Stop existing qwen-code-webui systemd service first
     stop_webui_systemd_service
     install_run_as_wrapper || print_warning "run-as wrapper 安装失败，跨用户 agent 启动可能受限"
+    install_fetch_wrapper || print_warning "fetch wrapper 安装失败，特权数据采集可能受限"
     if ! install_git_gh_wrappers; then
         print_error "git/gh wrappers 安装失败，拒绝写入 wrapper-only sudoers"
         exit 1

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2228,6 +2228,35 @@ _install_wrapper() {
     return 0
 }
 
+# Install the privileged data fetch wrapper (Issue #3145).
+# This wrapper is required when FETCH_USE_SUDO=true in multi-user systemd deployments.
+# It allows the scheduler to run fetch scripts with root privileges to read
+# user home directories, then drops privileges to write to the database.
+# Must run BEFORE configure_sudoers so the sudoers rule (which keys off -x $wrapper_path)
+# sees it.
+install_fetch_wrapper() {
+    local install_dir="$1"
+    local src="$install_dir/scripts/openace-fetch-wrapper"
+    local dst="/usr/local/bin/openace-fetch-wrapper"
+
+    if [ ! -f "$src" ]; then
+        print_warning "openace-fetch-wrapper not found at $src; skipping wrapper install"
+        return 1
+    fi
+    if ! cp "$src" "$dst" 2>/dev/null; then
+        print_warning "Failed to copy openace-fetch-wrapper to $dst (need root?)"
+        return 1
+    fi
+    chown root:root "$dst" 2>/dev/null || true
+    chmod 755 "$dst"
+
+    # Create audit log directory
+    install -d -o root -g root -m 755 /var/log/openace 2>/dev/null || true
+
+    print_success "Installed fetch wrapper to $dst"
+    return 0
+}
+
 install_git_gh_wrappers() {
     local install_dir="$1"
     local config_src_dir="$install_dir/config/openace"
@@ -2484,26 +2513,16 @@ configure_sudoers() {
     # Create sudoers file
     local sudoers_file="/etc/sudoers.d/open-ace-webui"
 
-    # Build fetch script rules (check all 5 scripts)
-    # 【修复 Issue #1977】支持 Python 3.10+ 类型注解语法
-    # 使用安装的 Python 版本，而非系统 /usr/bin/python3（可能是 3.9）
-    local python_bin="${install_dir}/agent_bin/python3"
-    if [ ! -x "$python_bin" ]; then
-        python_bin="/usr/local/bin/python3.12"
+    # Build fetch script rules (Issue #3145: use wrapper instead of direct Python paths)
+    # The wrapper /usr/local/bin/openace-fetch-wrapper is installed by install_fetch_wrapper().
+    # It validates parameters, logs audit trails, and drops privileges for database writes.
+    local fetch_wrapper_rule=""
+    local fetch_wrapper_path="/usr/local/bin/openace-fetch-wrapper"
+    if [ -x "$fetch_wrapper_path" ]; then
+        fetch_wrapper_rule="$run_user ALL=(root) NOPASSWD: FETCH_WRAPPER"
+    else
+        print_warning "openace-fetch-wrapper not found; privileged data collection will be disabled"
     fi
-    if [ ! -x "$python_bin" ]; then
-        python_bin="/usr/bin/python3"
-    fi
-    local fetch_scripts=("fetch_qwen.py" "fetch_claude.py" "fetch_openclaw.py" "fetch_codex.py" "fetch_zcode.py")
-    local fetch_rules=""
-    for script in "${fetch_scripts[@]}"; do
-        local script_path="$install_dir/scripts/$script"
-        if [ -f "$script_path" ]; then
-            fetch_rules="${fetch_rules}
-# Allow $run_user to run $script as root for multi-user data collection
-$run_user ALL=(root) NOPASSWD: $python_bin $script_path *"
-        fi
-    done
 
     # Add /usr/local/bin/qwen-code-webui rule if it exists (Node.js v20+ may be installed there)
     local webui_local_path="/usr/local/bin/qwen-code-webui"
@@ -2591,10 +2610,10 @@ ${security_wrapper_rules}"
 ${wrapper_rule}"
     fi
 
-    # Only add fetch_rules if not empty
-    if [ -n "$fetch_rules" ]; then
+    # Add fetch wrapper rule if the wrapper is installed (Issue #3145)
+    if [ -n "$fetch_wrapper_rule" ]; then
         current_user_rules="${current_user_rules}
-${fetch_rules}"
+${fetch_wrapper_rule}"
     fi
 
     # Build header and defaults section
@@ -2654,6 +2673,10 @@ Cmnd_Alias OPENACE_UTILS = /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr
 # 而 verifier worktree 必须由执行 git 的身份持有）。sudo 按调用方 PATH 解析
 # 裸 mkdir，/usr/bin 与 /bin 两种解析路径都必须匹配。
 Cmnd_Alias MKDIR_SAFE = /usr/bin/mkdir *, /bin/mkdir *
+
+# Fetch wrapper for privileged data collection (Issue #3145).
+# Required for multi-user systemd deployments with FETCH_USE_SUDO=true.
+Cmnd_Alias FETCH_WRAPPER = /usr/local/bin/openace-fetch-wrapper *
 
 # 【安全加固 Issue #2181】安全 wrapper 规则
 # 以下 wrapper 替代原通配命令，内部验证参数安全性
@@ -4346,6 +4369,10 @@ install_local() {
         # Install the run-as wrapper BEFORE configure_sudoers (Issue #1395):
         # the sudoers rule keys off `[ -x /usr/local/bin/openace-run-as ]`.
         install_run_as_wrapper "$sudoers_install_dir"
+
+        # Install the fetch wrapper BEFORE configure_sudoers (Issue #3145):
+        # the sudoers rule keys off `[ -x /usr/local/bin/openace-fetch-wrapper ]`.
+        install_fetch_wrapper "$sudoers_install_dir"
 
         # Install the write-as wrapper BEFORE configure_sudoers (Issue #1916):
         # the sudoers rule keys off `[ -x /usr/local/bin/openace-write-as ]`.

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -121,7 +121,9 @@ class TestRunFetchScriptsReturns:
 
         # Set degraded state
         fetch_mod._fetch_status["degraded"] = True
-        fetch_mod._fetch_status["degraded_reason"] = "Wrapper not found: /usr/local/bin/openace-fetch-wrapper"
+        fetch_mod._fetch_status["degraded_reason"] = (
+            "Wrapper not found: /usr/local/bin/openace-fetch-wrapper"
+        )
 
         result = run_fetch_scripts()
 

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -26,6 +26,8 @@ class TestRunFetchScriptsReturns:
             "last_run": None,
             "last_result": None,
             "error": None,
+            "degraded": False,
+            "degraded_reason": None,
         }
 
     @patch("os.path.exists", return_value=False)
@@ -112,6 +114,23 @@ class TestRunFetchScriptsReturns:
 
         assert result is None
 
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_degraded_when_wrapper_missing(self, mock_run):
+        """Issue #3145: When degraded is True, skip fetch and return degraded status."""
+        from app.routes import fetch as fetch_mod
+
+        # Set degraded state
+        fetch_mod._fetch_status["degraded"] = True
+        fetch_mod._fetch_status["degraded_reason"] = "Wrapper not found: /usr/local/bin/openace-fetch-wrapper"
+
+        result = run_fetch_scripts()
+
+        assert result == {
+            "_degraded": True,
+            "reason": "Wrapper not found: /usr/local/bin/openace-fetch-wrapper",
+        }
+        mock_run.assert_not_called()  # Should not attempt to run scripts
+
 
 class TestConfigPathScope:
     """Test Bug 3 fix: config_path must be defined outside per-script blocks."""
@@ -124,6 +143,8 @@ class TestConfigPathScope:
             "last_run": None,
             "last_result": None,
             "error": None,
+            "degraded": False,
+            "degraded_reason": None,
         }
 
     def test_config_path_available_when_qwen_missing(self):
@@ -171,3 +192,88 @@ class TestConfigPathScope:
         # Verify the default is "false" in getenv call
         assert '"FETCH_USE_SUDO", "false")' in source
         assert '"FETCH_USE_SUDO", "true")' not in source
+
+
+class TestFetchDegradedState:
+    """Issue #3145: Test degraded state management."""
+
+    def setup_method(self):
+        """Reset global fetch status before each test."""
+        from app.routes import fetch as fetch_mod
+
+        fetch_mod._fetch_status = {
+            "is_running": False,
+            "last_run": None,
+            "last_result": None,
+            "error": None,
+            "degraded": False,
+            "degraded_reason": None,
+        }
+
+    def test_set_fetch_degraded_sets_flag(self):
+        """set_fetch_degraded() should set degraded flag and reason."""
+        from app.routes import fetch as fetch_mod
+
+        fetch_mod.set_fetch_degraded("Wrapper not found")
+
+        assert fetch_mod._fetch_status["degraded"] is True
+        assert fetch_mod._fetch_status["degraded_reason"] == "Wrapper not found"
+
+    def test_set_fetch_degraded_clears_flag(self):
+        """set_fetch_degraded(None) should clear degraded state."""
+        from app.routes import fetch as fetch_mod
+
+        # First set degraded
+        fetch_mod.set_fetch_degraded("Wrapper not found")
+        assert fetch_mod._fetch_status["degraded"] is True
+
+        # Then clear it
+        fetch_mod.set_fetch_degraded(None)
+        assert fetch_mod._fetch_status["degraded"] is False
+        assert fetch_mod._fetch_status["degraded_reason"] is None
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_degraded_prevents_fetch_execution(self, mock_run, mock_exists):
+        """When degraded is True, run_fetch_scripts should skip execution."""
+        from app.routes import fetch as fetch_mod
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "OK"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        # Set degraded state
+        fetch_mod.set_fetch_degraded("Test degraded")
+
+        result = run_fetch_scripts()
+
+        # Should return degraded status
+        assert result == {"_degraded": True, "reason": "Test degraded"}
+        # Should NOT call subprocess
+        mock_run.assert_not_called()
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_degraded_cleared_allows_fetch_execution(self, mock_run, mock_exists):
+        """After clearing degraded, run_fetch_scripts should work normally."""
+        from app.routes import fetch as fetch_mod
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "OK"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        # Set and then clear degraded
+        fetch_mod.set_fetch_degraded("Wrapper missing")
+        fetch_mod.set_fetch_degraded(None)
+
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            result = run_fetch_scripts()
+
+        # Should run normally
+        assert isinstance(result, dict)
+        assert "_degraded" not in result
+        mock_run.assert_called()


### PR DESCRIPTION
## Summary

Fixes #3145 - Privileged automatic collection fails after install/upgrade because wrapper and sudoers do not converge.

In multi-user systemd deployments with `FETCH_USE_SUDO=true`, the scheduler was failing to collect data because:
1. The `openace-fetch-wrapper` was not installed by install scripts
2. Sudoers lacked `FETCH_WRAPPER` rules, using hardcoded Python paths instead
3. Python path mismatch between sudoers and `sys.executable`
4. Config drift detection only logged but didn't block broken jobs

## Changes

### Install Scripts
- Add `install_fetch_wrapper()` to both Docker and Package install scripts
- Add `FETCH_WRAPPER` Cmnd_Alias and rules to `configure_sudoers()`
- Replace direct Python paths with wrapper in Package sudoers

### Runtime Protection
- Add `set_fetch_degraded()` mechanism in `fetch.py`
- When wrapper missing + `FETCH_USE_SUDO=true`, scheduler skips fetch jobs instead of repeatedly failing
- Degraded state visible in `/fetch/status` API

### Tests
- Add unit tests for degraded state management
- Verify degraded flag prevents fetch execution
- Verify clearing degraded allows normal operation

## Acceptance Criteria

- [x] Fresh multi-user installation installs the wrapper and valid sudoers rules
- [x] Upgrade from a pre-wrapper installation converges to the same state
- [x] The service does not depend on a hard-coded Python path in sudoers
- [x] Missing or invalid privileged collection configuration prevents a false-healthy scheduler state
- [x] Tests cover degraded state management

## Root Cause

Four related root causes identified and addressed:
1. Install scripts never copy `openace-fetch-wrapper` to `/usr/local/bin/`
2. Sudoers rules use hardcoded Python paths that don't match `sys.executable`
3. Config drift detection only logs, doesn't block broken jobs
4. No FETCH_WRAPPER Cmnd_Alias in sudoers