### PR TITLE
fix(#3175): SSO provider update 409 due to timestamp format mismatch

### DIFF
--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -31,6 +31,47 @@ from app.utils.outbound_url_guard import OutboundUrlBlockedError, safe_request
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_timestamp(ts: str) -> datetime | None:
+    """Parse RFC 1123, ISO 8601, or SQLite datetime string.
+
+    Issue #3175: Accept multiple formats for optimistic lock comparison.
+    GET endpoint now returns ISO 8601, but PUT must accept:
+    - ISO 8601 (current GET endpoint format)
+    - RFC 1123 (legacy Flask jsonify format)
+    - SQLite datetime string (from SQLite databases)
+
+    Args:
+        ts: Timestamp string in various formats.
+
+    Returns:
+        datetime object with timezone info, or None if parsing fails.
+    """
+    from email.utils import parsedate_to_datetime
+
+    # Try ISO 8601 first (current format from GET endpoint)
+    try:
+        # Handle both 'Z' suffix and explicit timezone offsets
+        normalized = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        pass
+
+    # Try RFC 1123 (legacy format from Flask jsonify)
+    try:
+        return parsedate_to_datetime(ts)
+    except (ValueError, TypeError):
+        pass
+
+    # Try SQLite datetime string format (e.g., "2026-08-28 06:55:31.973892")
+    try:
+        # Replace space with T to make it ISO 8601 compatible
+        sqlite_normalized = ts.replace(" ", "T")
+        return datetime.fromisoformat(sqlite_normalized)
+    except ValueError:
+        return None
+
+
 # Issue #1826 F6: Transition warning for SSO_NULL_TENANT_POLICY=warn
 # Check at module load time and emit deprecation notice if warn policy is configured
 _null_tenant_policy = os.environ.get("SSO_NULL_TENANT_POLICY", "reject")
@@ -495,8 +536,26 @@ def get_provider_detail(provider_name: str):
             "userinfo_url": config_data.get("userinfo_url"),
             "issuer_url": config_data.get("issuer_url"),
             "extra_params": sanitize_config_for_audit(config_data.get("extra_params", {})),
-            "created_at": row.get("created_at"),
-            "updated_at": row.get("updated_at"),
+            "created_at": (
+                row.get("created_at").isoformat()
+                if isinstance(row.get("created_at"), datetime)
+                else (
+                    # SQLite may return datetime as string - convert to ISO 8601
+                    row.get("created_at").replace(" ", "T")
+                    if isinstance(row.get("created_at"), str) and row.get("created_at")
+                    else row.get("created_at")
+                )
+            ),
+            "updated_at": (
+                row.get("updated_at").isoformat()
+                if isinstance(row.get("updated_at"), datetime)
+                else (
+                    # SQLite may return datetime as string - convert to ISO 8601
+                    row.get("updated_at").replace(" ", "T")
+                    if isinstance(row.get("updated_at"), str) and row.get("updated_at")
+                    else row.get("updated_at")
+                )
+            ),
         }
 
         return jsonify(response)
@@ -628,25 +687,62 @@ def update_provider(provider_name: str):
     except Exception:
         return jsonify({"error": "Failed to parse existing configuration"}), 500
 
-    # Optimistic lock check
+    # Optimistic lock check - Issue #3175: Compare time values, not strings
     expected_updated_at = data.get("updated_at")
     if expected_updated_at:
         current_updated_at = existing.get("updated_at")
         if current_updated_at:
+            # Normalize current_updated_at to UTC naive datetime
             if isinstance(current_updated_at, datetime):
-                current_str = current_updated_at.isoformat()
+                if current_updated_at.tzinfo:
+                    # Convert to UTC and remove timezone info for comparison
+                    current_dt = current_updated_at.astimezone(timezone.utc).replace(tzinfo=None)
+                else:
+                    # Already naive, assume UTC
+                    current_dt = current_updated_at
+            elif isinstance(current_updated_at, str):
+                # SQLite may return datetime as string
+                parsed_current = _parse_timestamp(current_updated_at)
+                if parsed_current:
+                    if parsed_current.tzinfo:
+                        current_dt = parsed_current.astimezone(timezone.utc).replace(tzinfo=None)
+                    else:
+                        current_dt = parsed_current
+                else:
+                    # Invalid stored timestamp - skip check
+                    logger.warning(f"Invalid stored updated_at format: {current_updated_at}")
+                    current_dt = None
             else:
-                current_str = str(current_updated_at)
-            if current_str != expected_updated_at:
-                return (
-                    jsonify(
-                        {
-                            "error": "配置已被他人修改，请刷新后重新编辑",
-                            "current_updated_at": current_str,
-                        }
-                    ),
-                    409,
-                )
+                # Non-datetime type (shouldn't happen, but handle gracefully)
+                logger.warning(f"Unexpected updated_at type: {type(current_updated_at)}")
+                current_dt = None
+
+            # Parse and normalize expected_updated_at
+            expected_dt = _parse_timestamp(expected_updated_at)
+            if expected_dt:
+                # Convert to UTC naive datetime for comparison
+                if expected_dt.tzinfo:
+                    expected_dt = expected_dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+                # Issue #3175: Truncate microseconds before comparison
+                # RFC 1123 format only supports second precision, so we compare
+                # at second granularity to handle format differences.
+                current_dt_seconds = current_dt.replace(microsecond=0) if current_dt else None
+                expected_dt_seconds = expected_dt.replace(microsecond=0)
+
+                # Compare time values (at second granularity)
+                if current_dt_seconds and current_dt_seconds != expected_dt_seconds:
+                    return (
+                        jsonify(
+                            {
+                                "error": "配置已被他人修改，请刷新后重新编辑",
+                            }
+                        ),
+                        409,
+                    )
+            else:
+                # Invalid timestamp format
+                return jsonify({"error": "无效的时间戳格式"}), 400
     else:
         logger.warning(f"Update provider {provider_name} without updated_at (old client)")
 

--- a/tests/integration/routes/test_sso_provider_storage.py
+++ b/tests/integration/routes/test_sso_provider_storage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -176,3 +176,221 @@ def test_test_url_accessible_blocks_redirect_to_private_address():
     assert not result["success"]
     assert "blocked non-public address" in result["error"]
     assert mock_safe.call_count == 2
+
+
+# Issue #3175: Test updated_at timestamp format compatibility
+
+
+def test_get_provider_detail_returns_iso8601_format(client, sso_manager):
+    """GET endpoint should return updated_at in ISO 8601 format."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-iso",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "test-iso",
+                    "provider_type": "oauth2",
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "scope": ["openid"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    resp = client.get("/api/sso/providers/test-iso", headers={"Authorization": "Bearer t"})
+    assert resp.status_code == 200
+
+    data = resp.get_json()
+    assert "updated_at" in data
+    # Should be ISO 8601 format, not RFC 1123
+    updated_at = data["updated_at"]
+    assert "T" in updated_at  # ISO 8601 contains 'T' separator
+    assert "GMT" not in updated_at  # RFC 1123 contains 'GMT'
+
+
+def test_update_provider_accepts_rfc1123_timestamp(client, sso_manager):
+    """PUT endpoint should accept RFC 1123 format for optimistic lock check."""
+    # Use time without microseconds - RFC 1123 doesn't support microseconds
+    now = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-rfc",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "test-rfc",
+                    "provider_type": "oauth2",
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "scope": ["openid"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    # Simulate frontend sending RFC 1123 format (legacy Flask jsonify behavior)
+    rfc1123_time = now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    resp = client.put(
+        "/api/sso/providers/test-rfc",
+        headers={"Authorization": "Bearer t"},
+        json={
+            "client_id": "updated-client",
+            "updated_at": rfc1123_time,
+        },
+    )
+
+    # Should succeed (200), not return 409
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.get_json()}"
+
+
+def test_update_provider_accepts_iso8601_timestamp(client, sso_manager):
+    """PUT endpoint should accept ISO 8601 format for optimistic lock check."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-iso-update",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "test-iso-update",
+                    "provider_type": "oauth2",
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "scope": ["openid"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    # Simulate frontend sending ISO 8601 format (current GET endpoint behavior)
+    iso_time = now.isoformat()
+
+    resp = client.put(
+        "/api/sso/providers/test-iso-update",
+        headers={"Authorization": "Bearer t"},
+        json={
+            "client_id": "updated-client",
+            "updated_at": iso_time,
+        },
+    )
+
+    # Should succeed (200), not return 409
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.get_json()}"
+
+
+def test_update_provider_returns_409_on_real_conflict(client, sso_manager):
+    """PUT endpoint should return 409 when there's a real concurrent modification."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-conflict",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "test-conflict",
+                    "provider_type": "oauth2",
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "scope": ["openid"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    # Use an old timestamp to simulate concurrent modification
+    old_time = (now - timedelta(hours=1)).isoformat()
+
+    resp = client.put(
+        "/api/sso/providers/test-conflict",
+        headers={"Authorization": "Bearer t"},
+        json={
+            "client_id": "updated-client",
+            "updated_at": old_time,
+        },
+    )
+
+    # Should return 409 for real conflict
+    assert resp.status_code == 409
+    assert "已被他人修改" in resp.get_json()["error"]
+
+
+def test_update_provider_returns_400_on_invalid_timestamp(client, sso_manager):
+    """PUT endpoint should return 400 for invalid timestamp format."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-invalid",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "test-invalid",
+                    "provider_type": "oauth2",
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "scope": ["openid"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    resp = client.put(
+        "/api/sso/providers/test-invalid",
+        headers={"Authorization": "Bearer t"},
+        json={
+            "client_id": "updated-client",
+            "updated_at": "not-a-valid-timestamp",
+        },
+    )
+
+    # Should return 400 for invalid format
+    assert resp.status_code == 400
+    assert "无效的时间戳格式" in resp.get_json()["error"]


### PR DESCRIPTION
## Summary

Fixes #3175: SSO provider update always fails with HTTP 409 due to timestamp format mismatch.

## Problem

When editing an SSO provider, the update always failed with HTTP 409 even when there was no concurrent modification:

- GET `/api/sso/providers/{name}` returned `updated_at` as RFC 1123 format (Flask `jsonify` default behavior): `Fri, 28 Aug 2026 03:56:50 GMT`
- PUT `/api/sso/providers/{name}` compared with ISO 8601 format (`datetime.isoformat()`): `2026-08-28T03:56:50+00:00`
- String comparison always failed, causing false 409 responses

## Solution

1. **GET endpoint**: Explicitly convert `datetime` to ISO 8601 format
2. **PUT endpoint**: Accept both RFC 1123 and ISO 8601 formats for optimistic lock
3. **Comparison**: Compare time values instead of strings

## Changes

- `app/routes/sso.py`: Add `_parse_timestamp()` helper function to parse multiple timestamp formats
- `app/routes/sso.py`: Update GET endpoint to return ISO 8601 format
- `app/routes/sso.py`: Update PUT endpoint to compare time values
- `tests/integration/routes/test_sso_provider_storage.py`: Add comprehensive tests for ISO 8601 and RFC 1123 timestamp handling

## Test Plan

- [x] GET returns ISO 8601 format
- [x] PUT accepts RFC 1123 format and succeeds when timestamps match
- [x] PUT accepts ISO 8601 format and succeeds when timestamps match
- [x] PUT returns 409 when there's a real concurrent modification
- [x] PUT returns 400 for invalid timestamp format
- [x] All existing SSO tests pass

## Risk Assessment

- **Low risk**: Changes are isolated to timestamp handling in GET/PUT endpoints
- **Backward compatible**: PUT accepts both old (RFC 1123) and new (ISO 8601) formats
- **Rollback plan**: Simple revert if needed