### PR TITLE
fix(#3280): absorb runner variance in python-core budget and fail fast on hung unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed the required `test (3.11)` CI lane intermittently dying with "Command exceeded 599s" on healthy runs: the `python-core` suite budget is raised 600s→1200s (matching `python-min`, #3240) because GitHub-hosted runner variance swings the same suite between ~289s and ~535s, so the old budget sat inside the variance band; both unit lanes now also run pytest with `--timeout 300 --timeout-method thread --durations 20` so a hung test dumps its stacks and fails loudly in bounded time instead of burning the whole suite budget undiagnosably (Issue #3280)
 - Fixed the remote LLM-proxy failover loop deadlocking when a key resolver ignores `exclude_key_ids` and keeps returning an already-excluded key (e.g. a non-quota upstream 429): the handler now treats that as failover-pool exhaustion and returns 502 instead of retrying the same key forever, which could hang the process (Issue #2466)
 - Fixed configuration persistence in docker-compose.multi-user.yml by adding `OPENACE_CONFIG_DIR` environment variable to ensure config persists to mounted volume when running as root (Issue #2235)
 - Fixed install.sh script to automatically add required multi-user mode configurations (`user: "0"`, `OPENACE_ALLOW_ROOT_MULTI_USER=1`, `OPENACE_CONFIG_DIR`) when `WORKSPACE_MULTI_USER_MODE=true`

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -110,7 +110,7 @@
     },
     "python-core": {
       "description": "Required deterministic Python suite on the production runtime",
-      "timeout_seconds": 600,
+      "timeout_seconds": 1200,
       "commands": [
         [
           "{python}",
@@ -121,6 +121,12 @@
           "-n",
           "auto",
           "--maxfail=1",
+          "--timeout",
+          "300",
+          "--timeout-method",
+          "thread",
+          "--durations",
+          "20",
           "--cov=scripts/shared",
           "--cov=app/auth",
           "--cov=app/remote_ws_handler",
@@ -171,6 +177,12 @@
           "-n",
           "auto",
           "--maxfail=1",
+          "--timeout",
+          "300",
+          "--timeout-method",
+          "thread",
+          "--durations",
+          "20",
           "-m",
           "not postgres and not performance"
         ]

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -88,7 +88,13 @@ python scripts/run_extended_tests.py --category e2e --isolated-home
 GitHub Actions 都通过 `python scripts/ci.py` 执行。PR 矩阵按版本分工（#2868）：
 
 - **3.11（生产运行时）**：`python-core`——全量 `pytest tests/`（含 integration）
-  + 覆盖率，每个非文档改动都跑。
+  + 覆盖率，每个非文档改动都跑。该 suite 的预算同样已因 GitHub runner 方差
+  从 600s 抬至 1200s——同分支健康运行曾 289s↔535s 波动，慢 runner 的长尾
+  会直接撞穿 600s（#3280）。`python-core` 与 `python-min` 的 pytest 命令均
+  带 `--timeout 300 --timeout-method thread --durations 20`：单个测试 hang
+  时在 300s 处 dump 全部线程堆栈并大声失败，而不是烧光整个 suite 预算后
+  只留一句不可诊断的 "Command exceeded"；`--durations` 让预算余量的收缩
+  在日志里先于超时可见。
 - **false-positive-scan**：测试代码假阳性扫描（Issue #2189，Scope #6），
   每个非文档改动都跑，独立于 `python-core` 以避免超时。
 - **3.10（最低支持版本）**：`python-min`——`compileall` + 全量 `pytest tests/unit/`，

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -158,9 +158,10 @@ def test_unit_lanes_fail_fast_on_hung_tests():
     cites) burned the ENTIRE suite budget and died with a bare
     "Command exceeded 599s" plus undiagnosable "OSError: cannot send". A
     300s per-test bound with the thread method dumps every thread's stack
-    and kills the hung worker loudly: 300s is 2x the slowest healthy suite
-    runtime ever observed for a single test on record, while a hang surfaces
-    in bounded time with a stack trace instead of at the suite ceiling.
+    and kills the hung worker loudly: 300s is ~6x the slowest single test
+    on record (46.7s, full-suite --durations measurement on 2026-09-01),
+    so it cannot falsely kill a healthy test, while a hang surfaces in
+    bounded time with a stack trace instead of at the suite ceiling.
     --durations=20 prints the slowest tests on every run so a shrinking
     budget margin is visible in the log before it becomes a timeout.
     """

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -102,16 +102,78 @@ def test_python_min_timeout_budget_absorbs_runner_variance():
     599s ("Command exceeded 599s") with ZERO test failures. The lane is a
     required check, so the kill randomly blocked merges. The 600s budget was
     shared by compileall + the whole pytest run. 1200s keeps ~1.8x headroom
-    over the worst observed run without masking a real slowdown: the same
-    unit tests also run under python-core's unchanged 600s on 3.11 (typical
-    340-388s), which would trip first. Changing this pin requires consciously
-    re-deriving the budget from fresh variance evidence, not silently
-    trimming it back toward the variance cliff.
+    over the worst observed run without masking a real slowdown: per-test
+    --timeout on both unit lanes (see test_unit_lanes_fail_fast_on_hung_tests)
+    now catches genuine hangs far below the suite budget. Changing this pin
+    requires consciously re-deriving the budget from fresh variance
+    evidence, not silently trimming it back toward the variance cliff.
     """
     import json
 
     suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
     assert suites["python-min"]["timeout_seconds"] == 1200
+
+
+def test_python_core_timeout_budget_absorbs_runner_variance():
+    """#3280: python-core's suite budget must absorb GitHub-hosted runner variance.
+
+    #3241 kept python-core at 600s as a "tripwire" that would trip before
+    python-min's raised budget if the suite genuinely slowed down. The
+    2026-09-01 evidence in #3280 shows that tripwire sits INSIDE the runner
+    variance band, so it fires on healthy runs: the same main-branch suite
+    passed in 535.69s (run 33497187190) while two other runs were killed at
+    599s (33490406262, 33482741069) and the fast tail finishes in ~290-385s.
+    A required check that dies on a 1.6x slow runner is a flake source, not
+    a regression tripwire; the regression signal now comes from per-test
+    --timeout instead (test_unit_lanes_fail_fast_on_hung_tests). 1200s matches
+    python-min and keeps ~2.2x headroom over the slowest observed healthy
+    run. Changing this pin requires re-deriving the budget from fresh
+    variance evidence, not trimming it back toward the variance cliff.
+    """
+    import json
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    assert suites["python-core"]["timeout_seconds"] == 1200
+
+
+def _pytest_command(suite_name: str) -> list[str]:
+    import json
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    commands = [tuple(c) for c in suites[suite_name]["commands"]]
+    pytest_cmd = next((c for c in commands if c[:3] == ("{python}", "-m", "pytest")), None)
+    assert pytest_cmd is not None, f"{suite_name} must run pytest"
+    return list(pytest_cmd)
+
+
+def _has_flag_pair(command: list[str], pair: tuple[str, str]) -> bool:
+    return any(command[i : i + 2] == list(pair) for i in range(len(command) - 1))
+
+
+def test_unit_lanes_fail_fast_on_hung_tests():
+    """#3280: unit lanes must bound each test instead of only the whole suite.
+
+    pytest-timeout is installed but was never passed on these lanes, so a
+    hung xdist worker (e.g. the gevent-at-collection deadlock shape #3280
+    cites) burned the ENTIRE suite budget and died with a bare
+    "Command exceeded 599s" plus undiagnosable "OSError: cannot send". A
+    300s per-test bound with the thread method dumps every thread's stack
+    and kills the hung worker loudly: 300s is 2x the slowest healthy suite
+    runtime ever observed for a single test on record, while a hang surfaces
+    in bounded time with a stack trace instead of at the suite ceiling.
+    --durations=20 prints the slowest tests on every run so a shrinking
+    budget margin is visible in the log before it becomes a timeout.
+    """
+    for lane in ("python-core", "python-min"):
+        command = _pytest_command(lane)
+        for flag, value in (("--timeout", "300"), ("--timeout-method", "thread")):
+            pair = (flag, value)
+            assert _has_flag_pair(
+                command, pair
+            ), f"{lane} pytest command must pass {flag} {value} (got {command})"
+        assert (
+            "--durations" in command
+        ), f"{lane} pytest command must pass --durations (got {command})"
 
 
 def test_backend_change_runs_the_min_version_unit_lane():


### PR DESCRIPTION
Fixes #3280

## Root cause

Two overlapping problems, both now addressed:

**1. The `python-core` 600s budget sat inside the runner variance band.**
#3241 deliberately left `python-core` at 600s as a "tripwire" that would trip before `python-min`'s raised budget if the suite genuinely slowed down. The 2026-09-01 evidence in #3280 shows healthy runs already straddle that line: the same main-branch suite passed in **535.69s** (run 33497187190) on a slow GitHub-hosted runner while the fast tail finishes in ~290–385s, and two runs were killed at 599s (33490406262, 33482741069). A required check that fires on a 1.6x-slow runner is a flake source, not a regression tripwire. → Raised to **1200s**, matching the treatment `python-min` already received in #3240 (#3241), ~2.2x headroom over the slowest observed healthy run.

**2. No per-test timeout, so a hang was undiagnosable and budget-burning.**
`pytest-timeout` is a locked CI dependency but was never passed on these lanes. A hung xdist worker burned the entire suite budget and left nothing but `Command exceeded 599s` plus post-kill `OSError: cannot send` noise. → Both unit lanes now run pytest with `--timeout 300 --timeout-method thread --durations 20`:
- a hung test dumps every thread's stack and fails loudly in bounded time (thread method works under xdist: the worker process dies loudly with full stacks instead of stalling the controller);
- 300s has ~6x headroom over the slowest healthy test on record (46.7s, measured locally over the full suite);
- `--durations 20` prints the slowest tests on every run so budget-margin erosion becomes visible in the log *before* it turns into a timeout.

## Changes

- `ci/suites.json`: `python-core.timeout_seconds` 600 → 1200; `--timeout 300 --timeout-method thread --durations 20` added to the pytest command of both `python-core` and `python-min`.
- `tests/unit/test_ci_runner.py`: new tests pin the raised budget and the per-test-timeout flags (TDD: red before the suites.json change, green after); the #3240 test's docstring no longer cites python-core's 600s as the tripwire since that premise is what this PR retires.
- `docs/TEST_LAYERS.md` + `CHANGELOG.md`: document the new budget rationale and flags.

## Verification

- `tests/unit/test_ci_runner.py`: 26/26 passed locally.
- Full `python-core` command executed via `python scripts/ci.py run python-core` locally: new flags work end-to-end (`--durations` report produced, slowest test 46.7s ≪ 300s). The only failure was `test_fetch_wrapper_2543.py` — reproduced on a clean `origin/main` checkout too (macOS-bash-only `set -u` interaction, passes on CI Linux; pre-existing, out of scope).
- Full `tests/unit/` with the new flags: **10242 passed, 2 skipped, 5 xfailed** in 230s — zero timeout interference.
- JSON validity + suite count (12) asserted; `scripts/ci.py list` works with the new config.

## Review round 1 outcome

Independent agent review (fresh reviewer, hands-on verification incl. plugin source, live `scripts/ci.py run python-min` under the new flags, red/green TDD check, 300s false-kill audit of long sleeps and gevent usage): **0 Critical / 0 Important / 5 Minor**, verdict "Ready to merge: Yes".

Disposition of the 5 Minors:
- **Minor 1 (docstring headroom figure wrong)** — fixed in a3c87721 (300s is ~6x the measured slowest test 46.7s, not "2x").
- **Minors 2–4 (postgres/compatibility-smoke lack per-test timeout; uniform-slowdown signal; collection-time hangs)** — all out of this issue's scope by design; tracked in follow-up #3282 as the reviewer recommended.
- **Minor 5 (`@pytest.mark.timeout(15)` now inherits `thread` method)** — reviewer's own assessment: stack-dump exit is the better outcome for that pipe-deadlock guard; no action.
