### PR TITLE
fix(#3141): decouple model gateway management access from routing flag

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -415,17 +415,6 @@ const PolicyRouteGuard: React.FC = () => {
   );
 };
 
-// Model Gateway Route Guard - waits for config and checks feature flag
-const ModelGatewayRouteGuard: React.FC = () => {
-  const modelGatewayEnabled = useAppStore((state) => state.modelGatewayEnabled);
-
-  return (
-    <FeatureRouteGuard enabled={modelGatewayEnabled} redirectPath="/manage/dashboard">
-      <ModelGatewayConfig />
-    </FeatureRouteGuard>
-  );
-};
-
 const ManageRoutes: React.FC = () => {
   return (
     <ManageLayout>
@@ -483,7 +472,7 @@ const ManageRoutes: React.FC = () => {
               />
             }
           />
-          <Route path="settings/model-gateway" element={<ModelGatewayRouteGuard />} />
+          <Route path="settings/model-gateway" element={<ModelGatewayConfig />} />
           <Route
             path="settings/feishu"
             element={


### PR DESCRIPTION
## Summary

Remove `ModelGatewayRouteGuard` to allow admin access to model gateway configuration page even when `model_gateway.enabled` is false.

## Root Cause

Single Feature Flag `model_gateway.enabled` mixed two responsibilities:
1. **Runtime routing switch**: whether to route model requests to external gateway
2. **Management access switch**: whether to allow admin to view, save and test gateway config

When `model_gateway.enabled=false`, admin was redirected to `/manage/dashboard` and could not access the configuration page, even though:
- Backend API (`/api/management/model-gateway-config`) is independent of the flag
- Configuration component already handles "disabled" status display

## Changes

- Remove `ModelGatewayRouteGuard` component from `App.tsx`
- Route `/manage/settings/model-gateway` now directly renders `ModelGatewayConfig`
- Navigation menu still shows disabled state as visual indicator
- Component internal `enabled` status correctly shows "gatewayDisabled" warning

## Benefits

This enables the workflow:
```
configure → test connection → enable routing
```
instead of:
```
enable routing → configure/test
```

## Acceptance Criteria Mapping

| Criteria | Status |
|----------|--------|
| Admin can configure and test connection when routing is disabled | ✅ Route Guard removed |
| Test operation does not trigger actual model traffic routing | ✅ Component internal `enabled` state is independent |
| Page clearly distinguishes "management available" vs "routing enabled" | ✅ `getStatusInfo()` already implemented |
| Non-admin permission boundary unchanged | ✅ Backend `admin_required` protects API |
| No regression on #2793 test coverage | ✅ Navigation menu disabled logic retained |

## Test Evidence

- TypeScript type check: ✅ Passed
- Frontend lint: ✅ No errors (62 warnings)
- Frontend unit tests: ✅ 1188 tests passed

Fixes #3141