### PR TITLE
fix: create project_path directory before gh repo clone (#3155)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10007,7 +10007,7 @@ class AutonomousOrchestrator:
                                 "and not a git repo"
                             )
                 else:
-                    os.makedirs(os.path.dirname(project_path), exist_ok=True)
+                    os.makedirs(project_path, exist_ok=True)
 
                 if not os.path.isdir(os.path.join(project_path, ".git")):
                     # Issue #3070: Use gh repo clone for private repo authentication

--- a/tests/unit/test_new_project_local_repo_init_2963.py
+++ b/tests/unit/test_new_project_local_repo_init_2963.py
@@ -263,7 +263,8 @@ class TestCloneAfterCreateRepo:
             repo_scoped=False,
             check=True,
         )
-        makedirs.assert_any_call("/workspace/alice", exist_ok=True)
+        # Issue #3155: Create project_path directory before gh repo clone
+        makedirs.assert_any_call(fallback_path, exist_ok=True)
         orch._update_workflow.assert_any_call({"project_path": fallback_path})
         assert result.next_phase == "planning"
 
@@ -354,7 +355,8 @@ class TestCloneAfterCreateRepo:
             repo_scoped=False,
             check=True,
         )
-        makedirs.assert_any_call("/workspace/alice", exist_ok=True)
+        # Issue #3155: Create project_path directory before gh repo clone
+        makedirs.assert_any_call(fallback_path, exist_ok=True)
         orch._update_workflow.assert_any_call({"project_path": fallback_path})
         assert result.next_phase == "planning"
 


### PR DESCRIPTION
Closes #3155

## 修复内容

修复了 AI 自主开发工作流在 preparation 阶段报错 "gh CLI not found" 的问题（实际是 project_path 目录不存在）。

## 问题根因

Issue #3070 引入的回归：`os.makedirs(os.path.dirname(project_path), exist_ok=True)` 只创建父目录，但 `GitHubOps(project_path)` 实例化时 `project_path` 目录还不存在，导致 `subprocess.run(cwd=不存在的路径)` 抛出 `FileNotFoundError`，被错误地报告为 "gh CLI not found"。

## 修复方案

将 `os.makedirs(os.path.dirname(project_path), exist_ok=True)` 改为 `os.makedirs(project_path, exist_ok=True)`，在调用 `GitHubOps(project_path)` 之前创建完整路径。

## 修复方案讨论

详见 Issue #3155 中的修复方案和评估报告。