### PR TITLE
fix(#3231): use session_messages subquery for requests in fallback path

### DIFF
--- a/app/modules/governance/quota_manager.py
+++ b/app/modules/governance/quota_manager.py
@@ -529,15 +529,20 @@ class QuotaManager:
         # never sees because local agents connect to the model API directly.
         # daily_messages then adds only messages NOT tied to a session
         # (agent_session_id IS NULL), so the two legs don't double-count.
+        # Uses session_messages subquery for requests (same as aggregator) for consistency.
         session_result = self.db.fetch_one(
             adapt_sql("""
             SELECT
-                COALESCE(SUM(total_tokens), 0) as tokens,
-                COUNT(*) as requests
-            FROM agent_sessions
-            WHERE user_id = ?
-              AND workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+                COALESCE(SUM(as2.total_tokens), 0) as tokens,
+                COALESCE(SUM((
+                    SELECT COUNT(*) FROM session_messages sm
+                    WHERE sm.session_id = as2.session_id
+                      AND sm.role = 'assistant'
+                )), 0) as requests
+            FROM agent_sessions as2
+            WHERE as2.user_id = ?
+              AND as2.workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(as2.created_at AS DATE) >= ? AND CAST(as2.created_at AS DATE) <= ?
         """),
             (user_id, start_date, end_date),
         )

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -2139,16 +2139,20 @@ class UsageRepository:
             pass
 
         # Fallback: agent_sessions.total_tokens with created_at date attribution.
-        # Matches quota_manager._get_usage_in_range() legacy path.
+        # Uses session_messages subquery for requests (same as aggregator) for consistency.
         session_row = self.db.fetch_one(
             """
             SELECT
-                COALESCE(SUM(total_tokens), 0) as tokens,
-                COUNT(*) as requests
-            FROM agent_sessions
-            WHERE user_id = ?
-              AND workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+                COALESCE(SUM(as2.total_tokens), 0) as tokens,
+                COALESCE(SUM((
+                    SELECT COUNT(*) FROM session_messages sm
+                    WHERE sm.session_id = as2.session_id
+                      AND sm.role = 'assistant'
+                )), 0) as requests
+            FROM agent_sessions as2
+            WHERE as2.user_id = ?
+              AND as2.workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(as2.created_at AS DATE) >= ? AND CAST(as2.created_at AS DATE) <= ?
             """,
             (user_id, start_date, end_date),
         )

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -81,11 +81,11 @@ class TestGetSessionOnlyUsage:
         assert result["tokens"] == 9_999_999
         assert result["requests"] == 77
         assert db.fetch_one.call_count == 2
-        # Second call must query agent_sessions (not session_messages, not daily_messages).
+        # Second call must query agent_sessions (daily_messages forbidden by #1125).
+        # session_messages subquery is allowed and matches aggregator behavior (#3231).
         fallback_sql = db.fetch_one.call_args_list[1][0][0]
         assert "FROM agent_sessions" in fallback_sql
         assert "total_tokens" in fallback_sql
-        assert "session_messages" not in fallback_sql
         assert "daily_messages" not in fallback_sql
 
     @pytest.mark.regression


### PR DESCRIPTION
## Summary

Fixes #3231 (problem 1 only): Work page StatusBar displayed fewer requests than actual usage.

## Problem

1. Fallback path in `_session_usage` used `COUNT(*)` which counts sessions, not requests
2. Each session may contain multiple requests, causing undercount
3. Same issue existed in `quota_manager._get_usage_in_range` legacy path

## Root Cause

The aggregator uses `session_messages` subquery to count requests:
```sql
COALESCE((SELECT COUNT(*) FROM session_messages sm
          WHERE sm.session_id = as2.session_id
            AND sm.role = 'assistant'), 0) as requests
```

But fallback path used `COUNT(*)` which counts session rows.

## Solution

- Use `session_messages` subquery in both fallback paths
- This ensures consistency with the aggregator and `user_daily_stats` main path

## Changes

| File | Change |
|------|--------|
| `app/repositories/usage_repo.py` | Update fallback SQL to use session_messages subquery |
| `app/modules/governance/quota_manager.py` | Update legacy path SQL |
| `tests/unit/test_usage_repo_session_only.py` | Update test assertion |

## Testing

- ✅ All 14 related unit tests pass
- ✅ Python syntax check passes

## Issue 2 Note

Token count missing local CLI usage in fallback path (Issue #3231 problem 2) is **not fixed** in this PR. It requires design trade-offs per #1125 and can be addressed in a follow-up PR.

Fixes #3231 (problem 1 only)