### PR TITLE
fix(ci): build the production docker stage and satisfy its entrypoint contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,10 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: .
+          # Issue #3169: build the web (production) image — without an
+          # explicit target Docker builds the LAST stage (migration), whose
+          # entrypoint ignores the command and execs server.py.
+          target: production
           push: false
           # Issue #3169: load the image into the local Docker engine — the
           # verify/size steps below run `docker run`/`docker images` against
@@ -437,7 +441,13 @@ jobs:
       - name: Verify code-server installation
         run: |
           echo "=== Verifying code-server installation (Issue #2238) ==="
-          docker run --rm open-ace:${{ github.sha }} bash /app/scripts/verify-code-server.sh
+          # The production image is FLASK_ENV=production, so its entrypoint's
+          # fail-closed security-mode validation (docker-entrypoint.sh) needs
+          # an explicit OPENACE_SECURITY_MODE even for one-shot verification
+          # commands; development fits a verify-only container that never
+          # starts the application.
+          docker run --rm -e OPENACE_SECURITY_MODE=development \
+            open-ace:${{ github.sha }} bash /app/scripts/verify-code-server.sh
       - name: Check image size
         run: |
           echo "=== Checking Docker image size ==="

--- a/tests/unit/test_ci_docker_job_contract.py
+++ b/tests/unit/test_ci_docker_job_contract.py
@@ -60,9 +60,17 @@ def test_local_tag_consumers_require_the_build_step_to_load_the_image():
         "built tag via docker run/docker images (image must exist locally)"
     )
     assert build["with"].get("push") is False
+    # Without an explicit target Docker builds the LAST stage (migration),
+    # whose entrypoint ignores the command and execs server.py — the image
+    # verified here must be the web image.
+    assert build["with"].get("target") == "production"
 
     verify = next(step for step in steps if step.get("name") == "Verify code-server installation")
     assert TAG_PATTERN.search(verify["run"]) and "docker run" in verify["run"]
+    # The production image is production-capable (FLASK_ENV=production), so
+    # its entrypoint's fail-closed security-mode validation rejects one-shot
+    # commands without an explicit OPENACE_SECURITY_MODE.
+    assert "-e OPENACE_SECURITY_MODE=" in verify["run"]
     size = next(step for step in steps if step.get("name") == "Check image size")
     assert TAG_PATTERN.search(size["run"]) and "docker images" in size["run"]
     assert "GITHUB_STEP_SUMMARY" in size["run"]


### PR DESCRIPTION
Continues #3169 (batch 2). Ref: #2429 (P1 item 2).

## What batch 1 (PR #3172) exposed
After `load: true` the verify step finally executed the container at merge SHA `a26cf9da` (run 33142275406) — and immediately surfaced the defects the missing image had been masking:
1. **Wrong stage**: no `target:` on `docker/build-push-action` → Docker builds the LAST Dockerfile stage = `migration`, whose `/entrypoint.sh` ignores the command entirely and `exec python server.py` (log proof: no docker-entrypoint.sh banners, direct server.py traceback).
2. **Fail-closed entrypoint contract**: `docker-entrypoint.sh` runs `validate_security_mode` (top-level, line 276) before the custom-command dispatch; the production image bakes `FLASK_ENV=production` → production-capable → a one-shot `docker run … bash verify.sh` is rejected without explicit `OPENACE_SECURITY_MODE`.

## Change
- Build step: `target: production` (the web image this job exists to verify; migration/development stages remain available via explicit `--target`).
- Verify step: `docker run --rm -e OPENACE_SECURITY_MODE=development …` — verification-only container, never starts the app; explicit mode passes the entrypoint's validation, then the command dispatch execs the script.
- Contract test extended: local consumers of the built tag require `target: production` AND the verify `docker run` must carry `-e OPENACE_SECURITY_MODE=`.

## Evidence
- Contract tests: 2 passed locally (now pinning both layers).
- Batch-1 merge + failing-run analysis: #3169 comment 5448570696.

## Acceptance follow-through (post-merge)
- [ ] Real main push run at the exact merge SHA: `docker` job success with code-server verification + size summary (backfilled to #3169).