### PR TITLE
fix(#3179): reject legacy 'admin' role in user create/update/restore APIs

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -22,8 +22,12 @@ class UserRole(Enum):
     READONLY = "readonly"
 
 
-# Admin roles that have system-wide access
+# Admin roles that have system-wide access (includes legacy 'admin' for compatibility)
 ADMIN_ROLES = frozenset({"admin", "platform_admin", "tenant_admin"})
+
+# Roles that can be persisted to the database (excludes legacy 'admin')
+# These are the only roles accepted in create/update/restore operations
+PERSISTABLE_ROLES = frozenset({"platform_admin", "tenant_admin", "manager", "user", "readonly"})
 
 
 @dataclass

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -80,6 +80,42 @@ def reject_privilege_escalation(role: object) -> tuple[Any, int] | None:
     return jsonify({"error": "Cannot assign platform-level role"}), 403
 
 
+def validate_persistable_role(role: object) -> tuple[Any, int] | None:
+    """Validate that the role is in the list of persistable roles.
+
+    Issue #3179: The legacy 'admin' role is no longer accepted in
+    create/update/restore operations. Only roles in PERSISTABLE_ROLES
+    (platform_admin, tenant_admin, manager, user, readonly) are allowed.
+
+    Returns ``None`` when the role is valid or not provided,
+    otherwise returns a 400 error response.
+    """
+    from app.models.user import PERSISTABLE_ROLES
+
+    if role is None:
+        return None
+
+    role_str = cast("str", role)
+    if role_str in PERSISTABLE_ROLES:
+        return None
+
+    logger.warning(
+        "Invalid role rejected: role=%s valid_roles=%s path=%s",
+        role_str,
+        list(PERSISTABLE_ROLES),
+        request.path,
+    )
+    return (
+        jsonify(
+            {
+                "error": "Invalid role",
+                "message": f"Role must be one of: {', '.join(sorted(PERSISTABLE_ROLES))}",
+            }
+        ),
+        400,
+    )
+
+
 @admin_bp.route("/admin/users", methods=["GET"])
 @admin_required
 def api_get_users():
@@ -137,6 +173,11 @@ def api_create_user():
     escalation = reject_privilege_escalation(role)
     if escalation is not None:
         return escalation
+
+    # Issue #3179: Validate that role is a persistable role
+    invalid_role = validate_persistable_role(role)
+    if invalid_role is not None:
+        return invalid_role
 
     # Validate inputs
     if not validate_username(username):
@@ -279,6 +320,11 @@ def api_update_user(user_id):
     escalation = reject_privilege_escalation(data.get("role"))
     if escalation is not None:
         return escalation
+
+    # Issue #3179: Validate that role is a persistable role
+    invalid_role = validate_persistable_role(data.get("role"))
+    if invalid_role is not None:
+        return invalid_role
 
     # Use the value the scope guard returns, never the raw body value. A value
     # the guard cannot normalize (0, -1, "", "abc") comes back as None, which
@@ -494,6 +540,11 @@ def api_restore_user(user_id):
         escalation = reject_privilege_escalation(role)
         if escalation is not None:
             return escalation
+
+        # Issue #3179: Validate that role is a persistable role
+        invalid_role = validate_persistable_role(role)
+        if invalid_role is not None:
+            return invalid_role
 
     # Validate password if provided
     password = data.get("password")

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -26,7 +26,7 @@ export interface CreateUserRequest {
   username: string;
   email: string;
   password: string;
-  role?: 'admin' | 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
+  role?: 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
   system_account?: string;
   tenant_id?: number;
 }
@@ -34,7 +34,7 @@ export interface CreateUserRequest {
 export interface UpdateUserRequest {
   username?: string;
   email?: string;
-  role?: 'admin' | 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
+  role?: 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
   is_active?: boolean;
   system_account?: string;
   password?: string;
@@ -144,7 +144,7 @@ export interface RestoreUserRequest {
   username?: string;
   email?: string;
   password?: string;
-  role?: 'admin' | 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
+  role?: 'platform_admin' | 'tenant_admin' | 'manager' | 'user' | 'readonly';
 }
 
 export interface RestoreUserResponse {

--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -101,7 +101,6 @@ export const UserManagement: React.FC = () => {
   });
 
   const roleOptions = [
-    { value: 'admin', label: t('roleAdmin', language) },
     { value: 'platform_admin', label: t('rolePlatformAdmin', language) },
     { value: 'tenant_admin', label: t('roleTenantAdmin', language) },
     { value: 'manager', label: t('roleManager', language) },


### PR DESCRIPTION
## Summary

- Add `PERSISTABLE_ROLES` constant to define roles that can be persisted to database
- Add `validate_persistable_role()` function to validate role before database write
- Return 400 instead of 500 when invalid role is submitted
- Remove 'admin' from frontend role dropdown options
- Remove 'admin' from `CreateUserRequest`, `UpdateUserRequest`, `RestoreUserRequest` types

## Root Cause

The legacy 'admin' role was still available in the frontend role dropdown, but the database constraint `chk_2332_users_role_valid` only allows `platform_admin`, `tenant_admin`, `manager`, `user`, `readonly`. Submitting 'admin' role triggered a database constraint violation and returned HTTP 500.

## Fix

1. **Backend**: Added role validation in create/update/restore APIs that rejects 'admin' and returns 400 with a clear error message
2. **Frontend**: Removed 'admin' from the role options dropdown
3. **Type definitions**: Updated TypeScript types to only accept persistable roles

## Compatibility

- `ADMIN_ROLES` remains unchanged (includes 'admin' for permission checks on existing accounts)
- `UserRole` enum remains unchanged (for reading legacy data)
- Response types still include 'admin' for backward compatibility with existing accounts

## Testing

- All role-related unit tests pass
- TypeScript type check passes
- All frontend tests pass

Closes #3179