### PR TITLE
fix(#3246): correct off-by-one error in date range calculation

### DIFF
--- a/frontend/src/components/features/Analysis.tsx
+++ b/frontend/src/components/features/Analysis.tsx
@@ -20,7 +20,7 @@ import {
   SimpleTabs,
   DatePicker,
 } from '@/components/common';
-import { formatTokens, formatDate, formatToolName, formatHourRange } from '@/utils';
+import { formatTokens, formatToolName, formatHourRange, getQuickRangeDateRange } from '@/utils';
 import {
   useKeyMetrics,
   useDailyHourlyUsage,
@@ -72,36 +72,9 @@ export const Analysis: React.FC = () => {
   const dataRange = dataRangeRef.current;
 
   // Date range based on quick range selection
+  // Uses getQuickRangeDateRange to ensure exactly N calendar days with proper local date handling
   const dateRange = useMemo(() => {
-    const end = new Date();
-    let start: Date;
-
-    switch (quickRange) {
-      case '7':
-        start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-        break;
-      case '30':
-        start = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-        break;
-      case '90':
-        start = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
-        break;
-      case 'all':
-      default:
-        // Use the actual data range when available; fall back to last year.
-        if (dataRange?.min_date && dataRange?.max_date) {
-          start = new Date(dataRange.min_date);
-          end.setTime(new Date(dataRange.max_date).getTime());
-        } else {
-          start = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000); // Last year as "all"
-        }
-        break;
-    }
-
-    return {
-      start: formatDate(start, 'iso'),
-      end: formatDate(end, 'iso'),
-    };
+    return getQuickRangeDateRange(quickRange, dataRange ?? undefined);
   }, [quickRange, dataRange]);
 
   const [startDate, setStartDate] = useState(dateRange.start);

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useState, useMemo, useRef } from 'react';
-import { cn, createMatcherConfig } from '@/utils';
+import { cn, createMatcherConfig, getQuickRangeDateRange } from '@/utils';
 import { useLanguage } from '@/store';
 import { t, type Language } from '@/i18n';
 import {
@@ -99,36 +99,9 @@ export const AnomalyDetection: React.FC = () => {
   const dataRange = dataRangeRef.current;
 
   // Date range based on quick range selection
+  // Uses getQuickRangeDateRange to ensure exactly N calendar days with proper local date handling
   const dateRange = useMemo(() => {
-    const end = new Date();
-    let start: Date;
-
-    switch (quickRange) {
-      case '7':
-        start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-        break;
-      case '30':
-        start = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-        break;
-      case '90':
-        start = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
-        break;
-      case 'all':
-      default:
-        // Use the actual data range when available; fall back to 365 days.
-        if (dataRange?.min_date && dataRange?.max_date) {
-          start = new Date(dataRange.min_date);
-          end.setTime(new Date(dataRange.max_date).getTime());
-        } else {
-          start = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
-        }
-        break;
-    }
-
-    return {
-      start: start.toISOString().split('T')[0],
-      end: end.toISOString().split('T')[0],
-    };
+    return getQuickRangeDateRange(quickRange, dataRange ?? undefined);
   }, [quickRange, dataRange]);
 
   const [startDate, setStartDate] = useState(dateRange.start);

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -33,7 +33,13 @@ import {
   Skeleton,
   PageRefreshControl,
 } from '@/components/common';
-import { formatTokens, formatToolName, createMatcherConfig, formatHourRange } from '@/utils';
+import {
+  formatTokens,
+  formatToolName,
+  createMatcherConfig,
+  formatHourRange,
+  getQuickRangeDateRange,
+} from '@/utils';
 import { useBatchAnalysis, useHosts, useTools, usePageRefresh } from '@/hooks';
 import { SessionStatisticsCard, calculateHealthScore } from './SessionStatisticsCard';
 
@@ -124,39 +130,9 @@ export const TrendAnalysis: React.FC = () => {
   const dataRange = dataRangeRef.current;
 
   // Date range based on quick range selection
-  // Uses dataRange for 'all' case, fallback to 365 days if dataRange unavailable
+  // Uses getQuickRangeDateRange to ensure exactly N calendar days with proper local date handling
   const dateRange = useMemo(() => {
-    const end = new Date();
-    let start: Date;
-
-    switch (quickRange) {
-      case '7':
-        start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-        break;
-      case '30':
-        start = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-        break;
-      case '90':
-        start = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
-        break;
-      case 'all':
-      default:
-        // Use actual data range from API if available, otherwise fallback to 365 days
-        if (dataRange?.min_date && dataRange?.max_date) {
-          start = new Date(dataRange.min_date);
-          // Use the actual max date from data range
-          end.setTime(new Date(dataRange.max_date).getTime());
-        } else {
-          // Fallback: 365 days ago when data_range is not available or invalid
-          start = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
-        }
-        break;
-    }
-
-    return {
-      start: start.toISOString().split('T')[0],
-      end: end.toISOString().split('T')[0],
-    };
+    return getQuickRangeDateRange(quickRange, dataRange ?? undefined);
   }, [quickRange, dataRange]);
 
   // Update date range when quick range changes

--- a/frontend/src/components/features/analysis/UsageForecast.tsx
+++ b/frontend/src/components/features/analysis/UsageForecast.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/utils';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Card, StatCard, Error, EmptyState, LineChart, Loading } from '@/components/common';
-import { formatTokens } from '@/utils';
+import { formatTokens, getDefaultDateRange } from '@/utils';
 import { useUsageForecast, useDailyHourlyUsage } from '@/hooks';
 
 /**
@@ -64,14 +64,8 @@ export const UsageForecast: React.FC = () => {
   } = useUsageForecast(forecastDays);
 
   // Fetch historical data (past 7 days, matching backend moving average window)
-  const historicalDateRange = useMemo(() => {
-    const end = new Date();
-    const start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    return {
-      start: start.toISOString().split('T')[0],
-      end: end.toISOString().split('T')[0],
-    };
-  }, []);
+  // Use getDefaultDateRange to ensure exactly 7 calendar days with proper local date handling
+  const historicalDateRange = useMemo(() => getDefaultDateRange(7), []);
 
   const {
     data: historicalData,

--- a/frontend/src/utils/dateRange.test.ts
+++ b/frontend/src/utils/dateRange.test.ts
@@ -39,29 +39,36 @@ describe('getDefaultDateRange', () => {
     vi.useRealTimers();
   });
 
-  it('defaults to a 30-day window ending today', () => {
+  it('defaults to a 30-day window ending today (exactly 30 calendar days)', () => {
     const range = getDefaultDateRange();
     expect(range.end).toBe('2024-06-15');
-    expect(range.start).toBe('2024-05-16'); // 30 days before 2024-06-15
+    expect(range.start).toBe('2024-05-17'); // 30 days: 05-17 to 06-15
   });
 
-  it('honors a custom day count', () => {
+  it('returns exactly N calendar days (inclusive range)', () => {
     const range = getDefaultDateRange(7);
     expect(range.end).toBe('2024-06-15');
-    expect(range.start).toBe('2024-06-08'); // 7 days before
+    expect(range.start).toBe('2024-06-09'); // 7 days: 06-09,10,11,12,13,14,15
   });
 
   it('crosses month and year boundaries correctly', () => {
     vi.setSystemTime(new Date(2024, 0, 5, 12, 0, 0)); // local 2024-01-05
     const range = getDefaultDateRange(30);
     expect(range.end).toBe('2024-01-05');
-    expect(range.start).toBe('2023-12-06'); // 30 days before, crosses year
+    expect(range.start).toBe('2023-12-07'); // 30 days: 12-07 to 01-05
   });
 
   it('returns start == end for a 0-day lookback', () => {
     const range = getDefaultDateRange(0);
     expect(range.start).toBe(range.end);
     expect(range.end).toBe('2024-06-15');
+  });
+
+  it('handles leap year correctly', () => {
+    vi.setSystemTime(new Date(2024, 2, 1, 12, 0, 0)); // local 2024-03-01 (leap year)
+    const range = getDefaultDateRange(7);
+    expect(range.end).toBe('2024-03-01');
+    expect(range.start).toBe('2024-02-24'); // 7 days including Feb 29
   });
 
   it('always returns start <= end', () => {

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -34,18 +34,60 @@ export function toLocalDateString(date: Date): string {
 }
 
 /**
- * Build a `{ start, end }` range covering the last `days` days through today,
+ * Build a `{ start, end }` range covering exactly `days` calendar days through today,
  * expressed as local YYYY-MM-DD strings.
  *
- * @param days - Number of days to look back (today is the inclusive end).
+ * IMPORTANT: Backend APIs use inclusive date range (date >= start AND date <= end).
+ * To return exactly `days` days, we set start = today - (days - 1).
+ *
+ * Uses toLocalDateString to avoid UTC timezone offset issues.
+ *
+ * @param days - Number of calendar days to include (today is the inclusive end).
  *               Defaults to `DEFAULT_DATE_RANGE_DAYS` (30) to match the default
  *               on other analysis pages.
+ *               Example: days=7 returns start=2024-06-09, end=2024-06-15 (7 days total)
  */
 export function getDefaultDateRange(days: number = DEFAULT_DATE_RANGE_DAYS): DateRange {
+  if (days <= 0) {
+    const today = toLocalDateString(new Date());
+    return { start: today, end: today };
+  }
   const end = new Date();
-  const start = new Date(end.getTime() - days * MS_PER_DAY);
+  const start = new Date(end.getTime() - (days - 1) * MS_PER_DAY);
   return {
     start: toLocalDateString(start),
     end: toLocalDateString(end),
   };
+}
+
+/**
+ * Quick range options type for date range selection.
+ */
+export type QuickRangeOption = '7' | '30' | '90' | 'all';
+
+/**
+ * Get date range for quick range selection.
+ *
+ * @param quickRange - Quick range option ('7', '30', '90', 'all')
+ * @param dataRange - Optional data range for 'all' option (min_date, max_date)
+ * @returns Date range as local date strings
+ */
+export function getQuickRangeDateRange(
+  quickRange: QuickRangeOption,
+  dataRange?: { min_date: string; max_date: string }
+): DateRange {
+  switch (quickRange) {
+    case '7':
+      return getDefaultDateRange(7);
+    case '30':
+      return getDefaultDateRange(30);
+    case '90':
+      return getDefaultDateRange(90);
+    case 'all':
+    default:
+      if (dataRange?.min_date && dataRange?.max_date) {
+        return { start: dataRange.min_date, end: dataRange.max_date };
+      }
+      return getDefaultDateRange(365);
+  }
 }

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -19,9 +19,11 @@ export {
 } from './format';
 export {
   getDefaultDateRange,
+  getQuickRangeDateRange,
   toLocalDateString,
   DEFAULT_DATE_RANGE_DAYS,
   type DateRange,
+  type QuickRangeOption,
 } from './dateRange';
 
 export {


### PR DESCRIPTION
## Summary

Fixes off-by-one error in date range calculation that caused "Last 7 days" to display 8 calendar days instead of 7.

## Problem

- `getDefaultDateRange(N)` returned N+1 calendar days instead of N
- Root cause: Backend uses inclusive date range (`date >= start AND date <= end`)
- Frontend calculated `start = today - N days`, resulting in N+1 days

## Solution

1. **Fix `getDefaultDateRange`**: Use `days - 1` for correct count
2. **Add `getQuickRangeDateRange`**: Helper for quick range selection ('7', '30', '90', 'all')
3. **Update affected components**: Use unified functions
4. **Add test cases**: Leap year and boundary conditions

## Changes

| File | Change |
|------|--------|
| `frontend/src/utils/dateRange.ts` | Core fix + new helper function |
| `frontend/src/utils/dateRange.test.ts` | Updated test expectations |
| `frontend/src/components/features/analysis/UsageForecast.tsx` | Use `getDefaultDateRange(7)` |
| `frontend/src/components/features/analysis/TrendAnalysis.tsx` | Use `getQuickRangeDateRange` |
| `frontend/src/components/features/analysis/AnomalyDetection.tsx` | Use `getQuickRangeDateRange` |
| `frontend/src/components/features/Analysis.tsx` | Use `getQuickRangeDateRange` |

## Root Cause Analysis

### Evidence

1. **Backend query** (`scripts/shared/db.py:2434-2435`):
   ```python
   conditions = ["date >= ?", "date <= ?", ...]  # Inclusive on both ends
   ```

2. **Frontend calculation** (before fix):
   ```typescript
   const start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);  // 7 days before
   const end = new Date();  // today
   // Result: 8 calendar days!
   ```

3. **Example**: Today is 2026-09-01
   - Before: start=2026-08-25, end=2026-09-01 → 8 days
   - After: start=2026-08-26, end=2026-09-01 → 7 days

## Test Plan

- [ ] Unit tests pass for `dateRange.test.ts`
- [ ] Manual test: Forecast page shows exactly 7 days
- [ ] Manual test: Analysis page quick ranges work correctly
- [ ] No timezone-related issues in UTC+8/UTC-5

Fixes #3246