### PR TITLE
fix(#3181): normalize lone LF to CRLF for Windows pipe terminal output

### DIFF
--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -288,6 +288,9 @@ class SinglePtyTerminalServer:
         # One-shot guard so resize_pty() warns once about the pipe-mode resize
         # limitation instead of spamming on every keystroke-driven resize.
         self._resize_warned = False
+        # Windows pipe mode: track if last character was CR for lone-LF normalization.
+        # This handles the case where CR and LF appear in separate read chunks.
+        self._last_char_was_cr = False
 
     def spawn_pty(self) -> bool:
         """Spawn PTY process once at startup."""
@@ -508,6 +511,55 @@ class SinglePtyTerminalServer:
         if not self._pty_alive:
             await self._notify_pty_exit()
 
+    def _normalize_lone_lf(self, data: bytes) -> bytes:
+        """Normalize lone LF to CRLF for Windows pipe terminal output.
+
+        xterm.js expects CRLF for line breaks. Windows pipe output may contain
+        lone LF without preceding CR, causing the cursor to move down but stay
+        at the same column position. This method converts any LF not preceded
+        by CR to CRLF.
+
+        Must be stateful to handle CR and LF appearing in separate read chunks.
+        """
+        if not data:
+            return data
+
+        result = bytearray()
+        for i, byte in enumerate(data):
+            if byte == ord("\n"):
+                # Check if this LF is preceded by CR in this chunk
+                if i > 0 and data[i - 1] == ord("\r"):
+                    # Already has preceding CR, keep as-is
+                    result.append(byte)
+                elif self._last_char_was_cr:
+                    # Previous chunk ended with CR, this chunk starts with LF
+                    # This is already CRLF across chunk boundary
+                    result.append(byte)
+                    self._last_char_was_cr = False
+                else:
+                    # Lone LF: insert CR before LF
+                    result.append(ord("\r"))
+                    result.append(byte)
+            elif byte == ord("\r"):
+                result.append(byte)
+                # Track CR for next chunk (if LF follows in next chunk)
+                # But if next char is not LF, we need to clear this flag
+                if i + 1 < len(data):
+                    # Next char exists in this chunk
+                    if data[i + 1] != ord("\n"):
+                        # CR not followed by LF in this chunk, clear flag
+                        self._last_char_was_cr = False
+                    # else: CR followed by LF in this chunk, flag will be handled by LF branch
+                else:
+                    # CR is last char in this chunk, set flag for next chunk
+                    self._last_char_was_cr = True
+            else:
+                # Any other character clears the CR flag
+                self._last_char_was_cr = False
+                result.append(byte)
+
+        return bytes(result)
+
     async def _relay_pipe_output_loop(self) -> None:
         """Read subprocess output continuously and broadcast to WebSockets."""
         loop = asyncio.get_event_loop()
@@ -533,6 +585,8 @@ class SinglePtyTerminalServer:
                 if raw_data:
                     # Windows: convert system code page output to UTF-8
                     data = _decode_windows_output(raw_data, encoding)
+                    # Normalize lone LF to CRLF for xterm.js compatibility (Issue #3181)
+                    data = self._normalize_lone_lf(data)
                     await self.broadcast_output(data)
                 else:
                     logger.info("Terminal output stream closed (process likely exited)")

--- a/tests/unit/test_terminal_server.py
+++ b/tests/unit/test_terminal_server.py
@@ -541,3 +541,148 @@ def test_resize_pty_path_updates_bookkeeping_without_io(monkeypatch):
 
     assert server._pty_cols == 132
     assert server._pty_rows == 43
+
+
+# --- Issue #3181: lone-LF normalization for Windows pipe terminal output ---
+
+
+class _NormalizeLoneLfTests:
+    """Test helper class for _normalize_lone_lf method tests."""
+
+    @staticmethod
+    def create_server():
+        terminal_server = load_terminal_server()
+        server = terminal_server.SinglePtyTerminalServer()
+        server._last_char_was_cr = False
+        return server
+
+
+def test_normalize_lone_lf_converts_lone_lf_to_crlf(monkeypatch):
+    """Lone LF without preceding CR should be converted to CRLF."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # PowerShell output with lone LF
+    result = server._normalize_lone_lf(b"line-one\nline-two\n")
+
+    assert result == b"line-one\r\nline-two\r\n"
+
+
+def test_normalize_lone_lf_preserves_existing_crlf(monkeypatch):
+    """Existing CRLF should not be double-converted."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # Already has CRLF
+    result = server._normalize_lone_lf(b"line-one\r\nline-two\r\n")
+
+    assert result == b"line-one\r\nline-two\r\n"
+
+
+def test_normalize_lone_lf_handles_mixed_newlines(monkeypatch):
+    """Mixed lone LF and CRLF should be handled correctly."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # Mix of lone LF and CRLF
+    result = server._normalize_lone_lf(b"line-one\nline-two\r\nline-three\n")
+
+    assert result == b"line-one\r\nline-two\r\nline-three\r\n"
+
+
+def test_normalize_lone_lf_handles_cr_lf_across_chunks(monkeypatch):
+    """CR at end of chunk and LF at start of next chunk should not produce extra CR."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # First chunk ends with CR
+    result1 = server._normalize_lone_lf(b"line-one\r")
+    assert result1 == b"line-one\r"
+    assert server._last_char_was_cr is True
+
+    # Second chunk starts with LF
+    result2 = server._normalize_lone_lf(b"\nline-two")
+    assert result2 == b"\nline-two"
+    assert server._last_char_was_cr is False
+
+
+def test_normalize_lone_lf_cr_not_followed_by_lf(monkeypatch):
+    """CR not followed by LF should clear the state flag."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # CR followed by other character
+    result = server._normalize_lone_lf(b"line-one\rX")
+
+    assert result == b"line-one\rX"
+    assert server._last_char_was_cr is False
+
+
+def test_normalize_lone_lf_empty_input(monkeypatch):
+    """Empty input should return empty."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    result = server._normalize_lone_lf(b"")
+
+    assert result == b""
+    assert server._last_char_was_cr is False
+
+
+def test_normalize_lone_lf_consecutive_empty_lines(monkeypatch):
+    """Consecutive empty lines (multiple lone LFs) should be converted correctly."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    result = server._normalize_lone_lf(b"\n\n\n")
+
+    assert result == b"\r\n\r\n\r\n"
+
+
+def test_normalize_lone_lf_regular_text_unchanged(monkeypatch):
+    """Regular text without newlines should pass through unchanged."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    result = server._normalize_lone_lf(b"hello world")
+
+    assert result == b"hello world"
+
+
+def test_normalize_lone_lf_preserves_ansi_sequences(monkeypatch):
+    """ANSI escape sequences should not be affected."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # ANSI color sequence with lone LF
+    result = server._normalize_lone_lf(b"\x1b[32mOK\x1b[0m\nDone")
+
+    assert result == b"\x1b[32mOK\x1b[0m\r\nDone"
+
+
+def test_normalize_lone_lf_preserves_utf8_multibyte(monkeypatch):
+    """UTF-8 multibyte characters should not be affected."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # UTF-8 Chinese characters with lone LF
+    result = server._normalize_lone_lf(b"\xe4\xb8\xad\xe6\x96\x87\n")
+
+    assert result == b"\xe4\xb8\xad\xe6\x96\x87\r\n"
+
+
+def test_normalize_lone_lf_multiple_chunks_simulation(monkeypatch):
+    """Simulate multiple chunks to verify state persistence."""
+    server = _NormalizeLoneLfTests.create_server()
+
+    # Chunk 1: text with lone LF
+    result1 = server._normalize_lone_lf(b"line1\n")
+    assert result1 == b"line1\r\n"
+
+    # Chunk 2: text with CRLF
+    result2 = server._normalize_lone_lf(b"line2\r\n")
+    assert result2 == b"line2\r\n"
+
+    # Chunk 3: text ending with CR
+    result3 = server._normalize_lone_lf(b"line3\r")
+    assert result3 == b"line3\r"
+    assert server._last_char_was_cr is True
+
+    # Chunk 4: LF at start
+    result4 = server._normalize_lone_lf(b"\nline4")
+    assert result4 == b"\nline4"
+    assert server._last_char_was_cr is False
+
+    # Chunk 5: lone LF again
+    result5 = server._normalize_lone_lf(b"line5\n")
+    assert result5 == b"line5\r\n"


### PR DESCRIPTION
## Summary

Fixes #3181

Windows pipe terminal output may contain lone LF (`\n`) without preceding CR (`\r`), causing xterm.js to move cursor down but stay at the same column position. This results in PowerShell prompts and command outputs being horizontally concatenated, making the terminal difficult to read.

## Root Cause

- Windows Remote Agent uses pipe mode (`subprocess.PIPE`) for terminal, not ConPTY
- Windows pipe output only goes through code page to UTF-8 conversion, without handling line break semantics
- xterm.js expects CRLF for line breaks; lone LF only moves cursor down, not to the start of the line

## Solution

Add a stateful `_normalize_lone_lf` method that converts lone LF to CRLF while preserving existing CRLF sequences. The state is maintained across read chunks to correctly handle CR and LF appearing in separate chunks.

### Key Implementation Details

1. **State tracking**: Added `_last_char_was_cr` to track if the previous chunk ended with CR
2. **Lone LF detection**: A LF is "lone" if:
   - It's not preceded by CR in the same chunk, AND
   - The previous chunk did not end with CR
3. **CR-LF across chunks**: Correctly handles the case where CR and LF appear in separate chunks
4. **Preservation**: Existing CRLF sequences are passed through unchanged

## Changes

- `remote-agent/terminal_server.py`:
  - Add `_last_char_was_cr` state variable
  - Add `_normalize_lone_lf` method
  - Call `_normalize_lone_lf` in `_relay_pipe_output_loop`

- `tests/unit/test_terminal_server.py`:
  - Add 11 comprehensive unit tests covering all edge cases

## Test Coverage

- ✅ Lone LF conversion to CRLF
- ✅ Existing CRLF preservation
- ✅ Mixed lone LF and CRLF
- ✅ CR-LF across chunk boundaries
- ✅ CR not followed by LF
- ✅ Empty input
- ✅ Consecutive empty lines
- ✅ Regular text unchanged
- ✅ ANSI escape sequences preserved
- ✅ UTF-8 multibyte characters preserved
- ✅ Multiple chunks simulation

## Test Results

```
25 passed in 0.59s
```

All existing tests continue to pass with no regressions.