### PR TITLE
fix(#3137): add free plan to frontend tenant management

### DIFF
--- a/frontend/src/api/tenant.ts
+++ b/frontend/src/api/tenant.ts
@@ -9,7 +9,7 @@ export interface Tenant {
   id: number;
   name: string;
   slug: string;
-  plan: 'standard' | 'premium' | 'enterprise';
+  plan: 'free' | 'standard' | 'premium' | 'enterprise';
   status: 'active' | 'suspended' | 'trial';
   contact_email?: string;
   contact_name?: string;
@@ -37,7 +37,7 @@ export interface TenantQuota {
 export interface CreateTenantRequest {
   name: string;
   slug?: string;
-  plan?: 'standard' | 'premium' | 'enterprise';
+  plan?: 'free' | 'standard' | 'premium' | 'enterprise';
   contact_email?: string;
   contact_name?: string;
   trial_days?: number;
@@ -49,7 +49,7 @@ export interface CreateTenantRequest {
 export interface UpdateTenantRequest {
   name?: string;
   slug?: string;
-  plan?: 'standard' | 'premium' | 'enterprise';
+  plan?: 'free' | 'standard' | 'premium' | 'enterprise';
   status?: 'active' | 'suspended' | 'trial';
   contact_email?: string;
   contact_phone?: string;

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -35,6 +35,7 @@ import { formatQuotaForDisplay } from '@/utils/quotaFormatter';
 // Tenant i18n fixes (Issue #1500)
 // Type-safe label mappings for plan and status
 const PLAN_LABELS: Record<string, string> = {
+  free: 'tenantPlanFree',
   standard: 'tenantPlanStandard',
   premium: 'tenantPlanPremium',
   enterprise: 'tenantPlanEnterprise',
@@ -69,6 +70,7 @@ const getTenantPlanOptions = (language: Language, includeAll: boolean = true) =>
   const options = includeAll ? [{ value: '', label: t('tenantAllPlans', language) }] : [];
   return [
     ...options,
+    { value: 'free', label: t('tenantPlanFree', language) },
     { value: 'standard', label: t('tenantPlanStandard', language) },
     { value: 'premium', label: t('tenantPlanPremium', language) },
     { value: 'enterprise', label: t('tenantPlanEnterprise', language) },
@@ -414,6 +416,10 @@ export const TenantManagement: React.FC = () => {
         return 'primary';
       case 'premium':
         return 'info';
+      case 'standard':
+        return 'secondary';
+      case 'free':
+        return 'light';
       default:
         return 'secondary';
     }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1606,6 +1606,7 @@ export const translations: Record<Language, Translations> = {
     // Tenant i18n fixes (Issue #1500)
     tenantAllStatuses: 'All Statuses',
     tenantAllPlans: 'All Plans',
+    tenantPlanFree: 'Free',
     tenantPlanStandard: 'Standard',
     tenantPlanPremium: 'Premium',
     tenantPlanEnterprise: 'Enterprise',
@@ -3803,6 +3804,7 @@ export const translations: Record<Language, Translations> = {
     // Tenant i18n fixes (Issue #1500)
     tenantAllStatuses: '全部状态',
     tenantAllPlans: '全部套餐',
+    tenantPlanFree: '免费版',
     tenantPlanStandard: '标准版',
     tenantPlanPremium: '高级版',
     tenantPlanEnterprise: '企业版',
@@ -5884,6 +5886,7 @@ export const translations: Record<Language, Translations> = {
     // Tenant i18n fixes (Issue #1500)
     tenantAllStatuses: 'すべての状態',
     tenantAllPlans: 'すべてのプラン',
+    tenantPlanFree: '無料',
     tenantPlanStandard: 'スタンダード',
     tenantPlanPremium: 'プレミアム',
     tenantPlanEnterprise: 'エンタープライズ',
@@ -7913,6 +7916,7 @@ export const translations: Record<Language, Translations> = {
     // Tenant i18n fixes (Issue #1500)
     tenantAllStatuses: '모든 상태',
     tenantAllPlans: '모든 플랜',
+    tenantPlanFree: '무료',
     tenantPlanStandard: '스탠다드',
     tenantPlanPremium: '프리미엄',
     tenantPlanEnterprise: '엔터프라이즈',


### PR DESCRIPTION
## Summary

This PR adds the `free` plan to the frontend tenant management, which was missing despite being supported by the backend.

## Problem

The frontend only provided three plan options (`standard`, `premium`, `enterprise`) while the backend `PLAN_QUOTAS` supports four plans including `free`. This caused:

- Unable to select `free` when creating or editing tenants
- Unable to filter tenants by `free` plan
- Existing `free` tenants could not be properly displayed or preserved

## Changes

1. **Type definitions** (`frontend/src/api/tenant.ts`):
   - Added `'free'` to `Tenant.plan`, `CreateTenantRequest.plan`, `UpdateTenantRequest.plan` types

2. **Component logic** (`frontend/src/components/features/management/TenantManagement.tsx`):
   - Added `free: 'tenantPlanFree'` to `PLAN_LABELS`
   - Added `free` option to `getTenantPlanOptions()`
   - Added Badge variant for `free` plan (uses `light` style)

3. **Translations** (`frontend/src/i18n/index.ts`):
   - Added `tenantPlanFree` for all 4 languages:
     - English: 'Free'
     - Chinese: '免费版'
     - Japanese: '無料'
     - Korean: '무료'

## Testing

- [x] TypeScript type check passed
- [x] ESLint check passed for modified files

## Related Issue

Closes #3137