### PR TITLE
fix(e2e): align the weekly lane's login contract with the seeded admin

### DIFF
--- a/.github/workflows/weekly-quality.yml
+++ b/.github/workflows/weekly-quality.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Initialize isolated test database
         env:
           HOME: ${{ runner.temp }}/openace-home
+          # Same lane contract as the python e2e lanes (run_extended_tests.py):
+          # the seeded admin must not require a forced password change — the
+          # frontend specs' shared login helper hard-fails on that modal by
+          # design (#3214).
+          OPENACE_DEFAULT_ADMIN_MUST_CHANGE_PASSWORD: "false"
         run: |
           mkdir -p "$HOME/.open-ace"
           sqlite3 "$HOME/.open-ace/ace.db" < schema/schema-sqlite.sql

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -23,31 +23,44 @@ export async function login(page: Page, username = 'admin', password = 'admin123
     await page.waitForURL(/\/(manage|work)\//, { timeout: 15000 });
   } catch {
     // Fallback: wait for any URL change away from /login
-    const navigated = await page.waitForURL(/^(?!.*\/login).+$/, { timeout: 5000 }).then(() => true).catch(() => false);
+    const navigated = await page
+      .waitForURL(/^(?!.*\/login).+$/, { timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
     if (!navigated) {
       console.warn(`Login redirect failed — still at ${page.url()}, navigating to /`);
       await page.goto('/');
     }
   }
 
-  // Handle ForceChangePasswordModal if it appears (for users with must_change_password=true)
-  // The modal is loaded lazily via Suspense, so it may take time to appear in CI environments
+  // Post-login modal contract (#3214): the seeded-lane user must NOT carry
+  // must_change_password (lanes init with OPENACE_DEFAULT_ADMIN_MUST_CHANGE_
+  // PASSWORD=false, same contract as the python e2e lanes). If the forced
+  // password-change modal DOES appear, the lane is misconfigured and every
+  // test would otherwise hang — fail fast with a clear diagnostic instead.
+  // The historical "Skip tour" modal is gone from the product (no Skip
+  // button exists in any current dialog), so a bounded short wait replaces
+  // the old 15s unconditional one (545 logins x 15s of dead waiting would
+  // sink the weekly lane on a single worker).
   const modalDialog = page.locator('[role="dialog"][aria-modal="true"]');
-  const skipButton = modalDialog.locator('button:has-text("Skip"), button:has-text("跳过")');
-
-  // Wait for modal to appear (up to 15s for CI environments with slow networks)
-  // Playwright's waitFor polls every ~100ms, so it returns immediately when visible
-  const modalVisible = await modalDialog.waitFor({ state: 'visible', timeout: 15000 })
+  const modalVisible = await modalDialog
+    .waitFor({ state: 'visible', timeout: 2500 })
     .then(() => true)
     .catch(() => false);
 
   if (modalVisible) {
-    // Wait for Skip button to be visible and clickable
-    await skipButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
-    // Click Skip button to dismiss the modal
-    await skipButton.click({ force: true });
-    // Wait for modal to disappear completely
-    await modalDialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    const forceChange = modalDialog.locator('[data-testid="force-change-password-modal"]');
+    if (await forceChange.count()) {
+      throw new Error(
+        'Lane contract violation: the forced password-change modal appeared after login. ' +
+          'The test lane must seed its database with ' +
+          'OPENACE_DEFAULT_ADMIN_MUST_CHANGE_PASSWORD=false (see scripts/init_db.py and the ' +
+          'weekly-quality workflow) — the modal has no Skip button by design and cannot be ' +
+          'dismissed from tests.'
+      );
+    }
+    // Unknown dismissible dialog: tolerate and continue (spec-level
+    // assertions remain responsible for the UI state they depend on).
   }
 
   // Wait for page to be ready
@@ -60,19 +73,25 @@ export async function login(page: Page, username = 'admin', password = 'admin123
 export async function waitForApp(page: Page) {
   await page.waitForLoadState('networkidle');
 
-  // Fallback: handle ForceChangePasswordModal if login helper missed it
+  // Same contract as login(): the forced password-change modal means the
+  // lane is misconfigured — fail fast rather than timeout downstream.
   const modalDialog = page.locator('[role="dialog"][aria-modal="true"]');
   const isModalVisible = await modalDialog.isVisible().catch(() => false);
   if (isModalVisible) {
-    const skipButton = modalDialog.locator('button:has-text("Skip"), button:has-text("跳过")');
-    if (await skipButton.isVisible().catch(() => false)) {
-      await skipButton.click({ force: true });
-      await modalDialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    const forceChange = modalDialog.locator('[data-testid="force-change-password-modal"]');
+    if (await forceChange.count()) {
+      throw new Error(
+        'Lane contract violation: forced password-change modal is open — the lane must seed ' +
+          'with OPENACE_DEFAULT_ADMIN_MUST_CHANGE_PASSWORD=false (see scripts/init_db.py).'
+      );
     }
   }
 
   // Wait for main content to be visible
-  await page.locator('main').waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+  await page
+    .locator('main')
+    .waitFor({ state: 'visible', timeout: 10000 })
+    .catch(() => {});
 }
 
 /**

--- a/frontend/e2e/quota-fullscreen-exit.spec.ts
+++ b/frontend/e2e/quota-fullscreen-exit.spec.ts
@@ -8,18 +8,88 @@
  * 4. A toast notification should be shown to inform the user
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { test, expect } from '@playwright/test';
 
+/**
+ * The workspace surface these tests exercise is gated behind
+ * workspace.enabled in the lane's ~/.open-ace/config.json (freshly
+ * initialized homes default it to false, and the specs run on the same
+ * host as the server). The config endpoint re-reads the file per request,
+ * so flipping it needs no restart — same pattern as the python e2e lanes
+ * (tests/e2e/ui/test_language_sync.py's _ensure_workspace_enabled).
+ */
+function ensureWorkspaceEnabled(): void {
+  const configPath = path.join(process.env.HOME ?? '', '.open-ace', 'config.json');
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    // missing/corrupt file — start from an empty object
+  }
+  const workspace = (config.workspace ?? {}) as Record<string, unknown>;
+  if (workspace.enabled !== true) {
+    workspace.enabled = true;
+    config.workspace = workspace;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    workspaceWasEnabledByUs = true;
+  }
+}
+
+let workspaceWasEnabledByUs = false;
+
+function restoreWorkspaceFlag(): void {
+  if (!workspaceWasEnabledByUs) {
+    return;
+  }
+  const configPath = path.join(process.env.HOME ?? '', '.open-ace', 'config.json');
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    const workspace = (config.workspace ?? {}) as Record<string, unknown>;
+    workspace.enabled = false;
+    config.workspace = workspace;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  } catch {
+    // best-effort restore only
+  }
+}
+
 test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
+  test.beforeAll(() => {
+    ensureWorkspaceEnabled();
+  });
+
+  test.afterAll(() => {
+    restoreWorkspaceFlag();
+  });
+
   test.beforeEach(async ({ page }) => {
-    // Login first
+    // The workspace surface needs a webui URL; the lane has no qwen-code-webui
+    // instance, so /api/workspace/user-url would 503 forever. Fulfill it with
+    // a placeholder (same pattern as the python lanes' session-restore tests).
+    await page.route('**/api/workspace/user-url', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          url: 'http://127.0.0.1:1/',
+          token: 'e2e-mock-token',
+        }),
+      })
+    );
+
+    // Login first (current Login.tsx contract: #username/#password; the app
+    // navigates to "/" after submit — there is no /dashboard route).
     await page.goto('/login');
-    await page.fill('input[name="username"]', 'admin');
-    await page.fill('input[name="password"]', 'admin123');
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'admin123');
     await page.click('button[type="submit"]');
 
-    // Wait for redirect to dashboard
-    await page.waitForURL(/dashboard/, { timeout: 10000 });
+    // Wait for the post-login landing (root WorkLayout shell)
+    await page.waitForURL(/\/(work)?$/, { timeout: 10000 });
   });
 
   test('should show quota exceeded warning when quota is over limit', async ({ page }) => {
@@ -63,11 +133,12 @@ test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
     const fullscreenBtn = await page.locator('.fullscreen-toggle-btn');
     await fullscreenBtn.click();
 
-    // Wait for fullscreen mode
-    await page.waitForSelector('.fullscreen-mode', { timeout: 5000 });
+    // Wait for fullscreen mode — both .work-layout and .workspace receive
+    // the class, so scope to the workspace element.
+    await page.waitForSelector('.workspace.fullscreen-mode', { timeout: 5000 });
 
     // Verify fullscreen mode is active
-    const workspace = await page.locator('.fullscreen-mode');
+    const workspace = page.locator('.workspace.fullscreen-mode');
     await expect(workspace).toBeVisible();
 
     // Take screenshot

--- a/frontend/src/components/features/ForceChangePasswordModal.tsx
+++ b/frontend/src/components/features/ForceChangePasswordModal.tsx
@@ -77,51 +77,57 @@ export const ForceChangePasswordModal: React.FC = () => {
         </Button>
       }
     >
-      <div className="alert alert-warning mb-3">
-        <i className="bi bi-exclamation-triangle-fill me-2" />
-        {t('mustChangePasswordHint', language) ??
-          'Your password was reset by an administrator. You must change it before continuing.'}
-      </div>
-
-      {(error ?? changePasswordError) && (
-        <div className="alert alert-danger mb-3" role="alert">
+      <div data-testid="force-change-password-modal">
+        <div className="alert alert-warning mb-3">
           <i className="bi bi-exclamation-triangle-fill me-2" />
-          {error ?? (changePasswordError as Error)?.message}
+          {t('mustChangePasswordHint', language) ??
+            'Your password was reset by an administrator. You must change it before continuing.'}
         </div>
-      )}
 
-      <div className="mb-3">
-        <label className="form-label">{t('currentPassword', language) ?? 'Current Password'}</label>
-        <TextInput
-          type="password"
-          value={currentPassword}
-          onChange={(value: string) => setCurrentPassword(value)}
-          placeholder={t('enterCurrentPassword', language) ?? 'Enter current password'}
-          aria-label="current-password"
-        />
-      </div>
+        {(error ?? changePasswordError) && (
+          <div className="alert alert-danger mb-3" role="alert">
+            <i className="bi bi-exclamation-triangle-fill me-2" />
+            {error ?? (changePasswordError as Error)?.message}
+          </div>
+        )}
 
-      <div className="mb-3">
-        <label className="form-label">{t('newPassword', language) ?? 'New Password'}</label>
-        <TextInput
-          type="password"
-          value={newPassword}
-          onChange={(value: string) => setNewPassword(value)}
-          placeholder={t('enterNewPassword', language) ?? 'Enter new password'}
-          aria-label="new-password"
-        />
-        <PasswordPolicyHint />
-      </div>
+        <div className="mb-3">
+          <label className="form-label">
+            {t('currentPassword', language) ?? 'Current Password'}
+          </label>
+          <TextInput
+            type="password"
+            value={currentPassword}
+            onChange={(value: string) => setCurrentPassword(value)}
+            placeholder={t('enterCurrentPassword', language) ?? 'Enter current password'}
+            aria-label="current-password"
+          />
+        </div>
 
-      <div className="mb-3">
-        <label className="form-label">{t('confirmPassword', language) ?? 'Confirm Password'}</label>
-        <TextInput
-          type="password"
-          value={confirmPassword}
-          onChange={(value: string) => setConfirmPassword(value)}
-          placeholder={t('confirmPassword', language) ?? 'Confirm password'}
-          aria-label="confirm-password"
-        />
+        <div className="mb-3">
+          <label className="form-label">{t('newPassword', language) ?? 'New Password'}</label>
+          <TextInput
+            type="password"
+            value={newPassword}
+            onChange={(value: string) => setNewPassword(value)}
+            placeholder={t('enterNewPassword', language) ?? 'Enter new password'}
+            aria-label="new-password"
+          />
+          <PasswordPolicyHint />
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label">
+            {t('confirmPassword', language) ?? 'Confirm Password'}
+          </label>
+          <TextInput
+            type="password"
+            value={confirmPassword}
+            onChange={(value: string) => setConfirmPassword(value)}
+            placeholder={t('confirmPassword', language) ?? 'Confirm password'}
+            aria-label="confirm-password"
+          />
+        </div>
       </div>
     </Modal>
   );


### PR DESCRIPTION
Batch 1 of #3214 (systemic root cause). Plan: #3214 comments 5457252938 + rev2 5457341457 (independently reviewed; 2 HIGH + 2 MED folded). Ref: #2429.

## Root cause (96–97% of the baseline failures)
The weekly lane seeded its DB without `OPENACE_DEFAULT_ADMIN_MUST_CHANGE_PASSWORD=false` (the python e2e lanes' standard — run_extended_tests.py:531), so admin logged in with `must_change_password=1` → the forced password-change modal (no Skip button **by design**) appeared → the shared `frontend/e2e/helpers.ts` login() blind force-clicked the nonexistent Skip → timeout ×3 attempts for every helpers-based spec. Baseline run 33148939387: **255/263 failure blocks** at helpers.ts:48; chromium+firefox had ZERO passing tests.

## Change
- `weekly-quality.yml`: DB init sets the flag (CI-lane-only; all production install paths keep the forced change — verified).
- `helpers.ts`: contract-explicit post-login handling — bounded 2.5s dialog wait (the old unconditional 15s burned ≈136 worker-minutes/lane), **fast-fail with a clear diagnostic** when the forced-change modal is present (locale-proof `data-testid` discriminator) instead of a blind timeout; `waitForApp` fallback tightened identically.
- `ForceChangePasswordModal.tsx`: the data-testid wrapper.
- `quota-fullscreen-exit.spec.ts` (the only other baseline failure family): inline login realigned (`#username`/`#password`, post-login landing at `/`), workspace premise self-provisioned (same-host config-file enable + `user-url` placeholder route — the python lanes' pattern), fullscreen locator scoped to `.workspace.fullscreen-mode` (dual-match strict violation).

## Local verification (reviewer's decisive set, all green)
- chromium: accessibility 6/6, quota-fullscreen-exit 4/4, **comprehensive-test 42/42** (3.4m).
- webkit: accessibility 6/6, quota-fullscreen-exit 4/4.
- **Negative control** (flag unset): the fast-fail fires immediately with the contract-violation diagnostic (no 10s hang).

## Acceptance follow-through (post-merge)
- [ ] Weekly `workflow_dispatch`: no helpers.ts:48-shaped failures; failure count and total runtime re-measured (feeds the batch-2 workers/sharding decision); residual failures triaged into follow-up batches.