### PR TITLE
fix(#3199): resolve owner/repo from local git remote for existing projects

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10119,13 +10119,35 @@ class AutonomousOrchestrator:
                 except GitHubOpsError:
                     pass
 
+            # Issue #3199: For existing projects (is_new_project=False), also try
+            # resolving owner/repo from the local git remote. This handles the case
+            # where the user selected an existing Git project directory that has a
+            # GitHub origin remote configured.
+            if not issue_repo and not wf.get("is_new_project"):
+                try:
+                    resolved = gh.get_repo_name()
+                    if resolved:
+                        issue_repo = resolved
+                        logger.info(
+                            "Resolved issue_repo from local git remote: %s",
+                            issue_repo,
+                        )
+                except GitHubOpsError as e:
+                    logger.warning(
+                        "Failed to resolve owner/repo from local git remote: %s",
+                        e,
+                    )
+
             # Last-resort guard: if we still cannot determine the target
-            # repo for a new-project workflow, raise rather than silently
-            # creating the issue in the wrong (cwd-inferred) repository.
-            if not issue_repo and wf.get("is_new_project"):
+            # repo, raise rather than silently creating the issue in the
+            # wrong (cwd-inferred) repository or failing with "not a git repository".
+            if not issue_repo:
                 raise GitHubOpsError(
                     "Cannot determine target repository for issue creation. "
-                    f"repo_url={repo_url!r}, issue_repo_url={issue_repo_url!r}"
+                    "For existing projects, ensure the project directory has a GitHub "
+                    "origin remote configured (git remote -v). "
+                    f"project_path={project_path!r}, repo_url={repo_url!r}, "
+                    f"issue_repo_url={issue_repo_url!r}"
                 )
 
             try:

--- a/tests/unit/test_issue_wrong_repo_3075.py
+++ b/tests/unit/test_issue_wrong_repo_3075.py
@@ -399,3 +399,191 @@ class TestPreparationIssueCreation:
 
             # Verify create_issue was NOT called (error raised before)
             mock_gh.create_issue.assert_not_called()
+
+
+class TestIssue3199ExistingProject:
+    """Test Issue #3199: existing project without project_repo_url should resolve from local git remote."""
+
+    def _make_existing_project_workflow(self, tmp_path):
+        """Create a test workflow dict for existing project scenario."""
+        return {
+            "id": "test-workflow-id-3199",
+            "workflow_id": "wf-3199-test",
+            "current_phase": "preparation",
+            "status": "preparing",
+            "is_new_project": False,  # Key: existing project, not new
+            "branch_strategy": "new-branch",
+            "requirements_text": "Add a README file",
+            "github_issue_number": None,
+            "project_repo_url": "",  # Empty: user didn't specify a repo URL
+            "project_path": str(tmp_path),
+            "title": "Test Existing Project",
+        }
+
+    def _setup_orchestrator(self, wf, mock_gh):
+        """Helper to create a partially-mocked orchestrator."""
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        repo = MagicMock()
+        repo.get_workflow.return_value = wf
+
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch.repo = repo
+        orch._workflow_id = wf.get("workflow_id", "wf-3199-test")
+        orch._gh = None
+        orch._shutdown_requested = threading.Event()
+        orch._session_usage_offsets = {}
+        orch._update_workflow = MagicMock(side_effect=lambda updates: wf.update(updates))
+        orch._create_milestone = MagicMock(return_value={"milestone_id": "ms"})
+        orch.emit_phase_change = MagicMock()
+        orch._get_gh = MagicMock(return_value=mock_gh)
+        return orch, repo
+
+    def test_existing_project_resolves_repo_from_local_remote(self, tmp_path):
+        """Verify existing project resolves owner/repo from local git remote.
+
+        Issue #3199: User selected an existing Git project directory that has a
+        GitHub origin remote. The issue_repo should be resolved from the local
+        git remote, not from project_repo_url (which is empty for existing projects).
+        """
+        wf = self._make_existing_project_workflow(tmp_path)
+        wf.update(
+            {
+                "user_id": 1,
+            }
+        )
+
+        mock_gh = MagicMock(name="gh")
+        # get_repo_name() returns the owner/repo from local git remote
+        mock_gh.get_repo_name.return_value = "user/existing-project"
+        mock_gh.create_issue.return_value = {
+            "number": 123,
+            "url": "https://github.com/user/existing-project/issues/123",
+        }
+        mock_gh.get_current_branch.return_value = "main"
+        mock_gh.list_worktrees.return_value = []
+
+        # Mock _run_git with a function that handles different commands
+        def mock_run_git(args, check=True, **kwargs):
+            stdout = ""
+            rc = 0
+            if "fetch" in args:
+                stdout = ""
+                rc = 0
+            elif "show-ref" in args:
+                # Return success for refs/remotes/origin/main
+                if "origin/main" in args:
+                    stdout = "refs/remotes/origin/main"
+                    rc = 0
+                else:
+                    rc = 1
+            elif "rev-parse" in args:
+                stdout = "abc123"  # Commit SHA
+            elif "branch" in args and "-a" in args:
+                stdout = "  main\n  remotes/origin/main"
+            return MagicMock(returncode=rc, stdout=stdout, stderr="")
+
+        mock_gh._run_git.side_effect = mock_run_git
+
+        orch, repo = self._setup_orchestrator(wf, mock_gh)
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+                return_value=mock_gh,
+            ),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.UserRepository"
+            ) as mock_user_repo_cls,
+        ):
+            mock_user_repo_cls.return_value.get_user_by_id.return_value = {
+                "system_account": "alice"
+            }
+            ctx = WorkflowContext(
+                workflow=wf,
+                definition_snapshot=None,
+                repository_context=None,
+                session_bindings={},
+                cancellation=threading.Event(),
+            )
+            deps = PhaseDeps(
+                host=orch,
+                gh=mock_gh,
+                git_workspace=MagicMock(),
+                evidence=MagicMock(),
+                sandbox=MagicMock(),
+                repo=repo,
+                agent_runner=MagicMock(),
+            )
+
+            result = orch._do_preparation(ctx, deps)
+
+        # Verify get_repo_name was called to resolve owner/repo from local remote
+        mock_gh.get_repo_name.assert_called()
+
+        # Verify create_issue was called with the correct repo
+        mock_gh.create_issue.assert_called_once()
+        call_kwargs = mock_gh.create_issue.call_args
+        assert call_kwargs.kwargs.get("repo") == "user/existing-project", (
+            f"Expected repo='user/existing-project', got "
+            f"repo={call_kwargs.kwargs.get('repo')!r}"
+        )
+        assert result.next_phase == "planning"
+
+    def test_existing_project_no_remote_raises_clear_error(self, tmp_path):
+        """Verify clear error when existing project has no GitHub remote configured.
+
+        Issue #3199: When the user selects a project directory that has no GitHub
+        origin remote, the error message should guide the user to configure one.
+        """
+        wf = self._make_existing_project_workflow(tmp_path)
+        wf.update(
+            {
+                "user_id": 1,
+            }
+        )
+
+        mock_gh = MagicMock(name="gh")
+        # get_repo_name() returns empty string (no remote configured)
+        mock_gh.get_repo_name.return_value = ""
+        mock_gh._run_git.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_gh.get_current_branch.return_value = "main"
+        mock_gh.list_worktrees.return_value = []
+
+        orch, repo = self._setup_orchestrator(wf, mock_gh)
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+                return_value=mock_gh,
+            ),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.UserRepository"
+            ) as mock_user_repo_cls,
+        ):
+            mock_user_repo_cls.return_value.get_user_by_id.return_value = {
+                "system_account": "alice"
+            }
+            ctx = WorkflowContext(
+                workflow=wf,
+                definition_snapshot=None,
+                repository_context=None,
+                session_bindings={},
+                cancellation=threading.Event(),
+            )
+            deps = PhaseDeps(
+                host=orch,
+                gh=mock_gh,
+                git_workspace=MagicMock(),
+                evidence=MagicMock(),
+                sandbox=MagicMock(),
+                repo=repo,
+                agent_runner=MagicMock(),
+            )
+
+            # Should raise clear error about missing GitHub remote
+            with pytest.raises(GitHubOpsError, match="Cannot determine target repository"):
+                orch._do_preparation(ctx, deps)
+
+            # Verify create_issue was NOT called
+            mock_gh.create_issue.assert_not_called()


### PR DESCRIPTION
## 问题描述

Issue #3199: 用户在 AI 自主开发模式下，选择已有 Git 项目路径后，执行 `gh issue create` 时报错 "not a git repository"。

## 根因分析

在 `_do_preparation` 函数中，当用户选择已有项目（`is_new_project=False`）时：

1. `project_repo_url` 为空（因为用户没有输入）
2. `repo_url` 也是空的（只有新项目才会创建仓库）
3. 现有的 fallback 逻辑只在 `repo_url` 有值时才调用 `gh.get_repo_name()`
4. 错误防护检查只在 `is_new_project=True` 时触发
5. `issue_repo` 保持为 `None`
6. `create_issue(repo=None)` 被调用
7. 在 `_run_gh` 中，跨用户执行时移除了 `cwd`，但没有 `-R owner/repo` 参数
8. `gh issue create` 没有仓库上下文，报错 "not a git repository"

## 修复方案

1. 为已有项目添加从本地 git remote 解析 `owner/repo` 的逻辑
2. 扩展错误防护到所有 `issue_repo` 为空的场景
3. 改进错误信息，引导用户配置 GitHub remote

## 测试

- `test_existing_project_resolves_repo_from_local_remote`: 验证从本地 git remote 正确解析
- `test_existing_project_no_remote_raises_clear_error`: 验证无 remote 时给出明确错误

Closes #3199