### PR TITLE
fix(ci): provide SECRET_KEY and absolute browser cache path to weekly cross-browser lane

### DIFF
--- a/.github/workflows/weekly-quality.yml
+++ b/.github/workflows/weekly-quality.yml
@@ -19,6 +19,15 @@ jobs:
     name: Chromium, Firefox and WebKit E2E
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    env:
+      # Issue #3170: the playwright webServer boots the real `server.py`,
+      # whose development-mode contract refuses to start without SECRET_KEY
+      # (same test key style as scripts/run_extended_tests.py). The absolute
+      # browser cache path keeps install/run resolving identically even though
+      # the E2E step swaps HOME for an isolated one (extended-tests.yml uses
+      # the same pattern).
+      SECRET_KEY: weekly-cross-browser-e2e-secret-key-32chars
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/unit/test_weekly_quality_workflow_contract.py
+++ b/tests/unit/test_weekly_quality_workflow_contract.py
@@ -1,0 +1,56 @@
+"""Contract for the weekly cross-browser lane's server/browser environment.
+
+The cross-browser job boots the real `server.py` through the playwright
+webServer (frontend/playwright.config.ts) and swaps HOME to an isolated
+directory for the E2E step. Two job-level env keys keep that combination
+alive (#3170): SECRET_KEY (the fail-closed development-mode boot contract)
+and PLAYWRIGHT_BROWSERS_PATH (browsers are installed under the real HOME;
+without an absolute cache path the HOME swap makes every browser launch
+fail with a missing executable).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEEKLY = REPO_ROOT / ".github" / "workflows" / "weekly-quality.yml"
+PLAYWRIGHT_CONFIG = REPO_ROOT / "frontend" / "playwright.config.ts"
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3170)]
+
+
+def _cross_browser_job():
+    workflow = yaml.load(WEEKLY.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    return workflow["jobs"]["cross-browser-e2e"]
+
+
+def test_playwright_web_server_boots_the_real_server_py():
+    config = PLAYWRIGHT_CONFIG.read_text(encoding="utf-8")
+    web_server = re.search(r"webServer:\s*\{.*?command:\s*'([^']+)'", config, re.DOTALL)
+    assert web_server, "playwright webServer command not found"
+    assert "server.py" in web_server.group(1)
+
+
+def test_server_booting_job_pins_secret_key_and_browser_cache_path():
+    job = _cross_browser_job()
+    env = job.get("env", {})
+
+    # The development-mode boot contract fails closed without a key; the pin
+    # keeps >= 32 chars of headroom over validate_secret_strength's floor.
+    secret = env.get("SECRET_KEY")
+    assert isinstance(secret, str) and secret and not secret.startswith("${{")
+    assert len(secret) >= 32
+
+    # Absolute cache path so the E2E step's HOME swap cannot hide the
+    # browsers installed under the runner's real HOME.
+    browsers = env.get("PLAYWRIGHT_BROWSERS_PATH")
+    assert isinstance(browsers, str) and browsers
+    assert browsers.startswith("${{") or browsers.startswith("/")
+
+    run_step = next(
+        step for step in job["steps"] if step.get("run", "").startswith("npm run test:e2e")
+    )
+    assert run_step["env"]["HOME"] == "${{ runner.temp }}/openace-home"


### PR DESCRIPTION
Closes #3170. Ref: #2429 (P1 item 4a).

## Root cause (two layers, both required)
1. The lane boots the real `server.py` (playwright webServer) under an isolated HOME with no `SECRET_KEY` and no config secret → `create_app` fails closed per the #2667/#2331 development-mode contract. Both recorded weekly runs (32519311371, 31835481448) died exactly there.
2. Behind that fix: browsers install under the runner's real HOME while the E2E step swaps HOME without `PLAYWRIGHT_BROWSERS_PATH` → every browser project would next fail with "Executable doesn't exist" (verified empirically during plan review; the same trap `scripts/run_extended_tests.py` already guards for the Python lanes).

## Change
- `weekly-quality.yml` cross-browser-e2e job-level env: `SECRET_KEY` (deterministic 32-char test key, style-aligned with `run_extended_tests.py`) + `PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright` (the exact pattern `extended-tests.yml` uses).
- `tests/unit/test_weekly_quality_workflow_contract.py` (regression+issue(3170)): pins both env keys (secret ≥32 chars; browsers path absolute/expression) against the playwright webServer `server.py` command and the HOME-swapping E2E step. App security invariant untouched — no app-code fallback added.

## Local evidence
- Negative: isolated HOME + schema + `python3 server.py` → the exact CI `RuntimeError: SECRET_KEY not set in development mode…`.
- Positive: same boot with the lane's key → `GET / → 200` (log captured in issue).
- Browser-path mechanics empirically verified during plan review (HOME→tmp breaks chromium.launch; absolute PLAYWRIGHT_BROWSERS_PATH fixes it).

Plan rev2 (folded 1 HIGH + 2 LOW review objections): #3170 comment 5448239919.

## Acceptance follow-through (post-merge)
- [ ] Real Weekly `workflow_dispatch`: cross-browser lane green.
- [ ] Next scheduled Weekly as continuing evidence, backfilled to #3170.