### PR TITLE
fix(e2e): align R1 server-premise tests with the runner's BASE_URL contract

### DIFF
--- a/ci/e2e-inventory.json
+++ b/ci/e2e-inventory.json
@@ -3210,19 +3210,19 @@
     },
     {
       "path": "tests/e2e/terminal/test_terminal_demo.py",
-      "mode": "pytest-automated",
+      "mode": "standalone-automated",
       "owner": "issue-394",
       "issue": 394,
       "home_lane": "nightly",
-      "executor": "pytest",
+      "executor": "standalone",
       "capabilities": [
         "browser",
         "server"
       ],
       "timeout_seconds": 240,
       "cadence": "nightly",
-      "collects": true,
-      "notes": "migrated from tests/issues/394 (#2429 batch 17)"
+      "collects": false,
+      "notes": "test_terminal skips in pytest lane by design (needs live machine_id fixture); executed standalone via main() - #2491 R1"
     },
     {
       "path": "tests/e2e/ui/check_custom_dropdown.py",

--- a/tests/e2e/ui/test_background_permission.py
+++ b/tests/e2e/ui/test_background_permission.py
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -105,7 +105,7 @@ def check_tab_notification(page, tab_index):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -128,7 +128,7 @@ def test_background_permission_notification():
         try:
             # Login
             print("\n[1] 登录...")
-            page.goto(f"{BASE_URL}/login")
+            page.goto(f"{BASE_URL}login")
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -137,7 +137,7 @@ def test_background_permission_notification():
 
             # Navigate to workspace
             print("\n[2] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace")
+            page.goto(f"{BASE_URL}work/workspace")
             page.wait_for_load_state("networkidle")
             page.wait_for_timeout(5000)
 

--- a/tests/e2e/ui/test_chat_restore.py
+++ b/tests/e2e/ui/test_chat_restore.py
@@ -30,7 +30,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(70)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -80,7 +80,7 @@ def restart_service():
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -119,7 +119,7 @@ def test_chat_restore():
         try:
             # Step 1: Login
             print("\n[1] 登录系统...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -129,7 +129,7 @@ def test_chat_restore():
 
             # Step 2: Navigate to workspace
             print("\n[2] 导航到工作区...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=30000)
             page.wait_for_timeout(5000)
             page.screenshot(path=f"{OUTPUT_DIR}/test_02_workspace.png")

--- a/tests/e2e/ui/test_conversation_history_no_id_column.py
+++ b/tests/e2e/ui/test_conversation_history_no_id_column.py
@@ -15,7 +15,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(29)]
 
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"
@@ -23,7 +23,7 @@ SCREENSHOT_DIR = "screenshots"
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -152,8 +152,8 @@ async def test_issue29():
                 results.append(("验证列选择器中无 Conversation ID", True, ""))
 
         except PlaywrightError as e:
-            print(f"   ✗ 测试出错: {str(e)}")
-            results.append(("测试执行", False, str(e)))
+            print(f"   ✗ 测试出错: {e.__class__.__name__}: {e}")
+            results.append(("测试执行", False, f"{e.__class__.__name__}: {e}"))
             await page.screenshot(
                 path=f"{SCREENSHOT_DIR}/issue29_error_{timestamp}.png", full_page=True
             )
@@ -179,7 +179,6 @@ async def test_issue29():
         print("=" * 60)
 
         assert failed == 0, (
-            f"{failed} issue-29 check(s) failed: "
-            f"{[name for name, success, _ in results if not success]}"
+            f"{failed} issue-29 check(s) failed: " f"{[r for r in results if not r[1]]}"
         )
         return failed == 0

--- a/tests/e2e/ui/test_conversation_history_page_size.py
+++ b/tests/e2e/ui/test_conversation_history_page_size.py
@@ -21,7 +21,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(38)]
 
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"
@@ -29,7 +29,7 @@ SCREENSHOT_DIR = "screenshots"
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -198,8 +198,8 @@ async def test_issue38():
             print("\n   ✓ Issue #38 测试通过！Page Size 功能正常工作")
 
         except PlaywrightError as e:
-            print(f"   ✗ 测试出错: {str(e)}")
-            results.append(("测试执行", False, str(e)))
+            print(f"   ✗ 测试出错: {e.__class__.__name__}: {e}")
+            results.append(("测试执行", False, f"{e.__class__.__name__}: {e}"))
             await page.screenshot(
                 path=f"{SCREENSHOT_DIR}/issue38_error_{timestamp}.png", full_page=True
             )
@@ -224,8 +224,5 @@ async def test_issue38():
 
     print("=" * 60)
 
-    assert failed == 0, (
-        f"{failed} issue-38 check(s) failed: "
-        f"{[name for name, success, _ in results if not success]}"
-    )
+    assert failed == 0, f"{failed} issue-38 check(s) failed: " f"{[r for r in results if not r[1]]}"
     return failed == 0

--- a/tests/e2e/ui/test_conversation_history_sort.py
+++ b/tests/e2e/ui/test_conversation_history_sort.py
@@ -25,7 +25,7 @@ from playwright.async_api import async_playwright
 pytestmark = [pytest.mark.regression, pytest.mark.issue(34)]
 
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"
@@ -56,7 +56,7 @@ def print_test_report(results):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -335,14 +335,12 @@ async def test_issue34():
             results.append(("其他列排序测试", True, ""))
 
         except PlaywrightError as e:
-            results.append(("测试执行", False, str(e)))
+            results.append(("测试执行", False, f"{e.__class__.__name__}: {e}"))
             await page.screenshot(path=f"{SCREENSHOT_DIR}/issue34_error_{timestamp}.png")
         finally:
             await browser.close()
 
     # 打印报告
     success = print_test_report(results)
-    assert success, (
-        f"issue-34 sort check(s) failed: " f"{[name for name, ok, _ in results if not ok]}"
-    )
+    assert success, f"issue-34 sort check(s) failed: " f"{[r for r in results if not r[1]]}"
     return success

--- a/tests/e2e/ui/test_conversation_history_ui.py
+++ b/tests/e2e/ui/test_conversation_history_ui.py
@@ -25,7 +25,7 @@ from playwright.sync_api import expect, sync_playwright
 pytestmark = [pytest.mark.regression, pytest.mark.issue(94)]
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -43,7 +43,7 @@ os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -62,7 +62,7 @@ async def test_conversation_history_ui():
         try:
             # Step 1: Navigate to login page
             print("Step 1: Navigate to login page...")
-            await page.goto(BASE_URL + "login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
             time.sleep(1)
 
@@ -242,7 +242,7 @@ def test_conversation_history_ui_sync():
         try:
             # Step 1: Navigate to login page
             print("Step 1: Navigate to login page...")
-            page.goto(BASE_URL + "login")
+            page.goto(f"{BASE_URL}login")
             page.wait_for_load_state("networkidle")
             time.sleep(1)
 

--- a/tests/e2e/ui/test_conversation_timeline_display.py
+++ b/tests/e2e/ui/test_conversation_timeline_display.py
@@ -15,7 +15,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(32)]
 
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"
@@ -23,7 +23,7 @@ SCREENSHOT_DIR = "screenshots"
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -237,8 +237,8 @@ async def test_issue32():
             print("   ✓ 详细截图已保存")
 
         except PlaywrightError as e:
-            print(f"   ✗ 测试出错: {str(e)}")
-            results.append(("测试执行", False, str(e)))
+            print(f"   ✗ 测试出错: {e.__class__.__name__}: {e}")
+            results.append(("测试执行", False, f"{e.__class__.__name__}: {e}"))
             await page.screenshot(
                 path=f"{SCREENSHOT_DIR}/issue32_error_{timestamp}.png", full_page=True
             )
@@ -264,7 +264,6 @@ async def test_issue32():
         print("=" * 60)
 
         assert failed == 0, (
-            f"{failed} issue-32 check(s) failed: "
-            f"{[name for name, success, _ in results if not success]}"
+            f"{failed} issue-32 check(s) failed: " f"{[r for r in results if not r[1]]}"
         )
         return failed == 0

--- a/tests/e2e/ui/test_cross_tab_message.py
+++ b/tests/e2e/ui/test_cross_tab_message.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -165,7 +165,7 @@ def select_project(chat_frame, page):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -193,7 +193,7 @@ def test_cross_tab_message_isolation():
         try:
             # ========== 初始化 ==========
             print("\n[初始化] 登录...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -201,7 +201,7 @@ def test_cross_tab_message_isolation():
             print("    ✓ 登录成功")
 
             print("\n[初始化] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=60000)
             page.wait_for_timeout(8000)
 

--- a/tests/e2e/ui/test_data_status_local.py
+++ b/tests/e2e/ui/test_data_status_local.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(73)]
 
 
 # Configuration
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "73")
@@ -44,7 +44,7 @@ async def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -64,12 +64,12 @@ async def test_data_status_local():
 
         try:
             # Login first
-            await page.goto(f"{BASE_URL}/login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
             await page.fill("#username", USERNAME)
             await page.fill("#password", PASSWORD)
             await page.click("#login-btn")
-            await page.wait_for_url(f"{BASE_URL}/", timeout=10000)
+            await page.wait_for_url(f"{BASE_URL}", timeout=10000)
             await page.wait_for_load_state("networkidle")
 
             # Wait for data status to load

--- a/tests/e2e/ui/test_data_status_simplified.py
+++ b/tests/e2e/ui/test_data_status_simplified.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(74)]
 
 
 # Configuration
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "74")
@@ -44,7 +44,7 @@ async def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -64,12 +64,12 @@ async def test_data_status_simplified():
 
         try:
             # Login first
-            await page.goto(f"{BASE_URL}/login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
             await page.fill("#username", USERNAME)
             await page.fill("#password", PASSWORD)
             await page.click("#login-btn")
-            await page.wait_for_url(f"{BASE_URL}/", timeout=10000)
+            await page.wait_for_url(f"{BASE_URL}", timeout=10000)
             await page.wait_for_load_state("networkidle")
 
             # Wait for data status to load

--- a/tests/e2e/ui/test_global_refresh.py
+++ b/tests/e2e/ui/test_global_refresh.py
@@ -8,6 +8,7 @@ Test script for Issue #98: 全局 refresh 和 auto-refresh 功能
 """
 
 import asyncio
+import os
 
 import pytest
 import requests
@@ -17,12 +18,12 @@ from playwright.async_api import async_playwright
 pytestmark = [pytest.mark.regression, pytest.mark.issue(98)]
 
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -39,7 +40,7 @@ async def test_global_refresh():
         try:
             # Step 1: Navigate to login page
             print("\n[Step 1] Navigating to login page...")
-            await page.goto(f"{BASE_URL}/login", wait_until="networkidle", timeout=30000)
+            await page.goto(f"{BASE_URL}login", wait_until="networkidle", timeout=30000)
             await page.wait_for_timeout(1000)
 
             # Step 2: Login
@@ -54,7 +55,7 @@ async def test_global_refresh():
             print("\n[Step 3] Checking Work mode (should NOT have refresh controls)...")
 
             # Navigate to work mode
-            await page.goto(f"{BASE_URL}/work", wait_until="networkidle", timeout=30000)
+            await page.goto(f"{BASE_URL}work", wait_until="networkidle", timeout=30000)
             await page.wait_for_timeout(2000)
 
             # Wait for header to be visible
@@ -88,7 +89,7 @@ async def test_global_refresh():
             print("\n[Step 4] Checking Manage mode (should have refresh controls on left)...")
 
             # Navigate to manage mode
-            await page.goto(f"{BASE_URL}/manage/dashboard", wait_until="networkidle", timeout=30000)
+            await page.goto(f"{BASE_URL}manage/dashboard", wait_until="networkidle", timeout=30000)
             await page.wait_for_timeout(2000)
 
             # Wait for header to be visible

--- a/tests/e2e/ui/test_keyboard_in_input.py
+++ b/tests/e2e/ui/test_keyboard_in_input.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(68)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -97,7 +97,7 @@ def select_project(chat_frame, page):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -129,7 +129,7 @@ def test_keyboard_shortcut_in_input():
         try:
             # ========== 初始化 ==========
             print("\n[初始化] 登录...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -137,7 +137,7 @@ def test_keyboard_shortcut_in_input():
             print("    ✓ 登录成功")
 
             print("\n[初始化] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=60000)
             page.wait_for_timeout(8000)
 

--- a/tests/e2e/ui/test_keyboard_shortcut_chat.py
+++ b/tests/e2e/ui/test_keyboard_shortcut_chat.py
@@ -29,7 +29,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(68)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -110,7 +110,7 @@ def select_project_and_enter_chat(chat_frame, page, project_name="open ace"):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -142,7 +142,7 @@ def test_keyboard_shortcut_in_chat():
         try:
             # ========== Step 1: 登录 ==========
             print("\n[Step 1] 登录...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -152,7 +152,7 @@ def test_keyboard_shortcut_in_chat():
 
             # ========== Step 2: 导航到 Workspace ==========
             print("\n[Step 2] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=60000)
             page.wait_for_timeout(5000)
             print("    ✓ Workspace 加载完成")

--- a/tests/e2e/ui/test_language_selector.py
+++ b/tests/e2e/ui/test_language_selector.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(75)]
 
 
 # Configuration
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "75")
@@ -43,7 +43,7 @@ async def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -63,12 +63,12 @@ async def test_language_selector():
 
         try:
             # Login first
-            await page.goto(f"{BASE_URL}/login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
             await page.fill("#username", USERNAME)
             await page.fill("#password", PASSWORD)
             await page.click("#login-btn")
-            await page.wait_for_url(f"{BASE_URL}/", timeout=10000)
+            await page.wait_for_url(f"{BASE_URL}", timeout=10000)
             await page.wait_for_load_state("networkidle")
 
             # Take screenshot

--- a/tests/e2e/ui/test_login_button.py
+++ b/tests/e2e/ui/test_login_button.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(78)]
 
 
 # Configuration
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "78")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
@@ -41,7 +41,7 @@ async def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -61,7 +61,7 @@ async def test_login_button():
 
         try:
             # Navigate to login page
-            await page.goto(f"{BASE_URL}/login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
 
             # Take screenshot of login page
@@ -69,16 +69,18 @@ async def test_login_button():
             print(f"  Screenshot: {screenshot_path}")
 
             # Check Sign In button exists and is visible
-            login_btn = await page.locator("#login-btn")
-            expect(login_btn).to_be_visible()
+            login_btn = page.locator("#login-btn")
+            await expect(login_btn).to_be_visible()
 
             # Check button has correct text
-            btn_text = login_btn.inner_text()
+            btn_text = await login_btn.inner_text()
             assert "Sign In" in btn_text, f"Button text should contain 'Sign In', got: {btn_text}"
             print(f"  ✓ Sign In button is visible with text: '{btn_text}'")
 
             # Check button has background color (not transparent)
-            btn_style = login_btn.evaluate("el => window.getComputedStyle(el).backgroundColor")
+            btn_style = await login_btn.evaluate(
+                "el => window.getComputedStyle(el).backgroundColor"
+            )
             print(f"  ✓ Button background color: {btn_style}")
             assert btn_style != "rgba(0, 0, 0, 0)", "Button should have a background color"
 

--- a/tests/e2e/ui/test_logout_position.py
+++ b/tests/e2e/ui/test_logout_position.py
@@ -24,7 +24,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(92)]
 
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("USERNAME", "testuser91")
 PASSWORD = os.environ.get("PASSWORD", "test123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -42,7 +42,7 @@ os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -61,7 +61,7 @@ def test_logout_position():
         try:
             # Step 1: Navigate to login page
             print("Step 1: Navigate to login page...")
-            page.goto(BASE_URL + "login")
+            page.goto(f"{BASE_URL}login")
             page.wait_for_load_state("networkidle")
             time.sleep(1)
 

--- a/tests/e2e/ui/test_notification_all_scenarios.py
+++ b/tests/e2e/ui/test_notification_all_scenarios.py
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -137,7 +137,7 @@ def select_project(chat_frame, page):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -166,7 +166,7 @@ def test_all_scenarios():
         try:
             # ========== 初始化 ==========
             print("\n[初始化] 登录...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -174,7 +174,7 @@ def test_all_scenarios():
             print("    ✓ 登录成功")
 
             print("\n[初始化] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=60000)
             page.wait_for_timeout(5000)
 

--- a/tests/e2e/ui/test_notification_console_log.py
+++ b/tests/e2e/ui/test_notification_console_log.py
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -48,7 +48,7 @@ def select_project(chat_frame, page):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -86,7 +86,7 @@ def test_console_logs():
         try:
             # Login
             print("\n[1] 登录...")
-            page.goto(f"{BASE_URL}/login")
+            page.goto(f"{BASE_URL}login")
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -95,7 +95,7 @@ def test_console_logs():
 
             # Navigate to workspace
             print("\n[2] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace")
+            page.goto(f"{BASE_URL}work/workspace")
             page.wait_for_load_state("networkidle")
             page.wait_for_timeout(5000)
 

--- a/tests/e2e/ui/test_notification_timing.py
+++ b/tests/e2e/ui/test_notification_timing.py
@@ -18,7 +18,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -88,7 +88,7 @@ def select_project(chat_frame, page):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -110,7 +110,7 @@ def test_notification_timing():
         try:
             # Login
             print("\n[1] 登录...")
-            page.goto(f"{BASE_URL}/login")
+            page.goto(f"{BASE_URL}login")
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -119,7 +119,7 @@ def test_notification_timing():
 
             # Navigate to workspace
             print("\n[2] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace")
+            page.goto(f"{BASE_URL}work/workspace")
             page.wait_for_load_state("networkidle")
             page.wait_for_timeout(5000)
 

--- a/tests/e2e/ui/test_realtime_cross_tab.py
+++ b/tests/e2e/ui/test_realtime_cross_tab.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(71)]
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -125,7 +125,7 @@ def check_for_tool_execution(frame):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -155,7 +155,7 @@ def test_realtime_cross_tab():
         try:
             # ========== 初始化 ==========
             print("\n[初始化] 登录...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -163,7 +163,7 @@ def test_realtime_cross_tab():
             print("    ✓ 登录成功")
 
             print("\n[初始化] 导航到 Workspace...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=60000)
             page.wait_for_timeout(8000)
 

--- a/tests/e2e/ui/test_report_charts.py
+++ b/tests/e2e/ui/test_report_charts.py
@@ -25,7 +25,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(91)]
 
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("USERNAME", "testuser91")
 PASSWORD = os.environ.get("PASSWORD", "test123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -43,7 +43,7 @@ os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -62,7 +62,7 @@ def test_report_charts():
         try:
             # Step 1: Navigate to login page
             print("Step 1: Navigate to login page...")
-            page.goto(BASE_URL + "login")
+            page.goto(f"{BASE_URL}login")
             page.wait_for_load_state("networkidle")
             time.sleep(1)
 

--- a/tests/e2e/ui/test_sidebar_scrollbar.py
+++ b/tests/e2e/ui/test_sidebar_scrollbar.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(77)]
 
 
 # Configuration
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "77")
@@ -43,7 +43,7 @@ async def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -63,12 +63,12 @@ async def test_sidebar_scrollbar():
 
         try:
             # Login first
-            await page.goto(f"{BASE_URL}/login")
+            await page.goto(f"{BASE_URL}login")
             await page.wait_for_load_state("networkidle")
             await page.fill("#username", USERNAME)
             await page.fill("#password", PASSWORD)
             await page.click("#login-btn")
-            await page.wait_for_url(f"{BASE_URL}/", timeout=10000)
+            await page.wait_for_url(f"{BASE_URL}", timeout=10000)
             await page.wait_for_load_state("networkidle")
 
             # Take screenshot of sidebar

--- a/tests/e2e/ui/test_user_scenario.py
+++ b/tests/e2e/ui/test_user_scenario.py
@@ -14,7 +14,7 @@ from playwright.sync_api import sync_playwright
 pytestmark = [pytest.mark.regression, pytest.mark.issue(55)]
 
 
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -30,7 +30,7 @@ def take_screenshot(page, name):
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -78,7 +78,7 @@ def test_user_scenario():
 
             # Login
             print("\n[Step 1] Login...")
-            page.goto(f"{BASE_URL}/login")
+            page.goto(f"{BASE_URL}login")
             page.wait_for_load_state("networkidle", timeout=10000)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
@@ -93,7 +93,7 @@ def test_user_scenario():
 
             # Navigate to quota page
             print("\n[Step 2] Navigate to /manage/quota...")
-            page.goto(f"{BASE_URL}/manage/quota")
+            page.goto(f"{BASE_URL}manage/quota")
             page.wait_for_load_state("networkidle", timeout=10000)
             time.sleep(3)
             print("  ✓ Quota page loaded")

--- a/tests/e2e/ui/test_workspace_restore_error.py
+++ b/tests/e2e/ui/test_workspace_restore_error.py
@@ -26,7 +26,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -40,7 +40,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -64,7 +64,7 @@ def test_workspace_restore():
         try:
             # Step 1: Login
             print("\n[1] 登录系统...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -109,7 +109,7 @@ def test_workspace_restore():
 
             # Step 3: Navigate to workspace
             print("\n[3] 导航到工作区...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=30000)
             page.wait_for_timeout(5000)  # Wait for tabs to load
 

--- a/tests/e2e/ui/test_workspace_restore_full.py
+++ b/tests/e2e/ui/test_workspace_restore_full.py
@@ -28,7 +28,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:19888"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}
@@ -42,7 +42,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def _skip_if_no_server():
     try:
-        requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
+        requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
@@ -67,7 +67,7 @@ def test_workspace_restore():
         try:
             # Step 1: Login
             print("\n[1] 登录系统...")
-            page.goto(f"{BASE_URL}/login", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}login", timeout=DEFAULT_TIMEOUT)
             page.fill("#username", USERNAME)
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
@@ -79,7 +79,7 @@ def test_workspace_restore():
 
             # Step 2: Navigate to work page
             print("\n[2] 导航到工作区...")
-            page.goto(f"{BASE_URL}/work", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=30000)
             page.wait_for_timeout(3000)
 
@@ -132,7 +132,7 @@ def test_workspace_restore():
 
             # Step 6: Navigate to workspace
             print("\n[6] 导航到 workspace 页面...")
-            page.goto(f"{BASE_URL}/work/workspace", timeout=DEFAULT_TIMEOUT)
+            page.goto(f"{BASE_URL}work/workspace", timeout=DEFAULT_TIMEOUT)
             page.wait_for_load_state("networkidle", timeout=30000)
             page.wait_for_timeout(5000)
 


### PR DESCRIPTION
Repair batch R1 of #2491 (26 items; worksheet: #2491 comment 5448670954). Ref: #2429.

## Root cause
The Full E2E runner (`--isolated-home`) serves on an ephemeral port and exports `BASE_URL` without a trailing slash. 18 migrated tests hardcoded `http://localhost:19888` (→ "server not reachable" self-skips), and 8 more used trailing-slash defaults with slash-less concatenation (`page.goto(f"{BASE_URL}login")` → invalid URL like `…:52635login` → "Cannot navigate" failures or PlaywrightErrors swallowed into a bare `['测试执行']` label).

## Change (26 files, +113/−117)
- Canonical `BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/") + "/"` with single-slash path concatenation everywhere.
- The 4 swallow sites now record the underlying error (`('测试执行', False, "Error: …")`) — diagnostics strengthened, assertions unchanged.
- `tests/e2e/terminal/test_terminal_demo.py` dispositioned to `standalone-automated` via `governance.py set-disposition` (its skip requires a live machine_id fixture; executed standalone via main()) — the lawful writer, no hand-edited state.

## Local verification (same runner as CI, per file)
- **Zero "server not reachable" skips remain.** 13 files PASS outright; 12 now reach their real assertions and FAIL on genuine UI drift that the skip/invalid-URL had masked (`#login-btn` absent ×4, `#analysis-start-date` absent ×4, workspace/quota/notification markup drift) — left failing deliberately; they enter the R3 drift ledger with fresh local evidence.
- Gates: inventory/manifest/governance validate clean; 45 e2e governance tests green; scanner holds the 69-finding baseline.

## Expected next-run delta
`unexpected_skips` 19 → 0 (18 converted + 1 dispositioned). `new_failures` drops by the 4 goto-family + grows by the drift-failures now actually running (counted and classified locally: 12) — each already ledgered for R3.

## Acceptance follow-through (post-merge)
- [ ] Real Full E2E run confirms the skip conversion and only-expected failure-set change (backfilled to #2491).