### PR TITLE
fix(docker): pre-create /app/logs for the non-root entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -293,7 +293,14 @@ RUN chmod 755 /usr/local/bin/openace-chown /usr/local/bin/openace-useradd \
                     /usr/local/bin/openace-git /usr/local/bin/openace-gh \
                     /etc/openace/git-wrapper.json /etc/openace/gh-wrapper.json && \
     chmod 0644 /etc/openace/git-wrapper.json /etc/openace/gh-wrapper.json && \
-    mkdir -p /var/lock && chmod 1777 /var/lock
+    mkdir -p /var/lock && chmod 1777 /var/lock && \
+    mkdir -p /app/logs && chown open-ace:open-ace /app/logs
+
+# /app itself stays root-owned (WORKDIR creates it before USER switching, and
+# COPY --chown only affects copied contents), while docker-entrypoint.sh's
+# `mkdir -p /app/logs` (Issue #1205) runs as uid 1000 before the command
+# dispatch. CI build contexts never contain a gitignored logs/ directory, so
+# the image must pre-create it open-ace-owned or every non-root boot fails.
 
 # NOTE: The image defaults to the non-root open-ace user (uid 1000) so that
 # `docker run`, docker-compose, and Kubernetes all execute the entrypoint as

--- a/tests/unit/test_ci_docker_job_contract.py
+++ b/tests/unit/test_ci_docker_job_contract.py
@@ -74,3 +74,13 @@ def test_local_tag_consumers_require_the_build_step_to_load_the_image():
     size = next(step for step in steps if step.get("name") == "Check image size")
     assert TAG_PATTERN.search(size["run"]) and "docker images" in size["run"]
     assert "GITHUB_STEP_SUMMARY" in size["run"]
+
+
+def test_production_image_precreates_logs_dir_for_non_root_entrypoint():
+    # docker-entrypoint.sh runs `mkdir -p /app/logs` (Issue #1205) as uid 1000
+    # before dispatching one-shot commands, /app itself is root-owned, and the
+    # gitignored logs/ directory never ships in CI build contexts — the image
+    # must therefore pre-create it with open-ace ownership.
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    production = dockerfile.split("FROM production AS development")[0]
+    assert "mkdir -p /app/logs && chown open-ace:open-ace /app/logs" in production


### PR DESCRIPTION
Continues #3169 (batch 3). Ref: #2429 (P1 item 2).

## What batch 2 (PR #3178, merged `b5c91734`) exposed
At SHA `ade61955` (run 33144225009) the verify container now runs the real production entrypoint: security-mode validation passes (banners + `Configuration OK` in the log), then the top-level `mkdir -p /app/logs` (docker-entrypoint.sh:553, Issue #1205) fails with `Permission denied` — uid 1000 cannot create a directory inside `/app`, which is root-owned (`WORKDIR /app` precedes `USER 1000`; `COPY --chown` only affects copied contents), and the gitignored `logs/` directory never ships in CI build contexts. Every non-root boot of a clean-context build hits this — a latent image bug the previously-unreachable verify step had been masking.

## Change
- `Dockerfile` production stage: `mkdir -p /app/logs && chown open-ace:open-ace /app/logs` (with an explanatory comment).
- `tests/unit/test_ci_docker_job_contract.py`: pins the production stage's pre-created, open-ace-owned logs dir (3 tests total, all green locally).

## Acceptance follow-through (post-merge)
- [ ] Real main push run at the exact merge SHA: `docker` job success with code-server verification + size summary (backfilled to #3169).