### PR TITLE
fix(#3247): add days parameter validation for forecast API

### DIFF
--- a/app/modules/analytics/usage_analytics.py
+++ b/app/modules/analytics/usage_analytics.py
@@ -721,11 +721,17 @@ class UsageAnalytics:
         Get usage forecast based on historical data.
 
         Args:
-            days: Number of days to forecast.
+            days: Number of days to forecast (must be 1-90).
 
         Returns:
             Dict with forecast data including quality metrics.
+
+        Raises:
+            ValueError: If days is not in valid range 1-90.
         """
+        if not isinstance(days, int) or days < 1 or days > 90:
+            raise ValueError(f"days must be an integer between 1 and 90, got {days}")
+
         # Get last 30 days of data
         end_date = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
         start_date = (

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -27,6 +27,43 @@ def get_client_info():
     }
 
 
+def validate_forecast_days(days_str: str | None) -> tuple[int, dict | None]:
+    """
+    Validate forecast days parameter.
+
+    Args:
+        days_str: Raw days parameter from request.
+
+    Returns:
+        Tuple of (validated_days, error_response).
+        If validation fails, error_response contains 400 response dict.
+    """
+    if days_str is None:
+        return 7, None
+
+    try:
+        days = int(days_str)
+    except ValueError:
+        return 7, {
+            "error": "invalid_parameter",
+            "message": "days must be an integer",
+            "parameter": "days",
+            "received": days_str,
+            "valid_range": "1-90",
+        }
+
+    if days < 1 or days > 90:
+        return 7, {
+            "error": "invalid_parameter",
+            "message": "days must be between 1 and 90",
+            "parameter": "days",
+            "received": days,
+            "valid_range": "1-90",
+        }
+
+    return days, None
+
+
 def parse_date_range():
     """
     Parse date range from request parameters.
@@ -104,7 +141,9 @@ def api_usage_report():
 @admin_required
 def api_usage_forecast():
     """Get usage forecast."""
-    days = request.args.get("days", default=7, type=int)
+    days, error = validate_forecast_days(request.args.get("days"))
+    if error:
+        return jsonify(error), 400
 
     forecast = usage_analytics.get_forecast(days=days)
 

--- a/tests/unit/test_analytics_routes.py
+++ b/tests/unit/test_analytics_routes.py
@@ -5,7 +5,76 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 
-from app.routes.analytics import parse_date_range
+from app.routes.analytics import parse_date_range, validate_forecast_days
+
+
+class TestValidateForecastDays:
+    """Test validate_forecast_days function."""
+
+    def test_none_returns_default(self):
+        """Test that None returns default value 7."""
+        days, error = validate_forecast_days(None)
+        assert days == 7
+        assert error is None
+
+    def test_valid_integer_1(self):
+        """Test valid integer 1."""
+        days, error = validate_forecast_days("1")
+        assert days == 1
+        assert error is None
+
+    def test_valid_integer_7(self):
+        """Test valid integer 7."""
+        days, error = validate_forecast_days("7")
+        assert days == 7
+        assert error is None
+
+    def test_valid_integer_90(self):
+        """Test valid integer 90."""
+        days, error = validate_forecast_days("90")
+        assert days == 90
+        assert error is None
+
+    def test_invalid_zero(self):
+        """Test that days=0 returns error."""
+        days, error = validate_forecast_days("0")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
+        assert "1 and 90" in error["message"]
+
+    def test_invalid_negative(self):
+        """Test that negative days returns error."""
+        days, error = validate_forecast_days("-1")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
+        assert error["received"] == -1
+
+    def test_invalid_exceeds_max(self):
+        """Test that days > 90 returns error."""
+        days, error = validate_forecast_days("91")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
+        assert error["received"] == 91
+
+    def test_invalid_non_integer(self):
+        """Test that non-integer returns error."""
+        days, error = validate_forecast_days("abc")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
+        assert error["received"] == "abc"
+
+    def test_invalid_float(self):
+        """Test that float returns error."""
+        days, error = validate_forecast_days("7.5")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
+        assert error["received"] == "7.5"
+
+    def test_large_integer(self):
+        """Test large integer returns error."""
+        days, error = validate_forecast_days("999999999")
+        assert error is not None
+        assert error["error"] == "invalid_parameter"
 
 
 class TestParseDateRange:


### PR DESCRIPTION
## 🔧 修复方案

fixes #3247

### 问题

forecast API 接受非法 days 参数：
- `days=-1` 返回负 total_forecast
- `days=91` 返回 91 个预报日期
- `days=abc` 静默使用默认值 7
- `days=7.5` 静默截断为 7

### 解决方案

1. 路由层添加 `validate_forecast_days()` 验证函数
2. 非法参数返回 400 错误，包含错误详情
3. Service 层添加防御性验证

### 变更

| 文件 | 变更 |
|------|------|
| `app/routes/analytics.py` | 添加 `validate_forecast_days()` |
| `app/modules/analytics/usage_analytics.py` | 添加防御性验证 |
| `tests/unit/test_analytics_routes.py` | 添加验证测试 |

### 测试矩阵

| 场景 | 预期结果 | 测试状态 |
|------|---------|---------|
| days=7（默认） | 200 OK | ✅ |
| days=1 | 200 OK | ✅ |
| days=90 | 200 OK | ✅ |
| days=0 | 400 | ✅ |
| days=-1 | 400 | ✅ |
| days=91 | 400 | ✅ |
| days=abc | 400 | ✅ |
| days=7.5 | 400 | ✅ |
| days=999999999 | 400 | ✅ |

### 验收标准映射

| 验收标准 | 状态 |
|---------|------|
| 只接受 1–90 整数 | ✅ |
| 非法参数不返回 200 | ✅ |
| 不可能生成负 Token/请求数 | ✅ |
| 两个路径共享验证 | ✅ |
| 文档、测试与实现一致 | ✅ |