### PR TITLE
fix(#3230): Dashboard 渲染失败 - 前后端趋势数据字段名对齐

### DIFF
--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -367,7 +367,7 @@ class UsageService:
             else:
                 merged[key] = {
                     "date": normalized_date,
-                    "tool_name": entry["tool_name"],
+                    "tool": entry["tool_name"],
                     "tokens": entry.get("tokens", 0),
                 }
 
@@ -379,10 +379,10 @@ class UsageService:
             else:
                 merged[key] = {
                     "date": normalized_date,
-                    "tool_name": entry["tool_name"],
+                    "tool": entry["tool_name"],
                     "tokens": entry.get("tokens", 0),
                 }
 
-        # Sort by date, then by tool_name
-        result = sorted(merged.values(), key=lambda x: (x["date"], x["tool_name"]))
+        # Sort by date, then by tool
+        result = sorted(merged.values(), key=lambda x: (x["date"], x["tool"]))
         return result

--- a/tests/unit/test_issue_3030_trend_webui_sessions.py
+++ b/tests/unit/test_issue_3030_trend_webui_sessions.py
@@ -223,7 +223,7 @@ class TestGetTrendDataMerge:
         result = svc.get_trend_data("2026-08-01", "2026-08-31")
 
         assert len(result) == 2
-        tools = {r["tool_name"] for r in result}
+        tools = {r["tool"] for r in result}
         assert "claude" in tools
         assert "qwen" in tools
 
@@ -499,8 +499,8 @@ class TestMixedDateTypes:
 
         # qwen should merge, claude should be separate
         assert len(result) == 2
-        qwen_record = next(r for r in result if r["tool_name"] == "qwen")
-        claude_record = next(r for r in result if r["tool_name"] == "claude")
+        qwen_record = next(r for r in result if r["tool"] == "qwen")
+        claude_record = next(r for r in result if r["tool"] == "claude")
         assert qwen_record["tokens"] == 15000
         assert claude_record["tokens"] == 5000
 


### PR DESCRIPTION
## Summary

- 修复 `/api/trend` 返回字段名 `tool_name` 与前端 `TrendDataPoint.tool` 不匹配的问题
- 后端现在返回 `tool` 字段，与前端类型定义一致

## Root Cause

**后端返回格式** (`/api/trend`):
```json
{"date":"2026-08-31","tool_name":"claude","tokens":31778856}
```

**前端期望格式** (`TrendDataPoint`):
```typescript
interface TrendDataPoint {
  date: string;
  tool: string;  // 期望 'tool'，实际返回 'tool_name'
  tokens: number;
}
```

**错误链路**:
`/api/trend` → `useDashboard` → `TokenTrendChart` → `d.tool` (undefined) → `toUpperCase()` → TypeError

## Changes

| 文件 | 修改内容 |
|------|----------|
| `app/services/usage_service.py` | `get_trend_data` 返回 `tool` 而非 `tool_name` |
| `tests/unit/test_issue_3030_trend_webui_sessions.py` | 同步更新测试断言 |

## Test Evidence

```
pytest tests/unit/test_usage_service.py tests/unit/test_issue_3030_trend_webui_sessions.py -v
38 passed in 0.72s
```

## Risk Assessment

- **影响范围**: 仅影响 `/api/trend` 端点
- **兼容性**: 无其他代码依赖此字段
- **风险级别**: 低

Fixes #3230