### PR TITLE
fix(#3252): honor start_date parameter in analytics APIs

### DIFF
--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -27,19 +27,52 @@ def get_client_info():
     }
 
 
+def parse_date_range():
+    """
+    Parse date range from request parameters.
+
+    Priority:
+    1. Explicit start_date + end_date
+    2. end_date + days (calculated from end_date backwards)
+    3. Default: end_date=today, days=30
+
+    Returns:
+        tuple: (start_date: str, end_date: str, days: int)
+    """
+    # Get end_date (default to today)
+    end_date = request.args.get(
+        "end_date", datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
+    )
+
+    # Get days parameter with validation
+    days = request.args.get("days", default=30, type=int)
+    if days <= 0:
+        days = 1
+    if days > 365:
+        days = 365
+
+    # Priority: use explicit start_date if provided
+    start_date = request.args.get("start_date")
+
+    if start_date:
+        # Validate start_date <= end_date, swap if needed
+        if start_date > end_date:
+            start_date, end_date = end_date, start_date
+    else:
+        # No start_date provided: calculate from end_date - days
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+        start_dt = end_dt - timedelta(days=days)
+        start_date = start_dt.strftime("%Y-%m-%d")
+
+    return start_date, end_date, days
+
+
 @analytics_bp.route("/analytics/report", methods=["GET"])
 @admin_required
 def api_usage_report():
     """Generate a comprehensive usage report."""
-    # Get date range
-    end_date = request.args.get(
-        "end_date", datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
-    )
-    days = request.args.get("days", default=30, type=int)
-
-    start_date = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)).strftime(
-        "%Y-%m-%d"
-    )
+    # Get date range using shared parser
+    start_date, end_date, days = parse_date_range()
 
     include_trends = request.args.get("trends", "true").lower() == "true"
     include_anomalies = request.args.get("anomalies", "true").lower() == "true"
@@ -82,15 +115,8 @@ def api_usage_forecast():
 @admin_required
 def api_efficiency_metrics():
     """Get efficiency metrics."""
-    # Get date range
-    end_date = request.args.get(
-        "end_date", datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
-    )
-    days = request.args.get("days", default=30, type=int)
-
-    start_date = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)).strftime(
-        "%Y-%m-%d"
-    )
+    # Get date range using shared parser
+    start_date, end_date, days = parse_date_range()
 
     metrics = usage_analytics.get_efficiency_metrics(start_date, end_date)
 
@@ -101,16 +127,9 @@ def api_efficiency_metrics():
 @admin_required
 def api_export_analytics():
     """Export analytics data."""
-    # Get parameters
-    end_date = request.args.get(
-        "end_date", datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
-    )
-    days = request.args.get("days", default=30, type=int)
+    # Get date range using shared parser
+    start_date, end_date, days = parse_date_range()
     format_type = request.args.get("format", "json")
-
-    start_date = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)).strftime(
-        "%Y-%m-%d"
-    )
 
     # Generate report
     report = usage_analytics.generate_report(

--- a/tests/unit/test_analytics_routes.py
+++ b/tests/unit/test_analytics_routes.py
@@ -1,0 +1,135 @@
+"""Unit tests for analytics routes date range parsing."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.routes.analytics import parse_date_range
+
+
+class TestParseDateRange:
+    """Test parse_date_range function."""
+
+    def _create_app_with_request_context(self, query_string=""):
+        """Create a Flask app with request context for testing."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        @app.route("/test")
+        def test_route():
+            return parse_date_range()
+
+        return app
+
+    def test_default_values(self):
+        """Test default date range when no parameters provided."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test"):
+                start_date, end_date, days = parse_date_range()
+                # Default: end_date=today, days=30
+                assert days == 30
+                assert end_date is not None
+                assert start_date is not None
+
+    def test_explicit_start_date_and_end_date(self):
+        """Test explicit start_date and end_date parameters."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?start_date=2026-01-01&end_date=2026-01-31"):
+                start_date, end_date, days = parse_date_range()
+                assert start_date == "2026-01-01"
+                assert end_date == "2026-01-31"
+                assert days == 30  # days is returned but not used when start_date is explicit
+
+    def test_only_start_date_uses_default_end_date(self):
+        """Test that providing only start_date uses default end_date (today)."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?start_date=2026-01-01"):
+                start_date, end_date, days = parse_date_range()
+                assert start_date == "2026-01-01"
+                # end_date defaults to today
+                assert end_date is not None
+
+    def test_only_end_date_uses_days_to_calculate_start(self):
+        """Test that providing end_date + days calculates start_date from end_date."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?end_date=2026-01-31&days=7"):
+                start_date, end_date, days = parse_date_range()
+                # start_date should be end_date - 7 days = 2026-01-24
+                assert start_date == "2026-01-24"
+                assert end_date == "2026-01-31"
+                assert days == 7
+
+    def test_days_7(self):
+        """Test 7-day range."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?days=7"):
+                start_date, end_date, days = parse_date_range()
+                assert days == 7
+
+    def test_days_90(self):
+        """Test 90-day range."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?days=90"):
+                start_date, end_date, days = parse_date_range()
+                assert days == 90
+
+    def test_days_zero_clamped_to_one(self):
+        """Test that days=0 is clamped to 1."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?days=0"):
+                start_date, end_date, days = parse_date_range()
+                assert days == 1
+
+    def test_days_negative_clamped_to_one(self):
+        """Test that negative days is clamped to 1."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?days=-5"):
+                start_date, end_date, days = parse_date_range()
+                assert days == 1
+
+    def test_days_over_365_clamped(self):
+        """Test that days > 365 is clamped to 365."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?days=500"):
+                start_date, end_date, days = parse_date_range()
+                assert days == 365
+
+    def test_start_date_greater_than_end_date_swapped(self):
+        """Test that start_date > end_date results in swap."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?start_date=2026-01-31&end_date=2026-01-01"):
+                start_date, end_date, days = parse_date_range()
+                # Should be swapped
+                assert start_date == "2026-01-01"
+                assert end_date == "2026-01-31"
+
+    def test_historical_end_date_with_days(self):
+        """Test historical end_date with days calculates correct start_date."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?end_date=2025-12-01&days=30"):
+                start_date, end_date, days = parse_date_range()
+                # start_date should be 2025-12-01 - 30 days = 2025-11-01
+                assert start_date == "2025-11-01"
+                assert end_date == "2025-12-01"
+                assert days == 30
+
+    def test_historical_range_with_explicit_dates(self):
+        """Test explicit historical date range."""
+        app = self._create_app_with_request_context()
+        with app.test_client():
+            with app.test_request_context("/test?start_date=2025-01-01&end_date=2025-01-31"):
+                start_date, end_date, days = parse_date_range()
+                assert start_date == "2025-01-01"
+                assert end_date == "2025-01-31"


### PR DESCRIPTION
## Summary

Fixes #3252

### Problem
- `/api/analytics/report`, `/api/analytics/efficiency`, and `/api/analytics/export` ignored the `start_date` parameter sent by frontend
- Always calculated `start_date` as `now - days`, causing:
  - Custom date ranges (7/90 days) ineffective
  - Historical ranges returning wrong period
  - `start > end` when `end_date < now - 30 days`

### Solution
- Added shared `parse_date_range()` function in `app/routes/analytics.py`
- Priority: explicit `start_date` > `end_date - days` > default
- Relative ranges anchor to `end_date`, not server current time
- Boundary handling: `start > end` swapped, `days` clamped to 1-365

### Changes
- `app/routes/analytics.py`: Added `parse_date_range()` function, modified 3 routes to use it
- `tests/unit/test_analytics_routes.py`: 12 new unit tests

### Test Evidence
- ✅ 12 new unit tests pass
- ✅ 14 existing usage_analytics tests pass

### Root Cause
See issue comments for detailed root cause analysis and solution review.