### PR TITLE
fix(#3227): add alert for webui aggregate session usage

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -37,6 +37,12 @@ _stopped_sessions_cache: dict[str, float] = {}  # session_id -> timestamp
 _stopped_sessions_cache_lock = threading.Lock()
 _STOPPED_SESSION_TTL_SECONDS = 60  # How long to reject requests after stop
 
+# Issue #3227: Deduplication cache for webui aggregate session alerts
+# Tracks last alert time per tenant to avoid alert spam.
+_webui_aggregate_alert_cache: dict[int, float] = {}  # tenant_id -> timestamp
+_webui_aggregate_alert_cache_lock = threading.Lock()
+_WEBUI_AGGREGATE_ALERT_INTERVAL_SECONDS = 3600  # 1 hour between alerts per tenant
+
 
 def mark_session_stopped(session_id: str) -> None:
     """Mark a session as stopped to trigger request circuit breaking."""
@@ -85,6 +91,58 @@ from app.modules.governance.content_filter_singleton import get_content_filter
 
 # Import shared cache function
 from app.modules.workspace.tenant_config_cache import get_tenant_sensitive_keyword_config
+
+
+def _create_webui_aggregate_session_alert(user_id: int, tenant_id: int) -> None:
+    """
+    Create a system alert when requests use webui aggregate session.
+
+    Issue #3227: When upstream webui doesn't send X-Session-Id header,
+    requests are recorded to the webui:<user_id> aggregate session instead
+    of the specific workspace session. This creates a system alert to notify
+    administrators that upstream needs to be upgraded.
+
+    Args:
+        user_id: The user ID from the token.
+        tenant_id: The tenant ID from the token.
+    """
+    global _webui_aggregate_alert_cache
+
+    # Check if we recently created an alert for this tenant
+    with _webui_aggregate_alert_cache_lock:
+        now = time.time()
+        last_alert_time = _webui_aggregate_alert_cache.get(tenant_id, 0)
+        if now - last_alert_time < _WEBUI_AGGREGATE_ALERT_INTERVAL_SECONDS:
+            logger.debug(
+                "Skipping webui aggregate session alert for tenant %d (recently alerted)",
+                tenant_id,
+            )
+            return
+
+        # Update timestamp before creating alert to prevent race conditions
+        _webui_aggregate_alert_cache[tenant_id] = now
+
+    try:
+        from app.modules.governance.alert_notifier import create_system_alert
+
+        create_system_alert(
+            title="WebUI Aggregate Session Warning",
+            message=(
+                "Requests are being recorded to the webui aggregate session "
+                "because the upstream webui is not sending X-Session-Id header. "
+                "Workspace sessions will show zero message/request counts. "
+                "Please upgrade the upstream webui to include X-Session-Id injection."
+            ),
+            severity="warning",
+            tool_name="llm-proxy",
+        )
+        logger.info(
+            "Created webui aggregate session alert for tenant %d, user %d",
+            tenant_id,
+            user_id,
+        )
+    except Exception as e:
+        logger.error("Failed to create webui aggregate session alert: %s", e)
 
 
 def _get_tenant_sensitive_keyword_config_wrapper(tenant_id: int | None) -> dict[str, Any]:
@@ -1377,6 +1435,10 @@ def handle_llm_proxy_request(
                 user_id,
                 tenant_id,
             )
+            # Issue #3227: Create alert for webui aggregate session usage
+            # This indicates upstream webui is not sending X-Session-Id,
+            # causing messages to be recorded to the wrong session.
+            _create_webui_aggregate_session_alert(user_id, tenant_id)
 
     # Issue #2547: Circuit breaking for stopped sessions
     # Reject requests from orphan processes that may still be retrying

--- a/tests/unit/issues/test_webui_active_session_2464.py
+++ b/tests/unit/issues/test_webui_active_session_2464.py
@@ -437,3 +437,217 @@ class TestWebuiSessionFilter:
         assert resp.status_code == 200
         # Issue #3025: No session lookup for webui:* tokens without X-Session-Id
         mock_sm.get_active_sessions.assert_not_called()
+
+
+# ===================================================================
+# F. Issue #3227: WebUI aggregate session alert
+# ===================================================================
+
+
+class TestWebuiAggregateSessionAlert:
+    """Test alert creation when webui aggregate session is used.
+
+    Issue #3227: When upstream webui doesn't send X-Session-Id header,
+    an alert should be created to notify administrators.
+    """
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_SESSION_MGR_PATH)
+    @patch(_PROXY_PATH)
+    @patch(
+        "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
+        _mock_validate_llm_proxy_url,
+    )
+    def test_alert_created_for_webui_aggregate(
+        self,
+        mock_get_proxy,
+        mock_session_mgr,
+        mock_quota_cls,
+        mock_http,
+        mock_create_alert,
+        mock_gateway,
+        workspace_app,
+    ):
+        """Using webui aggregate session should create a system alert."""
+        import app.modules.workspace.llm_proxy_handler as handler
+
+        # Reset the alert cache before test
+        with handler._webui_aggregate_alert_cache_lock:
+            handler._webui_aggregate_alert_cache.clear()
+
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.get_tool_model_pool.return_value = {
+            "models": [{"id": "qwen3"}],
+            "model_key_ids": {"qwen3": [42]},
+            "candidate_keys": [{"key_id": 42}],
+        }
+        mock_proxy.resolve_api_key_from_key_ids.return_value = (
+            "sk-key",
+            "https://api.openai.com/v1",
+            42,
+            None,
+            None,
+        )
+        mock_get_proxy.return_value = mock_proxy
+
+        mock_sm = MagicMock()
+        mock_session_mgr.return_value = mock_sm
+
+        mock_quota_cls.return_value = _make_quota_ok()
+        mock_http.return_value = _mock_upstream_response()
+
+        client = workspace_app.test_client()
+        resp = client.post(
+            "/api/workspace/llm-proxy",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert resp.status_code == 200
+        # Issue #3227: Alert should be created
+        mock_create_alert.assert_called_once()
+        call_kwargs = mock_create_alert.call_args[1]
+        assert call_kwargs["title"] == "WebUI Aggregate Session Warning"
+        assert call_kwargs["severity"] == "warning"
+        assert call_kwargs["tool_name"] == "llm-proxy"
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_SESSION_MGR_PATH)
+    @patch(_PROXY_PATH)
+    @patch(
+        "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
+        _mock_validate_llm_proxy_url,
+    )
+    def test_alert_deduplication(
+        self,
+        mock_get_proxy,
+        mock_session_mgr,
+        mock_quota_cls,
+        mock_http,
+        mock_create_alert,
+        mock_gateway,
+        workspace_app,
+    ):
+        """Alert should not be created twice within the same hour for same tenant."""
+        import app.modules.workspace.llm_proxy_handler as handler
+
+        # Reset the alert cache before test
+        with handler._webui_aggregate_alert_cache_lock:
+            handler._webui_aggregate_alert_cache.clear()
+
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.get_tool_model_pool.return_value = {
+            "models": [{"id": "qwen3"}],
+            "model_key_ids": {"qwen3": [42]},
+            "candidate_keys": [{"key_id": 42}],
+        }
+        mock_proxy.resolve_api_key_from_key_ids.return_value = (
+            "sk-key",
+            "https://api.openai.com/v1",
+            42,
+            None,
+            None,
+        )
+        mock_get_proxy.return_value = mock_proxy
+
+        mock_sm = MagicMock()
+        mock_session_mgr.return_value = mock_sm
+
+        mock_quota_cls.return_value = _make_quota_ok()
+        mock_http.return_value = _mock_upstream_response()
+
+        client = workspace_app.test_client()
+
+        # First request should create alert
+        resp1 = client.post(
+            "/api/workspace/llm-proxy",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert resp1.status_code == 200
+        assert mock_create_alert.call_count == 1
+
+        # Second request should NOT create alert (deduplication)
+        resp2 = client.post(
+            "/api/workspace/llm-proxy",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert resp2.status_code == 200
+        # Call count should still be 1 (no new alert)
+        assert mock_create_alert.call_count == 1
+
+    @patch(_GATEWAY_PATH, side_effect=lambda: _make_noop_gateway())
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_SESSION_MGR_PATH)
+    @patch(_PROXY_PATH)
+    @patch(
+        "app.utils.llm_proxy_url_validator.validate_llm_proxy_url",
+        _mock_validate_llm_proxy_url,
+    )
+    def test_no_alert_with_x_session_id_header(
+        self,
+        mock_get_proxy,
+        mock_session_mgr,
+        mock_quota_cls,
+        mock_http,
+        mock_create_alert,
+        mock_gateway,
+        workspace_app,
+    ):
+        """No alert should be created when X-Session-Id header is present."""
+        import app.modules.workspace.llm_proxy_handler as handler
+
+        # Reset the alert cache before test
+        with handler._webui_aggregate_alert_cache_lock:
+            handler._webui_aggregate_alert_cache.clear()
+
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.get_tool_model_pool.return_value = {
+            "models": [{"id": "qwen3"}],
+            "model_key_ids": {"qwen3": [42]},
+            "candidate_keys": [{"key_id": 42}],
+        }
+        mock_proxy.resolve_api_key_from_key_ids.return_value = (
+            "sk-key",
+            "https://api.openai.com/v1",
+            42,
+            None,
+            None,
+        )
+        mock_get_proxy.return_value = mock_proxy
+
+        mock_sm = MagicMock()
+        mock_session_mgr.return_value = mock_sm
+        # Mock session for ownership validation
+        mock_session = MagicMock()
+        mock_session.session_id = "header-session-456"
+        mock_session.user_id = 1
+        mock_session.tenant_id = 1
+        mock_sm.get_session.return_value = mock_session
+
+        mock_quota_cls.return_value = _make_quota_ok()
+        mock_http.return_value = _mock_upstream_response()
+
+        client = workspace_app.test_client()
+        resp = client.post(
+            "/api/workspace/llm-proxy",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+            headers={
+                "Authorization": "Bearer tok",
+                "X-Session-Id": "header-session-456",
+            },
+        )
+        assert resp.status_code == 200
+        # Issue #3227: No alert should be created when X-Session-Id is present
+        mock_create_alert.assert_not_called()


### PR DESCRIPTION
## 问题

Issue #3227: Qwen 本地工作区会话显示请求数/消息数为 0，但【恢复会话】可以正常恢复。

## 根因

1. #3025 移除了"猜测活跃会话"的兜底逻辑
2. 上游 qwen-code-webui 未发送 `X-Session-Id` 请求头
3. 消息被错误地写入 `webui:<user_id>` 聚合会话，而非用户期望的工作区会话

## 修复方案

在 open-ace 侧添加防御性加固：

1. **告警通知**：当检测到 webui aggregate session 被使用时，创建系统告警通知管理员
2. **去重机制**：同一租户 1 小时内最多创建一条告警，避免告警风暴
3. **无 X-Session-Id 时不告警**：当请求正确携带 `X-Session-Id` 头时，不会触发告警

## 修改文件

- `app/modules/workspace/llm_proxy_handler.py`：添加告警创建逻辑和去重缓存
- `tests/unit/issues/test_webui_active_session_2464.py`：添加 3 个单元测试验证功能

## 测试验证

- ✅ `test_alert_created_for_webui_aggregate`：验证告警被正确创建
- ✅ `test_alert_deduplication`：验证去重机制生效
- ✅ `test_no_alert_with_x_session_id_header`：验证有 X-Session-Id 时不创建告警

## 注意

此修复为防御性加固，让问题可观测。根本修复需要上游 qwen-code-webui 升级以包含 `X-Session-Id` 注入功能。

Closes #3227