### PR TITLE
fix(#3267): use request_count for accurate model turn counting

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -2139,16 +2139,13 @@ class UsageRepository:
             pass
 
         # Fallback: agent_sessions.total_tokens with created_at date attribution.
-        # Uses session_messages subquery for requests (same as aggregator) for consistency.
+        # Uses request_count for requests (model turn count, not message rows).
+        # Issue #3267: Use request_count for accurate model turn counting.
         session_row = self.db.fetch_one(
             """
             SELECT
                 COALESCE(SUM(as2.total_tokens), 0) as tokens,
-                COALESCE(SUM((
-                    SELECT COUNT(*) FROM session_messages sm
-                    WHERE sm.session_id = as2.session_id
-                      AND sm.role = 'assistant'
-                )), 0) as requests
+                COALESCE(SUM(as2.request_count), 0) as requests
             FROM agent_sessions as2
             WHERE as2.user_id = ?
               AND as2.workspace_type IN ('local', 'remote', 'terminal')

--- a/app/services/user_stats_aggregator.py
+++ b/app/services/user_stats_aggregator.py
@@ -123,11 +123,10 @@ class UserDailyStatsAggregator:
                             -- Session data from agent_sessions
                             -- Must match get_combined_usage filters:
                             -- - workspace_type IN ('local', 'remote', 'terminal')
-                            -- - requests from session_messages subquery (not request_count field)
+                            -- - requests from request_count (model turn count, not message rows)
+                            -- Issue #3267: Use request_count for accurate model turn counting
                             SELECT DATE(as2.created_at) as date,
-                                   COALESCE((SELECT COUNT(*) FROM session_messages sm
-                                             WHERE sm.session_id = as2.session_id
-                                               AND sm.role = 'assistant'), 0) as requests,
+                                   COALESCE(as2.request_count, 0) as requests,
                                    COALESCE(as2.total_tokens, 0) as tokens,
                                    COALESCE(as2.total_input_tokens, 0) as input_tokens,
                                    COALESCE(as2.total_output_tokens, 0) as output_tokens
@@ -202,11 +201,10 @@ class UserDailyStatsAggregator:
                             -- Session data from agent_sessions
                             -- Must match get_combined_usage filters:
                             -- - workspace_type IN ('local', 'remote', 'terminal')
-                            -- - requests from session_messages subquery (not request_count field)
+                            -- - requests from request_count (model turn count, not message rows)
+                            -- Issue #3267: Use request_count for accurate model turn counting
                             SELECT DATE(as2.created_at) as date,
-                                   COALESCE((SELECT COUNT(*) FROM session_messages sm
-                                             WHERE sm.session_id = as2.session_id
-                                               AND sm.role = 'assistant'), 0) as requests,
+                                   COALESCE(as2.request_count, 0) as requests,
                                    COALESCE(as2.total_tokens, 0) as tokens,
                                    COALESCE(as2.total_input_tokens, 0) as input_tokens,
                                    COALESCE(as2.total_output_tokens, 0) as output_tokens


### PR DESCRIPTION
## Summary

Fixes #3267

### Problem
StatusBar and quota displayed request counts based on `session_messages` rows (assistant messages), but autonomous workflows count requests by model turns. This caused severe undercounting for autonomous workflows where multiple model turns result in only one persisted assistant message.

### Solution
Use `agent_sessions.request_count` instead of counting `session_messages` rows in:
1. `user_stats_aggregator.py` (PostgreSQL and SQLite versions)
2. `usage_repo._session_usage()` fallback path

### Root Cause
- `agent_sessions.request_count` stores the correct model turn count
- The aggregator and fallback path were using `COUNT(*) FROM session_messages WHERE role = 'assistant'`
- This works for regular Workspace sessions but undercounts autonomous workflows

### Changes
- Modified aggregator SQL to use `as2.request_count` instead of subquery
- Modified fallback SQL to use `SUM(as2.request_count)` instead of subquery

### Test Plan
- [x] Unit tests pass: `test_user_stats_aggregator.py` and `test_usage_repo_session_only.py`
- [ ] Integration test with autonomous workflow
- [ ] Verify StatusBar shows correct request count

### Acceptance Criteria
- [ ] Autonomous workflow producing N model turns shows N requests in StatusBar
- [ ] Regular Workspace sessions continue to show correct request counts
- [ ] PostgreSQL and SQLite both work correctly