### PR TITLE
fix(packaging): ship the cli module in wheels and pin it in the package suite

### DIFF
--- a/ci/suites.json
+++ b/ci/suites.json
@@ -258,6 +258,10 @@
           "--wheel",
           "--outdir",
           "dist/"
+        ],
+        [
+          "{python}",
+          "scripts/ci/verify_wheel_entry.py"
         ]
       ]
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ dev = [
 [project.scripts]
 openace = "cli:main"
 
+[tool.setuptools]
+# Top-level modules referenced by console scripts must be packaged explicitly;
+# packages.find only covers the app*/scripts* package trees (issue #3171).
+py-modules = ["cli"]
+
 [tool.setuptools.packages.find]
 include = ["app*", "scripts*"]
 

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -72,6 +72,7 @@ PACKAGE_PATTERNS = (
     "requirements*.in",
     "requirements*.lock",
     "requirements*.txt",
+    "scripts/ci/**",
     "scripts/install-central/**",
 )
 DEPENDENCY_PATTERNS = (

--- a/scripts/ci/verify_wheel_entry.py
+++ b/scripts/ci/verify_wheel_entry.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify built wheels ship the console-script entry module (issue #3171).
+
+The ``openace`` console script targets the top-level ``cli`` module. If the
+wheel omits it (which packages.find alone allows), ``pip install`` succeeds
+and ``openace --help`` dies with ModuleNotFoundError — the weekly
+package-install failure mode. This checker runs inside the shared ``package``
+suite so every PR build behaviorally pins the wheel contents instead of
+waiting for the weekly lane. Stdlib-only on purpose: it executes under the
+suite runner's isolated environment.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+EXPECTED_MODULE = "cli.py"
+EXPECTED_ENTRY = re.compile(r"^openace\s*=\s*cli:main\s*$", re.MULTILINE)
+
+
+def verify_wheel(wheel: Path) -> str | None:
+    """Return a failure description, or None when the wheel is complete."""
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        if EXPECTED_MODULE not in names:
+            return f"{wheel.name}: missing top-level {EXPECTED_MODULE}"
+        entry_point_files = [name for name in names if name.endswith("entry_points.txt")]
+        combined = "\n".join(
+            archive.read(name).decode("utf-8", errors="replace") for name in entry_point_files
+        )
+    if not EXPECTED_ENTRY.search(combined):
+        return f"{wheel.name}: entry_points.txt lacks 'openace = cli:main'"
+    return None
+
+
+def main() -> int:
+    wheels = sorted(Path("dist").glob("*.whl"))
+    if not wheels:
+        print("verify_wheel_entry: no wheels found under dist/", file=sys.stderr)
+        return 1
+    failures = [detail for wheel in wheels if (detail := verify_wheel(wheel))]
+    if failures:
+        for detail in failures:
+            print(f"verify_wheel_entry: {detail}", file=sys.stderr)
+        return 1
+    print(
+        f"verify_wheel_entry: {len(wheels)} wheel(s) ship "
+        f"{EXPECTED_MODULE} + 'openace = cli:main'"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_verify_wheel_entry.py
+++ b/tests/unit/test_verify_wheel_entry.py
@@ -1,0 +1,95 @@
+"""Contracts for the wheel entry-module verifier (issue #3171)."""
+
+import importlib.util
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+spec = importlib.util.spec_from_file_location(
+    "openace_verify_wheel_entry", ROOT / "scripts" / "ci" / "verify_wheel_entry.py"
+)
+assert spec and spec.loader
+verify_wheel_entry = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(verify_wheel_entry)
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3171)]
+
+
+def _write_wheel(path: Path, *, with_module: bool, entry_line: str | None) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        if with_module:
+            archive.writestr("cli.py", "def main():\n    return 0\n")
+        archive.writestr("app/__init__.py", "")
+        archive.writestr("open_ace-1.2.0.dist-info/METADATA", "Name: open-ace\n")
+        if entry_line is not None:
+            archive.writestr(
+                "open_ace-1.2.0.dist-info/entry_points.txt",
+                f"[console_scripts]\n{entry_line}\n",
+            )
+
+
+def test_complete_wheel_passes(tmp_path, monkeypatch, capsys):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "open_ace-1.2.0-py3-none-any.whl",
+        with_module=True,
+        entry_line="openace = cli:main",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert verify_wheel_entry.main() == 0
+    assert "ship cli.py" in capsys.readouterr().out
+
+
+def test_wheel_missing_cli_module_fails(tmp_path, monkeypatch, capsys):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "open_ace-1.2.0-py3-none-any.whl",
+        with_module=False,
+        entry_line="openace = cli:main",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert verify_wheel_entry.main() == 1
+    assert "missing top-level cli.py" in capsys.readouterr().err
+
+
+def test_wheel_with_wrong_entry_point_fails(tmp_path, monkeypatch, capsys):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "open_ace-1.2.0-py3-none-any.whl",
+        with_module=True,
+        entry_line="openace = server:main",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert verify_wheel_entry.main() == 1
+    assert "lacks 'openace = cli:main'" in capsys.readouterr().err
+
+
+def test_every_wheel_is_checked_and_missing_dist_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    assert verify_wheel_entry.main() == 1
+    assert "no wheels found" in capsys.readouterr().err
+
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "open_ace-1.0.0-py3-none-any.whl",
+        with_module=True,
+        entry_line="openace = cli:main",
+    )
+    _write_wheel(
+        dist / "open_ace-2.0.0-py3-none-any.whl",
+        with_module=False,
+        entry_line="openace = cli:main",
+    )
+
+    assert verify_wheel_entry.main() == 1
+    assert "open_ace-2.0.0" in capsys.readouterr().err


### PR DESCRIPTION
Closes #3171. Ref: #2429 (P1 item 4b).

## Root cause
`[project.scripts] openace = "cli:main"` targets the top-level `cli` module, but `[tool.setuptools.packages.find] include = ["app*", "scripts*"]` never packages top-level modules — every wheel omitted `cli.py`, `pip install` succeeded, and `openace --help` died with `ModuleNotFoundError: No module named 'cli'` (weekly package-install red on all of 3.10/3.11/3.14; reproduced locally on main).

## Change
- `pyproject.toml`: `[tool.setuptools] py-modules = ["cli"]`.
- `scripts/ci/verify_wheel_entry.py` (stdlib-only): asserts every `dist/*.whl` ships `cli.py` and the `openace = cli:main` entry point; appended to the shared `package` suite in `ci/suites.json` — the PR `build` job runs the same suite, so the pin is behavioral and per-PR, not weekly-only.
- `scripts/ci.py` `PACKAGE_PATTERNS` gains `scripts/ci/**` so checker-only PRs still select the package suite.
- `tests/unit/test_verify_wheel_entry.py`: fabricated-wheel contracts (complete pass / missing module / wrong entry point / every-wheel-checked / no-dist fail).

## Local evidence (same runner as CI)
- Wheel now contains `cli.py` + `[console_scripts] openace = cli:main`.
- Clean venv: `pip install <wheel>` → `openace --help` exit 0.
- `python scripts/ci.py run package` green end-to-end (build + checker).
- 36 tests green (ci_runner + layout policy + verifier contracts).

Plan independently reviewed CLEAN: #3171 comment 5448165068.

## Acceptance follow-through (post-merge)
- [ ] Real Weekly `workflow_dispatch`: Package install 3.10/3.11/3.14 green.
- [ ] Next scheduled Weekly as continuing evidence, backfilled to #3171.