### PR TITLE
fix(#2899): add session recovery fallback for browser navigation

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -2007,7 +2007,7 @@ export const Workspace: React.FC = () => {
           } catch (error: any) {
             // Handle session not found
             if (error?.response?.status === 404 || error?.message?.includes('not found')) {
-              toast.warning(t('sessionNotFound', language), '');
+              toast.warning(t('sessionNotFound', language));
               // Clear invalid sessionId from URL
               url.searchParams.delete('sessionId');
               window.history.replaceState({}, '', url.toString());

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -137,6 +137,9 @@ export const Workspace: React.FC = () => {
   // Issue #2892: Session verification state
   const [sessionVerified, setSessionVerified] = useState<boolean | null>(null);
 
+  // Issue #2899: Session restoration state
+  const [isRestoringSessions, setIsRestoringSessions] = useState(false);
+
   // Remote projects list (Issue #417: Populate "Your Projects" for remote workspace)
   const [remoteProjects, setRemoteProjects] = useState<RemoteProject[]>([]);
 
@@ -277,6 +280,49 @@ export const Workspace: React.FC = () => {
 
     return userWebUI.token;
   }, [userWebUI]);
+
+  // Issue #2899: Restore missing sessionIds from backend
+  const restoreMissingSessionIds = useCallback(
+    async (tabsToRestore: WorkspaceTab[]): Promise<WorkspaceTab[]> => {
+      const updatedTabs = [...tabsToRestore];
+
+      for (let i = 0; i < updatedTabs.length; i++) {
+        const tab = updatedTabs[i];
+        // Only restore tabs with encodedProjectName but missing sessionId (non-terminal)
+        if (!tab.sessionId && tab.encodedProjectName && tab.tabType !== 'terminal') {
+          try {
+            const response = await sessionsApi.getSessions(
+              {
+                project_path: tab.encodedProjectName,
+                workspace_type: tab.workspaceType as 'local' | 'remote' | 'terminal',
+                remote_machine_id: tab.machineId,
+                status: 'active', // Prefer active sessions
+              },
+              1,
+              1
+            );
+
+            if (response.data?.sessions?.[0]) {
+              const recentSession = response.data.sessions[0];
+              updatedTabs[i] = {
+                ...tab,
+                sessionId: recentSession.session_id,
+              };
+              console.info('[Workspace] Restored sessionId from backend:', {
+                tabId: tab.id,
+                sessionId: recentSession.session_id,
+              });
+            }
+          } catch (error) {
+            console.warn('[Workspace] Failed to restore sessionId:', error);
+          }
+        }
+      }
+
+      return updatedTabs;
+    },
+    []
+  );
 
   // Load workspace config and user webui URL
   useEffect(() => {
@@ -1457,6 +1503,28 @@ export const Workspace: React.FC = () => {
       }
 
       setTabsInitialized(true);
+
+      // Issue #2899: Asynchronously restore missing sessionIds from backend
+      setIsRestoringSessions(true);
+      restoreMissingSessionIds(initialTabs)
+        .then((restoredTabs) => {
+          // Update tabs with restored sessionIds
+          setTabs((currentTabs) => {
+            // Merge restored sessionIds into current tabs
+            return currentTabs.map((currentTab) => {
+              const restoredTab = restoredTabs.find((t) => t.id === currentTab.id);
+              if (restoredTab?.sessionId && !currentTab.sessionId) {
+                // Update store with restored sessionId
+                updateStoredTab(currentTab.id, { sessionId: restoredTab.sessionId });
+                return restoredTab;
+              }
+              return currentTab;
+            });
+          });
+        })
+        .finally(() => {
+          setIsRestoringSessions(false);
+        });
     }
   }, [
     config,
@@ -1475,29 +1543,9 @@ export const Workspace: React.FC = () => {
 
     setStoredActiveTabId,
     sessionVerified, // Issue #2892
+    restoreMissingSessionIds, // Issue #2899
+    updateStoredTab, // Issue #2899
   ]);
-
-  // Listen for browser back/forward (Issue #2899)
-  useEffect(() => {
-    if (!tabsInitialized || tabs.length === 0) return;
-
-    const handlePopState = () => {
-      const url = new URL(window.location.href);
-      const sessionId = url.searchParams.get('sessionId');
-
-      if (sessionId) {
-        // Find the corresponding tab and switch to it
-        const tab = tabs.find((t) => t.sessionId === sessionId);
-        if (tab && tab.id !== activeTabId) {
-          setActiveTabId(tab.id);
-          setStoredActiveTabId(tab.id);
-        }
-      }
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [tabs, activeTabId, tabsInitialized, setActiveTabId, setStoredActiveTabId]);
 
   // Handle URL parameter for creating new tab
   useEffect(() => {
@@ -1930,6 +1978,64 @@ export const Workspace: React.FC = () => {
       setSwitchProjectRequest(null);
     }
   }, [switchProjectRequest, createNewTab]);
+
+  // Listen for browser back/forward (Issue #2899)
+  useEffect(() => {
+    if (!tabsInitialized || tabs.length === 0 || isRestoringSessions) return;
+
+    const handlePopState = async () => {
+      const url = new URL(window.location.href);
+      const sessionId = url.searchParams.get('sessionId');
+
+      if (sessionId) {
+        // Find the corresponding tab and switch to it
+        const tab = tabs.find((t) => t.sessionId === sessionId);
+
+        if (!tab) {
+          // Tab not found, try to restore from backend
+          try {
+            const sessionDetail = await sessionsApi.getSession(sessionId);
+            if (sessionDetail?.data) {
+              // Create new tab to restore session
+              createNewTab(sessionId, {
+                workspaceType: sessionDetail.data.workspace_type as 'local' | 'remote',
+                machineId: sessionDetail.data.remote_machine_id ?? undefined,
+                machineName: sessionDetail.data.machine_name ?? undefined,
+                projectPath: sessionDetail.data.project_path ?? undefined,
+              });
+            }
+          } catch (error: any) {
+            // Handle session not found
+            if (error?.response?.status === 404 || error?.message?.includes('not found')) {
+              toast.warning(t('sessionNotFound', language), '');
+              // Clear invalid sessionId from URL
+              url.searchParams.delete('sessionId');
+              window.history.replaceState({}, '', url.toString());
+            } else {
+              console.warn('[Workspace] Failed to restore session from URL:', error);
+            }
+          }
+        } else if (tab.id !== activeTabId) {
+          setActiveTabId(tab.id);
+          setStoredActiveTabId(tab.id);
+        }
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [
+    tabs,
+    activeTabId,
+    tabsInitialized,
+    isRestoringSessions,
+    setActiveTabId,
+    setStoredActiveTabId,
+    createNewTab,
+    language,
+    toast,
+    t,
+  ]);
 
   // Actually remove a tab (shared by closeTab and remote close confirmation)
   const doCloseTab = useCallback(


### PR DESCRIPTION
## 问题

Issue #2899 - 浏览器前进及刷新后无法恢复原会话页面

### 测试结果

| 测试项 | 修复前 | 修复后（预期） |
|--------|--------|----------------|
| 浏览器后退 | ✅ 正常 | ✅ 正常 |
| 浏览器前进 | ❌ 未恢复 | ✅ 恢复会话 |
| 页面刷新 | ❌ 回到首页 | ✅ 保持会话 |

## 根因

1. `qwen-code-session-update` 消息可能因 `sourceTabId` 匹配失败被丢弃
2. tab 缺少 `sessionId`
3. `popstate` 事件处理依赖 `sessionId`，找不到匹配的 tab
4. 浏览器前进/刷新无法恢复原会话

## 修复方案

### 1. 添加 `restoreMissingSessionIds` 函数

在 tab 初始化后，如果 tab 有 `encodedProjectName` 但缺少 `sessionId`，从后端 API 查询最近会话并补全：

```typescript
const restoreMissingSessionIds = useCallback(
  async (tabsToRestore: WorkspaceTab[]): Promise<WorkspaceTab[]> => {
    // 从后端查询缺失的 sessionId
    // 按 project_path, workspace_type, remote_machine_id 精确过滤
    // 优先恢复活跃会话
  },
  []
);
```

### 2. 增强 `popstate` 处理

如果 URL 中有 `sessionId` 但找不到对应的 tab，尝试从后端查询并创建新 tab 恢复会话：

```typescript
const handlePopState = async () => {
  const sessionId = url.searchParams.get('sessionId');
  let tab = tabs.find((t) => t.sessionId === sessionId);
  
  if (!tab) {
    // 从后端查询会话详情
    const sessionDetail = await sessionsApi.getSession(sessionId);
    // 创建新 tab 恢复会话
  }
};
```

### 3. 添加恢复状态

```typescript
const [isRestoringSessions, setIsRestoringSessions] = useState(false);
```

## 修改文件

- `frontend/src/components/features/Workspace.tsx`:
  - 添加 `isRestoringSessions` 状态
  - 添加 `restoreMissingSessionIds` 函数
  - 在初始化时异步恢复缺失的 sessionId
  - 增强 `popstate` 处理以从后端恢复会话

## 测试

- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过（无新错误）
- [ ] 测试环境验证
- [ ] CI 通过

## 风险评估

| 风险项 | 风险等级 | 应对措施 |
|--------|----------|----------|
| 后端 API 调用失败 | 低 | try-catch 处理，不影响其他恢复逻辑 |
| 恢复了错误的会话 | 低 | 按多个参数精确过滤 |
| 性能影响 | 低 | 只在缺少 sessionId 时查询 |

## 相关 Issue

Fixes #2899
Related to #3189 (第一阶段修复 - 可观测性增强)