### PR TITLE
fix(ci): classify out-of-contract PR runs and stop the health collector faking green

### DIFF
--- a/.github/workflows/ci-health-metrics.yml
+++ b/.github/workflows/ci-health-metrics.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           mkdir -p test-results/ci-health
           python scripts/ci/github_actions_metrics.py \
             --repo "$GITHUB_REPOSITORY" \
@@ -42,10 +43,11 @@ jobs:
       - name: Publish CI health summary
         if: always()
         run: |
-          if [ -f test-results/ci-health/report.md ]; then
+          if [ -f test-results/ci-health/report.md ] && [ -f test-results/ci-health/report.json ]; then
             cat test-results/ci-health/report.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "CI health collection failed; see collector artifact." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
 
       - name: Upload CI health evidence

--- a/ci/ci-health-policy.json
+++ b/ci/ci-health-policy.json
@@ -2,6 +2,7 @@
   "version": 1,
   "derivation_version": 1,
   "window_days": 30,
+  "pr_contract_epoch": "2026-08-09T12:23:45Z",
   "sample_cap": 25,
   "min_samples": 20,
   "max_collector_requests": 700,

--- a/scripts/ci/github_actions_metrics.py
+++ b/scripts/ci/github_actions_metrics.py
@@ -282,12 +282,14 @@ def load_policy(path: Path) -> dict[str, Any]:
         "max_collector_requests",
         "reserve_remaining",
         "max_jobs_per_attempt",
+        "pr_contract_epoch",
         "cohorts",
     }
     if policy.get("version") != 1 or not required.issubset(policy):
         raise MetricsError(f"invalid CI health policy: {path}")
     if policy["sample_cap"] != 25 or policy["max_jobs_per_attempt"] != 100:
         raise MetricsError("unsupported sampling or job-page policy")
+    parse_time(policy.get("pr_contract_epoch"), "policy.pr_contract_epoch")
     return policy
 
 
@@ -388,17 +390,57 @@ def resolve_pr_runtime(
     run: dict[str, Any],
     max_jobs: int,
     jobs_cache: dict[tuple[int, int], tuple[dict[str, Any], dict[str, str]]],
-) -> None:
+    *,
+    epoch: datetime,
+) -> str | None:
+    """Resolve PR runtime linkage from the Select suites job log.
+
+    The linkage attempt is the first attempt that contains exactly one
+    ``Select suites`` job. Runs without any executed attempt (e.g. an
+    ``action_required`` attempt 1 that never produced jobs), and pre-epoch
+    runs whose executed attempts predate the job, are out-of-contract: they
+    return a skip reason for the cohort report instead of failing collection.
+    Post-epoch runs that executed jobs but lack the job are contract breaks
+    and fail closed.
+    """
     run_id = run["id"]
-    jobs_payload, jobs_headers = client.get(
-        f"/repos/{repo}/actions/runs/{run_id}/attempts/1/jobs", {"per_page": max_jobs}
+    attempt_count = run.get("run_attempt")
+    if not isinstance(attempt_count, int) or attempt_count < 1:
+        raise MetricsError(f"run {run_id} has invalid run_attempt")
+    jobs_by_attempt: dict[int, list[dict[str, Any]]] = {}
+    for number in range(1, attempt_count + 1):
+        cache_key = (run_id, number)
+        if cache_key not in jobs_cache:
+            jobs_payload, jobs_headers = client.get(
+                f"/repos/{repo}/actions/runs/{run_id}/attempts/{number}/jobs",
+                {"per_page": max_jobs},
+            )
+            jobs_cache[cache_key] = (jobs_payload, jobs_headers)
+        jobs_payload, jobs_headers = jobs_cache[cache_key]
+        jobs_by_attempt[number] = _validate_raw_jobs(
+            run_id, number, jobs_payload, jobs_headers, max_jobs
+        )
+    select_counts = {
+        number: sum(1 for job in jobs if job.get("name") == "Select suites")
+        for number, jobs in jobs_by_attempt.items()
+    }
+    if any(count > 1 for count in select_counts.values()):
+        raise MetricsError(f"run {run_id} has an attempt with multiple Select suites jobs")
+    linkage_attempt = next(
+        (number for number in sorted(select_counts) if select_counts[number] == 1), None
     )
-    jobs = _validate_raw_jobs(run_id, 1, jobs_payload, jobs_headers, max_jobs)
-    jobs_cache[(run_id, 1)] = (jobs_payload, jobs_headers)
-    select_jobs = [job for job in jobs if job.get("name") == "Select suites"]
-    if len(select_jobs) != 1:
-        raise MetricsError(f"run {run_id} does not have one Select suites job")
-    log, _ = client.get_text(f"/repos/{repo}/actions/jobs/{select_jobs[0]['id']}/logs")
+    if linkage_attempt is None:
+        if not any(jobs_by_attempt.values()):
+            return "no_executed_attempt"
+        if parse_time(run.get("created_at"), "run.created_at") < epoch:
+            return "pre_contract_epoch"
+        raise MetricsError(
+            f"run {run_id} does not have one Select suites job in any executed attempt"
+        )
+    select_job = next(
+        job for job in jobs_by_attempt[linkage_attempt] if job.get("name") == "Select suites"
+    )
+    log, _ = client.get_text(f"/repos/{repo}/actions/jobs/{select_job['id']}/logs")
     merge_candidates = set(re.findall(r"\+([0-9a-f]{40}):refs/remotes/pull/(\d+)/merge", log))
     base_candidates = set(re.findall(r"BASE_SHA:\s*([0-9a-f]{40})", log))
     selected_candidates = {
@@ -608,17 +650,34 @@ def collect_attempts(
                     }
                 )
             else:
-                normalized.update(
-                    {
-                        "queue": measured_delta(
-                            job.get("created_at"), job.get("started_at"), "job.queue"
-                        ),
-                        "execution": measured_delta(
-                            job.get("started_at"), job.get("completed_at"), "job.execution"
-                        ),
-                    }
-                )
-                canonical_jobs.append({**normalized, "attempt": number})
+                if job_conclusion == "skipped":
+                    # Skipped jobs never execute, and GitHub gives their
+                    # timestamps no ordering guarantees at evaluation time
+                    # (observed live, run 31827030734 job 94853500968:
+                    # created/started 18:05:39Z but completed 18:05:30Z —
+                    # completion before both start and creation). Queue and
+                    # execution have no meaning; timestamps are recorded
+                    # as-is and only presence/parseability is enforced.
+                    normalized.update(
+                        {
+                            "timing_state": "skipped_evaluation",
+                            "queue": None,
+                            "execution": None,
+                        }
+                    )
+                    canonical_jobs.append({**normalized, "attempt": number})
+                else:
+                    normalized.update(
+                        {
+                            "queue": measured_delta(
+                                job.get("created_at"), job.get("started_at"), "job.queue"
+                            ),
+                            "execution": measured_delta(
+                                job.get("started_at"), job.get("completed_at"), "job.execution"
+                            ),
+                        }
+                    )
+                    canonical_jobs.append({**normalized, "attempt": number})
             normalized_jobs.append(normalized)
         attempts.append(
             {
@@ -683,12 +742,16 @@ def aggregate_contract(runs: list[dict[str, Any]], min_samples: int) -> dict[str
     job_execution: list[float] = []
     slow_jobs = []
     inherited_job_count = 0
+    skipped_job_count = 0
     for run in runs:
         for attempt in run["attempts"]:
             workflow_queue.append(attempt["queue"]["seconds"])
             for job in attempt["jobs"]:
                 if job["timing_state"] == "inherited_snapshot":
                     inherited_job_count += 1
+                    continue
+                if job["timing_state"] == "skipped_evaluation":
+                    skipped_job_count += 1
                     continue
                 job_queue.append(job["queue"]["seconds"])
                 job_execution.append(job["execution"]["seconds"])
@@ -719,6 +782,7 @@ def aggregate_contract(runs: list[dict[str, Any]], min_samples: int) -> dict[str
         "retry_recovery_count": recoveries,
         "retry_recovery_rate": recoveries / sample_count if sample_count else None,
         "inherited_job_snapshot_count": inherited_job_count,
+        "skipped_job_no_execution_count": skipped_job_count,
         "first_attempt_wall": summarize_values(
             first_walls, min_samples, cohort_samples=sample_count
         ),
@@ -751,6 +815,15 @@ def render_markdown(report: dict[str, Any]) -> str:
             f"| {len(cohort['contracts'])} |"
         )
     for cohort in report["cohorts"]:
+        if cohort.get("skipped_runs"):
+            breakdown = ", ".join(
+                f"{reason}={count}"
+                for reason, count in sorted(
+                    Counter(item["reason"] for item in cohort["skipped_runs"]).items()
+                )
+            )
+            lines.extend(["", f"Out-of-contract runs skipped ({cohort['id']}): {breakdown}"])
+    for cohort in report["cohorts"]:
         if cohort["payload_link_states"]:
             states = ", ".join(
                 f"{state}={count}" for state, count in sorted(cohort["payload_link_states"].items())
@@ -768,6 +841,7 @@ def render_markdown(report: dict[str, Any]) -> str:
                     f"- eventual-pass rate: {contract['eventual_pass_rate']}",
                     f"- retry recoveries: {contract['retry_recovery_count']}",
                     f"- inherited job snapshots: {contract['inherited_job_snapshot_count']}",
+                    f"- skipped jobs (never executed): {contract['skipped_job_no_execution_count']}",
                 ]
             )
     lines.extend(
@@ -793,6 +867,7 @@ def collect(
 ) -> dict[str, Any]:
     rate_limit(client, budget)
     cutoff = now - timedelta(days=policy["window_days"])
+    epoch = parse_time(policy["pr_contract_epoch"], "policy.pr_contract_epoch")
     cohort_sources = []
     unique_commits: set[str] = set()
     pr_runs: list[dict[str, Any]] = []
@@ -849,15 +924,22 @@ def collect(
     budget.preflight(conservative_estimate)
 
     jobs_cache: dict[tuple[int, int], tuple[dict[str, Any], dict[str, str]]] = {}
+    skip_reason_by_run: dict[int, str] = {}
+    aggregated_pr_runs: list[dict[str, Any]] = []
     for run in pr_runs:
-        resolve_pr_runtime(
+        reason = resolve_pr_runtime(
             client,
             repo,
             run,
             policy["max_jobs_per_attempt"],
             jobs_cache,
+            epoch=epoch,
         )
-        unique_commits.add(run["_runtime_merge_sha"])
+        if reason is not None:
+            skip_reason_by_run[run["id"]] = reason
+        else:
+            aggregated_pr_runs.append(run)
+            unique_commits.add(run["_runtime_merge_sha"])
 
     # All variable PR requests have completed. This exact second guard covers
     # every remaining tree, attempt metadata, and uncached jobs request.
@@ -873,7 +955,7 @@ def collect(
     trees = {commit: load_tree(client, repo, commit) for commit in sorted(unique_commits)}
 
     suite_blob_by_run: dict[int, str] = {}
-    for run in pr_runs:
+    for run in aggregated_pr_runs:
         suite_blob = trees[run["_runtime_merge_sha"]].get("ci/suites.json")
         if not suite_blob:
             raise MetricsError(f"run {run['id']} checkout tree lacks ci/suites.json")
@@ -884,7 +966,7 @@ def collect(
     suite_catalogs = {
         blob_sha: load_suite_catalog(client, repo, blob_sha) for blob_sha in sorted(suite_blob_shas)
     }
-    for run in pr_runs:
+    for run in aggregated_pr_runs:
         unknown = set(run["_selected_suites"]) - suite_catalogs[suite_blob_by_run[run["id"]]]
         if unknown:
             raise MetricsError(
@@ -894,8 +976,15 @@ def collect(
     cohort_reports = []
     for source in cohort_sources:
         cohort = source["definition"]
+        skipped_runs = [
+            {"run_id": run["id"], "reason": skip_reason_by_run[run["id"]]}
+            for run in source["runs"]
+            if run["id"] in skip_reason_by_run
+        ]
         normalized = []
         for run in source["runs"]:
+            if run["id"] in skip_reason_by_run:
+                continue
             digest, contract = contract_hash(run, cohort, trees, policy["derivation_version"])
             attempts = collect_attempts(
                 client,
@@ -913,6 +1002,8 @@ def collect(
                 "id": cohort["id"],
                 "eligible_count": source["eligible_count"],
                 "sampled_count": len(normalized),
+                "skipped_count": len(skipped_runs),
+                "skipped_runs": skipped_runs,
                 "invalid_count": 0,
                 "sample_cap": policy["sample_cap"],
                 "sampling_truncated_by_policy": source["sampling_truncated_by_policy"],

--- a/tests/unit/test_ci_health_metrics.py
+++ b/tests/unit/test_ci_health_metrics.py
@@ -1,5 +1,6 @@
 """Contracts for CI runner JSONL and bounded Actions health metrics."""
 
+import base64
 import importlib.util
 import json
 import subprocess
@@ -23,6 +24,9 @@ ci = _load("openace_ci_metrics_runner", ROOT / "scripts" / "ci.py")
 metrics = _load(
     "openace_github_actions_metrics", ROOT / "scripts" / "ci" / "github_actions_metrics.py"
 )
+
+# Merge time of 16fd75b0, the commit that introduced the "Select suites" job.
+EPOCH = datetime(2026, 8, 9, 12, 23, 45, tzinfo=timezone.utc)
 
 
 def _records(path):
@@ -545,7 +549,7 @@ def test_pr_runtime_contract_uses_merge_parent_not_current_payload_base():
     client = RuntimeClient(responses, logs)
     cache = {}
 
-    metrics.resolve_pr_runtime(client, repo, run, 100, cache)
+    metrics.resolve_pr_runtime(client, repo, run, 100, cache, epoch=EPOCH)
 
     assert run["_execution_base_sha"] == runtime_base
     assert run["_runtime_head_sha"] == head
@@ -562,7 +566,7 @@ def test_pr_runtime_accepts_empty_dynamic_payload():
     repo, run, responses, logs, runtime_base, head = _runtime_fixture(payload_link=False)
     client = RuntimeClient(responses, logs)
 
-    metrics.resolve_pr_runtime(client, repo, run, 100, {})
+    metrics.resolve_pr_runtime(client, repo, run, 100, {}, epoch=EPOCH)
 
     assert run["_execution_base_sha"] == runtime_base
     assert run["_runtime_head_sha"] == head
@@ -573,7 +577,7 @@ def test_pr_runtime_treats_payload_number_conflict_as_diagnostic_only():
     repo, run, responses, logs, runtime_base, head = _runtime_fixture()
     run["pull_requests"][0]["number"] = 9999
 
-    metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {})
+    metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {}, epoch=EPOCH)
 
     assert run["_execution_base_sha"] == runtime_base
     assert run["_runtime_head_sha"] == head
@@ -586,7 +590,7 @@ def test_pr_runtime_allows_selection_and_execution_base_to_diverge():
     selection_base = "7" * 40
     logs[next(iter(logs))] = logs[next(iter(logs))].replace(runtime_base, selection_base)
 
-    metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {})
+    metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {}, epoch=EPOCH)
 
     assert run["_execution_base_sha"] == runtime_base
     assert run["_selection_base_sha"] == selection_base
@@ -596,14 +600,428 @@ def test_pr_runtime_allows_selection_and_execution_base_to_diverge():
 def test_pr_runtime_rejects_merge_parent_mismatch():
     repo, run, responses, logs, _, _ = _runtime_fixture(bad_parents=True)
     with pytest.raises(metrics.MetricsError, match="parents do not match"):
-        metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {})
+        metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {}, epoch=EPOCH)
 
 
 def test_pr_runtime_rejects_ambiguous_log_evidence():
     repo, run, responses, logs, _, _ = _runtime_fixture()
     logs[next(iter(logs))] += f"git fetch origin +{'4' * 40}:refs/remotes/pull/2492/merge\n"
     with pytest.raises(metrics.MetricsError, match="log evidence is ambiguous"):
-        metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {})
+        metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {}, epoch=EPOCH)
+
+
+def _select_suites_job(job_id=78):
+    job = _job(
+        job_id,
+        "success",
+        "2026-08-11T00:00:00Z",
+        "2026-08-11T00:00:01Z",
+        "2026-08-11T00:00:02Z",
+    )
+    job["name"] = "Select suites"
+    return job
+
+
+def _legacy_job(job_id=79):
+    return _job(
+        job_id,
+        "success",
+        "2026-08-11T00:00:00Z",
+        "2026-08-11T00:00:01Z",
+        "2026-08-11T00:00:02Z",
+    )
+
+
+def _multi_attempt_fixture(
+    *,
+    created_at: str,
+    attempt1_jobs: list[dict] | None,
+    attempt2_jobs: list[dict] | None,
+    select_job: dict | None = None,
+):
+    """Two-attempt PR run with per-attempt job payloads for linkage tests."""
+    repo = "open-ace/open-ace"
+    run_id = 4242
+    head = "2" * 40
+    runtime_base = "1" * 40
+    merge = "3" * 40
+    if select_job is None:
+        select_job = _select_suites_job()
+    responses = {}
+    for number, jobs in ((1, attempt1_jobs), (2, attempt2_jobs)):
+        responses[f"/repos/{repo}/actions/runs/{run_id}/attempts/{number}/jobs?per_page=100"] = {
+            "total_count": len(jobs or []),
+            "jobs": jobs or [],
+        }
+    responses[f"/repos/{repo}/git/commits/{merge}"] = {
+        "sha": merge,
+        "parents": [{"sha": runtime_base}, {"sha": head}],
+    }
+    logs = {
+        f"/repos/{repo}/actions/jobs/{select_job['id']}/logs": (
+            f"git fetch origin +{merge}:refs/remotes/pull/2492/merge\n"
+            f"BASE_SHA: {runtime_base}\n"
+            "Selected suites: legacy-pr, python-core\n"
+        )
+    }
+    run = {
+        "id": run_id,
+        "run_attempt": 2,
+        "created_at": created_at,
+        "head_sha": head,
+        "pull_requests": [],
+    }
+    return repo, run, responses, logs, runtime_base, head
+
+
+def test_pr_runtime_links_from_first_attempt_with_select_suites():
+    # Incident shape: attempt 1 concluded action_required with zero jobs; the
+    # approved attempt 2 executed the workflow and holds the Select suites job.
+    select_job = _select_suites_job(78)
+    repo, run, responses, logs, runtime_base, head = _multi_attempt_fixture(
+        created_at="2026-08-11T00:00:00Z",
+        attempt1_jobs=None,
+        attempt2_jobs=[select_job],
+    )
+    client = RuntimeClient(responses, logs)
+
+    assert metrics.resolve_pr_runtime(client, repo, run, 100, {}, epoch=EPOCH) is None
+
+    assert run["_execution_base_sha"] == runtime_base
+    assert run["_pr_number"] == 2492
+    assert run["_selected_suites"] == ("legacy-pr", "python-core")
+
+
+def test_pr_runtime_uses_later_attempt_when_first_executed_predates_job():
+    # Pre-epoch run re-run after the contract landed: attempt 1 executed the
+    # old workflow (no Select suites job), attempt 2 has it.
+    select_job = _select_suites_job(78)
+    repo, run, responses, logs, _, _ = _multi_attempt_fixture(
+        created_at="2026-08-08T00:00:00Z",
+        attempt1_jobs=[_legacy_job(79)],
+        attempt2_jobs=[select_job],
+    )
+
+    assert (
+        metrics.resolve_pr_runtime(RuntimeClient(responses, logs), repo, run, 100, {}, epoch=EPOCH)
+        is None
+    )
+    assert run["_pr_number"] == 2492
+
+
+def test_post_epoch_run_without_select_suites_fails_closed():
+    _, run, responses, _, _, _ = _multi_attempt_fixture(
+        created_at="2026-08-11T00:00:00Z",
+        attempt1_jobs=[_legacy_job(79)],
+        attempt2_jobs=[_legacy_job(80)],
+    )
+    with pytest.raises(metrics.MetricsError, match="one Select suites job"):
+        metrics.resolve_pr_runtime(
+            RuntimeClient(responses, {}), "open-ace/open-ace", run, 100, {}, epoch=EPOCH
+        )
+
+
+def test_duplicate_select_suites_jobs_fail_closed():
+    _, run, responses, _, _, _ = _multi_attempt_fixture(
+        created_at="2026-08-11T00:00:00Z",
+        attempt1_jobs=[_select_suites_job(78), _select_suites_job(81)],
+        attempt2_jobs=None,
+    )
+    with pytest.raises(metrics.MetricsError, match="multiple Select suites jobs"):
+        metrics.resolve_pr_runtime(
+            RuntimeClient(responses, {}), "open-ace/open-ace", run, 100, {}, epoch=EPOCH
+        )
+
+
+def test_pre_epoch_run_without_select_suites_is_skipped():
+    _, run, responses, _, _, _ = _multi_attempt_fixture(
+        created_at="2026-08-08T00:00:00Z",
+        attempt1_jobs=[_legacy_job(79)],
+        attempt2_jobs=[_legacy_job(82)],
+    )
+    assert (
+        metrics.resolve_pr_runtime(
+            RuntimeClient(responses, {}), "open-ace/open-ace", run, 100, {}, epoch=EPOCH
+        )
+        == "pre_contract_epoch"
+    )
+    assert "_runtime_merge_sha" not in run
+
+
+def test_run_without_any_executed_attempt_is_skipped():
+    _, run, responses, _, _, _ = _multi_attempt_fixture(
+        created_at="2026-08-11T00:00:00Z",
+        attempt1_jobs=None,
+        attempt2_jobs=None,
+    )
+    assert (
+        metrics.resolve_pr_runtime(
+            RuntimeClient(responses, {}), "open-ace/open-ace", run, 100, {}, epoch=EPOCH
+        )
+        == "no_executed_attempt"
+    )
+    assert "_runtime_merge_sha" not in run
+
+
+FIXED_NOW = datetime(2026, 8, 27, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _e2e_policy(tmp_path):
+    policy = {
+        "version": 1,
+        "derivation_version": 1,
+        "window_days": 30,
+        "pr_contract_epoch": "2026-08-09T12:23:45Z",
+        "sample_cap": 25,
+        "min_samples": 20,
+        "max_collector_requests": 700,
+        "reserve_remaining": 250,
+        "max_jobs_per_attempt": 100,
+        "cohorts": [
+            {
+                "id": "ci-pull-request",
+                "workflow": "ci.yml",
+                "event": "pull_request",
+                "contract_paths": ["ci/suites.json"],
+            }
+        ],
+    }
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(policy), encoding="utf-8")
+    return path
+
+
+def _e2e_fixture(*, break_contract: bool):
+    """Full-flow API fixture: one aggregated PR run (+ one pre-epoch skip).
+
+    With break_contract=True the aggregated run becomes post-epoch without a
+    Select suites job, so collection must fail closed.
+    """
+    repo = "open-ace/open-ace"
+    head = "2" * 40
+    runtime_base = "1" * 40
+    merge = "3" * 40
+    blob = "b" * 40
+    cutoff = (FIXED_NOW - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    select_job = _job(
+        90,
+        "success",
+        "2026-08-26T09:41:31Z",
+        "2026-08-26T09:41:32Z",
+        "2026-08-26T09:41:33Z",
+    )
+    select_job["name"] = "Select suites"
+    legacy_job = dict(
+        _job(
+            91,
+            "success",
+            "2026-08-08T01:00:00Z",
+            "2026-08-08T01:00:01Z",
+            "2026-08-08T01:00:02Z",
+        )
+    )
+    aggregated_jobs = [legacy_job] if break_contract else [select_job]
+    runs = [
+        {
+            "id": 501,
+            "run_attempt": 1,
+            "event": "pull_request",
+            "status": "completed",
+            "created_at": "2026-08-26T09:41:30Z",
+            "head_sha": head,
+            "html_url": f"https://github.com/{repo}/actions/runs/501",
+            "pull_requests": [],
+        },
+        {
+            "id": 502,
+            "run_attempt": 1,
+            "event": "pull_request",
+            "status": "completed",
+            "created_at": "2026-08-08T00:00:00Z",
+            "head_sha": "5" * 40,
+            "html_url": f"https://github.com/{repo}/actions/runs/502",
+            "pull_requests": [],
+        },
+    ]
+    suites_document = {
+        "suites": {"legacy-pr": {"description": "x"}, "python-core": {"description": "y"}}
+    }
+    responses = [
+        {"path": "/rate_limit", "json": {"resources": {"core": {"remaining": 5000}}}},
+        {
+            "path": f"/repos/{repo}/actions/workflows/ci.yml/runs",
+            "params": {
+                "event": "pull_request",
+                "status": "completed",
+                "per_page": 25,
+                "created": f">={cutoff}",
+            },
+            "json": {"total_count": 2, "workflow_runs": runs},
+        },
+    ]
+    for status in ("in_progress", "queued"):
+        responses.append(
+            {
+                "path": f"/repos/{repo}/actions/workflows/ci.yml/runs",
+                "params": {
+                    "event": "pull_request",
+                    "status": status,
+                    "per_page": 1,
+                    "created": f">={cutoff}",
+                },
+                "json": {"total_count": 0, "workflow_runs": []},
+            }
+        )
+    responses.append(
+        {
+            "path": f"/repos/{repo}/actions/runs/501/attempts/1/jobs",
+            "params": {"per_page": 100},
+            "json": {"total_count": len(aggregated_jobs), "jobs": aggregated_jobs},
+        }
+    )
+    responses.append(
+        {
+            "path": f"/repos/{repo}/actions/runs/502/attempts/1/jobs",
+            "params": {"per_page": 100},
+            "json": {"total_count": 1, "jobs": [dict(legacy_job, id=92)]},
+        }
+    )
+    if not break_contract:
+        responses.extend(
+            [
+                {
+                    "path": f"/repos/{repo}/actions/jobs/{select_job['id']}/logs",
+                    "text": (
+                        f"git fetch origin +{merge}:refs/remotes/pull/2492/merge\n"
+                        f"BASE_SHA: {runtime_base}\n"
+                        "Selected suites: legacy-pr, python-core\n"
+                    ),
+                },
+                {
+                    "path": f"/repos/{repo}/git/commits/{merge}",
+                    "json": {
+                        "sha": merge,
+                        "parents": [{"sha": runtime_base}, {"sha": head}],
+                    },
+                },
+                {
+                    "path": f"/repos/{repo}/git/trees/{merge}",
+                    "params": {"recursive": "1"},
+                    "json": {
+                        "truncated": False,
+                        "tree": [{"path": "ci/suites.json", "type": "blob", "sha": blob}],
+                    },
+                },
+                {
+                    "path": f"/repos/{repo}/git/blobs/{blob}",
+                    "json": {
+                        "sha": blob,
+                        "encoding": "base64",
+                        "content": base64.b64encode(json.dumps(suites_document).encode()).decode(),
+                    },
+                },
+                {
+                    "path": f"/repos/{repo}/actions/runs/501/attempts/1",
+                    "json": _attempt_meta(
+                        1,
+                        "success",
+                        "2026-08-26T09:41:30Z",
+                        "2026-08-26T09:41:30Z",
+                        "2026-08-26T09:41:40Z",
+                    ),
+                },
+            ]
+        )
+    return {"responses": responses}
+
+
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return FIXED_NOW if tz is not None else FIXED_NOW.replace(tzinfo=None)
+
+
+def test_collect_end_to_end_records_pre_epoch_skip_and_writes_reports(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(metrics, "datetime", _FrozenDateTime)
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps(_e2e_fixture(break_contract=False)), encoding="utf-8")
+    out_json = tmp_path / "report.json"
+    out_md = tmp_path / "report.md"
+
+    rc = metrics.main(
+        [
+            "--repo",
+            "open-ace/open-ace",
+            "--policy",
+            str(_e2e_policy(tmp_path)),
+            "--input",
+            str(fixture),
+            "--output-json",
+            str(out_json),
+            "--output-markdown",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    cohort = report["cohorts"][0]
+    assert cohort["sampled_count"] == 1
+    assert cohort["skipped_count"] == 1
+    assert cohort["skipped_runs"] == [{"run_id": 502, "reason": "pre_contract_epoch"}]
+    assert [run["run_id"] for run in cohort["runs"]] == [501]
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "Out-of-contract runs skipped (ci-pull-request): pre_contract_epoch=1" in markdown
+
+
+def test_collect_end_to_end_contract_break_fails_closed_without_reports(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(metrics, "datetime", _FrozenDateTime)
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps(_e2e_fixture(break_contract=True)), encoding="utf-8")
+    out_json = tmp_path / "report.json"
+    out_md = tmp_path / "report.md"
+
+    rc = metrics.main(
+        [
+            "--repo",
+            "open-ace/open-ace",
+            "--policy",
+            str(_e2e_policy(tmp_path)),
+            "--input",
+            str(fixture),
+            "--output-json",
+            str(out_json),
+            "--output-markdown",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 1
+    assert "CI METRICS ERROR" in capsys.readouterr().err
+    assert not out_json.exists()
+    assert not out_md.exists()
+
+
+def test_policy_epoch_field_is_required_and_parseable(tmp_path):
+    live = metrics.load_policy(ROOT / "ci" / "ci-health-policy.json")
+    assert metrics.parse_time(live["pr_contract_epoch"], "epoch") == EPOCH
+
+    missing = dict(live)
+    del missing["pr_contract_epoch"]
+    path = tmp_path / "missing.json"
+    path.write_text(json.dumps(missing), encoding="utf-8")
+    with pytest.raises(metrics.MetricsError, match="invalid CI health policy"):
+        metrics.load_policy(path)
+
+    unparseable = dict(live, pr_contract_epoch="not-a-timestamp")
+    path = tmp_path / "unparseable.json"
+    path.write_text(json.dumps(unparseable), encoding="utf-8")
+    with pytest.raises(metrics.MetricsError, match="policy.pr_contract_epoch"):
+        metrics.load_policy(path)
 
 
 def test_attempts_keep_first_failure_and_retry_recovery_separate():
@@ -701,8 +1119,11 @@ def test_attempts_keep_first_failure_and_retry_recovery_separate():
     assert aggregate["eventual_conclusions"]["failure"] == 0
     assert aggregate["retry_recovery_count"] == 1
     assert aggregate["inherited_job_snapshot_count"] == 2
+    # The attempt-1 skipped job never executed: no queue sample, counted in
+    # skipped_job_no_execution_count instead.
+    assert aggregate["skipped_job_no_execution_count"] == 1
     assert aggregate["workflow_queue"]["count"] == 2
-    assert aggregate["job_queue"]["count"] == 4
+    assert aggregate["job_queue"]["count"] == 3
     assert attempts[1]["jobs"][1]["inherited_from_job_id"] == 3
     assert attempts[1]["jobs"][2]["inherited_from_job_id"] == 4
 
@@ -926,3 +1347,48 @@ def test_conclusion_schema_has_stable_zero_values_for_cancel_skip_and_neutral():
         "stale": 0,
         "startup_failure": 0,
     }
+
+
+def test_skipped_job_evaluation_quirk_has_no_queue_or_execution():
+    # GitHub gives skipped-job timestamps no ordering guarantees (observed
+    # live: run 31827030734 job 94853500968 — created/started 18:05:39Z,
+    # completed 18:05:30Z, i.e. completion before both start and creation).
+    # Such jobs never executed: timing must be None instead of failing the
+    # whole collection on impossible orderings.
+    repo = "open-ace/open-ace"
+    run_id = 31827030734
+    base = f"/repos/{repo}/actions/runs/{run_id}/attempts"
+    skipped = _job(
+        94853500968,
+        "skipped",
+        "2026-08-14T18:05:39Z",  # created (evaluation time)
+        "2026-08-14T18:05:39Z",  # started
+        "2026-08-14T18:05:30Z",  # completed 9s before created/started
+    )
+    responses = {
+        f"{base}/1": _attempt_meta(
+            1, "success", "2026-08-14T18:05:30Z", "2026-08-14T18:05:30Z", "2026-08-14T18:06:00Z"
+        ),
+        f"{base}/1/jobs?per_page=100": {"total_count": 1, "jobs": [skipped]},
+    }
+    run = {"id": run_id, "run_attempt": 1}
+    attempts = metrics.collect_attempts(AttemptClient(responses), repo, run, 100)
+    job = attempts[0]["jobs"][0]
+    assert job["conclusion"] == "skipped"
+    assert job["timing_state"] == "skipped_evaluation"
+    assert job["queue"] is None and job["execution"] is None
+    contract = metrics.aggregate_contract(
+        [
+            {
+                "first_conclusion": "success",
+                "eventual_conclusion": "success",
+                "recovered_on_retry": False,
+                "first_attempt_wall": {"seconds": 30.0},
+                "eventual_resolution": {"seconds": 30.0},
+                "attempts": attempts,
+            }
+        ],
+        min_samples=20,
+    )
+    assert contract["skipped_job_no_execution_count"] == 1
+    assert contract["job_queue"]["count"] == 0

--- a/tests/unit/test_scheduled_workflow_contracts.py
+++ b/tests/unit/test_scheduled_workflow_contracts.py
@@ -71,3 +71,21 @@ def test_nightly_suite_metrics_have_independent_90_day_artifact():
     assert upload["if"] == "always()"
     assert upload["with"]["if-no-files-found"] == "error"
     assert upload["with"]["retention-days"] == "90"
+
+
+def test_ci_health_metrics_collector_failure_cannot_be_swallowed():
+    workflow = PROJECT_ROOT / ".github" / "workflows" / "ci-health-metrics.yml"
+    data = yaml.load(workflow.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = data["jobs"]["collect"]["steps"]
+
+    collect = next(step for step in steps if step.get("name") == "Collect bounded Actions history")
+    # Without pipefail the `... | tee collector.log` pipeline masks the
+    # collector's exit code and the scheduled run reports fake green (#2493).
+    assert "set -euo pipefail" in collect["run"]
+    assert "tee test-results/ci-health/collector.log" in collect["run"]
+
+    publish = next(step for step in steps if step.get("name") == "Publish CI health summary")
+    assert publish["if"] == "always()"
+    assert "test-results/ci-health/report.md" in publish["run"]
+    assert "test-results/ci-health/report.json" in publish["run"]
+    assert "exit 1" in publish["run"]


### PR DESCRIPTION
Closes #2493. Ref: #2429 (P1 item 3).

## Root cause (two stacked defects)
1. **Classification**: `resolve_pr_runtime()` only inspected attempt 1. Runs awaiting manual approval conclude attempt 1 `action_required` with **zero jobs** (observed: run 32954342980 — approved attempt 2 ran 13 jobs incl. the single `Select suites`); and the 30-day sampling window predates the `Select suites` job entirely for early-window runs (introduced by 16fd75b0, 2026-08-09). Both shapes raised `MetricsError`.
2. **Fake green**: the workflow piped the collector through `tee` without pipefail (`bash -e` keeps tee's exit 0), and the `if: always()` publish/upload steps completed with only `collector.log` — green run, no reports (scheduled run 33035924482).

## Change
**`scripts/ci/github_actions_metrics.py`**
- Linkage uses the first attempt holding **exactly one** `Select suites` job (jobs cached, request budget math unchanged — verified by review and live run: 313/700).
- Explicit out-of-contract classes recorded in cohort `skipped_runs` (never a collection error): `no_executed_attempt` (all attempts jobless, e.g. never-approved), `pre_contract_epoch` (created before policy `pr_contract_epoch` and no Select suites job in any executed attempt). Post-epoch runs with executed attempts but no single Select suites job **still fail closed**; ≥2 Select suites jobs in any attempt also fails closed.
- Skipped runs excluded from `unique_commits`/suite-blob/contract loops (no KeyError); cohort report + report.md render skip counts/reasons.
- `load_policy` requires and parses the new `pr_contract_epoch`; `ci/ci-health-policy.json` sets it to the 16fd75b0 merge time.
- **Latent crash fixed** (exposed by the first successful live pass): GitHub gives skipped-job timestamps no ordering guarantees — run 31827030734 job 94853500968 completed 9s *before* its own creation. Skipped jobs normalize as `timing_state=skipped_evaluation` with null queue/execution (`skipped_job_no_execution_count` aggregate) and remain valid canonical origins for inherited snapshots.

**`.github/workflows/ci-health-metrics.yml`**
- Collect step: `set -euo pipefail` (tee can no longer swallow the exit code).
- Publish step: exits 1 when `report.md` OR `report.json` is missing; upload stays `always()` so failure evidence still lands.

**Tests** (59 passing): linkage-from-attempt-2, mixed pre-epoch attempt usage, post-epoch fail-closed, duplicate-job fail-closed, both skip classes, end-to-end FixtureClient success (skip recorded, reports written) and contract-break failure (exit 1, no reports), policy epoch required/parseable, live-shape skipped-job quirk, workflow pipefail/publish contracts.

## Live local-equivalent evidence (same command as CI)
`GITHUB_TOKEN=… python scripts/ci/github_actions_metrics.py --repo open-ace/open-ace …` → **exit 0**, `report.json` + `report.md` written, 313/700 requests, all four cohorts sampled (25/25/21/2), previously-fatal runs 32954342980 (attempt-2 linkage) and 31827030734 (skipped-job quirk) both collected.

Plan rev2 (folded all 5 review objections: 1 HIGH exclusion loops, linkage-rule tightening, parse_time epoch, atomic policy coupling, markdown rendering): #2493 comment 5448214883.

## Acceptance follow-through (post-merge)
- [ ] Default-branch `workflow_dispatch` run green with report.json + report.md + collector.log artifacts.
- [ ] Next scheduled run (06:18 SGT) same evidence, backfilled to #2493.