### PR TITLE
fix(#3141): decouple model gateway management access from routing flag

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -415,17 +415,6 @@ const PolicyRouteGuard: React.FC = () => {
   );
 };
 
-// Model Gateway Route Guard - waits for config and checks feature flag
-const ModelGatewayRouteGuard: React.FC = () => {
-  const modelGatewayEnabled = useAppStore((state) => state.modelGatewayEnabled);
-
-  return (
-    <FeatureRouteGuard enabled={modelGatewayEnabled} redirectPath="/manage/dashboard">
-      <ModelGatewayConfig />
-    </FeatureRouteGuard>
-  );
-};
-
 const ManageRoutes: React.FC = () => {
   return (
     <ManageLayout>
@@ -483,7 +472,7 @@ const ManageRoutes: React.FC = () => {
               />
             }
           />
-          <Route path="settings/model-gateway" element={<ModelGatewayRouteGuard />} />
+          <Route path="settings/model-gateway" element={<ModelGatewayConfig />} />
           <Route
             path="settings/feishu"
             element={


### PR DESCRIPTION
## Summary

Decouple model gateway management access from the routing feature flag, enabling the workflow: configure → test connection → enable routing.

## Root Cause

Single Feature Flag `model_gateway.enabled` was controlling both:
1. **Runtime switch**: whether to route model requests to external gateway
2. **Management access**: whether admin can access configuration page

This prevented admins from configuring and testing connections before enabling actual routing.

## Changes

- Remove `ModelGatewayRouteGuard` from `frontend/src/App.tsx`
- Route `/manage/settings/model-gateway` now directly renders `ModelGatewayConfig`
- Navigation menu still shows disabled state as visual indicator
- Component internal `enabled` status correctly shows "gatewayDisabled" warning

## Verification

- ✅ TypeScript type check passed
- ✅ ESLint passed (0 errors)
- ✅ All 1188 frontend unit tests passed
- ✅ `ManageLayout.test.tsx` tests pass (navigation disabled state preserved)

## Acceptance Criteria Mapping

| Criteria | Status |
|----------|--------|
| Admin can configure/test when routing disabled | ✅ Route guard removed |
| Test operations don't trigger actual routing | ✅ Component `enabled=false` independent |
| Page distinguishes management vs routing status | ✅ `getStatusInfo()` already implemented |
| Non-admin permission boundary unchanged | ✅ Backend `admin_required` protects API |
| #2793 test coverage preserved | ✅ Navigation disabled logic unchanged |

Fixes #3141