### PR TITLE
fix(#3140): handle feishu secret decryption failure gracefully

### DIFF
--- a/app/repositories/exceptions.py
+++ b/app/repositories/exceptions.py
@@ -1,0 +1,32 @@
+"""
+Open ACE - Repository Exceptions
+
+Custom exceptions for repository layer operations.
+"""
+
+
+class SecretDecryptionError(Exception):
+    """Exception raised when encrypted secret cannot be decrypted.
+
+    This exception is raised when an encrypted configuration value (e.g., App Secret,
+    API key, password) cannot be decrypted, typically due to:
+    - Encryption key rotation without proper migration
+    - Data corruption
+    - Incompatible encryption context
+
+    The exception intentionally does NOT expose the underlying cryptographic error
+    details to prevent information leakage while still allowing proper error handling.
+
+    Attributes:
+        field_name: The name of the field that failed to decrypt.
+        integration_kind: The type of integration (e.g., "feishu", "dingtalk").
+    """
+
+    def __init__(self, field_name: str, integration_kind: str) -> None:
+        self.field_name = field_name
+        self.integration_kind = integration_kind
+        super().__init__(
+            f"Failed to decrypt {field_name} for {integration_kind} configuration. "
+            "The saved secret is incompatible with the current encryption context. "
+            "Please re-enter the secret and save the configuration."
+        )

--- a/app/repositories/notification_settings_repository.py
+++ b/app/repositories/notification_settings_repository.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Any
@@ -11,7 +12,10 @@ import psycopg2
 from psycopg2.extras import RealDictCursor
 
 from app.repositories.database import CONFIG_DIR, adapt_sql, get_database_url, is_postgresql
+from app.repositories.exceptions import SecretDecryptionError
 from app.utils.smtp_crypto import get_password_manager
+
+logger = logging.getLogger(__name__)
 
 
 class NotificationSettingsRepository:
@@ -58,7 +62,19 @@ class NotificationSettingsRepository:
             conn.close()
 
     def get(self, kind: str, include_secrets: bool = False) -> dict[str, Any] | None:
-        """Return masked settings, importing a legacy value at most once."""
+        """Return masked settings, importing a legacy value at most once.
+
+        Args:
+            kind: Integration type (e.g., "feishu", "dingtalk", "webhook").
+            include_secrets: If True, decrypt and include secret values.
+
+        Returns:
+            Configuration dict with masked secrets, or None if not configured.
+
+        Raises:
+            SecretDecryptionError: If include_secrets is True and the saved secret
+                cannot be decrypted with the current encryption key.
+        """
         row = self._get_raw(kind)
         if row is None and self._import_legacy(kind):
             row = self._get_raw(kind)
@@ -69,12 +85,29 @@ class NotificationSettingsRepository:
         encrypted = row.pop(column, None)
         row[f"{secret_name}_configured"] = bool(encrypted)
         if include_secrets and encrypted:
-            row[secret_name] = get_password_manager().decrypt(encrypted)
+            try:
+                row[secret_name] = get_password_manager().decrypt(encrypted)
+            except ValueError as e:
+                logger.error(
+                    f"Failed to decrypt {secret_name} for {kind}: decryption error"
+                )
+                raise SecretDecryptionError(secret_name, kind) from e
         if kind == "dingtalk":
             encrypted_fallback = row.pop("fallback_webhook_secret_enc", None)
             row["fallback_webhook_secret_configured"] = bool(encrypted_fallback)
             if include_secrets and encrypted_fallback:
-                row["fallback_webhook_secret"] = get_password_manager().decrypt(encrypted_fallback)
+                try:
+                    row["fallback_webhook_secret"] = get_password_manager().decrypt(
+                        encrypted_fallback
+                    )
+                except ValueError as e:
+                    logger.error(
+                        "Failed to decrypt fallback_webhook_secret for dingtalk: "
+                        "decryption error"
+                    )
+                    raise SecretDecryptionError(
+                        "fallback_webhook_secret", "dingtalk"
+                    ) from e
         return row
 
     def _legacy_values(self, kind: str, root: dict[str, Any]) -> dict[str, Any] | None:

--- a/app/repositories/notification_settings_repository.py
+++ b/app/repositories/notification_settings_repository.py
@@ -88,9 +88,7 @@ class NotificationSettingsRepository:
             try:
                 row[secret_name] = get_password_manager().decrypt(encrypted)
             except ValueError as e:
-                logger.error(
-                    f"Failed to decrypt {secret_name} for {kind}: decryption error"
-                )
+                logger.error(f"Failed to decrypt {secret_name} for {kind}: decryption error")
                 raise SecretDecryptionError(secret_name, kind) from e
         if kind == "dingtalk":
             encrypted_fallback = row.pop("fallback_webhook_secret_enc", None)
@@ -105,9 +103,7 @@ class NotificationSettingsRepository:
                         "Failed to decrypt fallback_webhook_secret for dingtalk: "
                         "decryption error"
                     )
-                    raise SecretDecryptionError(
-                        "fallback_webhook_secret", "dingtalk"
-                    ) from e
+                    raise SecretDecryptionError("fallback_webhook_secret", "dingtalk") from e
         return row
 
     def _legacy_values(self, kind: str, root: dict[str, Any]) -> dict[str, Any] | None:

--- a/app/routes/feishu_config.py
+++ b/app/routes/feishu_config.py
@@ -208,13 +208,16 @@ def test_feishu_connection():
         return jsonify(result)
     except SecretDecryptionError as e:
         logger.error(f"Secret decryption error for {e.field_name}: saved secret unreadable")
-        return jsonify(
-            {
-                "success": False,
-                "error": "FEISHU_SECRET_UNREADABLE",
-                "message": "The saved App Secret cannot be decrypted. Please re-enter the App Secret and save the configuration.",
-            }
-        ), 409
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "FEISHU_SECRET_UNREADABLE",
+                    "message": "The saved App Secret cannot be decrypted. Please re-enter the App Secret and save the configuration.",
+                }
+            ),
+            409,
+        )
     except Exception as e:
         logger.error(f"Error testing Feishu connection: {e}")
         return jsonify({"success": False, "error": "Internal server error"}), 500

--- a/app/routes/feishu_config.py
+++ b/app/routes/feishu_config.py
@@ -14,6 +14,7 @@ from flask import Blueprint, g, jsonify, request
 
 from app.auth.decorators import admin_required
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
+from app.repositories.exceptions import SecretDecryptionError
 from app.repositories.notification_settings_repository import get_notification_settings_repository
 from app.services.feishu_config_service import get_feishu_config_service
 
@@ -161,14 +162,27 @@ def test_feishu_connection():
     try:
         data = request.get_json() or {}
 
-        # Test with provided parameters or saved config
+        # If explicit credentials provided, use them directly without reading saved
+        explicit_app_id = data.get("app_id")
+        explicit_app_secret = data.get("app_secret")
+
         repo = get_notification_settings_repository()
-        saved = repo.get("feishu", include_secrets=True) or {}
-        service = get_feishu_config_service()
-        result = service.test_connection(
-            app_id=data.get("app_id") or saved.get("app_id"),
-            app_secret=data.get("app_secret") or saved.get("app_secret"),
-        )
+
+        if explicit_app_id and explicit_app_secret:
+            service = get_feishu_config_service()
+            result = service.test_connection(
+                app_id=explicit_app_id,
+                app_secret=explicit_app_secret,
+            )
+            saved = None  # No saved config needed for explicit credentials
+        else:
+            # Fall back to saved config only when no explicit credentials
+            saved = repo.get("feishu", include_secrets=True) or {}
+            service = get_feishu_config_service()
+            result = service.test_connection(
+                app_id=explicit_app_id or saved.get("app_id"),
+                app_secret=explicit_app_secret or saved.get("app_secret"),
+            )
 
         # Persist verification status if config exists in database
         if saved and saved.get("app_id"):
@@ -192,9 +206,18 @@ def test_feishu_connection():
                 logger.error(f"Feishu connection test failed: {result['message']}")
 
         return jsonify(result)
+    except SecretDecryptionError as e:
+        logger.error(f"Secret decryption error for {e.field_name}: saved secret unreadable")
+        return jsonify(
+            {
+                "success": False,
+                "error": "FEISHU_SECRET_UNREADABLE",
+                "message": "The saved App Secret cannot be decrypted. Please re-enter the App Secret and save the configuration.",
+            }
+        ), 409
     except Exception as e:
         logger.error(f"Error testing Feishu connection: {e}")
-        return jsonify({"success": False, "error": "Internal server error", "message": str(e)}), 500
+        return jsonify({"success": False, "error": "Internal server error"}), 500
 
 
 def _classify_feishu_error(message: str) -> str:

--- a/tests/unit/test_feishu_config_routes.py
+++ b/tests/unit/test_feishu_config_routes.py
@@ -1,0 +1,157 @@
+"""Tests for Issue #3140: Feishu config test connection decryption error handling."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.repositories.exceptions import SecretDecryptionError
+
+
+@pytest.fixture
+def app():
+    """Create a minimal Flask app with feishu config routes."""
+    from flask import Flask
+
+    from app.routes.feishu_config import feishu_config_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(feishu_config_bp, url_prefix="/api")
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret-key"
+    return app
+
+
+@pytest.fixture
+def admin_client(app):
+    """Create an admin-authenticated client."""
+    test_client = app.test_client()
+
+    class AuthenticatedClient:
+        def __init__(self, client):
+            self._client = client
+
+        def post(self, *args, **kwargs):
+            with patch("app.auth.decorators._extract_session_token", return_value="test-token"):
+                with patch(
+                    "app.auth.decorators._load_user_from_token",
+                    return_value={"id": 1, "role": "admin", "username": "test_admin"},
+                ):
+                    return self._client.post(*args, **kwargs)
+
+        def get(self, *args, **kwargs):
+            with patch("app.auth.decorators._extract_session_token", return_value="test-token"):
+                with patch(
+                    "app.auth.decorators._load_user_from_token",
+                    return_value={"id": 1, "role": "admin", "username": "test_admin"},
+                ):
+                    return self._client.get(*args, **kwargs)
+
+    return AuthenticatedClient(test_client)
+
+
+class TestFeishuConfigTestConnection:
+    """Tests for Issue #3140: Test connection decryption error handling."""
+
+    def test_returns_409_on_secret_decryption_error(self, admin_client):
+        """When saved secret cannot be decrypted, should return 409 with actionable error."""
+        with patch(
+            "app.routes.feishu_config.get_notification_settings_repository"
+        ) as mock_repo_getter:
+            mock_repo = MagicMock()
+            mock_repo.get.side_effect = SecretDecryptionError("app_secret", "feishu")
+            mock_repo_getter.return_value = mock_repo
+
+            response = admin_client.post("/api/management/feishu-config/test", json={})
+
+            assert response.status_code == 409
+            data = response.get_json()
+            assert data["success"] is False
+            assert data["error"] == "FEISHU_SECRET_UNREADABLE"
+            assert "re-enter" in data["message"].lower()
+            assert "secret" not in data.get("message", "").lower() or "app secret" in data["message"].lower()
+
+    def test_error_response_no_sensitive_info(self, admin_client):
+        """Error response should not expose cryptographic details or secret values."""
+        with patch(
+            "app.routes.feishu_config.get_notification_settings_repository"
+        ) as mock_repo_getter:
+            mock_repo = MagicMock()
+            mock_repo.get.side_effect = SecretDecryptionError("app_secret", "feishu")
+            mock_repo_getter.return_value = mock_repo
+
+            response = admin_client.post("/api/management/feishu-config/test", json={})
+            data = response.get_json()
+
+            assert "invalid key" not in str(data).lower()
+            assert "ciphertext" not in str(data).lower()
+            assert "decrypt" not in str(data).lower() or "cannot be decrypted" in data["message"]
+
+    def test_uses_explicit_secret_without_reading_saved(self, admin_client):
+        """When explicit secret provided, should not read saved (potentially broken) secret."""
+        with patch(
+            "app.routes.feishu_config.get_notification_settings_repository"
+        ) as mock_repo_getter:
+            mock_repo = MagicMock()
+            mock_repo.get.side_effect = SecretDecryptionError("app_secret", "feishu")
+            mock_repo_getter.return_value = mock_repo
+
+            with patch("app.routes.feishu_config.get_feishu_config_service") as mock_service_getter:
+                mock_service = MagicMock()
+                mock_service.test_connection.return_value = {
+                    "success": True,
+                    "message": "Connection successful",
+                }
+                mock_service_getter.return_value = mock_service
+
+                response = admin_client.post(
+                    "/api/management/feishu-config/test",
+                    json={"app_id": "cli_test", "app_secret": "explicit_secret"},
+                )
+
+                assert response.status_code == 200
+                data = response.get_json()
+                assert data["success"] is True
+
+    def test_normal_test_connection_succeeds(self, admin_client):
+        """Normal test connection should succeed with valid saved credentials."""
+        with patch(
+            "app.routes.feishu_config.get_notification_settings_repository"
+        ) as mock_repo_getter:
+            mock_repo = MagicMock()
+            mock_repo.get.return_value = {
+                "app_id": "cli_test",
+                "app_secret": "valid_secret",
+            }
+            mock_repo_getter.return_value = mock_repo
+
+            with patch("app.routes.feishu_config.get_feishu_config_service") as mock_service_getter:
+                mock_service = MagicMock()
+                mock_service.test_connection.return_value = {
+                    "success": True,
+                    "message": "Connection successful",
+                }
+                mock_service_getter.return_value = mock_service
+
+                response = admin_client.post("/api/management/feishu-config/test", json={})
+
+                assert response.status_code == 200
+                data = response.get_json()
+                assert data["success"] is True
+
+    def test_generic_exception_returns_500_without_details(self, admin_client):
+        """Generic exceptions should return 500 without exposing error details."""
+        with patch(
+            "app.routes.feishu_config.get_notification_settings_repository"
+        ) as mock_repo_getter:
+            mock_repo = MagicMock()
+            mock_repo.get.side_effect = RuntimeError("Database connection failed")
+            mock_repo_getter.return_value = mock_repo
+
+            response = admin_client.post("/api/management/feishu-config/test", json={})
+
+            assert response.status_code == 500
+            data = response.get_json()
+            assert data["success"] is False
+            assert data["error"] == "Internal server error"
+            assert "Database" not in str(data)
+            assert "connection" not in str(data).lower()

--- a/tests/unit/test_feishu_config_routes.py
+++ b/tests/unit/test_feishu_config_routes.py
@@ -68,7 +68,10 @@ class TestFeishuConfigTestConnection:
             assert data["success"] is False
             assert data["error"] == "FEISHU_SECRET_UNREADABLE"
             assert "re-enter" in data["message"].lower()
-            assert "secret" not in data.get("message", "").lower() or "app secret" in data["message"].lower()
+            assert (
+                "secret" not in data.get("message", "").lower()
+                or "app secret" in data["message"].lower()
+            )
 
     def test_error_response_no_sensitive_info(self, admin_client):
         """Error response should not expose cryptographic details or secret values."""

--- a/tests/unit/test_notification_settings_repository.py
+++ b/tests/unit/test_notification_settings_repository.py
@@ -168,6 +168,7 @@ def test_save_rolls_back_when_import_state_write_fails(repository, monkeypatch):
     current = repo.get("webhook", include_secrets=True)
     assert current is not None
     assert current["enabled"] == 1
+    assert current["webhook_secret"] == "original"
 
 
 def test_save_sets_configured_unverified_on_new_config(repository):
@@ -231,3 +232,149 @@ def test_verification_status_returned_in_get(repository):
     assert result["verification_status"] == "connected"
     assert "last_tested_at" in result
     assert "verified_config_fingerprint" in result
+
+
+class TestSecretDecryptionError:
+    """Tests for Issue #3140: Secret decryption failure handling."""
+
+    def test_raises_secret_decryption_error_on_decrypt_failure(self, repository, monkeypatch):
+        """When decryption fails, should raise SecretDecryptionError instead of ValueError."""
+        from app.repositories.exceptions import SecretDecryptionError
+
+        repo, _config_dir, _connection = repository
+        repo.save(
+            "feishu",
+            {
+                "app_id": "cli_test",
+                "app_secret": "test-secret",
+                "sync_enabled": False,
+            },
+        )
+
+        def mock_decrypt(encrypted):
+            raise ValueError("Decryption failed: invalid key")
+
+        monkeypatch.setattr(module.get_password_manager(), "decrypt", mock_decrypt)
+
+        with pytest.raises(SecretDecryptionError) as exc_info:
+            repo.get("feishu", include_secrets=True)
+
+        assert exc_info.value.field_name == "app_secret"
+        assert exc_info.value.integration_kind == "feishu"
+        assert "incompatible" in str(exc_info.value).lower()
+
+    def test_error_message_does_not_expose_cryptographic_details(self, repository, monkeypatch):
+        """Error message should not contain original cryptographic error details."""
+        from app.repositories.exceptions import SecretDecryptionError
+
+        repo, _config_dir, _connection = repository
+        repo.save(
+            "feishu",
+            {
+                "app_id": "cli_test",
+                "app_secret": "test-secret",
+                "sync_enabled": False,
+            },
+        )
+
+        def mock_decrypt(encrypted):
+            raise ValueError("Decryption failed: invalid key or corrupted ciphertext")
+
+        monkeypatch.setattr(module.get_password_manager(), "decrypt", mock_decrypt)
+
+        with pytest.raises(SecretDecryptionError) as exc_info:
+            repo.get("feishu", include_secrets=True)
+
+        error_message = str(exc_info.value)
+        assert "invalid key" not in error_message
+        assert "corrupted ciphertext" not in error_message
+        assert "test-secret" not in error_message
+
+    def test_dingtalk_fallback_secret_decryption_error(self, repository, monkeypatch):
+        """DingTalk fallback webhook secret should also raise SecretDecryptionError."""
+        from app.repositories.exceptions import SecretDecryptionError
+
+        repo, _config_dir, _connection = repository
+        repo.save(
+            "dingtalk",
+            {
+                "app_key": "test_key",
+                "app_secret": "test-secret",
+                "fallback_webhook_secret": "fallback-secret",
+                "sync_enabled": False,
+            },
+        )
+
+        # Get the encrypted values
+        saved = repo.get("dingtalk", include_secrets=True)
+        assert saved is not None
+        assert saved["app_secret"] == "test-secret"
+        assert saved["fallback_webhook_secret"] == "fallback-secret"
+
+        # Now save again and mock to fail only on second call (fallback)
+        repo.save(
+            "dingtalk",
+            {
+                "app_key": "test_key",
+                "app_secret": "test-secret",
+                "fallback_webhook_secret": "fallback-secret",
+                "sync_enabled": False,
+            },
+        )
+
+        call_count = [0]
+
+        def mock_decrypt(encrypted):
+            call_count[0] += 1
+            # First call is for app_secret, second is for fallback_webhook_secret
+            if call_count[0] == 2:
+                raise ValueError("Decryption failed")
+            return "decrypted"
+
+        monkeypatch.setattr(module.get_password_manager(), "decrypt", mock_decrypt)
+
+        with pytest.raises(SecretDecryptionError) as exc_info:
+            repo.get("dingtalk", include_secrets=True)
+
+        assert exc_info.value.field_name == "fallback_webhook_secret"
+        assert exc_info.value.integration_kind == "dingtalk"
+
+    def test_normal_decrypt_succeeds(self, repository):
+        """Normal decryption should work without raising SecretDecryptionError."""
+        repo, _config_dir, _connection = repository
+        repo.save(
+            "feishu",
+            {
+                "app_id": "cli_test",
+                "app_secret": "test-secret-value",
+                "sync_enabled": False,
+            },
+        )
+
+        result = repo.get("feishu", include_secrets=True)
+
+        assert result is not None
+        assert result["app_secret"] == "test-secret-value"
+
+    def test_get_without_secrets_does_not_raise_decrypt_error(self, repository, monkeypatch):
+        """get(include_secrets=False) should not trigger decryption or errors."""
+        repo, _config_dir, _connection = repository
+        repo.save(
+            "feishu",
+            {
+                "app_id": "cli_test",
+                "app_secret": "test-secret",
+                "sync_enabled": False,
+            },
+        )
+
+        def mock_decrypt(encrypted):
+            raise ValueError("Should not be called")
+
+        monkeypatch.setattr(module.get_password_manager(), "decrypt", mock_decrypt)
+
+        result = repo.get("feishu", include_secrets=False)
+
+        assert result is not None
+        assert result["app_secret_configured"] is True
+        assert "app_secret" not in result


### PR DESCRIPTION
## Summary

Fixes #3140

When saved App Secret cannot be decrypted with the current encryption key, return a stable 409 error with actionable message instead of HTTP 500.

## Root Cause

The `test_feishu_connection` route calls `repo.get("feishu", include_secrets=True)` to read saved configuration. When decryption fails, the `ValueError` from the crypto layer was caught by the generic `except Exception` handler and returned as HTTP 500 with `str(e)` exposed in the response.

## Fix

1. **Add `SecretDecryptionError` exception** - A dedicated exception that doesn't expose cryptographic details
2. **Catch decryption failures in repository** - Convert `ValueError` from crypto layer to `SecretDecryptionError`
3. **Handle in routes** - Return 409 with actionable error code `FEISHU_SECRET_UNREADABLE`
4. **Skip saved secret when explicit credentials provided** - Avoid triggering decryption errors when user provides new credentials

## Test Plan

- [x] Decryption failure returns 409 with `FEISHU_SECRET_UNREADABLE` error code
- [x] Error message doesn't expose cryptographic details or secret values
- [x] Explicit credentials bypass saved secret reading
- [x] Normal decryption continues to work
- [x] `get(include_secrets=False)` doesn't trigger decryption

## Files Changed

- `app/repositories/exceptions.py` - New `SecretDecryptionError` exception
- `app/repositories/notification_settings_repository.py` - Catch decryption failures
- `app/routes/feishu_config.py` - Handle `SecretDecryptionError`, return 409
- `tests/unit/test_notification_settings_repository.py` - Repository tests
- `tests/unit/test_feishu_config_routes.py` - Route tests