### PR TITLE
fix(#3166): normalize date types in trend data merge

### DIFF
--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -5,7 +5,7 @@ Business logic for usage data operations.
 """
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
 
 from app.repositories.usage_repo import UsageRepository
 from app.utils.cache import cached
@@ -301,7 +301,7 @@ class UsageService:
         )
 
     @staticmethod
-    def _normalize_date(date_value: str | datetime | object) -> str:
+    def _normalize_date(date_value: str | date | datetime) -> str:
         """Normalize date value to ISO format string (YYYY-MM-DD).
 
         Issue #3166: Different data sources return different date types:
@@ -320,10 +320,8 @@ class UsageService:
             return date_value
         if isinstance(date_value, datetime):
             return date_value.date().isoformat()
-        # Handle datetime.date or other date-like objects
-        if hasattr(date_value, "isoformat"):
-            return date_value.isoformat()
-        return str(date_value)
+        # At this point, date_value is datetime.date
+        return date_value.isoformat()
 
     @cached(ttl=60, key_prefix="usage", skip_args=[0])
     def get_trend_data(

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -300,6 +300,31 @@ class UsageService:
             tenant_id=tenant_id,
         )
 
+    @staticmethod
+    def _normalize_date(date_value: str | datetime | object) -> str:
+        """Normalize date value to ISO format string (YYYY-MM-DD).
+
+        Issue #3166: Different data sources return different date types:
+        - get_daily_by_tool() returns string dates
+        - get_session_trend_by_tool() returns datetime.date objects
+
+        This method ensures consistent date format for merging and sorting.
+
+        Args:
+            date_value: Date value from any source (str, datetime.date, datetime).
+
+        Returns:
+            str: ISO format date string (YYYY-MM-DD).
+        """
+        if isinstance(date_value, str):
+            return date_value
+        if isinstance(date_value, datetime):
+            return date_value.date().isoformat()
+        # Handle datetime.date or other date-like objects
+        if hasattr(date_value, "isoformat"):
+            return date_value.isoformat()
+        return str(date_value)
+
     @cached(ttl=60, key_prefix="usage", skip_args=[0])
     def get_trend_data(
         self,
@@ -313,6 +338,9 @@ class UsageService:
 
         Issue #3030: Merge daily_stats (CLI data) with agent_sessions (WebUI data)
         to ensure trend charts include all session types.
+
+        Issue #3166: Normalize date values to consistent format before merging
+        and sorting to avoid TypeError from mixed date/str types.
 
         Args:
             start_date: Start date string (YYYY-MM-DD).
@@ -331,26 +359,28 @@ class UsageService:
             start_date, end_date, host_name, tenant_id
         )
 
-        # 3. Merge both data sources
+        # 3. Merge both data sources with normalized dates
         merged: dict[tuple, dict] = {}
         for entry in dm_trend:
-            key = (entry["date"], entry["tool_name"])
+            normalized_date = self._normalize_date(entry["date"])
+            key = (normalized_date, entry["tool_name"])
             if key in merged:
                 merged[key]["tokens"] += entry.get("tokens", 0)
             else:
                 merged[key] = {
-                    "date": entry["date"],
+                    "date": normalized_date,
                     "tool_name": entry["tool_name"],
                     "tokens": entry.get("tokens", 0),
                 }
 
         for entry in session_trend:
-            key = (entry["date"], entry["tool_name"])
+            normalized_date = self._normalize_date(entry["date"])
+            key = (normalized_date, entry["tool_name"])
             if key in merged:
                 merged[key]["tokens"] += entry.get("tokens", 0)
             else:
                 merged[key] = {
-                    "date": entry["date"],
+                    "date": normalized_date,
                     "tool_name": entry["tool_name"],
                     "tokens": entry.get("tokens", 0),
                 }

--- a/tests/unit/test_issue_3030_trend_webui_sessions.py
+++ b/tests/unit/test_issue_3030_trend_webui_sessions.py
@@ -6,8 +6,11 @@ Verifies that:
 3. get_trend_data() merges both daily_stats and agent_sessions
 4. get_key_metrics() merges session data into totals
 5. Edge cases: empty data, host_name filter, tenant_id filter, date filters
+
+Issue #3166: Added tests for mixed date type handling (datetime.date vs str).
 """
 
+from datetime import date
 from unittest.mock import MagicMock
 
 import pytest
@@ -393,3 +396,126 @@ class TestGetKeyMetricsMerge:
             host_name="my-host",
             tenant_id=42,
         )
+
+
+class TestMixedDateTypes:
+    """Test Issue #3166: get_trend_data handles mixed date types correctly.
+
+    PostgreSQL returns datetime.date for CAST(created_at AS DATE),
+    while daily_stats returns string dates. This class tests that
+    the merge and sort logic handles this correctly.
+    """
+
+    def _make_service(self):
+        mock_repo = MagicMock()
+        svc = UsageService(usage_repo=mock_repo)
+        return svc, mock_repo
+
+    def setup_method(self):
+        get_cache().clear()
+
+    def test_mixed_date_types_no_type_error(self):
+        """Should not raise TypeError when merging date objects with strings."""
+        svc, mock_repo = self._make_service()
+        # daily_stats returns string dates
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 10000},
+        ]
+        # agent_sessions returns datetime.date objects
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": date(2026, 8, 2), "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        # Should not raise TypeError
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 2
+
+    def test_same_date_different_types_merge_correctly(self):
+        """Same date with different types should merge into one record."""
+        svc, mock_repo = self._make_service()
+        # Both sources have the same date but different types
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 10000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": date(2026, 8, 1), "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        # Should merge into a single record with summed tokens
+        assert len(result) == 1
+        assert result[0]["tokens"] == 15000
+        assert result[0]["date"] == "2026-08-01"
+
+    def test_sorting_with_mixed_date_types(self):
+        """Sorting should work correctly with mixed date types."""
+        svc, mock_repo = self._make_service()
+        # Multiple dates with different types
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-03", "tool_name": "qwen", "tokens": 3000},
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 1000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": date(2026, 8, 2), "tool_name": "qwen", "tokens": 2000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        # Should be sorted by date ascending
+        assert len(result) == 3
+        assert result[0]["date"] == "2026-08-01"
+        assert result[1]["date"] == "2026-08-02"
+        assert result[2]["date"] == "2026-08-03"
+
+    def test_normalize_date_static_method(self):
+        """Test _normalize_date handles all date types correctly."""
+        svc = UsageService()
+
+        # String date
+        assert svc._normalize_date("2026-08-01") == "2026-08-01"
+
+        # datetime.date object
+        assert svc._normalize_date(date(2026, 8, 1)) == "2026-08-01"
+
+        # datetime.datetime object
+        from datetime import datetime
+
+        assert svc._normalize_date(datetime(2026, 8, 1, 12, 30, 0)) == "2026-08-01"
+
+    def test_multiple_tools_same_date_mixed_types(self):
+        """Multiple tools on same date with mixed types should merge correctly."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": "2026-08-01", "tool_name": "qwen", "tokens": 10000},
+            {"date": "2026-08-01", "tool_name": "claude", "tokens": 5000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": date(2026, 8, 1), "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        # qwen should merge, claude should be separate
+        assert len(result) == 2
+        qwen_record = next(r for r in result if r["tool_name"] == "qwen")
+        claude_record = next(r for r in result if r["tool_name"] == "claude")
+        assert qwen_record["tokens"] == 15000
+        assert claude_record["tokens"] == 5000
+
+    def test_only_date_objects(self):
+        """Should work correctly when all dates are datetime.date objects."""
+        svc, mock_repo = self._make_service()
+        mock_repo.get_daily_by_tool.return_value = [
+            {"date": date(2026, 8, 1), "tool_name": "qwen", "tokens": 10000},
+        ]
+        mock_repo.get_session_trend_by_tool.return_value = [
+            {"date": date(2026, 8, 2), "tool_name": "qwen", "tokens": 5000},
+        ]
+
+        result = svc.get_trend_data("2026-08-01", "2026-08-31")
+
+        assert len(result) == 2
+        assert result[0]["date"] == "2026-08-01"
+        assert result[1]["date"] == "2026-08-02"


### PR DESCRIPTION
## Summary

Fixes #3166

## Root Cause

`/api/trend` returns HTTP 500 when `daily_stats` and `agent_sessions` return different date types:
- `get_daily_by_tool()` returns string dates (`"2026-08-01"`)
- `get_session_trend_by_tool()` returns `datetime.date` objects (PostgreSQL's `CAST(created_at AS DATE)`)

When merging data from both sources and sorting by date, Python raises:
```
TypeError: '<' not supported between instances of 'datetime.date' and 'str'
```

## Fix

Add `_normalize_date()` static method in `UsageService` to convert all date values to ISO format strings (`YYYY-MM-DD`) before merging and sorting.

This ensures:
1. Same date from different sources merges correctly (tokens are summed)
2. Sorting works with any date type
3. Output is always consistent string format

## Changes

- `app/services/usage_service.py`: Add `_normalize_date()` method and update `get_trend_data()` to normalize dates before merging
- `tests/unit/test_issue_3030_trend_webui_sessions.py`: Add `TestMixedDateTypes` class with 6 new test cases

## Test Coverage

New tests verify:
- Mixed date types without TypeError
- Same date with different types merges correctly
- Sorting works with mixed date types
- Multiple tools on same date with mixed types
- Only date objects scenario
- `_normalize_date()` handles str, datetime.date, and datetime objects

## Verification

- All 27 unit tests pass (including 6 new tests)
- Ruff lint check passes
- No database migration required
- No API contract change (date field was and remains string in JSON response)