### PR TITLE
fix(#3228): add fetch wrapper sudoers rule check in upgrade scenarios

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2838,6 +2838,16 @@ ${line}"
             fi
         done
 
+        # 【Issue #3228】检查 fetch wrapper 规则
+        # 存量部署升级场景：wrapper 已安装但 sudoers 未更新，导致 "sudo: a password is required"
+        local fetch_wrapper_path="/usr/local/bin/openace-fetch-wrapper"
+        if [ -x "$fetch_wrapper_path" ] && \
+           ! grep -E "^${run_user} .*(NOPASSWD: )?${fetch_wrapper_path}( |\*|$)" "$sudoers_file" 2>/dev/null && \
+           ! grep -E "Cmnd_Alias FETCH_WRAPPER.*${fetch_wrapper_path}" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing fetch wrapper rule for user '$run_user' (wrapper installed but not authorized)"
+            need_update=true
+        fi
+
         # 【安全加固 Issue #2181】检查是否存在已废弃的 OPENACE_CLI 规则
         # 如果存在，触发更新以删除这些规则
         if grep -q "Cmnd_Alias OPENACE_CLI" "$sudoers_file" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Fixes #3228

### Problem

In package upgrade scenarios, `openace-fetch-wrapper` is installed but the corresponding sudoers rule may not be updated if the existing checks (all other wrapper rules) pass. This causes `sudo: a password is required` errors for all fetch collectors.

### Root Cause

The sudoers check loop in `install.sh` (lines 2831-2839) verified 5 security wrappers (`openace-chown`, `openace-useradd`, `openace-cat`, `openace-mkdir`, `openace-rm`) but **missed the fetch wrapper**.

When upgrading an existing deployment:
1. The fetch wrapper is installed to `/usr/local/bin/openace-fetch-wrapper`
2. The sudoers validation checks pass for all 5 security wrappers
3. `need_update` remains `false`, so sudoers is not regenerated
4. The fetch wrapper exists but has no NOPASSWD authorization → all fetch commands fail

### Fix

Add explicit check for `openace-fetch-wrapper` in the sudoers validation loop, mirroring the existing pattern for other wrappers.

### Testing

- ✅ Bash syntax validation passed
- ✅ Unit tests passed (12 tests in `tests/unit/test_fetch.py`)

### Files Changed

- `scripts/install-central/package-method/install.sh`: Added fetch wrapper sudoers rule check