### PR TITLE
fix(e2e): repair R3b-part-2 shard drift (interactions + skip conversions)

### DIFF
--- a/tests/e2e/browser/test_manage_analysis_conversation_pagination.py
+++ b/tests/e2e/browser/test_manage_analysis_conversation_pagination.py
@@ -159,7 +159,94 @@ def wait_table(page, timeout=10000):
         return False
 
 
-def test_pagination():
+SEED_PREFIX = "e2e-conv-page824-"
+SEED_CONVERSATIONS = 25  # > ITEMS_PER_PAGE (20) -> a multi-page dataset
+
+
+def _seed_conversation_rows():
+    """Self-seed the data precondition: >1 page of conversations.
+
+    The pagination contract needs a multi-page dataset; a freshly
+    initialized lane home has none, which used to reduce this test to a
+    skip. Seed distinct conversation_ids for user_id=1 (same pattern as
+    tests/e2e/manage/e2e_conversation_history.py) so the test RUNS, with
+    cleanup on teardown via the fixture below.
+    """
+    conv_ids = []
+    import sqlite3
+    from datetime import datetime, timedelta, timezone
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return conv_ids
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            # Date the rows with UTC "today": /api/conversation-history
+            # defaults its window to datetime.now(timezone.utc), which can
+            # lag the local calendar date (the frontend's default range uses
+            # local dates and always includes it either way).
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            existing = conn.execute(
+                "SELECT COUNT(DISTINCT conversation_id) FROM daily_messages "
+                "WHERE conversation_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            ).fetchone()[0]
+            if existing < SEED_CONVERSATIONS:
+                for i in range(SEED_CONVERSATIONS - existing):
+                    conv_id = f"{SEED_PREFIX}{existing + i:02d}"
+                    conv_ids.append(conv_id)
+                    ts = (datetime.now() - timedelta(seconds=i)).isoformat(timespec="seconds")
+                    conn.execute(
+                        "INSERT INTO daily_messages "
+                        "(date, tool_name, host_name, role, content, tokens_used, "
+                        "input_tokens, output_tokens, timestamp, sender_name, "
+                        "message_id, agent_session_id, conversation_id, user_id) "
+                        "VALUES (?, 'claude-code', 'e2e-host-824', 'user', "
+                        "'e2e pagination probe', 10, 5, 5, ?, 'admin', "
+                        "'e2e-msg-824-" + str(existing + i) + "', ?, ?, 1)",
+                        (today, ts, conv_id, conv_id),
+                    )
+                conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return conv_ids
+
+
+def _cleanup_conversation_rows(seeded_ids):
+    """Delete exactly what this test seeded (fixture teardown)."""
+    import sqlite3
+
+    if not seeded_ids:
+        return
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "DELETE FROM daily_messages WHERE conversation_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+@pytest.fixture()
+def _multi_page_conversations():
+    """Seed the multi-page precondition and remove it afterwards."""
+    seeded = _seed_conversation_rows()
+    yield
+    _cleanup_conversation_rows(seeded)
+
+
+def test_pagination(_multi_page_conversations):
     print("=" * 60)
     print("Conversation History Pagination E2E Test (#824)")
     print(f"  WEB_BASE={WEB_BASE}  API_BASE={API_BASE}  HEADLESS={HEADLESS}")

--- a/tests/e2e/manage/e2e_conversation_history.py
+++ b/tests/e2e/manage/e2e_conversation_history.py
@@ -118,6 +118,11 @@ def check(desc, condition, detail=""):
 
 def test_conversation_history():
     global passed, failed
+    # Reset the module-level counters so pytest --reruns attempts report
+    # their own tallies instead of accumulating across attempts (the CI
+    # envelope double-counted one failing check as two).
+    passed = 0
+    failed = 0
     print("=" * 60)
     print("Conversation History Page E2E Test")
     print("=" * 60)
@@ -149,8 +154,19 @@ def test_conversation_history():
     )
 
     r = session.get(f"{BASE_URL}/api/senders")
-    senders = r.json() if r.status_code == 200 else []
-    check("GET /api/senders returns data", len(senders) > 0, f"({len(senders)} senders)")
+    senders_resp = r.json() if r.status_code == 200 else None
+    # /api/senders carries its own 5-minute in-process cache
+    # (app/routes/messages.py api_senders), so like /api/tools its CONTENT
+    # on the shared lane reflects whatever data existed when an earlier
+    # file's page load primed it — pinning "returns data" here failed the
+    # nightly shard whenever the cache was primed before this test's seed.
+    # Pin the contract; the seeded sender is asserted through the uncached
+    # conversation-history data below (non-vacuous).
+    check(
+        "GET /api/senders returns a sender list",
+        isinstance(senders_resp, list) and all(isinstance(s, str) for s in senders_resp),
+        f"({len(senders_resp or [])} senders)",
+    )
 
     r = session.get(
         f"{BASE_URL}/api/conversation-history",
@@ -162,9 +178,14 @@ def test_conversation_history():
     # The tools dropdown is fed by DISTINCT tool_name over daily_messages —
     # the same derivation /api/tools caches. Derive the expected tools from
     # the uncached rows so the page-visibility checks below always run
-    # against the seeded data (never vacuously).
+    # against the seeded data (never vacuously). The same holds for the
+    # sender (the /api/senders cache has identical staleness semantics).
     tools = sorted({row["tool_name"] for row in ch_data.get("data", []) if row.get("tool_name")})
     check("Seeded conversation exposes its tool", len(tools) > 0, f"(tools: {tools})")
+    senders = sorted(
+        {row["sender_name"] for row in ch_data.get("data", []) if row.get("sender_name")}
+    )
+    check("Seeded conversation exposes its sender", len(senders) > 0, f"(senders: {senders})")
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=HEADLESS)

--- a/tests/e2e/ui/test_data_status.py
+++ b/tests/e2e/ui/test_data_status.py
@@ -1,17 +1,24 @@
 """
-UI 测试: Issue 68 - Data Status 远程机器状态检查功能
+UI 测试: Issue 68 - 远程机器状态检查功能
+
+#2491 realignment: the sidebar "Data Status" panel this test originally
+asserted (``#data-status-container`` / ``.refresh-btn`` / ``.data-status-item``)
+was removed from the product (commit 360fc592 "feat: remove Data Status panel
+from sidebar"; the ``dataStatus`` i18n key is orphaned). The remote-host
+status surface now lives on the Remote Machines page —
+``frontend/src/components/features/management/RemoteMachineManagement.tsx``
+served at ``/manage/remote/machines`` (App.tsx route "remote/machines"):
+total/online/offline machine stat cards (RemoteMachineManagement.tsx lines
+424-452), a machine table whose rows carry online/offline status badges
+(lines 477-505), or the registered-machines empty state on a fresh lane
+(lines 454-457), plus per-machine Active-Sessions refresh buttons. The test
+asserts that current contract and that the page renders without page errors.
 
 测试目标:
-1. 验证 Data Status 面板显示正确
-2. 验证刷新按钮存在并可点击
-3. 验证远程机器状态检查功能
-
-测试步骤:
-1. 登录系统
-2. 导航到 Dashboard 页面
-3. 检查 Data Status 面板
-4. 点击刷新按钮
-5. 验证远程机器状态更新
+1. 验证 Remote Machines 页面（远程机器状态面板）显示正确
+2. 验证机器统计卡（总数/在线/离线）存在
+3. 验证机器状态徽章或空状态（未注册机器）正确渲染
+4. 验证页面无脚本错误
 """
 
 import os
@@ -67,15 +74,16 @@ def _skip_if_no_server():
 
 @pytest.mark.asyncio
 async def test_data_status():
-    """Test Data Status remote host check functionality."""
+    """Test the remote machine status surface (Remote Machines page)."""
     _skip_if_no_server()
     print("\n" + "=" * 60)
-    print("UI 测试: Issue 68 - Data Status 远程机器状态检查")
+    print("UI 测试: Issue 68 - 远程机器状态检查（Remote Machines 页面）")
     print("=" * 60)
 
     ensure_screenshot_dir()
     screenshots = []
     test_passed = True
+    console_errors = []
 
     async with async_playwright() as p:
         # Launch browser
@@ -83,127 +91,116 @@ async def test_data_status():
         browser = await p.chromium.launch(headless=HEADLESS)
         context = await browser.new_context(viewport={"width": 1280, "height": 800})
         page = await context.new_page()
+        page.on(
+            "console",
+            lambda msg: console_errors.append(msg.text) if msg.type == "error" else None,
+        )
 
         try:
             # Step 1: Login
             print("\n步骤 1: 登录系统")
             await page.goto(f"{BASE_URL}/login")
-            await page.fill('input[name="username"]', USERNAME)
-            await page.fill('input[name="password"]', PASSWORD)
+            # The React login form re-mounts once its SSO/config effects
+            # settle, which can detach filled inputs; re-fill until the
+            # values persist (same pattern as test_user_scenario).
+            for _attempt in range(3):
+                await page.wait_for_selector("#username", timeout=10000)
+                await page.fill("#username", USERNAME)
+                await page.fill("#password", PASSWORD)
+                if (
+                    await page.input_value("#username") == USERNAME
+                    and await page.input_value("#password") == PASSWORD
+                ):
+                    break
+                time.sleep(0.5)
             await page.click('button[type="submit"]')
 
-            # Wait for redirect (could be / or /dashboard)
-            await page.wait_for_url("**/", timeout=10000)
+            # Admins land on /manage after login.
+            await page.wait_for_url("**/manage/**", timeout=10000)
             print("  ✓ 登录成功")
             screenshots.append(await take_screenshot(page, "01_login.png"))
 
-            # Step 2: Check Data Status panel
-            print("\n步骤 2: 检查 Data Status 面板")
-
-            # Wait for page to fully load
+            # Step 2: Open the Remote Machines page (current home of the
+            # remote-host status surface).
+            print("\n步骤 2: 打开 Remote Machines 页面")
+            await page.goto(f"{BASE_URL}/manage/remote/machines")
+            await page.wait_for_load_state("networkidle")
             time.sleep(3)
 
-            # Wait for sidebar to load
-            await page.wait_for_selector("#data-status-container", timeout=10000)
+            header = page.locator("h2")
+            header_count = await header.count()
+            assert header_count > 0, "Remote Machines page did not render a header"
+            header_text = (await header.first.inner_text()).strip()
+            print(f"  ✓ 页面标题: {header_text}")
+            assert (
+                header_text
+                in (
+                    "Remote Machines",
+                    "远程机器",
+                    "リモートマシン",
+                    "リモート・マシン",
+                    "원격 머신",
+                )
+                or "Remote" in header_text
+                or "机器" in header_text
+            ), f"unexpected Remote Machines page header: {header_text!r}"
+            screenshots.append(await take_screenshot(page, "02_machines_page.png"))
 
-            # Wait for data status to be populated
+            # Step 3: Machine stat cards (total / online / offline) must be
+            # rendered — the machine-status summary contract.
+            print("\n步骤 3: 检查机器统计卡")
+            stat_cards = page.locator(".row.g-3 .card .card-body .h3")
+            stat_count = await stat_cards.count()
+            assert (
+                stat_count >= 3
+            ), f"machine stats cards (total/online/offline) missing: found {stat_count}"
+            for i in range(stat_count):
+                value = (await stat_cards.nth(i).inner_text()).strip()
+                print(f"  - 统计值 {i + 1}: {value}")
+                assert value.isdigit(), f"machine stat card {i + 1} is not numeric: {value!r}"
+            print("  ✓ 机器统计卡（总数/在线/离线）已渲染")
+
+            # Step 4: Machine rows with status badges, or the registered-
+            # machines empty state on a fresh lane.
+            print("\n步骤 4: 检查机器状态列表")
             time.sleep(2)
-
-            print("  ✓ Data Status 面板已加载")
-
-            # Check if refresh button exists
-            refresh_btn = page.locator("#data-status-container .refresh-btn")
-            if await refresh_btn.count() > 0:
-                print("  ✓ 刷新按钮存在")
+            machine_rows = page.locator("table tbody tr")
+            row_count = await machine_rows.count()
+            if row_count > 0:
+                print(f"  发现 {row_count} 台机器")
+                badges = page.locator("table tbody tr .badge")
+                badge_count = await badges.count()
+                assert badge_count > 0, "machine rows must carry status badges"
+                for i in range(min(badge_count, 6)):
+                    badge_text = (await badges.nth(i).inner_text()).strip()
+                    print(f"  - 状态徽章: {badge_text}")
+                screenshots.append(await take_screenshot(page, "03_machine_rows.png"))
             else:
-                print("  ⚠ 刷新按钮不存在，等待加载...")
-                time.sleep(3)
-                refresh_btn = page.locator("#data-status-container .refresh-btn")
-                if await refresh_btn.count() > 0:
-                    print("  ✓ 刷新按钮存在")
-                else:
-                    print("  ✗ 刷新按钮不存在")
-                    test_passed = False
-            assert await refresh_btn.count() > 0, "Data Status refresh button missing"
+                body_text = await page.locator("body").inner_text()
+                empty_state = (
+                    "No machines registered" in body_text
+                    or "暂无已注册的机器" in body_text
+                    or "no machines" in body_text.lower()
+                )
+                assert (
+                    empty_state
+                ), "no machine rows rendered and no registered-machines empty state shown"
+                print("  ✓ 空状态正确显示（未注册机器）")
+                screenshots.append(await take_screenshot(page, "03_empty_state.png"))
 
-            screenshots.append(await take_screenshot(page, "02_data_status_panel.png"))
+            # Step 5: Page health — the machine status surface must render
+            # without page errors. "Failed to load resource" notices are
+            # excluded: on a fresh lane the platform-admin machines query
+            # legitimately answers 400 until a tenant is selected
+            # (app/routes/remote.py list_machines requires tenant_id for
+            # platform admins) and the UI surfaces that via its own state.
+            print("\n步骤 5: 检查页面错误")
+            js_errors = [e for e in console_errors if "Failed to load resource" not in e]
+            for err in console_errors:
+                print(f"  - console error: {err}")
+            assert not js_errors, f"Remote Machines page emitted JS errors: {js_errors[:5]}"
+            print("  ✓ 页面无脚本错误")
 
-            # Step 3: Check host items
-            print("\n步骤 3: 检查主机状态项")
-            host_items = page.locator(".data-status-item")
-            host_count = await host_items.count()
-            print(f"  发现 {host_count} 个主机")
-
-            for i in range(host_count):
-                item = host_items.nth(i)
-                host_name = await item.locator(".host-name").text_content()
-                last_updated = await item.locator(".last-updated").text_content()
-
-                # Check status indicator class
-                item_class = await item.get_attribute("class")
-                status = "unknown"
-                if "status-online" in item_class:
-                    status = "online"
-                elif "status-offline" in item_class:
-                    status = "offline"
-                elif "status-fresh" in item_class:
-                    status = "fresh"
-                elif "status-recent" in item_class:
-                    status = "recent"
-                elif "status-stale" in item_class:
-                    status = "stale"
-
-                print(f"  - {host_name}: {last_updated} ({status})")
-
-            # Step 4: Click refresh button
-            print("\n步骤 4: 点击刷新按钮检查远程机器状态")
-            if await refresh_btn.count() > 0:
-                await refresh_btn.click()
-                print("  ✓ 已点击刷新按钮")
-
-                # Wait for loading state
-                time.sleep(1)
-                screenshots.append(await take_screenshot(page, "03_refresh_loading.png"))
-
-                # Wait for response (up to 15 seconds for SSH check)
-                print("  等待远程机器状态检查...")
-                time.sleep(10)
-
-                # Check if refresh button is no longer loading
-                refresh_btn_after = page.locator("#data-status-container .refresh-btn")
-                if await refresh_btn_after.count() > 0:
-                    btn_class = await refresh_btn_after.get_attribute("class")
-                    if "loading" not in btn_class:
-                        print("  ✓ 刷新完成")
-                    else:
-                        print("  ⚠ 刷新仍在进行中")
-
-                screenshots.append(await take_screenshot(page, "04_after_refresh.png"))
-
-                # Step 5: Verify remote host status
-                print("\n步骤 5: 验证远程机器状态")
-                host_items_after = page.locator(".data-status-item")
-                for i in range(await host_items_after.count()):
-                    item = host_items_after.nth(i)
-                    host_name = await item.locator(".host-name").text_content()
-                    item_class = await item.get_attribute("class")
-
-                    if (
-                        "is_remote" in str(item)
-                        or "ai-lab" in host_name
-                        or "remote" in host_name.lower()
-                    ):
-                        if "status-online" in item_class:
-                            print(f"  ✓ {host_name}: 在线")
-                        elif "status-offline" in item_class:
-                            print(f"  ✓ {host_name}: 离线（状态检查正常工作）")
-                        else:
-                            print(f"  - {host_name}: 状态未知")
-            else:
-                print("  ✗ 无法找到刷新按钮")
-                test_passed = False
-
-            # Final screenshot
             screenshots.append(await take_screenshot(page, "05_final.png"))
 
         except PlaywrightError as e:

--- a/tests/e2e/ui/test_i18n_translations.py
+++ b/tests/e2e/ui/test_i18n_translations.py
@@ -230,19 +230,28 @@ def test_main_page_i18n():
                 print("  ✗ English Messages nav not found")
                 results.append(("English Messages Nav", "FAIL", ""))
 
-            # Switch to Chinese - find lang selector in manage sidebar
-            # The lang selector is a dropdown button, not a select element
-            lang_dropdown = page.locator('button.dropdown-item:has-text("Chinese")')
-            if lang_dropdown.count() > 0:
-                # Click the dropdown toggle first
-                dropdown_toggle = page.locator('[data-bs-toggle="dropdown"]')
-                if dropdown_toggle.count() > 0:
-                    dropdown_toggle.first.click()
-                    page.wait_for_timeout(500)
-                lang_dropdown.first.click()
-                page.wait_for_timeout(1000)
+            # Switch to Chinese via the Header language dropdown. The toggle
+            # must be the globe one: the Header renders the help dropdown
+            # BEFORE the language dropdown (frontend/src/components/layout/
+            # Header.tsx), so an unscoped [data-bs-toggle="dropdown"] locator
+            # resolves to the help dropdown and the click times out. Same
+            # pattern as tests/e2e/ui/test_language_sync.py.
+            toggle = page.locator("header button:has(i.bi-globe)")
+            if toggle.count() > 0:
+                toggle.first.wait_for(state="visible", timeout=10000)
+                toggle.first.click()
+                page.wait_for_timeout(500)
+                zh_item = page.locator(
+                    "div.dropdown:has(button.dropdown-toggle i.bi-globe) "
+                    ".dropdown-menu.show button.dropdown-item"
+                ).filter(has_text="中文")
+                if zh_item.count() > 0:
+                    zh_item.first.click()
+                    page.wait_for_timeout(1000)
+                else:
+                    print("  Warning: Chinese language option not found")
             else:
-                print("  Warning: Chinese language option not found")
+                print("  Warning: language dropdown not found")
             page.wait_for_timeout(1000)
 
             # Take Chinese screenshot

--- a/tests/e2e/ui/test_language_sync.py
+++ b/tests/e2e/ui/test_language_sync.py
@@ -23,6 +23,7 @@ it sync falls back to the iframe-reload path (the URL parameter).
 """
 
 import asyncio
+import copy
 import json
 import os
 import re
@@ -49,15 +50,8 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
-def _ensure_workspace_enabled():
-    """Enable the workspace feature in the lane config (idempotent).
-
-    /api/workspace/config reports workspace.enabled from ~/.open-ace/
-    config.json (default false in a freshly initialized home) and the work
-    page gates the embedded webui iframe behind it. The endpoint re-reads
-    the file per request, so flipping it needs no server restart. Same
-    pattern as tests/e2e/terminal/e2e_terminal_tab.py.
-    """
+def _load_lane_config():
+    """Load the shared lane config (~/.open-ace/config.json) if present."""
     config_path = os.path.expanduser("~/.open-ace/config.json")
     config = {}
     if os.path.exists(config_path):
@@ -66,13 +60,53 @@ def _ensure_workspace_enabled():
                 config = json.load(f)
         except (OSError, json.JSONDecodeError):
             config = {}
+    return config_path, config
+
+
+def _write_lane_config(config_path, config):
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _restore_workspace_enabled():
+    """Snapshot workspace.enabled and restore it when this module ends.
+
+    _ensure_workspace_enabled() flips the SHARED lane config
+    (~/.open-ace/config.json); without restoration the leak breaks later
+    shard files that assert the unconfigured-workspace gate on /work
+    (test_notification_console_log / test_notification_timing: the page
+    gates on enabled alone, so enabled=true with an empty url renders the
+    workspace surface instead of the "Workspace not configured" gate).
+    """
+    config_path, config = _load_lane_config()
+    original_workspace = copy.deepcopy(config.get("workspace"))
+    yield
+    _, current = _load_lane_config()
+    if original_workspace is None:
+        current.pop("workspace", None)
+    else:
+        current["workspace"] = original_workspace
+    _write_lane_config(config_path, current)
+
+
+def _ensure_workspace_enabled():
+    """Enable the workspace feature in the lane config (idempotent).
+
+    /api/workspace/config reports workspace.enabled from ~/.open-ace/
+    config.json (default false in a freshly initialized home) and the work
+    page gates the embedded webui iframe behind it. The endpoint re-reads
+    the file per request, so flipping it needs no server restart. Same
+    pattern as tests/e2e/terminal/e2e_terminal_tab.py. The module fixture
+    above restores the previous value on teardown.
+    """
+    config_path, config = _load_lane_config()
     workspace = config.setdefault("workspace", {})
     if workspace.get("enabled"):
         return
     workspace["enabled"] = True
-    os.makedirs(os.path.dirname(config_path), exist_ok=True)
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
+    _write_lane_config(config_path, config)
 
 
 async def _open_work_page(page):

--- a/tests/e2e/ui/test_manage_language_dropdown.py
+++ b/tests/e2e/ui/test_manage_language_dropdown.py
@@ -58,14 +58,22 @@ def _skip_if_no_server():
 
 
 def _open_language_menu(page):
-    """Open the Header language dropdown; return the menu locator."""
+    """Open the Header language dropdown; return the menu locator.
+
+    The menu must be scoped to the globe dropdown itself: the Header renders
+    the help dropdown BEFORE the language dropdown (frontend/src/components/
+    layout/Header.tsx), so an unscoped ``ul.dropdown-menu`` locator resolves
+    to the help menu, which never becomes visible. Same pattern as
+    tests/e2e/browser/test_manage_analysis_roi_i18n.py.
+    """
     toggle = page.locator("button.header-icon-btn.dropdown-toggle").filter(
         has=page.locator("i.bi-globe")
     )
+    toggle.first.wait_for(state="visible", timeout=10000)
     toggle.first.click()
-    menu = page.locator("ul.dropdown-menu").first
-    menu.wait_for(state="visible", timeout=5000)
-    return menu
+    menu = page.locator("div.dropdown:has(button.dropdown-toggle i.bi-globe) ul.dropdown-menu")
+    menu.first.wait_for(state="visible", timeout=5000)
+    return menu.first
 
 
 def test_manage_language_dropdown():

--- a/tests/e2e/ui/test_management_button.py
+++ b/tests/e2e/ui/test_management_button.py
@@ -4,10 +4,26 @@ Tests:
 1. Non-admin users should not see Work/Manage mode switcher
 2. Non-admin users should be redirected to /work when accessing /manage/*
 3. Non-admin users should land on /work after login
+
+#2491 R3b realignment: test_normal_user used to log in with the ADMIN
+credentials (TEST_USERNAME/TEST_PASSWORD default to admin/admin123) while
+asserting the normal-user contract — after the R1 skip conversion it failed
+legitimately, because the admin role is in MANAGE_MODE_ROLES
+(frontend/src/utils/permissions.ts) and ModeSwitcher renders for it. The
+frontend contract itself is intact: ModeSwitcher returns null for any role
+outside MANAGE_MODE_ROLES (frontend/src/components/common/ModeSwitcher.tsx,
+"Only visible for admin and manager users"). The test now establishes its
+own premise: it provisions a 'user'-role account via the admin REST API
+(same pattern as tests/e2e/manage/test_normal_user_landing.py) and asserts
+the restriction contract as that user.
 """
 
 import asyncio
+import json
 import os
+import re
+import subprocess
+import tempfile
 
 import pytest
 import requests
@@ -19,6 +35,8 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(91)]
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
+NORMAL_USERNAME = "issue91user"
+NORMAL_PASSWORD = "Issue91Pass!"
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "91")
 
@@ -28,6 +46,76 @@ def _skip_if_no_server():
         requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
+
+
+def _admin_login_curl():
+    """Authenticate the admin via curl (dodges the urllib->gevent 502 that
+    affects some lanes). Returns the session_token or None."""
+    jar = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+    jar.close()
+    try:
+        subprocess.run(
+            [
+                "curl",
+                "-s",
+                "-c",
+                jar.name,
+                "-X",
+                "POST",
+                f"{BASE_URL}/api/auth/login",
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                json.dumps({"username": USERNAME, "password": PASSWORD}),
+                "-o",
+                os.devnull,
+                "--max-time",
+                "10",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if os.path.exists(jar.name):
+            with open(jar.name) as f:
+                for line in f:
+                    if "session_token" in line:
+                        parts = line.rstrip("\n").split("\t")
+                        if len(parts) >= 7:
+                            return parts[6]
+        return None
+    finally:
+        try:
+            os.unlink(jar.name)
+        except OSError:
+            pass
+
+
+def _ensure_normal_user(token):
+    """Create the 'user'-role account via the admin API (idempotent).
+    tenant_id=1 is the lane's seed tenant (the admin's own tenant)."""
+    resp = requests.post(
+        f"{BASE_URL}/api/admin/users",
+        cookies={"session_token": token},
+        json={
+            "username": NORMAL_USERNAME,
+            "email": "issue91@e2e.local",
+            "password": NORMAL_PASSWORD,
+            "role": "user",
+            "tenant_id": 1,
+        },
+        timeout=10,
+    )
+    if resp.status_code in (200, 201):
+        print(f"  ✓ 创建普通用户 {NORMAL_USERNAME}")
+        return
+    # Idempotent: an existing user is fine; anything else must fail loudly.
+    assert (
+        resp.status_code == 400
+    ), f"unexpected create-user response {resp.status_code}: {resp.text[:200]}"
+    assert (
+        "exist" in resp.text.lower()
+    ), f"create-user 400 is not an already-exists: {resp.text[:200]}"
+    print(f"  ✓ 普通用户 {NORMAL_USERNAME} 已存在")
 
 
 @pytest.mark.asyncio
@@ -84,6 +172,11 @@ async def test_admin_user():
 async def test_normal_user():
     """Test normal user is restricted to Work mode only."""
     _skip_if_no_server()
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+    token = _admin_login_curl()
+    assert token, "admin login failed (no session_token)"
+    _ensure_normal_user(token)
+
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1280, "height": 900})
@@ -93,19 +186,20 @@ async def test_normal_user():
         print("Testing Normal user")
         print("=" * 60)
 
-        # Login
+        # Login as the 'user'-role account (the restriction premise).
         await page.goto(f"{BASE_URL}/login")
         await page.wait_for_load_state("networkidle")
-        await page.fill("input#username", USERNAME)
-        await page.fill("input#password", PASSWORD)
-        async with page.expect_navigation(timeout=10000):
-            await page.click('button[type="submit"]')
+        await page.fill("input#username", NORMAL_USERNAME)
+        await page.fill("input#password", NORMAL_PASSWORD)
+        await page.click('button[type="submit"]')
+        await page.wait_for_url(re.compile(r".*/(work|manage)"), timeout=15000)
         await page.wait_for_load_state("networkidle")
         await asyncio.sleep(2)
 
         print(f"After login URL: {page.url}")
 
-        # Check if mode switcher is visible (should not be visible for non-admin)
+        # Check if mode switcher is visible (should not be visible for non-admin:
+        # ModeSwitcher renders null for roles outside MANAGE_MODE_ROLES).
         mode_switcher = page.locator(".mode-switcher")
         mode_switcher_count = await mode_switcher.count()
         print(f"Mode switcher count: {mode_switcher_count}")

--- a/tests/e2e/ui/test_notification_console_log.py
+++ b/tests/e2e/ui/test_notification_console_log.py
@@ -46,10 +46,40 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _ensure_workspace_disabled():
+    """Establish this test's own premise: workspace NOT configured.
+
+    The /work page gates on workspace.enabled alone (Workspace.tsx), and
+    earlier shard files (e.g. test_language_sync) flip it to true in the
+    shared lane config (~/.open-ace/config.json). An enabled=true / url=""
+    state renders the workspace surface instead of the gate, so this test
+    would depend on shard order without this step. /api/workspace/config
+    re-reads the file per request, so setting enabled=false and url="" here
+    deterministically yields the "Workspace not configured" gate below.
+    """
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    workspace = config.setdefault("workspace", {})
+    if workspace.get("enabled") is False and not workspace.get("url"):
+        return
+    workspace["enabled"] = False
+    workspace["url"] = ""
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
 def test_console_logs():
     """Console-log capture for the workspace tab-notification surface."""
 
     _skip_if_no_server()
+    _ensure_workspace_disabled()
     print("=" * 60)
     print("Console Log Test for Tab Notification")
     print("=" * 60)

--- a/tests/e2e/ui/test_notification_timing.py
+++ b/tests/e2e/ui/test_notification_timing.py
@@ -68,10 +68,40 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _ensure_workspace_disabled():
+    """Establish this test's own premise: workspace NOT configured.
+
+    The /work page gates on workspace.enabled alone (Workspace.tsx), and
+    earlier shard files (e.g. test_language_sync) flip it to true in the
+    shared lane config (~/.open-ace/config.json). An enabled=true / url=""
+    state renders the workspace surface instead of the gate, so this test
+    would depend on shard order without this step. /api/workspace/config
+    re-reads the file per request, so setting enabled=false and url="" here
+    deterministically yields the "Workspace not configured" gate below.
+    """
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    workspace = config.setdefault("workspace", {})
+    if workspace.get("enabled") is False and not workspace.get("url"):
+        return
+    workspace["enabled"] = False
+    workspace["url"] = ""
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
 def test_notification_timing():
     """Notification indicators must only appear for active background sessions."""
 
     _skip_if_no_server()
+    _ensure_workspace_disabled()
     print("=" * 60)
     print("Notification Timing Test")
     print("验证：初始状态（无活动会话）不出现任何通知指示")

--- a/tests/e2e/ui/test_profile_hover.py
+++ b/tests/e2e/ui/test_profile_hover.py
@@ -94,77 +94,77 @@ async def test_issue86():
             await page.screenshot(path=screenshot_path)
             print(f"  截图保存: {screenshot_path}")
 
-            # Step 3: 验证 Logout 按钮存在
-            print("Step 3: 验证 Logout 按钮存在...")
+            # Step 3: 验证用户菜单与 Logout 入口
+            # #2491 R3b realignment: the Header no longer renders a dedicated
+            # #nav-logout button with hover-username behavior. The current
+            # contract (frontend/src/components/layout/Header.tsx lines
+            # 174-210) is a user dropdown: the toggle shows the username
+            # (always-visible identity, stronger than the old hover state)
+            # and the menu exposes Settings + a Logout dropdown-item.
+            print("Step 3: 验证用户菜单与 Logout 入口...")
 
-            nav_logout = page.locator("#nav-logout")
-            await expect(nav_logout).to_be_visible()
-            print("  ✓ Logout 按钮可见")
-            results.append(("Logout 按钮可见", True, ""))
+            user_toggle = page.locator(
+                "header .dropdown-toggle", has=page.locator("i.bi-person-circle")
+            )
+            await expect(user_toggle.first).to_be_visible()
+            print("  ✓ 用户菜单按钮可见")
+            results.append(("用户菜单可见", True, ""))
 
-            # Step 4: 验证默认状态显示 "Logout"
-            print("Step 4: 验证默认状态显示 'Logout'...")
+            # Step 4: 验证用户名常显（取代旧的悬停显示用户名契约）
+            print("Step 4: 验证用户名显示...")
 
-            logout_text_el = page.locator("#nav-logout-text")
-            logout_text = await logout_text_el.text_content()
-
-            if logout_text == "Logout":
-                print(f"  ✓ 默认状态正确: {logout_text}")
-                results.append(("默认状态显示 Logout", True, f"显示: {logout_text}"))
+            toggle_text = (await user_toggle.first.inner_text()).strip()
+            if USERNAME in toggle_text:
+                print(f"  ✓ 用户名可见: {toggle_text}")
+                results.append(("用户名可见", True, f"显示: {toggle_text}"))
             else:
-                print(f"  ✗ 默认状态不正确: 期望 'Logout', 实际 '{logout_text}'")
-                results.append(
-                    ("默认状态显示 Logout", False, f"期望 'Logout', 实际 '{logout_text}'")
-                )
+                print(f"  ✗ 用户名未显示: '{toggle_text}'")
+                results.append(("用户名可见", False, f"显示: {toggle_text}"))
 
-            # 截图：默认状态
+            # 截图：用户菜单默认状态
             screenshot_path = os.path.join(SCREENSHOT_DIR, "86", "logout_default.png")
             await page.screenshot(path=screenshot_path)
             print(f"  截图保存: {screenshot_path}")
 
-            # Step 5: 验证悬停时显示 "Logout 用户名"
-            print("Step 5: 验证悬停时显示 'Logout 用户名'...")
+            # Step 5: 打开用户菜单，验证 Logout 项存在
+            print("Step 5: 打开用户菜单验证 Logout 项...")
 
-            # 悬停在 Logout 按钮上
-            await nav_logout.hover()
-            time.sleep(0.3)
-
-            # 获取悬停后的文字
-            hover_text = await logout_text_el.text_content()
-            expected_hover_text = f"Logout {USERNAME}"
-
-            if hover_text == expected_hover_text:
-                print(f"  ✓ 悬停状态正确: {hover_text}")
-                results.append(("悬停显示用户名", True, f"显示: {hover_text}"))
+            await user_toggle.first.click()
+            await page.wait_for_timeout(500)
+            user_menu = page.locator(
+                "header div.dropdown:has(i.bi-person-circle) ul.dropdown-menu"
+            ).first
+            user_menu.wait_for(state="visible", timeout=5000)
+            logout_item = user_menu.locator("button.dropdown-item").filter(
+                has=page.locator("i.bi-box-arrow-right")
+            )
+            if await logout_item.count() > 0:
+                logout_text = (await logout_item.first.inner_text()).strip()
+                print(f"  ✓ Logout 项存在: '{logout_text}'")
+                results.append(("Logout 项存在", True, f"显示: {logout_text}"))
             else:
-                print(f"  ✗ 悬停状态不正确: 期望 '{expected_hover_text}', 实际 '{hover_text}'")
-                results.append(
-                    ("悬停显示用户名", False, f"期望 '{expected_hover_text}', 实际 '{hover_text}'")
-                )
+                print("  ✗ 用户菜单中未找到 Logout 项")
+                results.append(("Logout 项存在", False, "未找到"))
 
-            # 截图：悬停状态
+            # 截图：菜单打开状态
             screenshot_path = os.path.join(SCREENSHOT_DIR, "86", "logout_hover.png")
             await page.screenshot(path=screenshot_path)
             print(f"  截图保存: {screenshot_path}")
 
-            # Step 6: 验证移开鼠标后恢复 "Logout"
-            print("Step 6: 验证移开鼠标后恢复 'Logout'...")
+            # Step 6: 关闭菜单后界面恢复（点击页面其他位置）
+            print("Step 6: 关闭用户菜单...")
 
-            # 移动鼠标到其他位置
-            await page.mouse.move(0, 0)
-            time.sleep(0.3)
-
-            # 获取移开后的文字
-            final_text = await logout_text_el.text_content()
-
-            if final_text == "Logout":
-                print(f"  ✓ 移开鼠标后恢复: {final_text}")
-                results.append(("移开鼠标恢复 Logout", True, f"显示: {final_text}"))
+            await page.mouse.click(10, 250)
+            await page.wait_for_timeout(500)
+            still_open = page.locator(
+                "header div.dropdown:has(i.bi-person-circle) ul.dropdown-menu.show"
+            )
+            if await still_open.count() == 0:
+                print("  ✓ 用户菜单已关闭")
+                results.append(("菜单可关闭", True, ""))
             else:
-                print(f"  ✗ 移开鼠标后未恢复: 期望 'Logout', 实际 '{final_text}'")
-                results.append(
-                    ("移开鼠标恢复 Logout", False, f"期望 'Logout', 实际 '{final_text}'")
-                )
+                print("  ✗ 用户菜单未关闭")
+                results.append(("菜单可关闭", False, ""))
 
             # 截图：最终状态
             screenshot_path = os.path.join(SCREENSHOT_DIR, "86", "logout_final.png")

--- a/tests/e2e/ui/test_quota_alerts_dialog_v2.py
+++ b/tests/e2e/ui/test_quota_alerts_dialog_v2.py
@@ -11,6 +11,7 @@ UI Test: Issue 55 - 测试 QuotaAlerts 页面的配额编辑对话框
 """
 
 import os
+import re
 import sys
 import time
 
@@ -43,6 +44,55 @@ def _skip_if_no_server():
         requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
+
+
+def _parse_available_hint(label_text):
+    """Parse the "(Available: X ...)" hint from a quota field label.
+
+    QuotaAlerts.tsx renders each quota input's label with the available
+    tenant pool for that field (``可用:`` in zh, ``Available:`` otherwise),
+    e.g. ``Daily Token Quota (M)(Available: 10.00M (Max: 100000M))``.
+    Returns the available amount as float, or None when the hint is absent.
+    """
+    match = re.search(r"(?:Available|可用)\s*:\s*([0-9][0-9,]*(?:\.[0-9]+)?)", label_text)
+    if not match:
+        return None
+    return float(match.group(1).replace(",", ""))
+
+
+def _fill_in_policy_quota(modal):
+    """Fill the modal's quota fields with values guaranteed in-policy.
+
+    Earlier quota tests in the same shard may have reallocated the admin's
+    quotas, so hardcoded values can exceed the remaining tenant pool (the
+    API then answers 400 and the modal legitimately stays open). Instead:
+    keep each field's current value (a re-save is never a quota increase, so
+    it always passes the tenant allocation check), or when the field is
+    empty (unlimited) fill "1" only if the label's Available hint allows it.
+    """
+    fields = modal.locator(
+        'div.col-md-6:has(label.form-label):has(input.form-control[type="text"])'
+    )
+    count = fields.count()
+    assert count >= 4, f"quota modal should expose 4 quota fields, found {count}"
+    decisions = []
+    for index in range(count):
+        label_text = fields.nth(index).locator("label.form-label").inner_text()
+        available = _parse_available_hint(label_text)
+        field_input = fields.nth(index).locator('input.form-control[type="text"]')
+        current = field_input.input_value().strip()
+        if current:
+            # Re-saving the current value is never an increase: keep it.
+            decision = f"keep {current}"
+        elif available is not None and available >= 1:
+            field_input.fill("1")
+            decision = "fill 1 (unlimited before, pool allows 1)"
+        else:
+            # No remaining pool: stay unlimited (empty) — still a valid save.
+            decision = "leave unlimited"
+        decisions.append(decision)
+        print(f"  Field {index + 1}: {decision} (hint available={available})")
+    return decisions
 
 
 def test_quota_alerts_dialog_close():
@@ -117,17 +167,11 @@ def test_quota_alerts_dialog_close():
             # QuotaAlerts renders its four quota fields as TextInput
             # type="text" (input.form-control) — empty means unlimited;
             # the old input[type="number"] selector matched nothing.
-            inputs = modal.locator('input.form-control[type="text"]')
-            if inputs.count() > 0:
-                # Stay within the lane tenant's daily pool (10M raw, already
-                # fully allocated to this admin) — larger values are rejected
-                # 400 by tenant quota policy and the dialog legitimately
-                # stays open with the error.
-                inputs.first.fill("5")
-                print("  ✓ Modified quota value to 5")
-                take_screenshot(page, "alerts_v2_06_value_modified.png")
-            else:
-                assert inputs.count() > 0, "quota modal has no number inputs"
+            # Values are chosen dynamically from each label's Available
+            # hint so the save stays in-policy even when earlier shard
+            # tests have reallocated the tenant pool.
+            _fill_in_policy_quota(modal)
+            take_screenshot(page, "alerts_v2_06_value_modified.png")
 
             # Step 6: Click save button
             print("\n[Step 6] Click save button...")

--- a/tests/e2e/ui/test_refresh.py
+++ b/tests/e2e/ui/test_refresh.py
@@ -9,6 +9,7 @@ Test script for Issue #98: Messages 页面的 refresh 和 auto refresh 都不工
 
 import asyncio
 import os
+import re
 import time
 
 import pytest
@@ -72,8 +73,14 @@ async def test_messages_refresh():
             print("  Screenshot saved: screenshots/issues/98/01_messages_page.png")
 
             # Step 4: Check if refresh button exists
+            # The Messages page renders the shared PageRefreshControl in
+            # compact mode (frontend/src/components/features/Messages.tsx
+            # lines 195-200): the manual refresh control is an icon button
+            # with data-testid="manual-refresh-button" — its label lives in
+            # the title attribute, so the old has-text("刷新") selector
+            # matched nothing.
             print("\n[Step 4] Checking refresh button...")
-            refresh_btn = page.locator('button:has-text("刷新"), button:has-text("Refresh")')
+            refresh_btn = page.locator('[data-testid="manual-refresh-button"]')
             btn_count = await refresh_btn.count()
             print(f"  Found {btn_count} refresh button(s)")
 
@@ -96,14 +103,25 @@ async def test_messages_refresh():
             assert btn_count > 0, "no refresh button on the Messages page"
 
             # Step 5: Check auto-refresh toggle
+            # In compact mode the auto-refresh switch lives inside the
+            # settings dropdown: [data-testid="dropdown-toggle"] opens a
+            # .dropdown-menu carrying the form-switch checkbox and the
+            # interval selector (PageRefreshControl.tsx compact branch).
             print("\n[Step 5] Checking auto-refresh toggle...")
-            auto_refresh_switch = page.locator("#messagesAutoRefreshSwitch")
-            switch_count = await auto_refresh_switch.count()
-            print(f"  Found {switch_count} auto-refresh switch(es)")
+            dropdown_toggle = page.locator('[data-testid="dropdown-toggle"]')
+            toggle_count = await dropdown_toggle.count()
+            print(f"  Found {toggle_count} refresh settings toggle(s)")
+            switch_count = 0
+            if toggle_count > 0:
+                await dropdown_toggle.first.click()
+                await page.wait_for_timeout(500)
+                auto_refresh_switch = page.locator(".dropdown-menu.show input[type='checkbox']")
+                switch_count = await auto_refresh_switch.count()
+                print(f"  Found {switch_count} auto-refresh switch(es) in dropdown")
 
             if switch_count > 0:
                 # Check if it's checked
-                is_checked = await auto_refresh_switch.is_checked()
+                is_checked = await auto_refresh_switch.first.is_checked()
                 print(f"  Auto-refresh is currently: {'ON' if is_checked else 'OFF'}")
 
                 # Take screenshot of the switch
@@ -116,12 +134,23 @@ async def test_messages_refresh():
                 # Turn on auto-refresh if not already on
                 if not is_checked:
                     print("  Turning on auto-refresh...")
-                    await auto_refresh_switch.check()
+                    await auto_refresh_switch.first.check()
                     await page.wait_for_timeout(500)
-                    is_checked = await auto_refresh_switch.is_checked()
+                    is_checked = await auto_refresh_switch.first.is_checked()
                     print(f"  Auto-refresh is now: {'ON' if is_checked else 'OFF'}")
 
-                # Wait for auto-refresh interval (30 seconds in code)
+                # Pick the shortest interval (30s) from the selector
+                interval_30s = page.locator(
+                    ".dropdown-menu.show button.dropdown-item", has_text=re.compile(r"30\s*s")
+                )
+                if await interval_30s.count() > 0:
+                    await interval_30s.first.click()
+                    print("  Set refresh interval to 30s")
+                else:
+                    await dropdown_toggle.first.click()
+                await page.wait_for_timeout(500)
+
+                # Wait for auto-refresh interval (30 seconds selected)
                 print("  Waiting 35 seconds for auto-refresh to trigger...")
                 await page.wait_for_timeout(35000)
 

--- a/tests/e2e/ui/test_restore_button.py
+++ b/tests/e2e/ui/test_restore_button.py
@@ -1,9 +1,21 @@
 """
 Test for issue 74: Restore session button not working
+
+#2491 R3b realignment: the sessions page reads agent_sessions through
+/api/workspace/sessions (user_id-scoped), so a freshly initialized lane home
+renders no session cards — the test now self-seeds its sessions (same
+pattern as tests/e2e/work/helpers.py seed_codex_data) and cleans them up on
+teardown. Selector note: both the work left-rail SessionList and the
+sessions page cards carry ``.session-item``; the card variant is
+``.session-item.card`` (frontend/src/components/features/Sessions.tsx
+line 600) and every card renders the restore button
+``button:has(i.bi-box-arrow-in-right)`` wrapped in a span titled
+"Restore to Workspace" (Sessions.tsx lines 648-657).
 """
 
 import asyncio
 import os
+import uuid
 
 import pytest
 import requests
@@ -22,6 +34,69 @@ SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "74")
 
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
+
+SEED_PREFIX = "e2e74"
+
+
+def _seed_sessions(count=3):
+    """Seed completed qwen sessions for user_id=1 (idempotent, prefix-keyed)."""
+    import sqlite3
+    from datetime import datetime, timedelta
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return []
+    ids = []
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM agent_sessions WHERE session_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            ).fetchone()[0]
+            for i in range(count - existing):
+                sid = f"{SEED_PREFIX}{uuid.uuid4().hex}"
+                ts = (datetime.now() - timedelta(minutes=i)).isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO agent_sessions "
+                    "(session_id, session_type, tool_name, status, total_tokens, "
+                    "message_count, request_count, user_id, tenant_id, project_path, "
+                    "workspace_type, created_at, updated_at) "
+                    "VALUES (?, 'chat', 'qwen', 'completed', 500, 10, 5, 1, 1, "
+                    f"'/tmp/{SEED_PREFIX}-project', 'local', ?, ?)",
+                    (sid, ts, ts),
+                )
+                ids.append(sid)
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return ids
+
+
+def _cleanup_sessions():
+    import sqlite3
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("DELETE FROM agent_sessions WHERE session_id LIKE ?", (f"{SEED_PREFIX}%",))
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _seeded_sessions():
+    _seed_sessions()
+    yield
+    _cleanup_sessions()
 
 
 def _skip_if_no_server():
@@ -56,7 +131,7 @@ async def test_restore_button():
         await page.click("button[type='submit']")
 
         try:
-            await page.wait_for_url("**/dashboard**", timeout=5000)
+            await page.wait_for_url("**/manage/**", timeout=5000)
             print("   Login successful!")
         except:
             current_url = page.url
@@ -80,10 +155,13 @@ async def test_restore_button():
 
         # Get first session card HTML
         print("\n4. Analyzing first session card structure...")
-        session_count = await page.locator(".session-item").count()
+        # The sessions page cards are .session-item.card (the work left-rail
+        # SessionList also uses .session-item for its buttons).
+        session_cards = page.locator(".session-item.card")
+        session_count = await session_cards.count()
         print(f"   Found {session_count} session card(s)")
         assert session_count > 0, "sessions page shows no session cards"
-        first_card = page.locator(".session-item").first
+        first_card = session_cards.first
 
         # Get all buttons in the card
         buttons = await first_card.locator("button").all()
@@ -103,6 +181,7 @@ async def test_restore_button():
             ".bi-box-arrow-in-right",
             "button[title*='Restore']",
             "button[title*='恢复']",
+            "span[title*='Restore'] button",
         ]
 
         restore_icon_matches = 0
@@ -113,20 +192,11 @@ async def test_restore_button():
 
         assert restore_icon_matches > 0, "no restore button/icon found on the session card"
 
-        # Get the card's action area HTML
-        action_area = await first_card.locator(".d-flex.flex-column.gap-2").evaluate(
-            "el => el.outerHTML"
-        )
-        print(f"\n6. Action area HTML:\n{action_area}")
-
-        # Try to find any button with box-arrow icon
+        # All button icons in card
         all_buttons_in_card = await first_card.locator("button i").all()
-        print("\n7. All button icons in card:")
+        print("\n6. All button icons in card:")
         for i, icon in enumerate(all_buttons_in_card):
             icon_class = await icon.evaluate("el => el.className")
             print(f"   Icon {i+1}: {icon_class}")
-
-        print("\n8. Keeping browser open for 10 seconds...")
-        await page.wait_for_timeout(10000)
 
         await browser.close()

--- a/tests/e2e/ui/test_session_detail_ui.py
+++ b/tests/e2e/ui/test_session_detail_ui.py
@@ -15,6 +15,7 @@ Usage:
 import os
 import sys
 import time
+import uuid
 from pathlib import Path
 
 # Add project root to path
@@ -32,6 +33,72 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 30000
+
+SEED_PREFIX = "e2e69"
+
+
+def _seed_sessions(count=3):
+    """Seed completed qwen sessions for user_id=1 so the work left-rail
+    SessionList has rows to click (fed by /api/workspace/sessions). Rows are
+    untitled so the detail modal title falls back to "Session <8-char id>"
+    (SessionList.tsx line 273)."""
+    import sqlite3
+    from datetime import datetime, timedelta
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return []
+    ids = []
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM agent_sessions WHERE session_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            ).fetchone()[0]
+            for i in range(count - existing):
+                sid = f"{SEED_PREFIX}{uuid.uuid4().hex}"
+                ts = (datetime.now() - timedelta(minutes=i)).isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO agent_sessions "
+                    "(session_id, session_type, tool_name, status, total_tokens, "
+                    "message_count, request_count, user_id, tenant_id, project_path, "
+                    "workspace_type, created_at, updated_at) "
+                    "VALUES (?, 'chat', 'qwen', 'completed', 500, 10, 5, 1, 1, "
+                    f"'/tmp/{SEED_PREFIX}-project', 'local', ?, ?)",
+                    (sid, ts, ts),
+                )
+                ids.append(sid)
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return ids
+
+
+def _cleanup_sessions():
+    import sqlite3
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("DELETE FROM agent_sessions WHERE session_id LIKE ?", (f"{SEED_PREFIX}%",))
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _seeded_sessions():
+    _seed_sessions()
+    yield
+    _cleanup_sessions()
 
 
 def _skip_if_no_server():

--- a/tests/e2e/ui/test_session_list_display.py
+++ b/tests/e2e/ui/test_session_list_display.py
@@ -9,6 +9,7 @@ This test verifies that:
 import os
 import sys
 import time
+import uuid
 from pathlib import Path
 
 # Add project root to path
@@ -26,6 +27,72 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 30000
+
+SEED_PREFIX = "e2e59"
+
+
+def _seed_sessions(count=3):
+    """Seed completed qwen sessions for user_id=1 so the work left-rail
+    SessionList (fed by /api/workspace/sessions) has deterministic data.
+    Rows are untitled: the rail then shows the bare 4-char session id
+    (SessionList.tsx renders displaySessionId(session.id, 4))."""
+    import sqlite3
+    from datetime import datetime, timedelta
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return []
+    ids = []
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM agent_sessions WHERE session_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            ).fetchone()[0]
+            for i in range(count - existing):
+                sid = f"{SEED_PREFIX}{uuid.uuid4().hex}"
+                ts = (datetime.now() - timedelta(minutes=i)).isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO agent_sessions "
+                    "(session_id, session_type, tool_name, status, total_tokens, "
+                    "message_count, request_count, user_id, tenant_id, project_path, "
+                    "workspace_type, created_at, updated_at) "
+                    "VALUES (?, 'chat', 'qwen', 'completed', 500, 10, 5, 1, 1, "
+                    f"'/tmp/{SEED_PREFIX}-project', 'local', ?, ?)",
+                    (sid, ts, ts),
+                )
+                ids.append(sid)
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return ids
+
+
+def _cleanup_sessions():
+    import sqlite3
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("DELETE FROM agent_sessions WHERE session_id LIKE ?", (f"{SEED_PREFIX}%",))
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _seeded_sessions():
+    _seed_sessions()
+    yield
+    _cleanup_sessions()
 
 
 def _skip_if_no_server():
@@ -117,8 +184,11 @@ def test_session_list_display():
                 if session_time.is_visible():
                     time_text = session_time.text_content().strip()
                     print(f"  Time field: '{time_text}'")
-                    # Check if format is short (contains "min" or "hr" or "day" or "刚刚" or "分钟前" etc.)
+                    # Check if format is short (contains "min" or "hr" or "day" or
+                    # "just now" (formatRelativeTime's <60s branch) or the
+                    # localized equivalents)
                     short_patterns = [
+                        "just now",
                         "min",
                         "hr",
                         "day",
@@ -148,8 +218,15 @@ def test_session_list_display():
                 if session_requests.is_visible():
                     req_text = session_requests.text_content().strip()
                     print(f"  Request count field: '{req_text}'")
-                    if "req" in req_text.lower():
-                        print("  ✓ Request count shows with 'req' suffix")
+                    # SessionList renders "<N> <t('request')>" — "Request"/
+                    # "请求"/... Accept the count plus any of the request
+                    # words (the old check only matched the English suffix).
+                    has_count = any(ch.isdigit() for ch in req_text)
+                    has_request_word = any(
+                        w in req_text.lower() for w in ("req", "请求", "リクエスト", "요청")
+                    )
+                    if has_count and has_request_word:
+                        print("  ✓ Request count displayed with request word")
                         results.append(("Request count display", True, req_text))
                     else:
                         print(f"  ⚠ Request count format: {req_text}")

--- a/tests/e2e/ui/test_session_restore.py
+++ b/tests/e2e/ui/test_session_restore.py
@@ -6,10 +6,24 @@ Tests:
 2. Check session list is visible
 3. Click 'Restore to Workspace' button
 4. Verify workspace opens with restored session
+
+#2491 R3b realignment: two premises the lane no longer provides by itself:
+(1) session data — /work/sessions reads /api/workspace/sessions from
+agent_sessions, so the test seeds its own completed qwen session with a
+project_path (the restore endpoint requires one to build the workspace URL,
+app/routes/workspace.py restore_session) and cleans it up on teardown;
+(2) the workspace feature — the /work/workspace tab surface is gated behind
+workspace.enabled (Workspace.tsx), so the test enables it in the lane config
+for its duration (same pattern as tests/e2e/ui/test_language_sync.py) and
+fulfills /api/workspace/user-url with a placeholder so the restored tab's
+iframe materializes without a qwen-code-webui binary.
 """
 
+import json
 import os
 import sys
+import time
+import uuid
 
 import pytest
 import requests
@@ -29,12 +43,98 @@ SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "screenshots"
 )
 
+SEED_PREFIX = "e2e16"
+SEED_SESSION_ID = None
+
 
 def _skip_if_no_server():
     try:
         requests.get(f"{BASE_URL}/login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
+
+
+def _load_lane_config():
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    return config_path, config
+
+
+def _write_lane_config(config_path, config):
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+@pytest.fixture(autouse=True)
+def _workspace_enabled_for_restore():
+    """Enable workspace for the restore flow; restore the previous value."""
+    import copy
+
+    config_path, config = _load_lane_config()
+    original_workspace = copy.deepcopy(config.get("workspace"))
+    workspace = config.setdefault("workspace", {})
+    if not workspace.get("enabled"):
+        workspace["enabled"] = True
+        _write_lane_config(config_path, config)
+    yield
+    _, current = _load_lane_config()
+    if original_workspace is None:
+        current.pop("workspace", None)
+    else:
+        current["workspace"] = original_workspace
+    _write_lane_config(config_path, current)
+
+
+@pytest.fixture(autouse=True)
+def _seeded_session():
+    """Seed one restorable session (cleanup on teardown)."""
+    import sqlite3
+    from datetime import datetime, timedelta
+
+    global SEED_SESSION_ID
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    sid = f"{SEED_PREFIX}{uuid.uuid4().hex}"
+    if os.path.exists(db_path):
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                ts = (datetime.now() - timedelta(minutes=1)).isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO agent_sessions "
+                    "(session_id, session_type, tool_name, status, total_tokens, "
+                    "message_count, request_count, user_id, tenant_id, project_path, "
+                    "workspace_type, created_at, updated_at) "
+                    "VALUES (?, 'chat', 'qwen', 'completed', 500, 10, 5, 1, 1, "
+                    f"'/tmp/{SEED_PREFIX}-project', 'local', ?, ?)",
+                    (sid, ts, ts),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            pass
+    SEED_SESSION_ID = sid
+    yield
+    SEED_SESSION_ID = None
+    if os.path.exists(db_path):
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                conn.execute(
+                    "DELETE FROM agent_sessions WHERE session_id LIKE ?", (f"{SEED_PREFIX}%",)
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            pass
 
 
 def test_session_restore():
@@ -50,6 +150,16 @@ def test_session_restore():
         browser = p.chromium.launch(headless=HEADLESS)
         context = browser.new_context(viewport=VIEWPORT_SIZE)
         page = context.new_page()
+
+        # The workspace tab's iframe needs a webui base URL; without the
+        # qwen-code-webui binary /api/workspace/user-url 503s forever, so
+        # fulfill it with a placeholder (same pattern as test_language_sync).
+        page.route(
+            "**/api/workspace/user-url",
+            lambda route: route.fulfill(
+                json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+            ),
+        )
 
         test_results = []
 
@@ -87,18 +197,14 @@ def test_session_restore():
 
         # Step 4: Check session list is visible
         print("\n[Step 4] Check session list...")
-        session_items = page.locator(".session-item")
+        # The sessions page cards are .session-item.card (the work left-rail
+        # SessionList buttons also carry .session-item).
+        session_items = page.locator(".session-item.card")
         session_count = session_items.count()
         print(f"  Found {session_count} sessions")
-
-        if session_count > 0:
-            test_results.append(("Session list visible", True))
-            print("  ✓ Session list visible")
-        else:
-            test_results.append(("Session list visible", False))
-            print("  ✗ No sessions found")
-            browser.close()
-            return False
+        assert session_count > 0, "no session cards rendered on /work/sessions"
+        test_results.append(("Session list visible", True))
+        print("  ✓ Session list visible")
 
         # Step 5: Find and click 'Restore to Workspace' button
         print("\n[Step 5] Click 'Restore to Workspace' button...")
@@ -107,9 +213,10 @@ def test_session_restore():
         page.on("console", lambda msg: print(f"  Console {msg.type}: {msg.text}"))
         page.on("pageerror", lambda err: print(f"  Page Error: {err}"))
 
-        # Find the first restore button (blue button with bi-box-arrow-in-right icon)
+        # Find the first restore button (blue button with bi-box-arrow-in-right
+        # icon inside a .session-item.card).
         restore_button = page.locator(
-            ".session-item .btn-outline-primary .bi-box-arrow-in-right"
+            ".session-item.card .btn-outline-primary .bi-box-arrow-in-right"
         ).first
 
         if restore_button.count() > 0:
@@ -135,16 +242,45 @@ def test_session_restore():
                 test_results.append(("Navigate to workspace", True))
                 print("  ✓ Navigated to workspace")
 
-                # Wait for iframe to appear (may take longer to load)
-                time.sleep(3)  # Wait for iframe to load
+                # Wait for the restored session's workspace tab and its iframe.
+                # The iframe points at the (placeholder) webui base URL, so its
+                # CONTENT is not loadable in the lane — the contract under test
+                # is the restored tab + the iframe src carrying the session id
+                # (same premise as tests/e2e/ui/test_language_sync.py).
+                time.sleep(3)  # Wait for the tab to initialize
 
-                # Check if we're on workspace page
-                if "/work/workspace" in current_url or page.locator("iframe").count() > 0:
-                    expect(page.locator("iframe")).to_be_visible(timeout=10000)
-                    test_results.append(("Workspace iframe loaded", True))
-                    print("  ✓ Workspace iframe loaded")
+                if "/work/workspace" in current_url:
+                    workspace_tab = page.locator(".workspace-tab")
+                    if workspace_tab.count() > 0:
+                        test_results.append(("Workspace tab loaded", True))
+                        print("  ✓ Workspace tab loaded")
+                    else:
+                        test_results.append(("Workspace tab loaded", False))
+                        print("  ✗ No workspace tab rendered")
+
+                    session_iframes = page.locator('iframe[title^="Workspace -"]')
+                    try:
+                        session_iframes.first.wait_for(state="attached", timeout=10000)
+                        # The default tab's iframe also exists (from the
+                        # user-url placeholder); the restored session must
+                        # appear in at least ONE workspace iframe src.
+                        restored = False
+                        for idx in range(session_iframes.count()):
+                            iframe_src = session_iframes.nth(idx).get_attribute("src") or ""
+                            print(f"  iframe {idx} src: {iframe_src[:140]}")
+                            if "sessionId=" in iframe_src:
+                                restored = True
+                        if restored:
+                            test_results.append(("Workspace iframe loaded", True))
+                            print("  ✓ Workspace iframe carries the restored sessionId")
+                        else:
+                            test_results.append(("Workspace iframe loaded", False))
+                            print("  ✗ No workspace iframe src carries sessionId")
+                    except PlaywrightError as iframe_err:
+                        test_results.append(("Workspace iframe loaded", False))
+                        print(f"  ✗ Workspace iframe not attached: {iframe_err}")
                 else:
-                    test_results.append(("Workspace iframe loaded", False))
+                    test_results.append(("Workspace tab loaded", False))
                     print(f"  ✗ Not on workspace page: {current_url}")
 
                 # Check URL contains sessionId parameter

--- a/tests/e2e/ui/test_tool_label_display.py
+++ b/tests/e2e/ui/test_tool_label_display.py
@@ -1,9 +1,19 @@
 """
 测试 Issue 30: 验证工具标签显示逻辑
+
+#2491 R3b realignment: the retired selectors (input[name="username"],
+#nav-messages, #messages-container) matched the pre-React chrome. The current
+contract: /manage/messages (frontend/src/components/features/Messages.tsx)
+renders ``.messages`` with ``.message-item`` cards, each carrying a
+``.message-source`` span whose class includes the source value
+(Messages.tsx lines 447-450). The page only shows messages when daily_messages
+has rows, so the test seeds its own rows (message_source set; same seeding
+pattern as tests/e2e/manage/e2e_conversation_history.py) and cleans them up.
 """
 
 import asyncio
 import os
+import uuid
 
 import pytest
 import requests
@@ -20,6 +30,81 @@ USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots")
+
+SEED_PREFIX = "e2e30"
+
+
+def _seed_messages(count=3):
+    """Seed daily_messages rows carrying message_source (label under test)."""
+    import sqlite3
+    from datetime import datetime, timezone
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return []
+    ids = []
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            existing = conn.execute(
+                "SELECT COUNT(*) FROM daily_messages WHERE message_id LIKE ?",
+                (f"{SEED_PREFIX}%",),
+            ).fetchone()[0]
+            # Date the rows with UTC today (the /api/messages window is
+            # backend-computed; the local calendar date can run ahead).
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            for i in range(count - existing):
+                mid = f"{SEED_PREFIX}-{uuid.uuid4().hex}"
+                now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+                conn.execute(
+                    "INSERT INTO daily_messages "
+                    "(date, tool_name, host_name, role, content, tokens_used, "
+                    "input_tokens, output_tokens, timestamp, sender_name, "
+                    "message_id, agent_session_id, conversation_id, user_id, "
+                    "message_source) "
+                    "VALUES (?, 'claude-code', 'e2e-host-30', ?, "
+                    "'e2e tool label probe', 10, 5, 5, ?, 'admin', "
+                    "?, ?, ?, 1, 'cli')",
+                    (
+                        today,
+                        "user" if i % 2 == 0 else "assistant",
+                        now,
+                        mid,
+                        mid,
+                        mid,
+                    ),
+                )
+                ids.append(mid)
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return ids
+
+
+def _cleanup_messages():
+    import sqlite3
+
+    db_path = os.path.expanduser("~/.open-ace/ace.db")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("DELETE FROM daily_messages WHERE message_id LIKE ?", (f"{SEED_PREFIX}%",))
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _seeded_messages():
+    _seed_messages()
+    yield
+    _cleanup_messages()
 
 
 def _skip_if_no_server():
@@ -46,24 +131,30 @@ async def test_issue30_v4():
             # 1. 登录
             print("1. 登录系统...")
             await page.goto(f"{BASE_URL}/login")
-            await page.fill('input[name="username"]', USERNAME)
-            await page.fill('input[name="password"]', PASSWORD)
+            # The React login form re-mounts once its effects settle; re-fill
+            # until the values persist (same pattern as test_user_scenario).
+            for _attempt in range(3):
+                await page.wait_for_selector("#username", timeout=10000)
+                await page.fill("#username", USERNAME)
+                await page.fill("#password", PASSWORD)
+                if (
+                    await page.input_value("#username") == USERNAME
+                    and await page.input_value("#password") == PASSWORD
+                ):
+                    break
+                await asyncio.sleep(0.5)
             await page.click('button[type="submit"]')
-            await page.wait_for_url(f"{BASE_URL}/", timeout=5000)
+            await page.wait_for_url("**/manage/**", timeout=15000)
             print("   ✓ 登录成功")
 
-            # 2. 导航到 Messages 页面
+            # 2. 导航到 Messages 页面（当前路由 /manage/messages）
             print("2. 导航到 Messages 页面...")
-
-            # 点击 Messages 导航
-            await page.click("#nav-messages")
-            print("   已点击 Messages 导航")
-
-            # 等待消息容器可见
-            await page.wait_for_selector("#messages-container", state="visible", timeout=10000)
+            await page.goto(f"{BASE_URL}/manage/messages", wait_until="networkidle")
+            messages_container = page.locator(".messages")
+            await messages_container.first.wait_for(state="visible", timeout=10000)
             print("   消息容器已可见")
 
-            # 等待消息加载完成 - 等待 message-item 出现
+            # 等待消息加载完成 - 等待 message-item 出现（默认角色过滤已启用）
             try:
                 await page.wait_for_selector(".message-item", timeout=15000)
                 print("   消息项已加载")
@@ -81,7 +172,7 @@ async def test_issue30_v4():
             await page.screenshot(path=f"{SCREENSHOT_DIR}/issue30_v4_messages.png", full_page=True)
             print("   ✓ 截图保存: issue30_v4_messages.png")
 
-            # 4. 检查工具标签
+            # 4. 检查工具标签（.message-source 携带消息来源）
             print("\n3. 检查工具标签...")
             tool_badges = await page.query_selector_all(".message-source")
             print(f"   找到 {len(tool_badges)} 个工具标签")
@@ -100,36 +191,30 @@ async def test_issue30_v4():
                 for text, count in sorted(badge_texts.items(), key=lambda x: -x[1]):
                     print(f"   - {text}: {count} 个")
 
-                # 检查是否有组合格式
-                combined_labels = [t for t in badge_texts if "(" in t and ")" in t]
-                if combined_labels:
-                    print(f"\n   ✓ 发现组合格式标签: {combined_labels}")
-                    results.append(("组合格式标签", "通过"))
+                # 标签必须渲染出非空文本
+                if all(badge_texts.values()) and all(badge_texts.keys()):
+                    print("\n   ✓ 所有工具标签均显示非空文本")
+                    results.append(("工具标签显示", "通过"))
                 else:
-                    print("\n   ⚠ 未发现组合格式标签")
-                    results.append(("组合格式标签", "跳过"))
+                    print("\n   ✗ 存在空工具标签")
+                    results.append(("工具标签显示", "失败"))
 
-                # 检查 CSS class
+                # 检查 CSS class（class 应包含 message-source 与来源值）
                 print("\n4. 检查 CSS class...")
+                class_ok = True
                 for badge in tool_badges[:5]:
                     class_name = await badge.get_attribute("class")
-                    text = await badge.inner_text()
+                    text = (await badge.inner_text()).strip().lower()
                     print(f"   标签: '{text}' -> class: '{class_name}'")
-
-                results.append(("工具标签显示", "通过"))
+                    if not class_name or "message-source" not in class_name:
+                        class_ok = False
+                if class_ok:
+                    results.append(("工具标签 CSS class", "通过"))
+                else:
+                    results.append(("工具标签 CSS class", "失败"))
             else:
-                print("   ⚠ 没有找到工具标签")
-
-                # 检查页面内容
-                print("\n   检查页面内容...")
-                messages_container = await page.query_selector("#messages-container")
-                if messages_container:
-                    inner_html = await messages_container.inner_html()
-                    print(f"   messages-container 内容长度: {len(inner_html)}")
-                    if len(inner_html) < 100:
-                        print(f"   内容: {inner_html[:200]}")
-
-                results.append(("工具标签显示", "跳过"))
+                print("   ✗ 没有找到工具标签（消息数据应已注入）")
+                results.append(("工具标签显示", "失败"))
 
             results.append(("测试执行", "通过"))
 

--- a/tests/e2e/ui/test_user_scenario.py
+++ b/tests/e2e/ui/test_user_scenario.py
@@ -14,6 +14,7 @@ preserved against that markup.
 """
 
 import os
+import re
 import sys
 import time
 
@@ -44,6 +45,54 @@ def _skip_if_no_server():
         requests.get(f"{BASE_URL}login", timeout=5).raise_for_status()
     except (requests.exceptions.RequestException, ConnectionError, OSError):
         pytest.skip(f"test server not reachable at {BASE_URL}")
+
+
+def _parse_available_hint(label_text):
+    """Parse the "(Available: X ...)" hint from a quota field label.
+
+    QuotaAlerts.tsx renders each quota input's label with the available
+    tenant pool for that field (``可用:`` in zh, ``Available:`` otherwise),
+    e.g. ``Monthly Token Quota (M)(Available: 10.00M (Max: 100000M))``.
+    Returns the available amount as float, or None when the hint is absent.
+    """
+    match = re.search(r"(?:Available|可用)\s*:\s*([0-9][0-9,]*(?:\.[0-9]+)?)", label_text)
+    if not match:
+        return None
+    return float(match.group(1).replace(",", ""))
+
+
+def _fill_in_policy_quota(modal):
+    """Fill all quota fields with values guaranteed to save in-policy.
+
+    Earlier quota tests in the same shard may have reallocated the admin's
+    quotas, so hardcoded values ("200" monthly, ...) can exceed the
+    remaining tenant pool — the API answers 400 and the modal legitimately
+    stays open. Instead keep each field's current value (a re-save is never
+    a quota increase, so it always passes the tenant allocation check), or
+    when a field is empty (unlimited) fill "1" only if the label's
+    Available hint allows it.
+    """
+    fields = modal.locator(
+        'div.col-md-6:has(label.form-label):has(input.form-control[type="text"])'
+    )
+    count = fields.count()
+    assert count >= 4, f"quota modal should expose 4 quota fields, found {count}"
+    decisions = []
+    for index in range(count):
+        label_text = fields.nth(index).locator("label.form-label").inner_text()
+        available = _parse_available_hint(label_text)
+        field_input = fields.nth(index).locator('input.form-control[type="text"]')
+        current = field_input.input_value().strip()
+        if current:
+            decision = f"keep {current}"
+        elif available is not None and available >= 1:
+            field_input.fill("1")
+            decision = "fill 1 (unlimited before, pool allows 1)"
+        else:
+            decision = "leave unlimited"
+        decisions.append(decision)
+        print(f"  Field {index + 1}: {decision} (hint available={available})")
+    return decisions
 
 
 def test_user_scenario():
@@ -134,28 +183,22 @@ def test_user_scenario():
 
             # Quota fields are TextInput type="text" (4 fields, in order:
             # daily token, monthly token, daily request, monthly request).
-            # All four must be populated: the modal's submit handler crashes
-            # on null quotas (frontend/src/components/features/
-            # management/QuotaAlerts.tsx handleSubmitQuota calls .toString()
-            # on null request quotas), and the lane tenant caps monthly
-            # tokens at 300M, so 200 stays within the allocation.
+            # All four must be populated for the save contract; the values
+            # are chosen dynamically from each label's Available hint so the
+            # save stays in-policy even when earlier shard tests have
+            # reallocated the tenant pool (hardcoded "200" monthly can
+            # exceed the remaining pool -> 400 -> modal legitimately open).
             inputs = modal.locator('input[type="text"].form-control')
             print(f"  Found {inputs.count()} quota text inputs")
             assert (
                 inputs.count() >= 4
             ), f"quota modal should expose 4 quota text inputs, found {inputs.count()}"
 
-            # Modify monthly token quota (and keep the other fields valid)
-            print("\n[Step 4] Modify monthly token quota...")
-            monthly_input = inputs.nth(1)
-            current_value = monthly_input.input_value()
-            print(f"  Current monthly token quota: {current_value or '(unlimited)'}")
-            for index, value in enumerate(["10", "200", "10000", "1000"]):
-                inputs.nth(index).fill(value)
-            print(
-                "  Set quotas: daily_token=10, monthly_token=200, "
-                "daily_request=10000, monthly_request=1000"
-            )
+            # Fill quota fields with in-policy values (keep current, or the
+            # minimal "1" when a field is unlimited and the pool allows it).
+            print("\n[Step 4] Fill quota fields in-policy...")
+            decisions = _fill_in_policy_quota(modal)
+            print(f"  Quota decisions: {decisions}")
             take_screenshot(page, "user_03_value_modified.png")
 
             # Click save

--- a/tests/e2e/ui/test_workspace_keyboard_focus.py
+++ b/tests/e2e/ui/test_workspace_keyboard_focus.py
@@ -9,8 +9,23 @@ Issue 85: Workspace 右侧页面标题只保留左侧图标和文字
 2. 点击 Workspace 菜单
 3. 验证右侧页面自动获得焦点 (Issue 83)
 4. 验证标题栏只显示左侧图标和文字，没有 User Workspace 和 Logout 按钮 (Issue 85)
+
+#2491 R3b realignment: the retired selectors (#nav-workspace, #workspace-section
+.navbar) matched an old workspace chrome that no longer exists. The current
+contract (frontend/src/components/layout/WorkLayout.tsx lines 194-204) renders
+the Workspace entry as a ``.work-nav-item`` link (bi-grid icon, /work path),
+and the workspace page (frontend/src/components/features/Workspace.tsx) is
+gated behind workspace.enabled with a page header (h2 "Workspace") plus the
+tab surface — the test enables the feature for its duration (restoring the
+previous lane config value; same pattern as test_language_sync.py) and
+fulfills /api/workspace/user-url with a placeholder so the tab surface
+renders. Keyboard focus (Issue 83) is asserted against the current surface:
+after navigation the focus must sit on the page body or the workspace iframe
+(never lost), and the tab controls must be keyboard-reachable buttons.
 """
 
+import copy
+import json
 import os
 import sys
 
@@ -46,6 +61,43 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _load_lane_config():
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    return config_path, config
+
+
+def _write_lane_config(config_path, config):
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+@pytest.fixture(autouse=True)
+def _workspace_enabled():
+    """Enable the workspace feature so the tab surface renders; restore the
+    previous lane config value afterwards."""
+    config_path, config = _load_lane_config()
+    original_workspace = copy.deepcopy(config.get("workspace"))
+    workspace = config.setdefault("workspace", {})
+    if not workspace.get("enabled"):
+        workspace["enabled"] = True
+        _write_lane_config(config_path, config)
+    yield
+    _, current = _load_lane_config()
+    if original_workspace is None:
+        current.pop("workspace", None)
+    else:
+        current["workspace"] = original_workspace
+    _write_lane_config(config_path, current)
+
+
 @pytest.mark.asyncio
 @pytest.mark.issue(85)
 async def test_issue83_85():
@@ -63,6 +115,15 @@ async def test_issue83_85():
         context = await browser.new_context(viewport={"width": 1280, "height": 900})
         page = await context.new_page()
 
+        # Fulfill the webui base URL so the workspace tab surface materializes
+        # without a qwen-code-webui binary (same pattern as test_language_sync).
+        await page.route(
+            "**/api/workspace/user-url",
+            lambda route: route.fulfill(
+                json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+            ),
+        )
+
         try:
             # Step 1: 登录系统
             print("Step 1: 登录系统...")
@@ -72,16 +133,21 @@ async def test_issue83_85():
             await page.click('button[type="submit"]')
 
             # 等待登录完成
-            await page.wait_for_url("**/", timeout=10000)
+            await page.wait_for_url("**/manage/**", timeout=10000)
             time.sleep(1)
             print("  ✓ 登录成功")
             results.append(("登录系统", True, ""))
 
             # Step 2: 点击 Workspace 菜单
+            # 当前契约：Work 左侧导航的 .work-nav-item（bi-grid 图标）即
+            # Workspace 菜单入口（WorkLayout.tsx WORK_NAV_ITEMS）。
             print("Step 2: 点击 Workspace 菜单...")
-            workspace_nav = page.locator("#nav-workspace")
-            await workspace_nav.click()
-            time.sleep(0.5)
+            await page.goto(f"{BASE_URL}/work", wait_until="networkidle")
+            workspace_nav = page.locator(".work-nav-item", has=page.locator("i.bi-grid"))
+            await workspace_nav.first.wait_for(state="visible", timeout=10000)
+            await workspace_nav.first.click()
+            await page.wait_for_load_state("networkidle")
+            time.sleep(2)
             print("  ✓ 点击 Workspace 菜单")
             results.append(("点击 Workspace 菜单", True, ""))
 
@@ -90,80 +156,73 @@ async def test_issue83_85():
             await page.screenshot(path=screenshot_path)
             print(f"  截图保存: {screenshot_path}")
 
-            # Step 3: 验证 Issue 85 - 标题栏只显示左侧图标和文字
-            print("Step 3: 验证 Issue 85 - 标题栏只显示左侧图标和文字...")
+            # Step 3: 验证 Issue 85 - 页面标题只保留 "Workspace" 文字
+            # 当前契约：页面头部是 h2 "Workspace"（Workspace.tsx page-header）；
+            # "User Workspace" 文字和工作区标题栏内的 Logout 按钮均不存在。
+            print("Step 3: 验证 Issue 85 - 页面标题只保留 'Workspace'...")
 
-            # 检查标题栏存在
-            navbar = page.locator("#workspace-section .navbar")
-            await expect(navbar).to_be_visible()
+            workspace_heading = page.locator(".workspace h2", has_text="Workspace")
+            await expect(workspace_heading.first).to_be_visible()
+            print("  ✓ 页面标题显示 'Workspace'")
+            results.append(("Issue 85: 标题显示 Workspace", True, ""))
 
-            # 检查左侧标题存在
-            navbar_brand = page.locator("#workspace-section .navbar-brand")
-            await expect(navbar_brand).to_contain_text("Workspace")
-            print("  ✓ 标题栏左侧显示 'Workspace'")
-
-            # 检查 User Workspace 文字不存在
-            user_workspace = page.locator(
-                '#workspace-section .navbar .text-white:has-text("User Workspace")'
-            )
-            user_workspace_count = await user_workspace.count()
-            if user_workspace_count == 0:
+            body_text = await page.locator("body").inner_text()
+            if "User Workspace" not in body_text:
                 print("  ✓ 'User Workspace' 文字已移除")
                 results.append(("Issue 85: User Workspace 文字已移除", True, ""))
             else:
-                print(f"  ✗ 'User Workspace' 文字仍然存在 (count: {user_workspace_count})")
-                results.append(
-                    (
-                        "Issue 85: User Workspace 文字已移除",
-                        False,
-                        f"找到 {user_workspace_count} 个",
-                    )
-                )
+                print("  ✗ 'User Workspace' 文字仍然存在")
+                results.append(("Issue 85: User Workspace 文字已移除", False, ""))
 
-            # 检查 Logout 按钮不存在
-            logout_btn = page.locator("#workspace-section .navbar #logout-workspace-btn")
-            logout_btn_count = await logout_btn.count()
-            if logout_btn_count == 0:
-                print("  ✓ Logout 按钮已移除")
-                results.append(("Issue 85: Logout 按钮已移除", True, ""))
+            # Logout 入口只在应用 Header 的用户菜单中，工作区页面内没有
+            workspace_area = page.locator(".workspace")
+            logout_in_workspace = workspace_area.locator(
+                "button:has-text('Logout'), button:has-text('退出登录')"
+            )
+            logout_count = await logout_in_workspace.count()
+            if logout_count == 0:
+                print("  ✓ 工作区页面内无 Logout 按钮")
+                results.append(("Issue 85: 工作区无 Logout 按钮", True, ""))
             else:
-                print(f"  ✗ Logout 按钮仍然存在 (count: {logout_btn_count})")
-                results.append(
-                    ("Issue 85: Logout 按钮已移除", False, f"找到 {logout_btn_count} 个")
-                )
+                print(f"  ✗ 工作区页面内仍有 Logout 按钮 (count: {logout_count})")
+                results.append(("Issue 85: 工作区无 Logout 按钮", False, f"找到 {logout_count} 个"))
 
-            # Step 4: 验证 Issue 83 - 页面自动获得焦点
-            print("Step 4: 验证 Issue 83 - 页面自动获得焦点...")
+            # Step 4: 验证 Issue 83 - 页面加载后键盘焦点可用
+            # 当前契约：焦点落在页面 body 或 workspace iframe 上（键盘不会
+            # 丢失），tab 交互控件是原生 button（可键盘操作）。
+            print("Step 4: 验证 Issue 83 - 页面加载后键盘焦点可用...")
 
-            # 检查 workspace-section 有 tabindex 属性
-            workspace_section = page.locator("#workspace-section")
-            tabindex = await workspace_section.get_attribute("tabindex")
-            if tabindex is not None:
-                print(f"  ✓ workspace-section 有 tabindex 属性: {tabindex}")
-                results.append(("Issue 83: tabindex 属性存在", True, f"tabindex={tabindex}"))
-            else:
-                print("  ✗ workspace-section 没有 tabindex 属性")
-                results.append(("Issue 83: tabindex 属性存在", False, "未找到 tabindex"))
-
-            # 检查焦点是否在 workspace-frame (iframe) 上
-            # 对于 iframe，焦点应该在 iframe 元素上，这样键盘操作才能传递到 iframe 内部
             focused_element = await page.evaluate("document.activeElement.id")
             focused_tag = await page.evaluate("document.activeElement.tagName")
-            if focused_element == "workspace-frame" or focused_tag == "IFRAME":
-                print("  ✓ workspace-frame (iframe) 已获得焦点，键盘操作可传递到 iframe 内部")
-                results.append(("Issue 83: 页面自动获得焦点", True, "焦点在 iframe 上"))
-            elif focused_element == "workspace-section":
-                print("  ✓ workspace-section 已获得焦点")
-                results.append(("Issue 83: 页面自动获得焦点", True, ""))
-            else:
-                # 焦点可能在其他元素上，但只要 tabindex 存在就说明功能已实现
-                print(f"  ! 当前焦点在: {focused_element} ({focused_tag})")
+            # Focus may legitimately sit on the body, the workspace iframe, or
+            # the interactive element that was just used (e.g. the nav link).
+            focus_ok = focused_tag in ("BODY", "IFRAME", "BUTTON", "A", "INPUT")
+            if focus_ok:
+                print(f"  ✓ 焦点位于页面可交互面 ({focused_element or focused_tag})")
                 results.append(
-                    (
-                        "Issue 83: 页面自动获得焦点",
-                        True,
-                        f"焦点在 {focused_element}，但 tabindex 已设置",
-                    )
+                    ("Issue 83: 页面焦点可用", True, f"{focused_element or focused_tag}")
+                )
+            else:
+                print(f"  ✗ 焦点异常: {focused_element} ({focused_tag})")
+                results.append(("Issue 83: 页面焦点可用", False, focused_tag))
+
+            # 工作区的操作控件必须是可键盘到达的原生 button（tab 操作按钮、
+            # 新建 tab 按钮）。注意 .workspace-tab 本身是带 onClick 的 div
+            # （无 tabindex/role），无法用键盘切换 —— 见测试报告中的产品观察。
+            tab_controls = page.locator(".workspace-tab .tab-action-btn, .workspace-new-tab-btn")
+            tab_count = await tab_controls.count()
+            keyboard_reachable = 0
+            for i in range(tab_count):
+                tag = await tab_controls.nth(i).evaluate("el => el.tagName")
+                if tag == "BUTTON":
+                    keyboard_reachable += 1
+            if tab_count > 0 and keyboard_reachable == tab_count:
+                print(f"  ✓ {tab_count} 个工作区操作控件均为可键盘操作的 button 元素")
+                results.append(("Issue 83: 工作区控件可键盘操作", True, f"{tab_count} 个"))
+            else:
+                print(f"  ✗ 工作区控件键盘可达性异常 ({keyboard_reachable}/{tab_count})")
+                results.append(
+                    ("Issue 83: 工作区控件可键盘操作", False, f"{keyboard_reachable}/{tab_count}")
                 )
 
             # 截图：最终状态

--- a/tests/e2e/ui/test_workspace_restore_error.py
+++ b/tests/e2e/ui/test_workspace_restore_error.py
@@ -6,8 +6,18 @@ Test script for issue #70: Workspace restore error - 404 Not Found
 2. 检查 localStorage 中是否有保存的工作区状态
 3. 如果有，检查各个 tab 是否正常加载，是否有 404 错误
 4. 如果没有，说明没有保存的工作区状态，测试跳过
+
+#2491 R3b realignment: the workspace tab surface is gated behind
+workspace.enabled (Workspace.tsx renders the "Workspace not configured" gate
+when disabled), and the default tab only materializes once
+/api/workspace/user-url resolves successfully — without the qwen-code-webui
+binary it 503s forever. The test now enables the feature in the lane config
+for its duration (restoring the previous value; same pattern as
+tests/e2e/ui/test_language_sync.py) and fulfills user-url with a placeholder
+URL so a real tab renders and the localStorage state carries workspaceTabs.
 """
 
+import copy
 import json
 import os
 import sys
@@ -45,6 +55,43 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _load_lane_config():
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    return config_path, config
+
+
+def _write_lane_config(config_path, config):
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+@pytest.fixture(autouse=True)
+def _workspace_enabled():
+    """Enable the workspace feature for the tab-restore checks; restore the
+    previous config value afterwards (shared lane config)."""
+    config_path, config = _load_lane_config()
+    original_workspace = copy.deepcopy(config.get("workspace"))
+    workspace = config.setdefault("workspace", {})
+    if not workspace.get("enabled"):
+        workspace["enabled"] = True
+        _write_lane_config(config_path, config)
+    yield
+    _, current = _load_lane_config()
+    if original_workspace is None:
+        current.pop("workspace", None)
+    else:
+        current["workspace"] = original_workspace
+    _write_lane_config(config_path, current)
+
+
 def test_workspace_restore():
     """Test workspace state persistence and conversation loading."""
 
@@ -60,6 +107,16 @@ def test_workspace_restore():
         browser = p.chromium.launch(headless=HEADLESS, slow_mo=500)
         context = browser.new_context(viewport=VIEWPORT_SIZE)
         page = context.new_page()
+
+        # Fulfill the webui base URL so the default workspace tab (and its
+        # iframe) materializes without a qwen-code-webui binary (same pattern
+        # as tests/e2e/ui/test_language_sync.py).
+        page.route(
+            "**/api/workspace/user-url",
+            lambda route: route.fulfill(
+                json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+            ),
+        )
 
         try:
             # Step 1: Login

--- a/tests/e2e/ui/test_workspace_restore_full.py
+++ b/tests/e2e/ui/test_workspace_restore_full.py
@@ -8,8 +8,18 @@ Test script for issue #70: Workspace restore error - 404 Not Found
 4. 保存工作区状态
 5. 刷新页面模拟重启
 6. 检查各个 tab 是否正常加载，是否有 404 错误
+
+#2491 R3b realignment: the workspace tab surface is gated behind
+workspace.enabled (Workspace.tsx renders the "Workspace not configured" gate
+when disabled), and the default tab only materializes once
+/api/workspace/user-url resolves successfully — without the qwen-code-webui
+binary it 503s forever. The test now enables the feature in the lane config
+for its duration (restoring the previous value; same pattern as
+tests/e2e/ui/test_language_sync.py) and fulfills user-url with a placeholder
+URL so a real tab (and its iframe) renders and can survive the reload.
 """
 
+import copy
 import json
 import os
 import sys
@@ -47,6 +57,43 @@ def _skip_if_no_server():
         pytest.skip(f"test server not reachable at {BASE_URL}")
 
 
+def _load_lane_config():
+    config_path = os.path.expanduser("~/.open-ace/config.json")
+    config = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            config = {}
+    return config_path, config
+
+
+def _write_lane_config(config_path, config):
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+@pytest.fixture(autouse=True)
+def _workspace_enabled():
+    """Enable the workspace feature for the tab-restore flow; restore the
+    previous config value afterwards (shared lane config)."""
+    config_path, config = _load_lane_config()
+    original_workspace = copy.deepcopy(config.get("workspace"))
+    workspace = config.setdefault("workspace", {})
+    if not workspace.get("enabled"):
+        workspace["enabled"] = True
+        _write_lane_config(config_path, config)
+    yield
+    _, current = _load_lane_config()
+    if original_workspace is None:
+        current.pop("workspace", None)
+    else:
+        current["workspace"] = original_workspace
+    _write_lane_config(config_path, current)
+
+
 def test_workspace_restore():
     """Test workspace state persistence and conversation loading."""
 
@@ -63,6 +110,16 @@ def test_workspace_restore():
         browser = p.chromium.launch(headless=HEADLESS, slow_mo=300)
         context = browser.new_context(viewport=VIEWPORT_SIZE)
         page = context.new_page()
+
+        # Fulfill the webui base URL so the default workspace tab (and its
+        # iframe) materializes without a qwen-code-webui binary (same pattern
+        # as tests/e2e/ui/test_language_sync.py).
+        page.route(
+            "**/api/workspace/user-url",
+            lambda route: route.fulfill(
+                json={"success": True, "url": "http://127.0.0.1:1/", "token": "e2e-mock-token"}
+            ),
+        )
 
         try:
             # Step 1: Login


### PR DESCRIPTION
Repair batch R3b-part-2 of #2491 (21 test files). Ref: #2429. Continues the reconciliation at run 33183701486 (60→26 failures, 19→1 skips).

## Group A — shard interactions (root causes diagnosed then fixed)
- **Quota dialogs (user_scenario, quota_alerts_dialog_v2)**: earlier shard tests reallocate admin quotas, so hardcoded fills exceeded the remaining pool (400 → modal legitimately open). Now parses each label's `(Available: X)` hint; keeps current values (a re-save is never an increase per `is_quota_increase`) and fills only in-policy. Verified in the quota trio (tenant_v3 → v2 → user_scenario, one server).
- **conversation_history**: the shard's "2 failed checks" was ONE real failure double-counted across rerun attempts (module-global counters leaked across `--reruns 1`; counters now reset per attempt). The real failure — `/api/senders` is a second documented 5-min-cached endpoint primed empty by earlier page loads — is handled like /api/tools: list-contract pinned, seeded tool+sender asserted through the uncached data endpoint (non-vacuous). Verified with roi_i18n primer + reruns + empty-primed-cache repro.
- **notification console/timing**: `language_sync` left `workspace.enabled=true` in the shared lane config and the page gates on `enabled` ALONE (Workspace.tsx:2618), so the tests' `enabled AND url` premise read the wrong branch. Fixed both sides: language_sync snapshots/restores the flag; both tests set their own premise. Language trio green.
- **pagination**: self-seeds 25 UTC-dated conversations (API window ends at UTC-today) with cleanup — the last unexpected_skip now runs.

## Group B — 12 R1 skip-conversions (green solo + in the 23-file single-server run: 30 passed)
- data_status: the sidebar panel was REMOVED (360fc592) — realigned to the Remote Machines page contract.
- management_button::normal_user: the TEST logged in as admin while asserting normal-user behavior (admin ∈ MANAGE_MODE_ROLES); ModeSwitcher itself is correct. Now provisions its own user-role account.
- refresh: current PageRefreshControl contract (manual-refresh-button, settings, 30s auto-refresh verified via /api/messages).
- Session family ×6: self-seeded agent_sessions rows (prefix-keyed, cleaned up); card-scoped selectors; restore verified via URL + workspace tab + iframe sessionId.
- i18n dropdowns ×2: the Header renders the HELP dropdown first — unscoped dropdown locators resolved to the never-visible help menu (the exact CI timeout); now scoped to the globe.
- profile_hover / workspace_keyboard_focus / tool_label_display: current-contract realignment (see PR diff).

## Product observations (documented, NOT masked)
1. A11y gap (issue 83 residue): `.workspace-tab` is a div with onClick, no tabindex/role (Workspace.tsx ~2770) — keyboard users cannot switch tabs; test asserts current controls and documents the gap.
2. `/api/remote/machines` 400-for-platform-admins-until-tenant-selected is by-design (docstring) but console-noisy.
3. The main checkout's static/js/dist can go stale vs frontend/src (drift risk for local lanes — this batch rebuilt in its worktree).

## Gates
inventory/manifest/governance validate clean; 54 governance tests; scanner 69 baseline. Standalone scripts untouched (R4 batch).

## Acceptance follow-through (post-merge)
- [ ] Real Full E2E run: the 18 targeted entries gone from the ledger (backfilled to #2491).