### PR TITLE
fix(e2e+frontend): repair quota-save bugs and realign R3b manage/UI tests

### DIFF
--- a/frontend/src/api/governance.ts
+++ b/frontend/src/api/governance.ts
@@ -154,7 +154,15 @@ export const governanceApi = {
 
   // Content Filter
   async getFilterRules(): Promise<ContentFilterRule[]> {
-    return apiClient.get<ContentFilterRule[]>('/api/filter-rules');
+    // GET /api/filter-rules returns a paginated envelope
+    // ({rules, total, limit, offset} — see app/routes/governance.py).
+    // SecurityCenter consumes the bare rule array; unwrapping here keeps
+    // rules.map() from throwing ("N.map is not a function") and blanking
+    // the whole Security Center page.
+    const response = await apiClient.get<{ rules?: ContentFilterRule[] } | ContentFilterRule[]>(
+      '/api/filter-rules'
+    );
+    return Array.isArray(response) ? response : (response.rules ?? []);
   },
 
   async createFilterRule(data: CreateFilterRuleRequest): Promise<{ success: boolean; id: number }> {

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -191,8 +191,12 @@ export const QuotaAlerts: React.FC = () => {
     setFormData({
       daily_token_quota: user.daily_token_quota ?? undefined,
       monthly_token_quota: user.monthly_token_quota ?? undefined,
-      daily_request_quota: user.daily_request_quota,
-      monthly_request_quota: user.monthly_request_quota,
+      // Null (unlimited) request quotas must normalize to undefined like the
+      // token fields: handleSubmitQuota validates
+      // formData.<field>.toString() only when the value is !== undefined, so
+      // a stored null throws a TypeError and the Save silently no-ops.
+      daily_request_quota: user.daily_request_quota ?? undefined,
+      monthly_request_quota: user.monthly_request_quota ?? undefined,
     });
     setShowQuotaModal(true);
   };

--- a/tests/e2e/browser/test_manage_analysis_roi_i18n.py
+++ b/tests/e2e/browser/test_manage_analysis_roi_i18n.py
@@ -60,10 +60,23 @@ LEAK_PATTERNS = [
 
 
 def _switch_language(page, index):
-    """通过 Header 的语言下拉切换语言。"""
-    page.locator("button.dropdown-toggle .bi-globe").click()
-    page.wait_for_timeout(300)
-    page.locator(".dropdown-menu .dropdown-item").nth(index).click()
+    """通过 Header 的语言下拉切换语言。
+
+    Header.tsx renders the help dropdown BEFORE the language dropdown, so the
+    toggle is addressed via its globe icon (button.header-icon-btn with
+    i.bi-globe) instead of "first dropdown-toggle"; the menu is awaited
+    visible before clicking the item (the nightly lane hit click timeouts
+    when the menu was still animating in).
+    """
+    toggle = page.locator("button.dropdown-toggle").filter(has=page.locator("i.bi-globe"))
+    toggle.first.wait_for(state="visible", timeout=10000)
+    toggle.first.click()
+    # Scope the menu to the globe dropdown itself — the page (and the user
+    # menu in the same Header) render other hidden ul.dropdown-menu lists
+    # whose visibility must not be waited on.
+    menu = page.locator("div.dropdown:has(button.dropdown-toggle i.bi-globe) ul.dropdown-menu")
+    menu.first.wait_for(state="visible", timeout=10000)
+    menu.first.locator("button.dropdown-item").nth(index).click()
     page.wait_for_timeout(500)
 
 

--- a/tests/e2e/manage/e2e_conversation_history.py
+++ b/tests/e2e/manage/e2e_conversation_history.py
@@ -37,6 +37,71 @@ def shot(page, name):
     print(f"  screenshot: {name}.png")
 
 
+def _clear_seeded_password_gate():
+    """Clear must_change_password for the seeded admin (lane/CI only)."""
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "UPDATE users SET must_change_password = 0 "
+                "WHERE username = ? AND must_change_password = 1",
+                (USERNAME,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+def _seed_conversation_rows():
+    """Seed daily_messages rows so the page under test has real data.
+
+    The conversation-history contract (tools/senders dropdowns fed by
+    /api/tools and /api/senders, table rows, total count, pagination) only
+    renders content when daily_messages has rows; a freshly initialized
+    lane home starts empty. Idempotent: keyed on a fixed conversation_id.
+    Same seeding pattern as tests/e2e/ui/test_conversation_history_fullscreen.py.
+    """
+    import sqlite3
+    from datetime import datetime
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    conv_id = "e2e-conv-history-191"
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM daily_messages WHERE conversation_id = ?",
+                (conv_id,),
+            ).fetchone()[0]
+            if not existing:
+                today = datetime.now().strftime("%Y-%m-%d")
+                now = datetime.now().isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO daily_messages "
+                    "(date, tool_name, host_name, role, content, tokens_used, "
+                    "input_tokens, output_tokens, timestamp, sender_name, "
+                    "message_id, agent_session_id, conversation_id, user_id) "
+                    "VALUES (?, 'claude-code', 'e2e-host-191', 'user', "
+                    "'e2e conversation history probe', 10, 5, 5, ?, 'admin', "
+                    "'e2e-msg-191-1', ?, ?, 1)",
+                    (today, now, conv_id, conv_id),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
 passed = 0
 failed = 0
 
@@ -57,6 +122,9 @@ def test_conversation_history():
     print("Conversation History Page E2E Test")
     print("=" * 60)
 
+    _clear_seeded_password_gate()
+    _seed_conversation_rows()
+
     # API checks
     print("\n[1] API endpoints")
     session = requests.Session()
@@ -67,8 +135,18 @@ def test_conversation_history():
     token = r.cookies.get("session_token")
 
     r = session.get(f"{BASE_URL}/api/tools")
-    tools = r.json() if r.status_code == 200 else []
-    check("GET /api/tools returns data", len(tools) > 0, f"({len(tools)} tools: {tools})")
+    tools_resp = r.json() if r.status_code == 200 else None
+    # /api/tools is served under a 5-minute usage cache
+    # (usage_service.get_all_tools @cached ttl=300), and on the shared lane
+    # server earlier files' page loads prime it before this test seeds its
+    # row — so its CONTENT is timing-dependent. Pin the endpoint contract
+    # here; the seeded tool's presence is asserted through the uncached
+    # conversation-history data below.
+    check(
+        "GET /api/tools returns a tool list",
+        isinstance(tools_resp, list) and all(isinstance(t, str) for t in tools_resp),
+        f"({len(tools_resp or [])} tools)",
+    )
 
     r = session.get(f"{BASE_URL}/api/senders")
     senders = r.json() if r.status_code == 200 else []
@@ -81,13 +159,21 @@ def test_conversation_history():
     ch_data = r.json() if r.status_code == 200 else {}
     total = ch_data.get("total", 0)
     check("GET /api/conversation-history with date range", r.status_code == 200, f"(total={total})")
+    # The tools dropdown is fed by DISTINCT tool_name over daily_messages —
+    # the same derivation /api/tools caches. Derive the expected tools from
+    # the uncached rows so the page-visibility checks below always run
+    # against the seeded data (never vacuously).
+    tools = sorted({row["tool_name"] for row in ch_data.get("data", []) if row.get("tool_name")})
+    check("Seeded conversation exposes its tool", len(tools) > 0, f"(tools: {tools})")
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=HEADLESS)
         context = browser.new_context(viewport={"width": 1400, "height": 900})
-        context.add_cookies(
-            [{"name": "session_token", "value": token, "domain": "localhost", "path": "/"}]
-        )
+        # The lane exports BASE_URL with an IP-literal origin (127.0.0.1:PORT);
+        # a cookie pinned to domain "localhost" is never sent there and the
+        # SPA bounces back to /login (the baselined 20-failed-checks mode).
+        # Addressing the cookie by the actual origin fixes both hosts.
+        context.add_cookies([{"name": "session_token", "value": token, "url": f"{BASE_URL}/"}])
         page = context.new_page()
 
         print("\n[2] Page load and navigation")
@@ -102,7 +188,9 @@ def test_conversation_history():
         shot(page, "01_page_loaded")
 
         print("\n[3] #194 - Date range filter")
-        date_inputs = page.locator('input[type="date"]')
+        # DatePicker is a custom button input (react-datepicker with a
+        # button.form-control trigger + calendar icon), not input[type=date]
+        date_inputs = page.locator("button.form-control:has(i.bi-calendar3)")
         date_count = date_inputs.count()
         check("Two date inputs present", date_count >= 2, f"(found {date_count})")
         labels = page.locator("label.form-label")
@@ -115,7 +203,11 @@ def test_conversation_history():
         print("\n[4] #191 - Dynamic tool options")
         body_text = page.locator("body").inner_text()
         for tool in tools:
-            check(f"Tool '{tool}' in page", tool in body_text)
+            # The dropdown renders display names (formatToolName capitalizes
+            # unknown tools: "claude-code" -> "Claude-code"), so accept either
+            # the raw API value or its display form.
+            display = tool[:1].upper() + tool[1:]
+            check(f"Tool '{tool}' in page", tool in body_text or display in body_text)
 
         print("\n[5] #195 - Sender SearchableSelect")
         plain_text_sender = page.locator('.col-md-3 input[type="text"]')

--- a/tests/e2e/manage/e2e_ip_whitelist_input.py
+++ b/tests/e2e/manage/e2e_ip_whitelist_input.py
@@ -154,10 +154,20 @@ def _open_security_settings_tab(page):
 
     The default tab is Content Filter; the IP whitelist textarea only
     exists on the Security Settings tab (one textarea there), so every
-    UI check must switch explicitly.
+    UI check must switch explicitly. The tab strip is a ul.nav-tabs of
+    button.nav-link items (SecurityCenter.tsx) rendered by the lazy SPA
+    chunk — wait for it instead of racing a fixed 1s sleep.
     """
     page.goto(f"{BASE_URL}/manage/security", wait_until="domcontentloaded", timeout=30000)
-    pause(1)
+    try:
+        page.wait_for_selector("ul.nav-tabs button.nav-link", timeout=15000)
+    except PlaywrightError:
+        # Surface why the tab strip never rendered (blank page / redirect)
+        # instead of failing on the first tab click below.
+        raise AssertionError(
+            "Security Center tab strip never rendered — body: "
+            f"{page.locator('body').inner_text()[:300]!r}, url: {page.url}"
+        )
     try:
         page.click("text=Security Settings", timeout=5000)
     except PlaywrightError:

--- a/tests/e2e/manage/test_conversation_detail_modal.py
+++ b/tests/e2e/manage/test_conversation_detail_modal.py
@@ -188,7 +188,12 @@ async def test_frontend_build():
     import os
 
     # Check if the build directory exists
-    PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    # This file lives at <repo>/tests/e2e/manage/ — four dirname() hops reach
+    # the repo root, where the Vite build output (static/js/dist) actually
+    # lives. Three hops landed on tests/ and always failed the premise check.
+    PROJECT_ROOT = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
     build_dir = os.path.join(PROJECT_ROOT, "static", "js", "dist")
     assert os.path.exists(build_dir), f"frontend build directory not found: {build_dir}"
     print(f"✓ Build directory exists: {build_dir}")

--- a/tests/e2e/manage/test_usage_trend_stats.py
+++ b/tests/e2e/manage/test_usage_trend_stats.py
@@ -37,8 +37,51 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
+def _seed_user_daily_stats():
+    """Seed user_daily_stats rows so the trend charts have data.
+
+    UsageOverview only renders the Token/Request trend cards when
+    /api/quota/usage/me returns a non-empty usage.trend, and that trend is
+    served from the pre-aggregated user_daily_stats table (app/routes/
+    quota.py -> usage_repo.get_user_request_trend_by_user_id). A freshly
+    initialized lane home has no rows, so both cards stayed hidden (the
+    baselined failure). Idempotent on a fixed date.
+    """
+    import sqlite3
+    from datetime import date, timedelta
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    seed_date = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            cols = [row[1] for row in conn.execute("PRAGMA table_info(user_daily_stats)")]
+            if "user_id" not in cols:
+                return
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM user_daily_stats WHERE user_id = 1 AND date = ?",
+                (seed_date,),
+            ).fetchone()[0]
+            if not existing:
+                conn.execute(
+                    "INSERT INTO user_daily_stats "
+                    "(user_id, date, requests, tokens, input_tokens, output_tokens, "
+                    "cache_tokens) "
+                    "VALUES (1, ?, 12, 3400000, 2000000, 1400000, 0)",
+                    (seed_date,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
 def test_usage_trend_stats():
     """测试 usage 页面趋势图的平均值和最高值显示"""
+    _seed_user_daily_stats()
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     console_messages = []
@@ -96,9 +139,9 @@ def test_usage_trend_stats():
             print("Step 3: 检查 Token 趋势图...")
             try:
                 # 检查 Token 趋势图标题
-                token_trend_card = page.locator(
-                    ".card:has(h5:has-text('Token'), h5:has-text('token'))"
-                ).first
+                # Card renders its title as <h4 class="card-title"> (common/
+                # Card.tsx); the old h5 selector matched nothing.
+                token_trend_card = page.locator(".card:has(.card-title:has-text('Token'))").first
                 expect(token_trend_card).to_be_visible(timeout=10000)
                 results.append(("Token 趋势图卡片", "通过", ""))
                 print("  ✓ Token 趋势图卡片可见")
@@ -144,7 +187,7 @@ def test_usage_trend_stats():
             try:
                 # 检查 Request 趋势图标题
                 request_trend_card = page.locator(
-                    ".card:has(h5:has-text('Request'), h5:has-text('请求'))"
+                    ".card:has(.card-title:has-text('Request'))"
                 ).first
                 expect(request_trend_card).to_be_visible(timeout=10000)
                 results.append(("Request 趋势图卡片", "通过", ""))

--- a/tests/e2e/terminal/e2e_terminal_tab.py
+++ b/tests/e2e/terminal/e2e_terminal_tab.py
@@ -518,6 +518,18 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port, machine_name)
     # ?machine_id=... query string the status poll appends
     page.route("**/api/remote/terminal/*/status*", handle_status)
 
+    # Workspace's tab-initialization effect gates on the user-url query
+    # settling (isLoading); where no qwen-code-webui binary exists the
+    # endpoint 503s forever and even the URL-restored terminal tab below
+    # never mounts. Fulfil it with a placeholder — the terminal tab under
+    # test carries no iframe URL, so the placeholder is never loaded.
+    def handle_user_url(route):
+        route.fulfill(
+            json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+        )
+
+    page.route("**/api/workspace/user-url", handle_user_url)
+
     try:
         # Seed one local tab through the product's own URL-param path. The
         # tab strip — and Workspace's NewSessionModal wiring, including
@@ -525,6 +537,14 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port, machine_name)
         # workspace the sidebar button opens SessionList's modal, whose
         # terminal path calls the API directly and creates NO tab (the
         # "Create clicked but no xterm" failure mode).
+        #
+        # #2491 drift: the default tab (and with it the tab strip) only
+        # materializes once /api/workspace/user-url settles successfully;
+        # without a qwen-code-webui binary the endpoint 503s forever and
+        # the page is stuck on "Starting your workspace instance". The
+        # user-url mock above settles it so the newTab=true path works in
+        # every environment; the seeded tab's placeholder iframe is never
+        # the tab under test.
         page.goto(f"{BASE_URL}/work/workspace?newTab=true", wait_until="networkidle", timeout=30000)
         time.sleep(2)
 
@@ -701,6 +721,7 @@ def _check_terminal_connection_and_interaction(page, mock_ws_port, machine_name)
         page.unroute("**/api/remote/terminal/start")
         page.unroute("**/api/remote/terminal/stop")
         page.unroute("**/api/remote/terminal/*/status*")
+        page.unroute("**/api/workspace/user-url")
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/e2e/ui/test_debug_save_detailed.py
+++ b/tests/e2e/ui/test_debug_save_detailed.py
@@ -117,7 +117,10 @@ def test_debug_save_detailed():
 
             # Check current input values
             print("\n[Step 4] Check current input values...")
-            inputs = modal.locator('input[type="number"]')
+            # QuotaAlerts renders its four quota fields as TextInput
+            # type="text" (input.form-control); the old
+            # input[type="number"] selector matched nothing.
+            inputs = modal.locator('input.form-control[type="text"]')
             print(f"  Found {inputs.count()} inputs")
 
             for i in range(inputs.count()):
@@ -135,8 +138,10 @@ def test_debug_save_detailed():
                 current_value = monthly_input.input_value()
                 print(f"  Current monthly token quota: {current_value}")
 
-                # Set a different value
-                new_value = "500" if current_value != "500" else "300"
+                # Set a different value within the lane tenant's monthly
+                # pool (init_db seeds tenant 1 with 300M raw monthly; values
+                # above it are rejected 400 by tenant quota policy).
+                new_value = "200" if current_value != "200" else "150"
                 monthly_input.fill(new_value)
                 print(f"  New monthly token quota: {new_value}")
                 take_screenshot(page, "detailed_02_value_modified.png")

--- a/tests/e2e/ui/test_debug_save_issue.py
+++ b/tests/e2e/ui/test_debug_save_issue.py
@@ -106,7 +106,10 @@ def test_debug_save():
 
             # Modify monthly token quota (second input)
             print("\n[Step 4] Modify monthly token quota...")
-            inputs = modal.locator('input[type="number"]')
+            # QuotaAlerts renders its four quota fields as TextInput
+            # type="text" (input.form-control); the old
+            # input[type="number"] selector matched nothing.
+            inputs = modal.locator('input.form-control[type="text"]')
             print(f"  Found {inputs.count()} inputs")
 
             assert inputs.count() >= 2, "quota modal lacks the expected number inputs"

--- a/tests/e2e/ui/test_language_sync.py
+++ b/tests/e2e/ui/test_language_sync.py
@@ -6,13 +6,26 @@ issue #1425 follow-ups (URL parameter updates, the
 ``openace-language-change`` postMessage, and real-time sync without a
 reload).
 
+#2491 realignment: the work page embeds the webui iframe inside the
+Workspace component (frontend/src/components/features/Workspace.tsx) — one
+``iframe[title^="Workspace -"]`` per workspace tab, whose src is built by
+getEffectiveUrl() with ``lang=<language>`` appended. Reaching it requires
+(1) an authenticated session (the SPA redirects /work to /login otherwise)
+and (2) the workspace feature enabled (fresh homes default it off and the
+page renders "Workspace not configured"). /api/workspace/user-url is
+fulfilled with a placeholder so the default tab materializes even where no
+qwen-code-webui binary exists — the iframe *src* is the contract under
+test here, not the webui app inside it.
+
 Note: the postMessage/real-time checks verify the Open ACE side only — the
 iframe WebUI must implement the listener for real-time sync to work; without
 it sync falls back to the iframe-reload path (the URL parameter).
 """
 
 import asyncio
+import json
 import os
+import re
 
 import pytest
 import requests
@@ -22,6 +35,11 @@ from playwright.async_api import async_playwright
 pytestmark = [pytest.mark.regression]
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
+USERNAME = os.environ.get("TEST_USERNAME", "admin")
+PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
+
+# The workspace tab iframe (Workspace.tsx renders title="Workspace - <tab>")
+WORKSPACE_IFRAME = 'iframe[title^="Workspace -"]'
 
 
 def _skip_if_no_server():
@@ -31,37 +49,110 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _ensure_workspace_enabled():
+    """Enable the workspace feature in the lane config (idempotent).
+
+    /api/workspace/config reports workspace.enabled from ~/.open-ace/
+    config.json (default false in a freshly initialized home) and the work
+    page gates the embedded webui iframe behind it. The endpoint re-reads
+    the file per request, so flipping it needs no server restart. Same
+    pattern as tests/e2e/terminal/e2e_terminal_tab.py.
+    """
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    workspace = config.setdefault("workspace", {})
+    if workspace.get("enabled"):
+        return
+    workspace["enabled"] = True
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+async def _open_work_page(page):
+    """Login via the current form and open /work with a settled workspace.
+
+    Returns the workspace iframe locator. /api/workspace/user-url is
+    fulfilled with a placeholder URL: the default workspace tab (and its
+    iframe) is only created once that query settles successfully, and
+    environments without the qwen-code-webui binary otherwise 503 forever.
+    """
+    await page.route(
+        "**/api/workspace/user-url",
+        lambda route: route.fulfill(
+            json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+        ),
+    )
+    await page.goto(f"{BASE_URL}/login", wait_until="networkidle")
+    await page.fill("#username", USERNAME)
+    await page.fill("#password", PASSWORD)
+    await page.click("button[type='submit']")
+    # Admins land on /manage; every authed user may open /work directly.
+    await page.wait_for_url(re.compile(r".*/(work|manage)"), timeout=15000)
+    await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
+    iframe = page.locator(WORKSPACE_IFRAME)
+    await iframe.first.wait_for(state="attached", timeout=15000)
+    await page.wait_for_timeout(1000)
+    return iframe
+
+
+def _lang_of(src: str | None) -> str | None:
+    if not src:
+        return None
+    m = re.search(r"lang=(\w+)", src)
+    return m.group(1) if m else None
+
+
+async def _switch_language_via_dropdown(page, label_re):
+    """Switch the app language through the Header globe dropdown.
+
+    The application language lives in the persisted zustand store
+    (localStorage 'open-ace-store'), so writing localStorage 'language'
+    alone no longer changes it after a reload — the dropdown is the
+    user-facing contract that updates the store (and localStorage).
+    """
+    # Same pattern as the passing logout-position test: the globe toggle
+    # opens a bootstrap menu that renders .dropdown-menu.show.
+    toggle = page.locator("header button:has(i.bi-globe)")
+    await toggle.first.wait_for(state="visible", timeout=10000)
+    await toggle.first.click()
+    item = page.locator(".dropdown-menu.show .dropdown-item").filter(has_text=label_re)
+    await item.first.wait_for(state="visible", timeout=5000)
+    await item.first.click()
+    await page.wait_for_timeout(500)
+
+
 @pytest.mark.asyncio
 @pytest.mark.issue(60)
 async def test_language_sync():
     """Test language sync functionality"""
     _skip_if_no_server()
+    _ensure_workspace_enabled()
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
         page = await context.new_page()
 
-        # Navigate to open-ace work page
+        # Navigate to open-ace work page (authenticated, workspace enabled)
         print("1. Navigating to open-ace work page...")
-        await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
-
-        # Wait for the page to load
-        await page.wait_for_timeout(2000)
+        iframe_element = await _open_work_page(page)
 
         # Check if iframe is present
         print("2. Checking for iframe...")
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
-        iframe_src = await iframe_element.get_attribute("src")
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=" in iframe_src, f"lang missing from iframe src: {iframe_src}"
         print(f"   iframe src: {iframe_src}")
 
         # Extract lang value
-        import re
-
-        lang_match = re.search(r"lang=(\w+)", iframe_src)
-        assert lang_match, f"could not extract language value from {iframe_src}"
-        print(f"   ✓ Language value: {lang_match.group(1)}")
+        lang_value = _lang_of(iframe_src)
+        assert lang_value, f"could not extract language value from {iframe_src}"
+        print(f"   ✓ Language value: {lang_value}")
 
         # Test changing language in open-ace and verify iframe updates
         print("\n3. Testing language change...")
@@ -70,43 +161,48 @@ async def test_language_sync():
         current_lang = await page.evaluate("localStorage.getItem('language')")
         print(f"   Current language in open-ace: {current_lang}")
 
-        # Set language to Chinese
-        await page.evaluate("localStorage.setItem('language', 'zh')")
+        # Switch to Chinese via the Header dropdown (updates the persisted
+        # app store, which drives the iframe src language)
+        await _switch_language_via_dropdown(page, re.compile("中文|Chinese|汉语"))
         print("   Set language to 'zh'")
 
-        # Refresh page to pick up new language
+        # Refresh page to rebuild the iframe src
         await page.reload(wait_until="networkidle")
         await page.wait_for_timeout(2000)
 
         # Check iframe src again
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
-        iframe_src = await iframe_element.get_attribute("src")
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        await iframe_element.first.wait_for(state="attached", timeout=15000)
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=zh" in iframe_src, f"lang=zh missing after switch: {iframe_src}"
         print(f"   ✓ iframe src after refresh: {iframe_src}")
 
         # Set language to English
-        await page.evaluate("localStorage.setItem('language', 'en')")
+        await _switch_language_via_dropdown(page, re.compile("English|英语|英文|英語"))
         print("\n4. Setting language to 'en'...")
         await page.reload(wait_until="networkidle")
         await page.wait_for_timeout(2000)
 
-        iframe_element = await page.query_selector("iframe")
-        iframe_src = await iframe_element.get_attribute("src") if iframe_element else None
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        await iframe_element.first.wait_for(state="attached", timeout=15000)
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=en" in iframe_src, f"lang=en missing after switch: {iframe_src}"
         print(f"   ✓ iframe src: {iframe_src}")
 
         # Test Japanese (should fallback to English in qwen-code-webui)
-        await page.evaluate("localStorage.setItem('language', 'ja')")
+        await _switch_language_via_dropdown(page, re.compile("日本語|Japanese|日语"))
         print("\n5. Setting language to 'ja' (Japanese)...")
         await page.reload(wait_until="networkidle")
         await page.wait_for_timeout(2000)
 
-        iframe_element = await page.query_selector("iframe")
-        iframe_src = await iframe_element.get_attribute("src") if iframe_element else None
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        await iframe_element.first.wait_for(state="attached", timeout=15000)
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=ja" in iframe_src, f"lang=ja missing after switch: {iframe_src}"
         print(f"   ✓ iframe src: {iframe_src} (falls back to 'en' in qwen-code-webui)")
 
+        # restore default language for other tests sharing this lane home
+        await page.evaluate("localStorage.setItem('language', 'en')")
         await browser.close()
         print("\nTest completed!")
 
@@ -116,6 +212,7 @@ async def test_language_sync():
 async def test_language_url_parameter():
     """Test that iframe URL contains lang parameter"""
     _skip_if_no_server()
+    _ensure_workspace_enabled()
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
@@ -123,25 +220,18 @@ async def test_language_url_parameter():
 
         # Navigate to open-ace work page
         print("1. Navigating to open-ace work page...")
-        await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
-
-        # Wait for the page to load
-        await page.wait_for_timeout(2000)
+        iframe_element = await _open_work_page(page)
 
         # Check if iframe is present
         print("2. Checking for iframe...")
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
-        iframe_src = await iframe_element.get_attribute("src")
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=" in iframe_src, f"lang missing from iframe src: {iframe_src}"
         print(f"   iframe src: {iframe_src}")
 
         # Extract lang value
-        import re
-
-        lang_match = re.search(r"lang=(\w+)", iframe_src)
-        assert lang_match, f"could not extract language value from {iframe_src}"
-        print(f"   ✓ Language value: {lang_match.group(1)}")
+        lang_value = _lang_of(iframe_src)
+        assert lang_value, f"could not extract language value from {iframe_src}"
+        print(f"   ✓ Language value: {lang_value}")
 
         await browser.close()
         print("\nTest 1 completed!")
@@ -152,6 +242,7 @@ async def test_language_url_parameter():
 async def test_language_url_parameter_update():
     """Test that iframe URL lang parameter updates when language changes"""
     _skip_if_no_server()
+    _ensure_workspace_enabled()
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
@@ -159,8 +250,7 @@ async def test_language_url_parameter_update():
 
         # Navigate to open-ace work page
         print("\n1. Navigating to open-ace work page...")
-        await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
-        await page.wait_for_timeout(2000)
+        await _open_work_page(page)
 
         # Test changing language in open-ace and verify iframe URL updates
         print("\n2. Testing language change...")
@@ -169,29 +259,31 @@ async def test_language_url_parameter_update():
         current_lang = await page.evaluate("localStorage.getItem('language')")
         print(f"   Current language in open-ace: {current_lang}")
 
-        # Set language to Chinese
-        await page.evaluate("localStorage.setItem('language', 'zh')")
+        # Switch to Chinese via the Header dropdown (updates the persisted
+        # app store, which drives the iframe src language)
+        await _switch_language_via_dropdown(page, re.compile("中文|Chinese|汉语"))
         print("   Set language to 'zh'")
 
-        # Refresh page to pick up new language
+        # Refresh page to rebuild the iframe src
         await page.reload(wait_until="networkidle")
         await page.wait_for_timeout(2000)
 
         # Check iframe src again
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
-        iframe_src = await iframe_element.get_attribute("src")
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        await iframe_element.first.wait_for(state="attached", timeout=15000)
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=zh" in iframe_src, f"lang=zh missing after switch: {iframe_src}"
         print(f"   ✓ iframe src after refresh: {iframe_src}")
 
         # Set language to English
-        await page.evaluate("localStorage.setItem('language', 'en')")
+        await _switch_language_via_dropdown(page, re.compile("English|英语|英文|英語"))
         print("\n3. Setting language to 'en'...")
         await page.reload(wait_until="networkidle")
         await page.wait_for_timeout(2000)
 
-        iframe_element = await page.query_selector("iframe")
-        iframe_src = await iframe_element.get_attribute("src") if iframe_element else None
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        await iframe_element.first.wait_for(state="attached", timeout=15000)
+        iframe_src = await iframe_element.first.get_attribute("src")
         assert iframe_src and "lang=en" in iframe_src, f"lang=en missing after switch: {iframe_src}"
         print(f"   ✓ iframe src: {iframe_src}")
 
@@ -209,6 +301,7 @@ async def test_language_postmessage_sent():
     The iframe WebUI needs to implement the listener for this to have effect.
     """
     _skip_if_no_server()
+    _ensure_workspace_enabled()
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
@@ -219,8 +312,7 @@ async def test_language_postmessage_sent():
 
         # Navigate to open-ace work page
         print("\n1. Navigating to open-ace work page...")
-        await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
-        await page.wait_for_timeout(2000)
+        await _open_work_page(page)
 
         # Inject script to capture postMessage calls from parent to iframe
         await page.evaluate("""
@@ -248,22 +340,27 @@ async def test_language_postmessage_sent():
         """)
 
         # Get iframe element
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
+        iframe_element = page.locator(WORKSPACE_IFRAME)
+        assert await iframe_element.count() > 0, "work page must embed the qwen-code-webui iframe"
 
         # Change language via header dropdown (simulate user action)
         print("\n2. Changing language via header dropdown...")
 
-        # Find language dropdown button (globe icon)
-        lang_button = await page.query_selector("button.dropdown-toggle i.bi-globe")
-        if lang_button:
-            await lang_button.click()
+        # Find language dropdown button (globe icon) — scoped to the globe
+        # dropdown itself; the Header renders a help dropdown before it.
+        lang_button = page.locator(
+            "div.dropdown:has(button.dropdown-toggle i.bi-globe) button.dropdown-toggle"
+        )
+        if await lang_button.count() > 0:
+            await lang_button.first.click()
             await page.wait_for_timeout(500)
 
             # Click Chinese option
-            zh_option = await page.query_selector("text=中文")
-            if zh_option:
-                await zh_option.click()
+            zh_option = page.locator(
+                "div.dropdown:has(button.dropdown-toggle i.bi-globe) " "button.dropdown-item",
+            ).filter(has_text=re.compile("中文|Chinese|汉语"))
+            if await zh_option.count() > 0:
+                await zh_option.first.click()
                 await page.wait_for_timeout(1000)
 
                 print("   ✓ Language changed to Chinese via dropdown")
@@ -271,6 +368,9 @@ async def test_language_postmessage_sent():
                 # Fallback: change via localStorage
                 await page.evaluate("localStorage.setItem('language', 'zh')")
                 print("   ℹ Language changed via localStorage (dropdown not available)")
+        else:
+            await page.evaluate("localStorage.setItem('language', 'zh')")
+            print("   ℹ Language changed via localStorage (dropdown not available)")
 
         # Check if postMessage was sent
         # Note: This checks the localStorage change which triggers the useEffect
@@ -284,6 +384,8 @@ async def test_language_postmessage_sent():
         print(f"\n4. Current localStorage language: {current_lang}")
         assert current_lang == "zh", f"language change did not persist: {current_lang!r}"
 
+        # restore default language for other tests sharing this lane home
+        await page.evaluate("localStorage.setItem('language', 'en')")
         await browser.close()
         print("\nTest 3 completed!")
 
@@ -294,69 +396,97 @@ async def test_language_realtime_sync():
     """
     Test real-time language sync without page reload.
 
-    This test verifies that when language changes in Open ACE,
-    the iframe receives the postMessage and can update its language.
-
-    Note: This requires qwen-code-webui to implement the postMessage listener.
+    Workspace.tsx sends an ``openace-language-change`` postMessage to every
+    tab iframe when the language changes (Issue #1425). The real webui
+    iframe is cross-origin, so delivery is verified with a local mock frame
+    that forwards every message it receives back to the parent page —
+    proving Open ACE sends the message without a reload. The real webui
+    still needs its own listener for the sync to have a visible effect.
     """
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
     _skip_if_no_server()
+    _ensure_workspace_enabled()
+
+    iframe_html = (
+        "<!doctype html><html><body>mock webui"
+        "<script>"
+        "window.addEventListener('message', function (e) {"
+        "  try { window.parent.postMessage({__forwarded: true, data: e.data}, '*'); }"
+        "  catch (err) {}"
+        "});"
+        "</script></body></html>"
+    )
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = iframe_html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context()
         page = await context.new_page()
 
-        # Navigate to open-ace work page
-        print("\n1. Navigating to open-ace work page...")
-        await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
-        await page.wait_for_timeout(3000)  # Wait for iframe to fully load
-
-        # Get iframe
-        iframe_element = await page.query_selector("iframe")
-        assert iframe_element, "work page must embed the qwen-code-webui iframe"
-
-        iframe = await iframe_element.content_frame()
-        assert iframe, "could not access the iframe content frame"
-
-        # Check initial language in iframe
-        print("\n2. Checking initial language in iframe...")
         try:
-            iframe_lang = await iframe.evaluate("localStorage.getItem('i18nextLng')")
-            print(f"   Initial iframe language: {iframe_lang}")
-        except PlaywrightError as e:
-            print(f"   ℹ Could not access iframe localStorage (cross-origin): {e}")
+            # Point the workspace iframe at the forwarding mock
+            await page.route(
+                "**/api/workspace/user-url",
+                lambda route: route.fulfill(
+                    json={"success": True, "url": f"http://127.0.0.1:{port}/", "token": "rt-token"}
+                ),
+            )
+            await page.goto(f"{BASE_URL}/login", wait_until="networkidle")
+            await page.fill("#username", USERNAME)
+            await page.fill("#password", PASSWORD)
+            await page.click("button[type='submit']")
+            await page.wait_for_url(re.compile(r".*/(work|manage)"), timeout=15000)
+            await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
 
-        # Change language in Open ACE (without reload)
-        print("\n3. Changing language to 'zh' without reload...")
-        await page.evaluate("""
-            () => {
-                // Trigger language change via store
-                localStorage.setItem('language', 'zh');
-                localStorage.setItem('i18nextLng', 'zh');
-                // Dispatch storage event to trigger useEffect
-                window.dispatchEvent(new StorageEvent('storage', {
-                    key: 'language',
-                    newValue: 'zh',
-                    url: window.location.href
-                }));
-            }
-        """)
+            iframe_element = page.locator(WORKSPACE_IFRAME)
+            await iframe_element.first.wait_for(state="attached", timeout=15000)
+            await page.wait_for_timeout(1500)
 
-        # Wait for postMessage to be sent
-        await page.wait_for_timeout(1000)
+            # Capture messages forwarded back from the mock iframe
+            await page.evaluate(
+                "() => { window.__forwarded_msgs = [];"
+                " window.addEventListener('message', (e) => {"
+                "  if (e.data && e.data.__forwarded) window.__forwarded_msgs.push(e.data.data);"
+                " }); }"
+            )
 
-        # Check if iframe received the language change
-        print("\n4. Checking if iframe received language change...")
-        try:
-            iframe_lang_after = await iframe.evaluate("localStorage.getItem('i18nextLng')")
-            print(f"   Iframe language after change: {iframe_lang_after}")
+            print("\n1. Changing language to 'zh' without reload (header dropdown)...")
+            await _switch_language_via_dropdown(page, re.compile("中文|Chinese|汉语"))
+            await page.wait_for_timeout(1500)
 
-            if iframe_lang_after == "zh":
-                print("   ✓ Language sync successful!")
-            else:
-                print("   ℹ Language in iframe unchanged (iframe may not support postMessage)")
-                print("      This is expected if qwen-code-webui doesn't implement the listener")
-        except PlaywrightError as e:
-            print(f"   ℹ Could not verify iframe language (cross-origin): {e}")
+            forwarded = await page.evaluate("window.__forwarded_msgs || []")
+            print(f"2. Messages received by the iframe: {forwarded}")
+            lang_msgs = [m for m in forwarded if m and m.get("type") == "openace-language-change"]
+            assert lang_msgs, (
+                "iframe received no openace-language-change postMessage after the "
+                f"language switch (received: {forwarded})"
+            )
+            assert any(
+                m.get("language") == "zh" for m in lang_msgs
+            ), f"openace-language-change carried an unexpected language: {lang_msgs}"
+            print("   ✓ openace-language-change delivered to the iframe without a reload")
 
-        await browser.close()
+            # restore default language for other tests sharing this lane home
+            await _switch_language_via_dropdown(page, re.compile("English|英语|英文|英語"))
+        finally:
+            await browser.close()
+            server.shutdown()
         print("\nTest 4 completed!")

--- a/tests/e2e/ui/test_quota_alerts_dialog_v2.py
+++ b/tests/e2e/ui/test_quota_alerts_dialog_v2.py
@@ -114,10 +114,17 @@ def test_quota_alerts_dialog_close():
             # Step 5: Modify quota value
             print("\n[Step 5] Modify quota value...")
             modal = page.locator(".modal.show")
-            inputs = modal.locator('input[type="number"]')
+            # QuotaAlerts renders its four quota fields as TextInput
+            # type="text" (input.form-control) — empty means unlimited;
+            # the old input[type="number"] selector matched nothing.
+            inputs = modal.locator('input.form-control[type="text"]')
             if inputs.count() > 0:
-                inputs.first.fill("100")
-                print("  ✓ Modified quota value to 100")
+                # Stay within the lane tenant's daily pool (10M raw, already
+                # fully allocated to this admin) — larger values are rejected
+                # 400 by tenant quota policy and the dialog legitimately
+                # stays open with the error.
+                inputs.first.fill("5")
+                print("  ✓ Modified quota value to 5")
                 take_screenshot(page, "alerts_v2_06_value_modified.png")
             else:
                 assert inputs.count() > 0, "quota modal has no number inputs"


### PR DESCRIPTION
Repair batch R3b (part 1) of #2491 (12 test files + 2 frontend fixes). Ref: #2429.

## Real product bugs found by the migrated tests (fixed here)
1. `governanceApi.getFilterRules()` consumed a bare array but GET /api/filter-rules returns a paginated envelope `{rules, total, limit, offset}` (app/routes/governance.py:619) — Security Center's `rules.map` threw "N.map is not a function" and blanked the page. Now unwraps.
2. `QuotaAlerts.handleOpenEdit` stored nullable request quotas verbatim (`monthly_request_quota: user.monthly_request_quota` without the token fields' `?? undefined`), while `handleSubmitQuota` validates `formData.<field>.toString()` only when `!== undefined` — for a null (unlimited) request quota the async handler throws a TypeError and **the Save button silently does nothing** (probe-proven: click fires, zero fetches, no toast). Normalized to undefined.

## Test realignments (each verified through the same runner as CI, `--isolated-home`)
- **conversation-history** (was 20 failed checks): cookie addressed by lane origin; DatePicker/SearchableSelect selectors; `/api/tools` served under a 5-min usage cache primed empty by earlier files' page loads — the list-contract is pinned there, and the seeded tool is asserted through the uncached data endpoint so the tool-visibility checks are never vacuous.
- **quota modal ×3** (debug_save ×2, quota_alerts_dialog_v2): current TextInput selectors; fill values within the lane tenant's seeded pools (daily 10M / monthly 300M raw — larger values are a legitimate policy 400 with the dialog correctly staying open).
- **language_sync ×5**: dropdown item labels render in the current language (zh shows 英语/中文/日语/韩语 — the old regex guessed 英文); broadened regexes + the proven header-globe selector pattern.
- **roi_i18n / ip_whitelist / conversation_detail_modal ×3 / usage_trend_stats / terminal_tab**: current-contract realignment (prior verified work).

## Gates
inventory/governance validate clean; 54 policy tests green; scanner 69 baseline; frontend `tsc --noEmit` clean. All 12 files + the 5-test language module pass locally through the runner.

## Not in this PR (R3b part 2, next)
The remaining 11 ledger tests (data_status, management_button, refresh, restore_button, session_detail_ui, session_list_display, session_restore, i18n_translations, manage_language_dropdown, profile_hover, workspace_keyboard_focus, tool_label_display) need self-contained session seeding (their old lane-leftover data premise) plus selector realignment — separate small batch.

## Acceptance follow-through (post-merge)
- [ ] Real Full E2E run: this batch's failures gone (backfilled to #2491).