### PR TITLE
fix(ci): give the weekly cross-browser lane the capacity it actually needs

### DIFF
--- a/.github/workflows/weekly-quality.yml
+++ b/.github/workflows/weekly-quality.yml
@@ -18,7 +18,12 @@ jobs:
   cross-browser-e2e:
     name: Chromium, Firefox and WebKit E2E
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # Issue #3170: 545 tests in total across the five browser projects
+    # (chromium/firefox/webkit + 2 mobile viewports) on a single worker with
+    # CI retries — ~88 minutes of test execution did not finish once the
+    # server actually booted (both historical runs died at boot, so runtime
+    # was unknown).
+    timeout-minutes: 240
     env:
       # Issue #3170: the playwright webServer boots the real `server.py`,
       # whose development-mode contract refuses to start without SECRET_KEY

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
 
   // Reporter
   reporter: [
+    // Live per-test output: html+json only write at the end, so a CI timeout
+    // leaves no progress evidence in the job log (#3170).
+    ...(process.env.CI ? [(['line'] as const)] : []),
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'playwright-report/results.json' }],
   ],

--- a/tests/unit/test_weekly_quality_workflow_contract.py
+++ b/tests/unit/test_weekly_quality_workflow_contract.py
@@ -54,3 +54,11 @@ def test_server_booting_job_pins_secret_key_and_browser_cache_path():
         step for step in job["steps"] if step.get("run", "").startswith("npm run test:e2e")
     )
     assert run_step["env"]["HOME"] == "${{ runner.temp }}/openace-home"
+
+
+def test_cross_browser_job_timeout_covers_the_full_matrix():
+    # The lane runs the full suite once per browser project on a single
+    # worker; 90 minutes was never measured (both historical runs died at
+    # server boot) and canceled the first real attempt (#3170).
+    job = _cross_browser_job()
+    assert int(job["timeout-minutes"]) >= 240


### PR DESCRIPTION
Continues #3170 (batch 2). Ref: #2429 (P1 item 4a).

## What batch 1 (PR #3174) unlocked
Weekly dispatch run 33142288086 at SHA `a26cf9da`: the server booted (no SECRET_KEY RuntimeError), all browser projects resolved (no missing-executable), the frontend built, and Playwright started `Running 545 tests using 1 worker` — the first time this lane ever executed tests (both historical runs died at boot, so its true runtime was never measured).

The lane then hit the 90-minute job timeout and was canceled (06:06Z). Capacity, not correctness.

## Change
- `weekly-quality.yml` cross-browser job: `timeout-minutes: 90 → 240` with rationale (545 tests × 5 browser projects, single worker, CI retries).
- `frontend/playwright.config.ts`: add the `line` reporter on CI only — html+json write at completion, so a timeout leaves no progress evidence in the log (exactly what happened).
- `tests/unit/test_weekly_quality_workflow_contract.py`: pin `timeout-minutes >= 240` for the matrix job.

No retries/assertions/gates touched; the required-lane summary enforcement is unchanged.

## Acceptance follow-through (post-merge)
- [ ] Weekly `workflow_dispatch`: cross-browser lane completes (pass, or real per-test failures now visible via line reporter — capacity no longer the confounder).
- [ ] Next scheduled Weekly as continuing evidence, backfilled to #3170.