### PR TITLE
fix(e2e): survive the 30-minute lane session timeout and per-test auth gaps (R2)

### DIFF
--- a/tests/e2e/browser/test_manage_analysis_conversation_pagination.py
+++ b/tests/e2e/browser/test_manage_analysis_conversation_pagination.py
@@ -39,6 +39,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -51,7 +52,10 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import sync_playwright
 
 WEB_BASE = os.environ.get("WEB_BASE", os.environ.get("BASE_URL", "http://localhost:19888"))
-API_BASE = os.environ.get("API_BASE", "http://localhost:19888")
+# API_BASE must follow BASE_URL too: the nightly lane serves the API on an
+# ephemeral port exported as BASE_URL; the fixed 19888 fallback curls a port
+# nobody listens on there (login yields http=0, no session token).
+API_BASE = os.environ.get("API_BASE", os.environ.get("BASE_URL", "http://localhost:19888"))
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
@@ -192,7 +196,16 @@ def test_pagination():
         browser = p.chromium.launch(headless=HEADLESS)
         context = browser.new_context(viewport={"width": 1400, "height": 900})
         context.add_cookies(
-            [{"name": "session_token", "value": token, "domain": "localhost", "path": "/"}]
+            [
+                {
+                    "name": "session_token",
+                    "value": token,
+                    # Cookie domain must match the browsed origin; the lane
+                    # serves WEB_BASE on 127.0.0.1, not localhost.
+                    "domain": urlsplit(WEB_BASE).hostname or "localhost",
+                    "path": "/",
+                }
+            ]
         )
         page = context.new_page()
 

--- a/tests/e2e/manage/test_conversation_detail_modal.py
+++ b/tests/e2e/manage/test_conversation_detail_modal.py
@@ -20,16 +20,42 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(79)]
 
 # The issues lane runs the server on an ephemeral port exported as BASE_URL.
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
+USERNAME = os.environ.get("TEST_USERNAME", "admin")
+PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
+
+
+async def _login(session) -> str:
+    """Login as the lane admin and return the session_token cookie value.
+
+    /api/conversation-history and /api/conversation-timeline (messages
+    blueprint) require auth; an unauthenticated GET returns 401. The token is
+    returned explicitly instead of relying on aiohttp's cookie jar, which does
+    not replay the host-only cookie the lane server sets on its IP-literal
+    origin — pass it via ``cookies={"session_token": token}`` on each request.
+    """
+    async with session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"username": USERNAME, "password": PASSWORD},
+    ) as resp:
+        assert resp.status == 200, f"login failed: {resp.status}"
+        morsel = resp.cookies.get("session_token")
+        assert morsel and morsel.value, "login response missing session_token cookie"
+        return morsel.value
 
 
 async def _fetch_first_session_id() -> str | None:
     """Fetch a session_id from the conversation-history API (or None)."""
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{BASE_URL}/api/conversation-history?limit=5") as resp:
+        token = await _login(session)
+        async with session.get(
+            f"{BASE_URL}/api/conversation-history?limit=5",
+            cookies={"session_token": token},
+        ) as resp:
             if resp.status != 200:
                 print(f"✗ Failed to get conversation history: {resp.status}")
                 return None
-            data = await resp.json()
+            payload = await resp.json()
+            data = payload.get("data", [])
             print(f"✓ Got {len(data)} conversations")
             if not data:
                 return None
@@ -46,10 +72,17 @@ async def test_conversation_history_api():
     print("\n=== Testing Conversation History API ===")
     session_id = None
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{BASE_URL}/api/conversation-history?limit=5") as resp:
+        token = await _login(session)
+        async with session.get(
+            f"{BASE_URL}/api/conversation-history?limit=5",
+            cookies={"session_token": token},
+        ) as resp:
             assert resp.status == 200, f"conversation-history API returned {resp.status}"
-            data = await resp.json()
-            assert isinstance(data, list), f"expected a list payload, got {type(data)}"
+            payload = await resp.json()
+            # Endpoint contract (app/routes/messages.py): {"data": [...], "total": N}
+            assert isinstance(payload, dict), f"expected a dict payload, got {type(payload)}"
+            data = payload.get("data")
+            assert isinstance(data, list), f"expected payload['data'] list, got {type(data)}"
             print(f"✓ Got {len(data)} conversations")
             if data:
                 session_id = data[0].get("session_id")
@@ -67,7 +100,11 @@ async def test_conversation_timeline_api():
         return
 
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{BASE_URL}/api/conversation-timeline/{session_id}") as resp:
+        token = await _login(session)
+        async with session.get(
+            f"{BASE_URL}/api/conversation-timeline/{session_id}",
+            cookies={"session_token": token},
+        ) as resp:
             assert resp.status == 200, f"timeline API returned {resp.status}"
             if resp.status == 200:
                 messages = await resp.json()

--- a/tests/e2e/ui/test_timeline_no_toolresult.py
+++ b/tests/e2e/ui/test_timeline_no_toolresult.py
@@ -39,6 +39,25 @@ USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 
 
+async def _api_login(session) -> str:
+    """Login as the lane admin and return the session_token cookie value.
+
+    /api/conversation-history and /api/conversation-timeline (messages
+    blueprint) require auth; an unauthenticated GET returns 401. The token is
+    returned explicitly instead of relying on aiohttp's cookie jar, which does
+    not replay the host-only cookie the lane server sets on its IP-literal
+    origin — pass it via ``cookies={"session_token": token}`` on each request.
+    """
+    async with session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"username": USERNAME, "password": PASSWORD},
+    ) as resp:
+        assert resp.status == 200, f"login failed: {resp.status}"
+        morsel = resp.cookies.get("session_token")
+        assert morsel and morsel.value, "login response missing session_token cookie"
+        return morsel.value
+
+
 def _skip_if_no_server():
     try:
         requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
@@ -245,10 +264,12 @@ async def test_api_timeline_no_toolresult():
     results = []
 
     async with aiohttp.ClientSession() as session:
+        token = await _api_login(session)
         # 获取 session 列表
         print("1. 获取 session 列表...")
         async with session.get(
-            f"{BASE_URL}/api/conversation-history?start={utils.get_days_ago(7)}&end={utils.get_today()}&page=1&limit=20"
+            f"{BASE_URL}/api/conversation-history?start={utils.get_days_ago(7)}&end={utils.get_today()}&page=1&limit=20",
+            cookies={"session_token": token},
         ) as resp:
             assert resp.status == 200, f"session list API returned {resp.status}"
 
@@ -271,7 +292,10 @@ async def test_api_timeline_no_toolresult():
 
         print(f"2. 测试 session: {session_id}")
 
-        async with session.get(f"{BASE_URL}/api/conversation-timeline/{session_id}") as resp:
+        async with session.get(
+            f"{BASE_URL}/api/conversation-timeline/{session_id}",
+            cookies={"session_token": token},
+        ) as resp:
             assert resp.status == 200, f"timeline API returned {resp.status}"
 
             timeline_data = await resp.json()

--- a/tests/e2e/work/helpers.py
+++ b/tests/e2e/work/helpers.py
@@ -109,9 +109,36 @@ def _clear_admin_password_flag():
         conn.close()
 
 
+def _cached_token_is_alive() -> bool:
+    """Probe the lane server: does the cached session token still authenticate?
+
+    The nightly lane runs ONE pytest process for the whole shard (~an hour)
+    against ONE server whose sessions expire (security_settings default
+    session_timeout is 30 minutes). A token cached by an early module — e.g.
+    browser/test_codex_frontend.py, the first file in the shard — is dead by
+    the time the work/* modules run last, so the cache must be validated,
+    never trusted.
+    """
+    if not _auth_token:
+        return False
+    try:
+        r = requests.get(
+            f"{BASE_URL}/api/auth/check",
+            cookies={"session_token": _auth_token},
+            timeout=10,
+        )
+        return r.status_code == 200 and bool(r.json().get("authenticated"))
+    except (requests.RequestException, ValueError):
+        return False
+
+
 def ensure_lane_login():
-    """Idempotently prepare lane auth: clear the password-change flag, login admin."""
-    if _auth_token:
+    """Idempotently prepare lane auth: clear the password-change flag, login admin.
+
+    Re-logins when the cached token no longer authenticates (mid-shard session
+    expiry in the nightly lane); see _cached_token_is_alive.
+    """
+    if _auth_token and _cached_token_is_alive():
         return _auth_token
     _clear_admin_password_flag()
     return api_login()
@@ -132,6 +159,20 @@ def api_login(username=None, password=None):
     return _auth_token
 
 
+def _relogin_on_rejected_session(status_code: int) -> bool:
+    """Handle a 401 caused by the cached lane token dying mid-run.
+
+    Session expiry (30-minute default) can invalidate the process-cached token
+    between module fixtures. Re-login once and let the caller retry with the
+    fresh token; assertions stay in place, so genuine auth failures still fail.
+    """
+    if status_code != 401:
+        return False
+    _clear_admin_password_flag()
+    api_login()
+    return True
+
+
 def api_get(path, params=None, expect_success=True):
     """Authenticated GET request."""
     assert _auth_token, "Not logged in"
@@ -140,6 +181,12 @@ def api_get(path, params=None, expect_success=True):
         params=params,
         cookies={"session_token": _auth_token},
     )
+    if r.status_code == 401 and _relogin_on_rejected_session(r.status_code):
+        r = requests.get(
+            f"{BASE_URL}/api{path}",
+            params=params,
+            cookies={"session_token": _auth_token},
+        )
     if expect_success:
         assert r.status_code == 200, f"GET {path} failed: {r.status_code} {r.text[:300]}"
         data = r.json()
@@ -157,6 +204,14 @@ def api_post(path, data=None, token=None):
         json=data,
         cookies={"session_token": t},
     )
+    # Only the shared lane token is retried; an explicitly passed token keeps
+    # its 401 semantics (callers test deliberately rejected credentials).
+    if r.status_code == 401 and token is None and _relogin_on_rejected_session(r.status_code):
+        r = requests.post(
+            f"{BASE_URL}/api{path}",
+            json=data,
+            cookies={"session_token": _auth_token},
+        )
     return r
 
 


### PR DESCRIPTION
Repair batch R2 of #2491 (17 items; worksheet: #2491 comment 5448670954). Ref: #2429.

## Root cause (proven by minimal failing pair)
The nightly shard runs browser→work files in ONE pytest process against ONE server. `tests/e2e/work/helpers.ensure_lane_login()` caches the admin token in a module global at minute 0 (first file), but the freshly-initialized lane DB has no `security_settings` row, so `GovernanceRepository` applies its **default 30-minute session timeout** (app/repositories/governance_repo.py:375; live-verified: session TTL exactly 1800s). The work/* files run last (~minute 46+) → dead cached token → the recorded 14 codex 401s in two shapes ("Authentication required" from workspace_bp, "Invalid or expired session" from @auth_required blueprints). Local proof: polluter + token-expiry simulation + victim reproduced the 7 failures byte-identically; victim alone passes 14/14.

The 3 non-codex items had distinct root causes: `test_manage_analysis_conversation_pagination` hit a hardcoded port + wrong cookie domain (http=0); `test_conversation_detail_modal`/`test_timeline_no_toolresult` called auth-required endpoints with no credentials at all (aiohttp's cookie jar doesn't replay host-only cookies on the IP-literal lane origin — now passed explicitly).

## Change (4 files, +141/−12)
- `tests/e2e/work/helpers.py`: `ensure_lane_login()` probes `/api/auth/check` and re-logins when the cached token is dead; `api_get`/`api_post` retry once after a fresh login on a 401 from the shared token (explicit `token=` keeps 401 semantics; no assert weakened).
- The 3 non-codex tests: derive endpoints/domains from `BASE_URL`/`WEB_BASE`; login and pass `session_token` explicitly; the modal test's payload assertion corrected to the endpoint's actual `{"data": […], "total": N}` contract (realigned to current API, per umbrella drift-repair precedent).

## Verification matrix (local lane, --isolated-home)
| Scenario | Before | After |
|---|---|---|
| polluter + expiry-simulation + codex_integration | 7 FAILED (nightly-identical) | 14/14 pass |
| polluter + expiry-simulation + codex_comprehensive | same mechanism | 16/16 pass |
| polluter + expiry-simulation + both work files | — | 38/38 pass |
| victims alone / polluter alone | pass | pass |
| modal history + timeline API | 401 | PASS |
| pagination | http=0 | login+API OK (skips on its own data precondition — lawful, pre-existing) |

Gates: inventory/manifest/governance validate clean; 45 e2e governance tests green; scanner 69-finding baseline held.

## Acceptance follow-through (post-merge)
- [ ] Real Full E2E run: the 17 auth-family failures gone (backfilled to #2491).