### PR TITLE
fix(ci): raise python-min suite budget 600s→1200s for runner variance

### DIFF
--- a/ci/suites.json
+++ b/ci/suites.json
@@ -150,7 +150,7 @@
     },
     "python-min": {
       "description": "compileall + full unit suite on the minimum supported Python (catches version-specific regressions on the oldest interpreter; #2868)",
-      "timeout_seconds": 600,
+      "timeout_seconds": 1200,
       "commands": [
         [
           "{python}",

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -95,8 +95,9 @@ GitHub Actions 都通过 `python scripts/ci.py` 执行。PR 矩阵按版本分�
   每个非文档改动都跑。版本特有的回归几乎总先在最老解释器上暴露（例如 3.11 之前
   `datetime.fromisoformat` 不接受 `Z` 后缀），旧矩阵只在 3.10 跑 7 文件 smoke，使
   这类**单元级**回归在 PR 与合并后 main 推送上都漏网、红 main 75 分钟无人察觉。
-  只跑 unit 使其快（~2min）且确定（无 integration flake、无覆盖率/超时——直接在
-  较慢的 3.10 上跑全量 `tests/` 会撞 10 分钟预算并放大 flake）。
+  只跑 unit 使其快（~2min）且确定（无 integration flake、无覆盖率开销；该 suite 的
+  预算已因 GitHub runner 方差从 600s 抬至 1200s——同 commit 曾 183s↔652s 波动（#3240）
+  ——但直接在较慢的 3.10 上跑全量 `tests/` 仍会拉长墙钟并放大 flake）。
 - **3.12、3.14（前向兼容）**：`compatibility-smoke`——`compileall` + 少量关键单元
   文件，按依赖变更选择。
 

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -96,8 +96,9 @@ def test_min_supported_python_runs_the_full_unit_suite():
 def test_python_min_timeout_budget_absorbs_runner_variance():
     """#3240: python-min's suite budget must absorb GitHub-hosted runner variance.
 
-    Evidence: the SAME commit ran 183s and 652s on the 3.10 lane (PR #3205,
-    run 33410540459 rerun), and main run 33384495716 was budget-killed at
+    Evidence: the SAME commit ran 183s and 652s on the 3.10 lane (PR #3205
+    run 33410540459 first attempt vs same-commit rerun), and main run
+    33384495716 was budget-killed at
     599s ("Command exceeded 599s") with ZERO test failures. The lane is a
     required check, so the kill randomly blocked merges. The 600s budget was
     shared by compileall + the whole pytest run. 1200s keeps ~1.8x headroom

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -93,6 +93,26 @@ def test_min_supported_python_runs_the_full_unit_suite():
     ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
 
 
+def test_python_min_timeout_budget_absorbs_runner_variance():
+    """#3240: python-min's suite budget must absorb GitHub-hosted runner variance.
+
+    Evidence: the SAME commit ran 183s and 652s on the 3.10 lane (PR #3205,
+    run 33410540459 rerun), and main run 33384495716 was budget-killed at
+    599s ("Command exceeded 599s") with ZERO test failures. The lane is a
+    required check, so the kill randomly blocked merges. The 600s budget was
+    shared by compileall + the whole pytest run. 1200s keeps ~1.8x headroom
+    over the worst observed run without masking a real slowdown: the same
+    unit tests also run under python-core's unchanged 600s on 3.11 (typical
+    340-388s), which would trip first. Changing this pin requires consciously
+    re-deriving the budget from fresh variance evidence, not silently
+    trimming it back toward the variance cliff.
+    """
+    import json
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    assert suites["python-min"]["timeout_seconds"] == 1200
+
+
 def test_backend_change_runs_the_min_version_unit_lane():
     """End-to-end of the #2868 fix: an app/** change selects python-min, and the
     matrix runs python-min on the minimum supported interpreter -- so the full


### PR DESCRIPTION
Closes #3240 (option 1 per the issue's cost/benefit ranking; options 2–3 recorded there as follow-ups).

## Root cause
Not slow code — budget too tight for GitHub-hosted runner variance. Evidence from the issue, independently re-verified against live run data in the plan review (https://github.com/open-ace/open-ace/issues/3240#issuecomment-5487425447):
- Same commit on the 3.10 lane: **183s vs 652s** (PR #3205, run 33410540459 rerun — run_attempt 2 + matching head SHA confirmed).
- Main run 33384495716: test(3.10) killed with the verbatim `CI ERROR: Command exceeded 599s: ... pytest tests/unit/ -q -n auto --maxfail=1 ...` — a budget kill, zero test failures; only that step failed.
- The 600s budget is suite-level and **shared** by compileall + the whole pytest run (`scripts/ci.py` `remaining = suite["timeout_seconds"] - elapsed`), so pytest had ~599s.
- The lane is required via PR Gate `TEST` (`fail-fast: false`), so the kill randomly blocked merges.
- `ci.yml`'s `test` job has no `timeout-minutes` (360-min default), so 1200s can never be clipped at the job level.

## Changes
1. `ci/suites.json`: `python-min.timeout_seconds` 600 → **1200** (~1.8x headroom over worst observed). No masking: pytest failures/`--maxfail=1` still fail the lane, and the same unit tests run under python-core's **unchanged** 600s on 3.11 (340–388s typical), which trips first on a genuine slowdown. No scheduled lane runs python-min, so no cross-lane inconsistency.
2. `tests/unit/test_ci_runner.py`: new contract test pinning `timeout_seconds == 1200`, docstring carrying the full evidence chain — reverting the budget now requires consciously updating the pin in review, preventing silent regression to the variance cliff.
3. `docs/TEST_LAYERS.md`: refresh the stale “撞 10 分钟预算” justification (suites.json stays the declared single source of truth).

## Non-goals (follow-ups tracked on #3240)
- Sharding `tests/unit/` (issue option 2).
- Replacing the two fixed 20s sleeps with a fake clock (~40s pure win, issue option 3).
- Touching `python-core`'s 600s: no observed timeout evidence; not raising budgets speculatively.

## Verification
- `pytest tests/unit/test_ci_runner.py -q` → **24 passed** (23 existing + new pin).
- `ci/suites.json` parses; python-core (600) and false-positive-scan (120) values verified unchanged.
- `ruff check` clean; diff minimal (3 files, +24/−3; no unrelated reformatting).
- Plan reviewed independently to **CLEAN** (verdict link above); its two LOW findings (acceptance wording → post-merge budget confirmation via merged suites.json, since the PR-lane run log does not print the budget; doc staleness) are both folded here.