### PR TITLE
fix(#3206): 远程会话创建幂等与去重

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -83,6 +83,25 @@ _STATE_MESSAGES = {
     "error": "Remote session encountered an error",
 }
 
+# ════════════════════════════════════════════
+# Issue #3206: Idempotency and dedup constants
+# ════════════════════════════════════════════
+
+# Idempotency key cache TTL (seconds)
+IDEMPOTENCY_KEY_TTL_SECONDS = int(os.environ.get("IDEMPOTENCY_KEY_TTL_SECONDS", "60"))
+
+# Deduplication window for session creation (seconds)
+REMOTE_SESSION_DEDUP_WINDOW_SECONDS = int(
+    os.environ.get("REMOTE_SESSION_DEDUP_WINDOW_SECONDS", "5")
+)
+
+# Retry-After header value for 429 responses (seconds)
+RETRY_AFTER_SECONDS = int(os.environ.get("RETRY_AFTER_SECONDS", "60"))
+
+# Cache key prefixes
+_IDEMPOTENCY_KEY_PREFIX = "rs:idempotency:"
+_DEDUP_KEY_PREFIX = "rs:dedup:"
+
 
 def _check_session_state(session_info: dict, operation: str) -> tuple | None:
     """Check if session state allows the operation.
@@ -210,6 +229,169 @@ def _check_machine_exists_for_session(session_info: dict, operation: str) -> tup
             ),
             409,
         )
+
+    return None
+
+
+# ════════════════════════════════════════════
+# Issue #3206: Idempotency and dedup helpers
+# ════════════════════════════════════════════
+
+
+def _get_idempotency_cache_key(idempotency_key: str) -> str:
+    """Generate cache key for idempotency key."""
+    return f"{_IDEMPOTENCY_KEY_PREFIX}{idempotency_key}"
+
+
+def _get_dedup_cache_key(user_id: int, machine_id: str, project_path: str) -> str:
+    """Generate cache key for deduplication window.
+
+    Uses SHA256 hash of project_path to avoid special characters in key.
+    """
+    path_hash = hashlib.sha256(project_path.encode(), usedforsecurity=False).hexdigest()[:16]
+    return f"{_DEDUP_KEY_PREFIX}{user_id}:{machine_id[:8]}:{path_hash}"
+
+
+def _check_idempotency_key(idempotency_key: str) -> dict | None:
+    """Check if idempotency key exists in cache.
+
+    Returns:
+        Cached session data if key exists, None otherwise.
+    """
+    if not idempotency_key:
+        return None
+
+    try:
+        from app.utils.cache import get_cache
+
+        cache = get_cache()
+        key = _get_idempotency_cache_key(idempotency_key)
+        return cache.get(key)
+    except Exception as e:
+        logger.error("Failed to check idempotency key: %s", e)
+        return None
+
+
+def _store_idempotency_key(idempotency_key: str, session_data: dict) -> bool:
+    """Store session data under idempotency key.
+
+    Returns:
+        True if stored successfully, False otherwise.
+    """
+    if not idempotency_key:
+        return False
+
+    try:
+        from app.utils.cache import get_cache
+
+        cache = get_cache()
+        key = _get_idempotency_cache_key(idempotency_key)
+        return cache.set(key, session_data, IDEMPOTENCY_KEY_TTL_SECONDS)
+    except Exception as e:
+        logger.error("Failed to store idempotency key: %s", e)
+        return False
+
+
+def _check_dedup_window(user_id: int, machine_id: str, project_path: str) -> dict | None:
+    """Check if a session was recently created in deduplication window.
+
+    Returns:
+        Cached session data if within window, None otherwise.
+    """
+    try:
+        from app.utils.cache import get_cache
+
+        cache = get_cache()
+        key = _get_dedup_cache_key(user_id, machine_id, project_path)
+        return cache.get(key)
+    except Exception as e:
+        logger.error("Failed to check dedup window: %s", e)
+        return None
+
+
+def _store_dedup_window(
+    user_id: int, machine_id: str, project_path: str, session_data: dict
+) -> bool:
+    """Store session data in deduplication window.
+
+    Returns:
+        True if stored successfully, False otherwise.
+    """
+    try:
+        from app.utils.cache import get_cache
+
+        cache = get_cache()
+        key = _get_dedup_cache_key(user_id, machine_id, project_path)
+        return cache.set(key, session_data, REMOTE_SESSION_DEDUP_WINDOW_SECONDS)
+    except Exception as e:
+        logger.error("Failed to store dedup window: %s", e)
+        return False
+
+
+def _check_remote_session_concurrent_limit(user_id: int) -> Response | None:
+    """Check if user has reached max_sessions_per_user limit for remote sessions.
+
+    Issue #3206: Mirrors autonomous._check_user_concurrent_limit for remote sessions.
+
+    Returns:
+        429 Response if limit reached, None to proceed.
+    """
+    from app.repositories.tenant_repo import TenantRepository
+
+    DEFAULT_MAX_SESSIONS = 5
+
+    try:
+        # Get user's tenant quota
+        from app.repositories.user_repo import UserRepository
+
+        user_repo = UserRepository()
+        user = user_repo.get_user_by_id(user_id)
+        if not user:
+            return jsonify({"error": "User not found"}), 404
+
+        tenant_id = user.get("tenant_id")
+        max_sessions = DEFAULT_MAX_SESSIONS
+
+        if tenant_id:
+            tenant_repo = TenantRepository()
+            tenant = tenant_repo.get_by_id(tenant_id)
+            if tenant:
+                max_sessions = tenant.quota.max_sessions_per_user
+
+        # Count user's active remote sessions
+        from app.repositories.database import adapt_sql, get_db_connection
+
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                adapt_sql(
+                    "SELECT COUNT(*) as cnt FROM agent_sessions "
+                    "WHERE user_id = ? AND status = 'active' AND workspace_type = 'remote'"
+                ),
+                (user_id,),
+            )
+            row = cursor.fetchone()
+            active_count = row["cnt"] if isinstance(row, dict) else row[0]
+
+        if active_count >= max_sessions:
+            logger.warning(
+                "User %s reached max concurrent remote sessions limit (%s)",
+                user_id,
+                max_sessions,
+            )
+            response = jsonify(
+                {
+                    "success": False,
+                    "error": f"User has reached maximum concurrent sessions limit ({max_sessions})",
+                    "retry_after": RETRY_AFTER_SECONDS,
+                }
+            )
+            response.headers["Retry-After"] = str(RETRY_AFTER_SECONDS)
+            return response, 429
+
+    except Exception as exc:
+        logger.error("Concurrent limit check failed: %s", exc)
+        # Fail-open: allow creation if check fails
 
     return None
 
@@ -1513,6 +1695,44 @@ def create_remote_session():
     if not project_path:
         return jsonify({"error": "project_path is required"}), 400
 
+    # ════════════════════════════════════════════
+    # Issue #3206: Idempotency and dedup checks
+    # ════════════════════════════════════════════
+
+    # Check idempotency key from request header
+    idempotency_key = request.headers.get("Idempotency-Key", "")
+    user_id = g.user["id"]
+
+    # 1. Check idempotency key first (most precise)
+    if idempotency_key:
+        cached_session = _check_idempotency_key(idempotency_key)
+        if cached_session:
+            logger.info(
+                "Idempotency key hit for remote session creation: user=%s, key=%s",
+                user_id,
+                idempotency_key[:8],
+            )
+            return jsonify({"success": True, "session": cached_session})
+
+    # 2. Check dedup window (fallback for requests without idempotency key)
+    cached_session = _check_dedup_window(user_id, machine_id, project_path)
+    if cached_session:
+        logger.info(
+            "Dedup window hit for remote session creation: user=%s, machine=%s",
+            user_id,
+            machine_id[:8],
+        )
+        return jsonify({"success": True, "session": cached_session})
+
+    # 3. Check concurrent session limit
+    limit_error = _check_remote_session_concurrent_limit(user_id)
+    if limit_error:
+        return limit_error
+
+    # ════════════════════════════════════════════
+    # End Issue #3206 checks
+    # ════════════════════════════════════════════
+
     # P2-1: Permission check moved to decorator @machine_access_required
     session_mgr = get_remote_session_manager()
 
@@ -1574,6 +1794,10 @@ def create_remote_session():
     )
 
     if result and result.get("success") is not False:
+        # Issue #3206: Store in idempotency and dedup caches
+        if idempotency_key:
+            _store_idempotency_key(idempotency_key, result)
+        _store_dedup_window(user_id, machine_id, project_path, result)
         return jsonify({"success": True, "session": result})
     return (
         jsonify(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -285,9 +285,10 @@ class ApiClient {
     body?: unknown,
     signal?: AbortSignal,
     timeout?: number,
-    raw?: boolean
+    raw?: boolean,
+    headers?: Record<string, string>
   ): Promise<T> {
-    return this.request<T>(endpoint, { method: 'POST', body, signal, timeout, raw });
+    return this.request<T>(endpoint, { method: 'POST', body, signal, timeout, raw, headers });
   }
 
   async put<T>(endpoint: string, body?: unknown, signal?: AbortSignal): Promise<T> {

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -382,9 +382,11 @@ export const remoteApi = {
   },
 
   createSession(
-    data: CreateRemoteSessionRequest
+    data: CreateRemoteSessionRequest,
+    idempotencyKey?: string
   ): Promise<{ success: boolean; session: RemoteSession }> {
-    return apiClient.post('/api/remote/sessions', data);
+    const headers = idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : undefined;
+    return apiClient.post('/api/remote/sessions', data, undefined, undefined, undefined, headers);
   },
 
   getSession(sessionId: string): Promise<{ success: boolean; session: RemoteSession }> {

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -178,7 +178,11 @@ export function useCreateRemoteSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateRemoteSessionRequest) => remoteApi.createSession(data),
+    mutationFn: (data: CreateRemoteSessionRequest) => {
+      // Issue #3206: Generate idempotency key for deduplication
+      const idempotencyKey = crypto.randomUUID();
+      return remoteApi.createSession(data, idempotencyKey);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
     },

--- a/tests/unit/test_remote_session_idempotency.py
+++ b/tests/unit/test_remote_session_idempotency.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 
-
 # Import constants from remote.py
 from app.routes.remote import (
     _DEDUP_KEY_PREFIX,
@@ -78,9 +77,7 @@ class TestIdempotencyKeyHelpers:
             result = _check_idempotency_key(idempotency_key)
 
             assert result == cached_data
-            mock_cache.get.assert_called_once_with(
-                _get_idempotency_cache_key(idempotency_key)
-            )
+            mock_cache.get.assert_called_once_with(_get_idempotency_cache_key(idempotency_key))
 
     def test_check_idempotency_key_not_exists(self):
         """Test checking idempotency key that does not exist."""

--- a/tests/unit/test_remote_session_idempotency.py
+++ b/tests/unit/test_remote_session_idempotency.py
@@ -1,0 +1,352 @@
+"""Unit tests for Issue #3206: Remote session idempotency and dedup.
+
+Tests idempotency key handling, dedup window, and concurrent session limits
+for POST /api/remote/sessions.
+"""
+
+import hashlib
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+
+# Import constants from remote.py
+from app.routes.remote import (
+    _DEDUP_KEY_PREFIX,
+    _IDEMPOTENCY_KEY_PREFIX,
+    IDEMPOTENCY_KEY_TTL_SECONDS,
+    REMOTE_SESSION_DEDUP_WINDOW_SECONDS,
+    RETRY_AFTER_SECONDS,
+    _check_dedup_window,
+    _check_idempotency_key,
+    _check_remote_session_concurrent_limit,
+    _get_dedup_cache_key,
+    _get_idempotency_cache_key,
+    _store_dedup_window,
+    _store_idempotency_key,
+)
+
+
+class TestIdempotencyKeyHelpers:
+    """Tests for idempotency key helper functions."""
+
+    def test_get_idempotency_cache_key(self):
+        """Test idempotency cache key generation."""
+        key = "test-key-123"
+        result = _get_idempotency_cache_key(key)
+        assert result == f"{_IDEMPOTENCY_KEY_PREFIX}{key}"
+
+    def test_get_dedup_cache_key(self):
+        """Test dedup cache key generation."""
+        user_id = 1
+        machine_id = "machine-uuid-123"
+        project_path = "/home/user/project"
+
+        result = _get_dedup_cache_key(user_id, machine_id, project_path)
+
+        # Verify format: prefix + user_id + machine_id prefix + path hash
+        path_hash = hashlib.sha256(project_path.encode(), usedforsecurity=False).hexdigest()[:16]
+        expected = f"{_DEDUP_KEY_PREFIX}{user_id}:{machine_id[:8]}:{path_hash}"
+        assert result == expected
+
+    def test_get_dedup_cache_key_special_chars(self):
+        """Test dedup cache key handles special characters in path."""
+        user_id = 1
+        machine_id = "machine-uuid-123"
+        project_path = "/home/user/path with spaces & special!@#$%"
+
+        result = _get_dedup_cache_key(user_id, machine_id, project_path)
+
+        # Should not raise and should produce a valid key
+        assert result.startswith(_DEDUP_KEY_PREFIX)
+        assert " " not in result  # No spaces in cache key
+        assert "&" not in result
+
+    def test_check_idempotency_key_exists(self):
+        """Test checking idempotency key that exists in cache."""
+        idempotency_key = str(uuid.uuid4())
+        cached_data = {"session_id": "test-session-id"}
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = cached_data
+            mock_get_cache.return_value = mock_cache
+
+            result = _check_idempotency_key(idempotency_key)
+
+            assert result == cached_data
+            mock_cache.get.assert_called_once_with(
+                _get_idempotency_cache_key(idempotency_key)
+            )
+
+    def test_check_idempotency_key_not_exists(self):
+        """Test checking idempotency key that does not exist."""
+        idempotency_key = str(uuid.uuid4())
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = None
+            mock_get_cache.return_value = mock_cache
+
+            result = _check_idempotency_key(idempotency_key)
+
+            assert result is None
+
+    def test_check_idempotency_key_empty(self):
+        """Test checking empty idempotency key."""
+        result = _check_idempotency_key("")
+        assert result is None
+
+    def test_check_idempotency_key_cache_error(self):
+        """Test handling cache errors gracefully."""
+        idempotency_key = str(uuid.uuid4())
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_get_cache.side_effect = Exception("Cache error")
+
+            result = _check_idempotency_key(idempotency_key)
+
+            # Should return None and not raise
+            assert result is None
+
+    def test_store_idempotency_key(self):
+        """Test storing idempotency key in cache."""
+        idempotency_key = str(uuid.uuid4())
+        session_data = {"session_id": "test-session-id"}
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.set.return_value = True
+            mock_get_cache.return_value = mock_cache
+
+            result = _store_idempotency_key(idempotency_key, session_data)
+
+            assert result is True
+            mock_cache.set.assert_called_once_with(
+                _get_idempotency_cache_key(idempotency_key),
+                session_data,
+                IDEMPOTENCY_KEY_TTL_SECONDS,
+            )
+
+    def test_store_idempotency_key_empty(self):
+        """Test storing empty idempotency key does nothing."""
+        result = _store_idempotency_key("", {"session_id": "test"})
+        assert result is False
+
+
+class TestDedupWindowHelpers:
+    """Tests for dedup window helper functions."""
+
+    def test_check_dedup_window_hit(self):
+        """Test dedup window returns cached session."""
+        user_id = 1
+        machine_id = "machine-uuid"
+        project_path = "/home/user/project"
+        cached_data = {"session_id": "cached-session-id"}
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = cached_data
+            mock_get_cache.return_value = mock_cache
+
+            result = _check_dedup_window(user_id, machine_id, project_path)
+
+            assert result == cached_data
+
+    def test_check_dedup_window_miss(self):
+        """Test dedup window returns None when no match."""
+        user_id = 1
+        machine_id = "machine-uuid"
+        project_path = "/home/user/project"
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = None
+            mock_get_cache.return_value = mock_cache
+
+            result = _check_dedup_window(user_id, machine_id, project_path)
+
+            assert result is None
+
+    def test_store_dedup_window(self):
+        """Test storing session in dedup window."""
+        user_id = 1
+        machine_id = "machine-uuid"
+        project_path = "/home/user/project"
+        session_data = {"session_id": "test-session-id"}
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.set.return_value = True
+            mock_get_cache.return_value = mock_cache
+
+            result = _store_dedup_window(user_id, machine_id, project_path, session_data)
+
+            assert result is True
+            mock_cache.set.assert_called_once()
+
+    def test_dedup_window_cache_error(self):
+        """Test handling cache errors gracefully in dedup window."""
+        user_id = 1
+        machine_id = "machine-uuid"
+        project_path = "/home/user/project"
+
+        with patch("app.utils.cache.get_cache") as mock_get_cache:
+            mock_get_cache.side_effect = Exception("Cache error")
+
+            result = _check_dedup_window(user_id, machine_id, project_path)
+
+            # Should return None and not raise
+            assert result is None
+
+
+class TestConcurrentSessionLimit:
+    """Tests for concurrent session limit check."""
+
+    @pytest.fixture
+    def app(self):
+        """Create a Flask app for testing."""
+        app = Flask(__name__)
+        return app
+
+    def test_concurrent_limit_below_limit(self, app):
+        """Test user below concurrent session limit."""
+        user_id = 1
+
+        with (
+            app.app_context(),
+            patch("app.repositories.user_repo.UserRepository") as mock_user_repo,
+            patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo,
+            patch("app.repositories.database.get_db_connection") as mock_db,
+        ):
+            # Mock user lookup
+            mock_user = {"tenant_id": 1}
+            mock_user_repo.return_value.get_user_by_id.return_value = mock_user
+
+            # Mock tenant lookup with max_sessions_per_user = 5
+            mock_tenant = MagicMock()
+            mock_tenant.quota.max_sessions_per_user = 5
+            mock_tenant_repo.return_value.get_by_id.return_value = mock_tenant
+
+            # Mock DB query - 3 active sessions (below limit)
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = {"cnt": 3}
+            mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+            mock_conn.__exit__ = MagicMock(return_value=None)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_db.return_value = mock_conn
+
+            result = _check_remote_session_concurrent_limit(user_id)
+
+            # Should return None (no error)
+            assert result is None
+
+    def test_concurrent_limit_at_limit(self, app):
+        """Test user at concurrent session limit returns 429."""
+        user_id = 1
+
+        with (
+            app.app_context(),
+            patch("app.repositories.user_repo.UserRepository") as mock_user_repo,
+            patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo,
+            patch("app.repositories.database.get_db_connection") as mock_db,
+        ):
+            # Mock user lookup
+            mock_user = {"tenant_id": 1}
+            mock_user_repo.return_value.get_user_by_id.return_value = mock_user
+
+            # Mock tenant lookup with max_sessions_per_user = 5
+            mock_tenant = MagicMock()
+            mock_tenant.quota.max_sessions_per_user = 5
+            mock_tenant_repo.return_value.get_by_id.return_value = mock_tenant
+
+            # Mock DB query - 5 active sessions (at limit)
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = {"cnt": 5}
+            mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+            mock_conn.__exit__ = MagicMock(return_value=None)
+            mock_conn.cursor.return_value = mock_cursor
+            mock_db.return_value = mock_conn
+
+            result = _check_remote_session_concurrent_limit(user_id)
+
+            # Should return 429 response
+            assert result is not None
+            response, status = result
+            assert status == 429
+            # Check JSON response contains error and retry_after
+            json_data = response.get_json()
+            assert "error" in json_data
+            assert "retry_after" in json_data
+            assert json_data["retry_after"] == RETRY_AFTER_SECONDS
+            # Check Retry-After header
+            assert "Retry-After" in response.headers
+
+    def test_concurrent_limit_user_not_found(self, app):
+        """Test user not found returns 404."""
+        user_id = 999
+
+        with (
+            app.app_context(),
+            patch("app.repositories.user_repo.UserRepository") as mock_user_repo,
+        ):
+            mock_user_repo.return_value.get_user_by_id.return_value = None
+
+            result = _check_remote_session_concurrent_limit(user_id)
+
+            # Should return 404 response
+            assert result is not None
+            _response, status = result
+            assert status == 404
+
+    def test_concurrent_limit_fail_open(self, app):
+        """Test that errors fail open (allow creation)."""
+        user_id = 1
+
+        with (
+            app.app_context(),
+            patch("app.repositories.user_repo.UserRepository") as mock_user_repo,
+        ):
+            mock_user_repo.side_effect = Exception("DB error")
+
+            result = _check_remote_session_concurrent_limit(user_id)
+
+            # Should return None (fail open)
+            assert result is None
+
+
+class TestConstants:
+    """Tests for environment variable constants."""
+
+    def test_default_constants(self):
+        """Test default values for constants."""
+        # These are the defaults from the code
+        assert IDEMPOTENCY_KEY_TTL_SECONDS == 60
+        assert REMOTE_SESSION_DEDUP_WINDOW_SECONDS == 5
+        assert RETRY_AFTER_SECONDS == 60
+
+    def test_custom_idempotency_ttl(self):
+        """Test custom idempotency TTL via environment variable."""
+        with patch.dict(os.environ, {"IDEMPOTENCY_KEY_TTL_SECONDS": "120"}):
+            # Re-import to get new value
+            from importlib import reload
+
+            import app.routes.remote as remote_module
+
+            reload(remote_module)
+            assert remote_module.IDEMPOTENCY_KEY_TTL_SECONDS == 120
+
+    def test_custom_dedup_window(self):
+        """Test custom dedup window via environment variable."""
+        with patch.dict(os.environ, {"REMOTE_SESSION_DEDUP_WINDOW_SECONDS": "10"}):
+            from importlib import reload
+
+            import app.routes.remote as remote_module
+
+            reload(remote_module)
+            assert remote_module.REMOTE_SESSION_DEDUP_WINDOW_SECONDS == 10


### PR DESCRIPTION
## 问题

Issue #3206：连续点击"创建会话"产生重复会话，远程会话重复下发 start_session

## 根因

1. `create_session()` 幂等性依赖显式传入 `session_id`，不传入时每次生成新 UUID
2. `create_remote_session()` 服务端自生成 `session_id` 无去重窗口
3. `remote.py` 路由无防重入
4. `max_sessions` 未在交互创建链路执行

## 修复方案

### 后端修改

1. **幂等键支持**：支持 `Idempotency-Key` 请求头，TTL 60 秒
2. **去重窗口**：无幂等键时，对 `user_id + machine_id + project_path` 去重（默认 5 秒，可配置）
3. **并发限制**：复用 `max_sessions_per_user` 检查远程会话并发数
4. **标准化响应**：429 响应包含 `Retry-After` 头

### 前端修改

1. `useCreateRemoteSession` 生成 UUID 作为 `Idempotency-Key`
2. 扩展 `apiClient.post` 支持 headers 参数

## 测试

- 新增单元测试 `test_remote_session_idempotency.py`
- 覆盖幂等键检查、去重窗口、并发限制

## 环境变量

- `IDEMPOTENCY_KEY_TTL_SECONDS`: 幂等键缓存 TTL（默认 60）
- `REMOTE_SESSION_DEDUP_WINDOW_SECONDS`: 去重窗口（默认 5）
- `RETRY_AFTER_SECONDS`: 429 重试时间（默认 60）

Fixes #3206