### PR TITLE
fix(#3250): normalize peak_day date to YYYY-MM-DD format

### DIFF
--- a/app/modules/analytics/usage_analytics.py
+++ b/app/modules/analytics/usage_analytics.py
@@ -262,6 +262,9 @@ class UsageAnalytics:
             # Aggregate by date
             date = d.get("date")
             if date:
+                # Normalize date to YYYY-MM-DD string (PostgreSQL returns datetime.date)
+                if hasattr(date, "strftime"):
+                    date = date.strftime("%Y-%m-%d")
                 daily_totals[date] = daily_totals.get(date, 0) + d.get("tokens", 0)
 
         # Calculate averages

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -257,6 +257,9 @@ class AnalysisService:
         for d in daily_data:
             date = d.get("date")
             if date:
+                # Normalize date to YYYY-MM-DD string (PostgreSQL returns datetime.date)
+                if hasattr(date, "strftime"):
+                    date = date.strftime("%Y-%m-%d")
                 daily_totals[date] = {
                     "date": date,
                     "tokens": d.get("total_tokens", 0) or 0,
@@ -271,15 +274,21 @@ class AnalysisService:
         daily_hourly_usage = {"daily": list(daily_totals.values()), "hourly": hourly_result}
 
         # Peak usage - use pre-aggregated data
-        daily_totals_for_peak = {
-            d.get("date"): d.get("total_tokens", 0) or 0 for d in daily_data if d.get("date")
-        }
+        daily_totals_for_peak = {}
+        for d in daily_data:
+            date = d.get("date")
+            if date:
+                # Normalize date to YYYY-MM-DD string (PostgreSQL returns datetime.date)
+                if hasattr(date, "strftime"):
+                    date = date.strftime("%Y-%m-%d")
+                daily_totals_for_peak[date] = d.get("total_tokens", 0) or 0
 
         sorted_days = (
             sorted(daily_totals_for_peak.items(), key=lambda x: x[1], reverse=True)
             if daily_totals_for_peak
             else []
         )
+        # peak_days already has normalized dates from daily_totals_for_peak keys
         peak_days = [{"date": d, "tokens": t} for d, t in sorted_days[:5]]
 
         hourly_totals: dict[int, int] = {}

--- a/frontend/src/components/features/analysis/EnterpriseReport.tsx
+++ b/frontend/src/components/features/analysis/EnterpriseReport.tsx
@@ -177,6 +177,24 @@ interface SummaryCardsProps {
   language: Language;
 }
 
+/**
+ * Format peak day value for display.
+ * Handles both ISO format (YYYY-MM-DD) and legacy RFC 1123 format from historical data.
+ */
+const formatPeakDay = (value: string | null): string => {
+  if (!value) return '-';
+  // Handle RFC 1123 format (e.g., "Tue, 25 Aug 2026 00:00:00 GMT")
+  if (value.includes('GMT') || value.includes(', ')) {
+    try {
+      const date = new Date(value);
+      return date.toISOString().split('T')[0];
+    } catch {
+      return value;
+    }
+  }
+  return value;
+};
+
 const SummaryCards: React.FC<SummaryCardsProps> = ({ summary, language }) => (
   <div className="row g-3 mb-4">
     <div className="col-md-2">
@@ -213,8 +231,8 @@ const SummaryCards: React.FC<SummaryCardsProps> = ({ summary, language }) => (
     </div>
     <div className="col-md-2">
       <StatCard
-        label={t('peakUsagePeriods', language)}
-        value={summary.peak_day ?? '-'}
+        label={t('peakDay', language)}
+        value={formatPeakDay(summary.peak_day)}
         icon={<i className="bi bi-calendar-check fs-4" />}
         variant="secondary"
       />

--- a/tests/unit/test_usage_analytics.py
+++ b/tests/unit/test_usage_analytics.py
@@ -63,6 +63,36 @@ class TestUsageAnalytics:
         assert result["peak_day"] == "2026-01-01"
         assert result["peak_tokens"] == 1000
 
+    def test_calculate_summary_normalizes_date_object(self):
+        """PostgreSQL returns datetime.date object; should normalize to YYYY-MM-DD string."""
+        from datetime import date
+
+        analytics, _, _ = self._make_analytics()
+        data = [
+            {
+                "date": date(2026, 1, 1),  # PostgreSQL returns datetime.date
+                "tool_name": "qwen",
+                "host_name": "h1",
+                "tokens": 1000,
+                "input_tokens": 800,
+                "output_tokens": 200,
+                "requests": 10,
+            },
+            {
+                "date": date(2026, 1, 2),
+                "tool_name": "claude",
+                "host_name": "h1",
+                "tokens": 500,
+                "input_tokens": 400,
+                "output_tokens": 100,
+                "requests": 5,
+            },
+        ]
+        result = analytics._calculate_summary(data)
+        # peak_day should be string, not datetime.date object
+        assert result["peak_day"] == "2026-01-01"
+        assert isinstance(result["peak_day"], str)
+
     def test_generate_report_no_data(self):
         analytics, mock_db, _ = self._make_analytics()
         mock_db.fetch_all.return_value = []


### PR DESCRIPTION
## Summary

Fixes #3250 - peak_day field leaking RFC 1123/GMT date format in enterprise report.

## Root Cause

PostgreSQL's psycopg2 driver returns `datetime.date` objects for SQL DATE columns, while SQLite returns strings. Flask's JSON serializer converts `datetime.date` to RFC 1123 format (e.g., `Tue, 25 Aug 2026 00:00:00 GMT`), causing the API contract drift.

## Changes

### Backend
- `app/modules/analytics/usage_analytics.py`: Normalize date to YYYY-MM-DD string in `_calculate_summary()`
- `app/services/analysis_service.py`: Normalize date in `get_enterprise_report()` for `daily_totals`, `daily_totals_for_peak`, and `peak_days`

### Frontend
- `frontend/src/components/features/analysis/EnterpriseReport.tsx`: 
  - Add `formatPeakDay()` to handle both ISO and legacy RFC 1123 formats
  - Change label from `peakUsagePeriods` to `peakDay` for semantic consistency

### Tests
- `tests/unit/test_usage_analytics.py`: Add `test_calculate_summary_normalizes_date_object()` to cover PostgreSQL scenario

## Verification

- ✅ Backend unit tests pass (14/14)
- ✅ Backend ruff lint passes
- ⏳ CI checks pending

## Acceptance Criteria

- [ ] Enterprise report page no longer shows RFC 1123/GMT format dates
- [ ] Both PostgreSQL and SQLite environments return YYYY-MM-DD format
- [ ] Label displays "峰值日期/Peak Day" instead of "峰值使用时段/Peak Usage Periods"
- [ ] New test passes