### PR TITLE
fix(ci): wire the false-positive scanner into a real, gated CI lane (#3186 Phase A)

### DIFF
--- a/.false-positive-baseline.json
+++ b/.false-positive-baseline.json
@@ -1,3 +1,0 @@
-{
-  "broad_except_swallow": 1
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       default_collection: ${{ steps.select.outputs.default_collection }}
       dependency_audit: ${{ steps.select.outputs.dependency_audit }}
       e2e_governance: ${{ steps.select.outputs.e2e_governance }}
+      false_positive_scan: ${{ steps.select.outputs.false_positive_scan }}
       frontend: ${{ steps.select.outputs.frontend }}
       package: ${{ steps.select.outputs.package }}
       postgres: ${{ steps.select.outputs.postgres }}
@@ -345,6 +346,30 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  false-positive-scan:
+    # #3186 Phase A: the test-code false-positive scanner as a real, gated
+    # lane. Selected for every non-docs change (ci.py select_pr_suites); the
+    # known-debt ledger (ci/false-positive-ledger.json) records today's 77
+    # findings by precise identity, so new or substituted debt is red while
+    # fixes only shrink the ledger (--prune-ledger, removal-only). Deliberately
+    # NOT advisory, no continue-on-error, no skip label: the result must be
+    # able to block merges via PR Gate.
+    name: False-positive scan
+    needs: changes
+    if: needs.changes.outputs.false_positive_scan == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      # The scanner and the shared runner are stdlib-only — no pip install.
+      - name: Scan test code through the shared runner
+        run: python scripts/ci.py run false-positive-scan
+
   security-gate:
     name: Dependency security audit
     needs: changes
@@ -387,7 +412,7 @@ jobs:
         github.event_name == 'pull_request' ||
         (github.event_name == 'workflow_dispatch' && inputs.healed_sha != '')
       )
-    needs: [changes, lint, test, frontend, build, postgres-test, security-gate]
+    needs: [changes, lint, test, frontend, build, postgres-test, false-positive-scan, security-gate]
     runs-on: ubuntu-24.04
     steps:
       - name: Validate required and selected lanes
@@ -398,12 +423,13 @@ jobs:
           FRONTEND: ${{ needs.frontend.result }}
           BUILD: ${{ needs.build.result }}
           POSTGRES: ${{ needs.postgres-test.result }}
+          SCAN: ${{ needs.false-positive-scan.result }}
           SECURITY: ${{ needs.security-gate.result }}
         run: |
           python - <<'PY'
           import os
           required = {name: os.environ[name] for name in ("CHANGES", "LINT", "TEST", "BUILD")}
-          selected = {name: os.environ[name] for name in ("FRONTEND", "POSTGRES", "SECURITY")}
+          selected = {name: os.environ[name] for name in ("FRONTEND", "POSTGRES", "SCAN", "SECURITY")}
           failures = {name: result for name, result in required.items() if result != "success"}
           failures.update(
               {name: result for name, result in selected.items() if result not in {"success", "skipped"}}

--- a/ci/ci-health-policy.json
+++ b/ci/ci-health-policy.json
@@ -15,7 +15,7 @@
       "event": "pull_request",
       "contract_paths": [
         ".github/workflows/ci.yml",
-        ".false-positive-baseline.json",
+        "ci/false-positive-ledger.json",
         ".dockerignore",
         ".pre-commit-config.yaml",
         ".test-baseline.json",
@@ -36,6 +36,7 @@
         "schema/schema-postgres.sql",
         "scripts/check_migration_heads.py",
         "scripts/ci.py",
+        "scripts/scan_test_false_positives.py",
         "scripts/hooks/check_schema_sync.sh",
         "scripts/lint/api_security_scanner.py",
         "scripts/lint/bandit_baseline.json",
@@ -57,7 +58,7 @@
       "branch": "main",
       "contract_paths": [
         ".github/workflows/ci.yml",
-        ".false-positive-baseline.json",
+        "ci/false-positive-ledger.json",
         ".dockerignore",
         ".pre-commit-config.yaml",
         ".test-baseline.json",
@@ -78,6 +79,7 @@
         "schema/schema-postgres.sql",
         "scripts/check_migration_heads.py",
         "scripts/ci.py",
+        "scripts/scan_test_false_positives.py",
         "scripts/hooks/check_schema_sync.sh",
         "scripts/lint/api_security_scanner.py",
         "scripts/lint/bandit_baseline.json",
@@ -111,6 +113,7 @@
         "requirements-ci.lock",
         "schema/schema-sqlite.sql",
         "scripts/ci.py",
+        "scripts/scan_test_false_positives.py",
         "scripts/init_db.py",
         "scripts/run_extended_tests.py",
         "tests/conftest.py"
@@ -135,6 +138,7 @@
         "requirements-ci.lock",
         "schema/schema-sqlite.sql",
         "scripts/ci.py",
+        "scripts/scan_test_false_positives.py",
         "scripts/init_db.py",
         "scripts/run_extended_tests.py"
       ]

--- a/ci/false-positive-ledger.json
+++ b/ci/false-positive-ledger.json
@@ -1,0 +1,467 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_batch_session_termination",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_deregister_with_active_session",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_full_deregistration_flow",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_coverage_data_in_result",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_multi_user_session_collection",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_session_data_persistence",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_single_user_session_collection",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_tenant_attribution",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_user_id_resolution",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_agent_sessions_user_id_filled",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_daily_messages_user_id_filled",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_by_username",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_system_user_sync_2735.py",
+      "function": "TestSystemUserSync.test_sync_failure_logging",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/integration/test_system_user_sync_2735.py",
+      "function": "TestSystemUserSync.test_sync_system_users_creates_users",
+      "count": 1
+    },
+    {
+      "pattern": "erroneous_skip",
+      "file": "tests/performance/test_qwen_performance_2735.py",
+      "function": "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_batch_session_termination",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_deregister_with_active_session",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/e2e/remote/test_deregister_e2e.py",
+      "function": "TestDeregisterE2E.test_full_deregistration_flow",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestErrorHandlingIntegration.test_degraded_status_on_partial_failure",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestErrorHandlingIntegration.test_idempotent_collection",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestPerformanceIntegration.test_100_users_performance",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestPerformanceIntegration.test_large_file_handling",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestPermission700Collection.test_message_count_correct",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestPermission700Collection.test_two_users_permission_700_collected",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestPermission700Collection.test_user_id_mapping_correct",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestSecurityIntegration.test_symlink_attack_blocked",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_fetch_wrapper_integration_2543.py",
+      "function": "TestSecurityIntegration.test_web_service_cannot_read_other_users",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_coverage_data_in_result",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_multi_user_session_collection",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_session_data_persistence",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_single_user_session_collection",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_tenant_attribution",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_multiuser_qwen_collection_2735.py",
+      "function": "TestMultiUserQwenCollection.test_user_id_resolution",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_agent_sessions_user_id_filled",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_daily_messages_user_id_filled",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_by_username",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_qwen_user_attribution_2735.py",
+      "function": "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_system_user_sync_2735.py",
+      "function": "TestSystemUserSync.test_sync_failure_logging",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/integration/test_system_user_sync_2735.py",
+      "function": "TestSystemUserSync.test_sync_system_users_creates_users",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/performance/test_qwen_performance_2735.py",
+      "function": "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_agent_transport.py",
+      "function": "test_shutdown_on_an_already_dead_process_does_not_raise",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_analytics_routes.py",
+      "function": "TestParseDateRange.test_route",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestAuditLogging.test_audit_log_created",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestAuditLogging.test_username_sanitized",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestFileSizeLimits.test_large_file_rejected",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestIntegration.test_degraded_status_on_partial_failure",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestIntegration.test_multi_user_collection_with_permission_700",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestParameterValidation.test_exact_match_valid_params",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestUserIdentityMapping.test_no_match_returns_none",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestUserIdentityMapping.test_resolve_user_id_by_system_account",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_fetch_wrapper_2543.py",
+      "function": "TestUserIdentityMapping.test_resolve_user_id_by_username",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_issue_wrong_repo_3075.py",
+      "function": "TestIssueRepoFallback.test_fallback_raises_githubopserror",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_new_project_local_repo_init_2963.py",
+      "function": "TestValidateProjectPath.test_pass_if_valid_git_repository",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_gh_wrapper.py",
+      "function": "test_admin_merge_is_config_gated",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_gh_wrapper.py",
+      "function": "test_current_github_ops_gh_shapes_are_allowed",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_gh_wrapper.py",
+      "function": "test_dangerous_gh_shapes_are_denied",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_gh_wrapper.py",
+      "function": "test_version_and_help_are_only_standalone_passthrough",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_current_github_ops_git_shapes_are_allowed",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_forbidden_global_options_and_configs_are_denied",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_git_commands_require_hardening_globals",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_mutating_branches_are_limited_to_workflow_branches",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_relative_path_operands_cannot_escape_worktree",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_show_tree_paths_allow_real_filenames_but_not_escapes",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_openace_git_wrapper.py",
+      "function": "test_version_and_help_are_only_standalone_passthrough",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_client.py",
+      "function": "test_delete_sandbox_treats_404_as_success",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_policy.py",
+      "function": "test_a_cni_tier_accepts_any_public_proxy_host",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_policy.py",
+      "function": "test_an_allowlisted_proxy_url_passes",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_provider.py",
+      "function": "test_destroy_attribution_never_raises",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_wiring.py",
+      "function": "test_sweep_survives_a_provider_failure_on_one_row",
+      "count": 1
+    },
+    {
+      "pattern": "no_assertion",
+      "file": "tests/unit/test_opensandbox_workspace.py",
+      "function": "test_apply_deleting_a_missing_path_is_not_an_error",
+      "count": 1
+    }
+  ]
+}

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -149,8 +149,8 @@
           "{python}",
           "scripts/scan_test_false_positives.py",
           "tests",
-          "--baseline",
-          ".false-positive-baseline.json"
+          "--ledger",
+          "ci/false-positive-ledger.json"
         ]
       ]
     },

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -96,7 +96,11 @@ GitHub Actions 都通过 `python scripts/ci.py` 执行。PR 矩阵按版本分�
   只留一句不可诊断的 "Command exceeded"；`--durations` 让预算余量的收缩
   在日志里先于超时可见。
 - **false-positive-scan**：测试代码假阳性扫描（Issue #2189，Scope #6），
-  每个非文档改动都跑，独立于 `python-core` 以避免超时。
+  每个非文档改动都跑（`ci.py select_pr_suites` 默认集 + `PR Gate` 消费，#3186
+  Phase A），独立于 `python-core` 以避免超时。已知债务以**精确身份 ledger**
+  （`ci/false-positive-ledger.json`：pattern + 文件 + 类限定函数名）表达——
+  新增/置换 finding 即红；修复只允许**收缩**（`--prune-ledger` 只删不增），
+  且规模由契约测试钉死（只减不增）。旧的按计数 baseline 已退役。
 - **3.10（最低支持版本）**：`python-min`——`compileall` + 全量 `pytest tests/unit/`，
   每个非文档改动都跑。版本特有的回归几乎总先在最老解释器上暴露（例如 3.11 之前
   `datetime.fromisoformat` 不接受 `Z` 后缀），旧矩阵只在 3.10 跑 7 文件 smoke，使

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -181,7 +181,7 @@ def select_pr_suites(changed_files: list[str]) -> list[str]:
     """Select coarse, fail-safe PR lanes from repository-relative paths."""
     clean = sorted({path.strip().lstrip("./") for path in changed_files if path.strip()})
     if not clean:
-        return ["default-collection", "python-core", "python-min"]
+        return ["default-collection", "false-positive-scan", "python-core", "python-min"]
 
     policy_change = any(matches(path, POLICY_PATTERNS) for path in clean)
     docs_only = all(matches(path, DOC_PATTERNS) for path in clean)
@@ -194,8 +194,11 @@ def select_pr_suites(changed_files: list[str]) -> list[str]:
     # for every code change (#2868): version-specific regressions surface on the
     # oldest Python first (e.g. datetime.fromisoformat rejecting 'Z' before
     # 3.11), and it is unit-only so it stays fast and deterministic.
+    # false-positive-scan rides along on every non-docs change (#3186 Phase A):
+    # a ~3s AST scan keeping new no-assert/skip debt out of required CI.
     selected = {
         "default-collection",
+        "false-positive-scan",
         "python-core",
         "python-min",
     }

--- a/scripts/scan_test_false_positives.py
+++ b/scripts/scan_test_false_positives.py
@@ -617,13 +617,15 @@ def _current_counts(findings: list[Finding], root: Path) -> dict[tuple[str, str,
 
 
 def _load_ledger(path: Path) -> dict[tuple[str, str, str], int]:
-    """Load and validate the ledger file; raise SystemExit-style errors via _ledger_error."""
+    """Load and validate the ledger file; malformed input raises LedgerError."""
     try:
         data = json.loads(path.read_text())
     except OSError as e:
         raise LedgerError(f"Cannot read ledger {path}: {e}") from e
     except json.JSONDecodeError as e:
         raise LedgerError(f"Ledger {path} is not valid JSON: {e}") from e
+    if not isinstance(data, dict):
+        raise LedgerError(f"Ledger {path} must be a JSON object, got {type(data).__name__}")
     if data.get("version") != LEDGER_VERSION:
         raise LedgerError(f"Ledger {path} has unsupported version {data.get('version')!r}")
     entries = data.get("entries")

--- a/scripts/scan_test_false_positives.py
+++ b/scripts/scan_test_false_positives.py
@@ -36,6 +36,10 @@ class Finding(NamedTuple):
     severity: str  # P0, P1, P2
     pattern: str
     message: str
+    # Class-qualified function name ("<Class>.<func>", bare "<func>" outside
+    # classes, "<module>" at module level) — the stable identity component for
+    # the known-debt ledger (line numbers churn, names do not).
+    function: str = "<module>"
 
 
 ASSERT_METHODS = frozenset(
@@ -180,7 +184,7 @@ def _extract_and_validate_annotation(
                 import warnings
 
                 warnings.warn(
-                    f"Invalid annotation content at line {i+1}: '{annotation_content}' "
+                    f"Invalid annotation content at line {i + 1}: '{annotation_content}' "
                     f"does not match any template for {pattern_type}",
                     UserWarning,
                     stacklevel=3,
@@ -216,6 +220,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
         self.findings: list[Finding] = []
         self.current_function: str | None = None
         self.current_func_node: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+        self.class_stack: list[str] = []
         self.is_test_function = False
         self.has_assertion = False
         self.has_return_true = False
@@ -230,7 +235,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
             self.has_return_true,
             self.cond_depth,
         )
-        self.current_function = node.name
+        self.current_function = ".".join([*self.class_stack, node.name])
         self.current_func_node = node
         self.is_test_function = node.name.startswith("test_")
         self.has_assertion = False
@@ -255,6 +260,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
                         severity="P0",
                         pattern="no_assertion",
                         message=f"Test function '{node.name}' has no assertions",
+                        function=self.current_function or "<module>",
                     )
                 )
             if self.has_return_true and not self.has_assertion and not allow_no_assert:
@@ -265,6 +271,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
                         severity="P0",
                         pattern="return_true",
                         message=f"Test function '{node.name}' returns True without asserting",
+                        function=self.current_function or "<module>",
                     )
                 )
 
@@ -282,6 +289,11 @@ class FalsePositiveScanner(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.class_stack.append(node.name)
+        self.generic_visit(node)
+        self.class_stack.pop()
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         broad = (
@@ -308,6 +320,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
                             f"Broad except {node.type.id} swallows (no raise/assert) "
                             f"in '{self.current_function}'"
                         ),
+                        function=self.current_function or "<module>",
                     )
                 )
         self.generic_visit(node)
@@ -347,6 +360,7 @@ class FalsePositiveScanner(ast.NodeVisitor):
                                     f"Unconditional pytest.skip() in '{self.current_function}' "
                                     f"hides failures"
                                 ),
+                                function=self.current_function or "<module>",
                             )
                         )
         self.generic_visit(node)
@@ -474,6 +488,22 @@ def main(argv: list[str] | None = None) -> int:
         metavar="FILE",
         help="Write the current per-pattern counts to FILE and exit 0.",
     )
+    parser.add_argument(
+        "--ledger",
+        metavar="FILE",
+        help="Known-debt ledger JSON (precise per-finding identities). Exit 1 on "
+        "any finding whose identity is absent from the ledger (or exceeds its "
+        "recorded count) AND on any stale ledger entry. Relative paths resolve "
+        "against the project root.",
+    )
+    parser.add_argument(
+        "--prune-ledger",
+        metavar="FILE",
+        help="Removal-only ledger maintenance: drop stale entries and lower "
+        "counts to the current values, then exit 0. REFUSES (exit 1) if any "
+        "current finding's identity is absent from the ledger or would need a "
+        "count increase — pruning can never enroll new debt.",
+    )
     args = parser.parse_args(argv)
 
     test_dir = Path(args.dir)
@@ -514,6 +544,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.baseline:
         return _compare_baseline(Path(args.baseline), by_pattern)
 
+    if args.ledger or args.prune_ledger:
+        if args.ledger and args.prune_ledger:
+            print("::error::--ledger and --prune-ledger are mutually exclusive")
+            return 1
+        ledger_path = Path(args.ledger or args.prune_ledger)
+        if not ledger_path.is_absolute():
+            ledger_path = project_root / ledger_path
+        if args.prune_ledger:
+            return _prune_ledger(ledger_path, findings, project_root)
+        return _compare_ledger(ledger_path, findings, project_root)
+
     for finding in findings:
         print(f"\n[{finding.severity}] {finding.pattern}")
         print(f"  File: {finding.file}:{finding.line}")
@@ -544,6 +585,173 @@ def _compare_baseline(baseline_path: Path, by_pattern: dict[str, int]) -> int:
             f"(regression — fix the new finding or run --update-baseline)"
         )
     return 1 if regressions else 0
+
+
+# ---------------------------------------------------------------------------
+# Known-debt ledger (Issue #3186 Phase A): precise per-finding identities so
+# the CI gate can distinguish "new debt" from "known debt" and make
+# same-count substitution (fix A, introduce B) programmatically red. The
+# count-based --baseline above is retired from CI consumption; it remains for
+# backwards compatibility only.
+# ---------------------------------------------------------------------------
+
+LEDGER_VERSION = 1
+MODULE_LEVEL = "<module>"
+
+
+def _ledger_identity(finding: Finding, root: Path) -> tuple[str, str, str]:
+    """Stable identity: (pattern, repo-relative file, class-qualified function)."""
+    try:
+        rel = Path(finding.file).relative_to(root)
+    except ValueError:
+        rel = Path(finding.file)
+    return (finding.pattern, rel.as_posix(), finding.function or MODULE_LEVEL)
+
+
+def _current_counts(findings: list[Finding], root: Path) -> dict[tuple[str, str, str], int]:
+    counts: dict[tuple[str, str, str], int] = {}
+    for finding in findings:
+        identity = _ledger_identity(finding, root)
+        counts[identity] = counts.get(identity, 0) + 1
+    return counts
+
+
+def _load_ledger(path: Path) -> dict[tuple[str, str, str], int]:
+    """Load and validate the ledger file; raise SystemExit-style errors via _ledger_error."""
+    try:
+        data = json.loads(path.read_text())
+    except OSError as e:
+        raise LedgerError(f"Cannot read ledger {path}: {e}") from e
+    except json.JSONDecodeError as e:
+        raise LedgerError(f"Ledger {path} is not valid JSON: {e}") from e
+    if data.get("version") != LEDGER_VERSION:
+        raise LedgerError(f"Ledger {path} has unsupported version {data.get('version')!r}")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise LedgerError(f"Ledger {path} must contain an 'entries' list")
+    counts: dict[tuple[str, str, str], int] = {}
+    for entry in entries:
+        try:
+            identity = (entry["pattern"], entry["file"], entry.get("function") or MODULE_LEVEL)
+            count = int(entry.get("count", 1))
+        except (KeyError, TypeError, ValueError) as e:
+            raise LedgerError(f"Ledger {path} has a malformed entry {entry!r}: {e}") from e
+        if identity in counts:
+            raise LedgerError(f"Ledger {path} has duplicate entry for {identity}")
+        if count < 1:
+            raise LedgerError(f"Ledger {path} entry {identity} has non-positive count {count}")
+        counts[identity] = count
+    return counts
+
+
+class LedgerError(RuntimeError):
+    """Invalid ledger file (unreadable, wrong version, malformed entries)."""
+
+
+def _render_identity(identity: tuple[str, str, str]) -> str:
+    return f"{identity[0]} | {identity[1]} | {identity[2]}"
+
+
+def _compare_ledger(ledger_path: Path, findings: list[Finding], root: Path) -> int:
+    """Exit 1 on unknown findings (new debt) or stale ledger entries.
+
+    Comparison is count-exact per identity: a second hit under an existing
+    identity must be covered by the recorded count, and a count above the
+    current value marks the entry stale (the debt was fixed — prune it).
+    """
+    try:
+        ledger = _load_ledger(ledger_path)
+    except LedgerError as e:
+        print(f"::error::{e}")
+        return 1
+    current = _current_counts(findings, root)
+
+    problems = []
+    for identity, count in sorted(current.items()):
+        allowed = ledger.get(identity, 0)
+        if count > allowed:
+            problems.append(
+                f"unknown finding {identity[2]} in {identity[1]} "
+                f"({identity[0]}): {count} hit(s), ledger covers {allowed}"
+            )
+    for identity, allowed in sorted(ledger.items()):
+        count = current.get(identity, 0)
+        if count < allowed:
+            problems.append(
+                f"stale ledger entry {identity[2]} in {identity[1]} "
+                f"({identity[0]}): ledger covers {allowed}, current {count} "
+                f"— fix confirmed, prune with --prune-ledger"
+            )
+    for problem in problems:
+        print(f"::error::{problem}")
+    print(f"Ledger check: {len(current)} finding identities, {len(ledger)} ledger entries")
+    if problems:
+        print(f"FAILED: {len(problems)} problem(s) — new debt is never enrollable via prune")
+        return 1
+    print("OK: every finding is known debt; ledger mirrors reality exactly")
+    return 0
+
+
+def _prune_ledger(ledger_path: Path, findings: list[Finding], root: Path) -> int:
+    """Removal-only ledger maintenance; refuses to enroll anything.
+
+    Drops identities the scan no longer finds and lowers counts to the
+    current values. If any current identity is absent from the ledger, or a
+    count would have to rise, refuse (exit 1): pruning can never absorb new
+    debt — enrollment is only possible by hand-editing the ledger, which the
+    FROZEN_SEED contract test (tests/unit/test_ci_runner.py) then rejects.
+    """
+    try:
+        ledger = _load_ledger(ledger_path)
+    except LedgerError as e:
+        print(f"::error::{e}")
+        return 1
+    current = _current_counts(findings, root)
+
+    refusals = []
+    for identity, count in sorted(current.items()):
+        allowed = ledger.get(identity, 0)
+        if allowed == 0:
+            refusals.append(
+                f"unknown finding {identity[2]} in {identity[1]} "
+                f"({identity[0]}) — prune cannot enroll new debt; fix the "
+                f"finding or hand-edit the ledger (contract test guards this)"
+            )
+        elif count > allowed:
+            refusals.append(
+                f"count increase for {identity[2]} in {identity[1]} "
+                f"({identity[0]}): {allowed} -> {count} — prune cannot raise counts"
+            )
+    for refusal in refusals:
+        print(f"::error::{refusal}")
+    if refusals:
+        print(f"FAILED: prune refused ({len(refusals)} problem(s)); ledger left unchanged")
+        return 1
+
+    removed = [
+        (identity, allowed) for identity, allowed in ledger.items() if identity not in current
+    ]
+    reduced = [
+        (identity, allowed, current[identity])
+        for identity, allowed in ledger.items()
+        if identity in current and current[identity] < allowed
+    ]
+    if not removed and not reduced:
+        print(f"Prune: no changes (ledger already mirrors reality: {len(current)} entries)")
+        return 0
+    entries = [
+        {"pattern": identity[0], "file": identity[1], "function": identity[2], "count": count}
+        for identity, count in sorted(current.items())
+    ]
+    ledger_path.write_text(
+        json.dumps({"version": LEDGER_VERSION, "entries": entries}, indent=2) + "\n"
+    )
+    print(f"Pruned ledger written to {ledger_path}: {len(entries)} entries")
+    for identity, allowed in sorted(removed):
+        print(f"  removed (fixed): {_render_identity(identity)} (was {allowed})")
+    for identity, allowed, now in sorted(reduced):
+        print(f"  reduced: {_render_identity(identity)} {allowed} -> {now}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -844,7 +844,6 @@ KNOWN_DEBT_FROZEN_SEED = (
 )
 
 KNOWN_DEBT_FINDING_TOTAL = 77  # total findings across all seed entries
-KNOWN_DEBT_LEDGER_SIZE = 77
 
 
 def _ledger_counts() -> dict[tuple[str, str, str], int]:

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -101,15 +101,15 @@ def test_min_supported_python_runs_the_full_unit_suite():
     suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
     commands = suites["python-min"]["commands"]
     flat = [tuple(c) for c in commands]
-    assert any(c[:3] == ("{python}", "-m", "compileall") for c in flat), (
-        "python-min must compileall"
-    )
+    assert any(
+        c[:3] == ("{python}", "-m", "compileall") for c in flat
+    ), "python-min must compileall"
     pytest_cmd = next((c for c in flat if c[:3] == ("{python}", "-m", "pytest")), None)
     assert pytest_cmd is not None, "python-min must run pytest"
     # The WHOLE unit tree, not a hand-picked subset — that is the #2868 fix.
-    assert "tests/unit/" in pytest_cmd, (
-        f"python-min must run the full tests/unit/, got {pytest_cmd}"
-    )
+    assert (
+        "tests/unit/" in pytest_cmd
+    ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
 
 
 def test_python_min_timeout_budget_absorbs_runner_variance():
@@ -809,9 +809,9 @@ def test_known_debt_ledger_is_frozen_seed_and_only_shrinks():
     scanner = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(scanner)
     live = set(scanner._current_counts(scanner.scan_tests(ROOT / "tests"), ROOT))
-    assert identities <= live, (
-        f"stale ledger entries (debt moved/fixed): {sorted(identities - live)}"
-    )
+    assert (
+        identities <= live
+    ), f"stale ledger entries (debt moved/fixed): {sorted(identities - live)}"
 
 
 def test_every_selectable_pr_suite_has_a_workflow_consumer():
@@ -894,9 +894,9 @@ def test_false_positive_scan_lane_is_gate_consumed():
         if "ci.py run false-positive-scan" in str(job)
     )
     gate = workflow["jobs"]["pr-gate"]
-    assert scan_job in gate["needs"], (
-        f"job {scan_job} executes the scanner but is absent from pr-gate needs"
-    )
+    assert (
+        scan_job in gate["needs"]
+    ), f"job {scan_job} executes the scanner but is absent from pr-gate needs"
     validate_step = next(s for s in gate["steps"] if "Validate required" in str(s.get("name", "")))
     snippet = str(validate_step["run"])
     assert "SCAN" in validate_step["env"], "pr-gate must map the scanner result to SCAN"

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -101,15 +101,15 @@ def test_min_supported_python_runs_the_full_unit_suite():
     suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
     commands = suites["python-min"]["commands"]
     flat = [tuple(c) for c in commands]
-    assert any(
-        c[:3] == ("{python}", "-m", "compileall") for c in flat
-    ), "python-min must compileall"
+    assert any(c[:3] == ("{python}", "-m", "compileall") for c in flat), (
+        "python-min must compileall"
+    )
     pytest_cmd = next((c for c in flat if c[:3] == ("{python}", "-m", "pytest")), None)
     assert pytest_cmd is not None, "python-min must run pytest"
     # The WHOLE unit tree, not a hand-picked subset — that is the #2868 fix.
-    assert (
-        "tests/unit/" in pytest_cmd
-    ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
+    assert "tests/unit/" in pytest_cmd, (
+        f"python-min must run the full tests/unit/, got {pytest_cmd}"
+    )
 
 
 def test_python_min_timeout_budget_absorbs_runner_variance():
@@ -388,416 +388,511 @@ KNOWN_DEBT_FROZEN_SEED = (
         "erroneous_skip",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_batch_session_termination",
+        1,
     ),
     (
         "no_assertion",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_batch_session_termination",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_deregister_with_active_session",
+        1,
     ),
     (
         "no_assertion",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_deregister_with_active_session",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_full_deregistration_flow",
+        1,
     ),
     (
         "no_assertion",
         "tests/e2e/remote/test_deregister_e2e.py",
         "TestDeregisterE2E.test_full_deregistration_flow",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestErrorHandlingIntegration.test_degraded_status_on_partial_failure",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestErrorHandlingIntegration.test_idempotent_collection",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestPerformanceIntegration.test_100_users_performance",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestPerformanceIntegration.test_large_file_handling",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestPermission700Collection.test_message_count_correct",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestPermission700Collection.test_two_users_permission_700_collected",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestPermission700Collection.test_user_id_mapping_correct",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestSecurityIntegration.test_symlink_attack_blocked",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_fetch_wrapper_integration_2543.py",
         "TestSecurityIntegration.test_web_service_cannot_read_other_users",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_coverage_data_in_result",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_coverage_data_in_result",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_multi_user_session_collection",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_multi_user_session_collection",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_session_data_persistence",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_session_data_persistence",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_single_user_session_collection",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_single_user_session_collection",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_tenant_attribution",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_tenant_attribution",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_user_id_resolution",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_multiuser_qwen_collection_2735.py",
         "TestMultiUserQwenCollection.test_user_id_resolution",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_agent_sessions_user_id_filled",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_agent_sessions_user_id_filled",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_daily_messages_user_id_filled",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_daily_messages_user_id_filled",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_by_username",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_by_username",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_qwen_user_attribution_2735.py",
         "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_system_user_sync_2735.py",
         "TestSystemUserSync.test_sync_failure_logging",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_system_user_sync_2735.py",
         "TestSystemUserSync.test_sync_failure_logging",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/integration/test_system_user_sync_2735.py",
         "TestSystemUserSync.test_sync_system_users_creates_users",
+        1,
     ),
     (
         "no_assertion",
         "tests/integration/test_system_user_sync_2735.py",
         "TestSystemUserSync.test_sync_system_users_creates_users",
+        1,
     ),
     (
         "erroneous_skip",
         "tests/performance/test_qwen_performance_2735.py",
         "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+        1,
     ),
     (
         "no_assertion",
         "tests/performance/test_qwen_performance_2735.py",
         "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_agent_transport.py",
         "test_shutdown_on_an_already_dead_process_does_not_raise",
+        1,
     ),
-    ("no_assertion", "tests/unit/test_analytics_routes.py", "TestParseDateRange.test_route"),
+    ("no_assertion", "tests/unit/test_analytics_routes.py", "TestParseDateRange.test_route", 1),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestAuditLogging.test_audit_log_created",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestAuditLogging.test_username_sanitized",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestFileSizeLimits.test_large_file_rejected",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestIntegration.test_degraded_status_on_partial_failure",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestIntegration.test_multi_user_collection_with_permission_700",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestParameterValidation.test_exact_match_valid_params",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestUserIdentityMapping.test_no_match_returns_none",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestUserIdentityMapping.test_resolve_user_id_by_system_account",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_fetch_wrapper_2543.py",
         "TestUserIdentityMapping.test_resolve_user_id_by_username",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_issue_wrong_repo_3075.py",
         "TestIssueRepoFallback.test_fallback_raises_githubopserror",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_new_project_local_repo_init_2963.py",
         "TestValidateProjectPath.test_pass_if_valid_git_repository",
+        1,
     ),
-    ("no_assertion", "tests/unit/test_openace_gh_wrapper.py", "test_admin_merge_is_config_gated"),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_gh_wrapper.py",
+        "test_admin_merge_is_config_gated",
+        1,
+    ),
     (
         "no_assertion",
         "tests/unit/test_openace_gh_wrapper.py",
         "test_current_github_ops_gh_shapes_are_allowed",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_gh_wrapper.py",
         "test_dangerous_gh_shapes_are_denied",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_gh_wrapper.py",
         "test_version_and_help_are_only_standalone_passthrough",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_current_github_ops_git_shapes_are_allowed",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_forbidden_global_options_and_configs_are_denied",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_git_commands_require_hardening_globals",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_mutating_branches_are_limited_to_workflow_branches",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_relative_path_operands_cannot_escape_worktree",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_show_tree_paths_allow_real_filenames_but_not_escapes",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_openace_git_wrapper.py",
         "test_version_and_help_are_only_standalone_passthrough",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_client.py",
         "test_delete_sandbox_treats_404_as_success",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_policy.py",
         "test_a_cni_tier_accepts_any_public_proxy_host",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_policy.py",
         "test_an_allowlisted_proxy_url_passes",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_provider.py",
         "test_destroy_attribution_never_raises",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_wiring.py",
         "test_sweep_survives_a_provider_failure_on_one_row",
+        1,
     ),
     (
         "no_assertion",
         "tests/unit/test_opensandbox_workspace.py",
         "test_apply_deleting_a_missing_path_is_not_an_error",
+        1,
     ),
 )
 
+KNOWN_DEBT_FINDING_TOTAL = 77  # total findings across all seed entries
 KNOWN_DEBT_LEDGER_SIZE = 77
 
 
-def _ledger_identities() -> set[tuple[str, str, str]]:
+def _ledger_counts() -> dict[tuple[str, str, str], int]:
     import json
 
     data = json.loads((ROOT / "ci" / "false-positive-ledger.json").read_text())
-    return {(e["pattern"], e["file"], e.get("function") or "<module>") for e in data["entries"]}
+    return {
+        (e["pattern"], e["file"], e.get("function") or "<module>"): int(e.get("count", 1))
+        for e in data["entries"]
+    }
 
 
 def test_known_debt_ledger_is_frozen_seed_and_only_shrinks():
     """#3186: the known-debt ledger starts EXACTLY as the frozen seed and only shrinks.
 
-    Three properties, all load-bearing:
-    1. entries ⊆ KNOWN_DEBT_FROZEN_SEED — substitution is programmatically red:
+    Four properties, all load-bearing (the seed tuples carry counts):
+    1. identities ⊆ seed identities — substitution is programmatically red:
        "fix A, introduce B, hand-edit the ledger to add B" fails here because
        B is not in the frozen seed. Enrollment is impossible via --prune-ledger
        (removal-only by design).
-    2. len == KNOWN_DEBT_LEDGER_SIZE — the EXACT size pin is the only guard
-       against RE-enrolling an identity that was already paid down but still
-       sits in the frozen seed (⊆ passes, size red). Do NOT relax this to <=.
-       A legitimate paydown (Phase B) shrinks the ledger AND edits this pin
-       in the same PR — that visible pin edit is the audit trail.
-    3. every ledger entry still matches a live finding — a stale entry means
-       someone moved/renamed debt without pruning; the CI scanner job fails
-       on stale entries too, this keeps the unit lane honest as well.
+    2. per-identity count <= seed count — raising an existing entry's count
+       (e.g. 1 -> 2 to absorb a second hit in an already-indebted function)
+       is red without a visible seed edit.
+    3. sum(counts) == KNOWN_DEBT_FINDING_TOTAL — the EXACT total pin is the
+       only guard against re-enrolling debt that was already paid down but
+       still sits in the frozen seed (⊆ passes, total red). Do NOT relax to
+       <=. A legitimate paydown (Phase B) prunes the ledger AND lowers this
+       pin in the same PR — that visible pin edit is the audit trail.
+    4. every ledger identity still matches a live finding — a stale entry
+       means debt moved/renamed without pruning; the CI scanner job fails on
+       stale entries too, this keeps the unit lane honest as well.
     """
-    identities = _ledger_identities()
-    assert identities <= set(KNOWN_DEBT_FROZEN_SEED), (
+    counts = _ledger_counts()
+    seed_counts = {(p, f, fn): c for p, f, fn, c in KNOWN_DEBT_FROZEN_SEED}
+    ledger_ids = set(counts)
+    assert ledger_ids <= set(seed_counts), (
         "ledger contains identities outside the frozen seed (substitution or "
-        "enrollment attempt): "
-        f"{sorted(identities - set(KNOWN_DEBT_FROZEN_SEED))}"
+        f"enrollment attempt): {sorted(ledger_ids - set(seed_counts))}"
     )
-    assert len(identities) == KNOWN_DEBT_LEDGER_SIZE, (
-        f"known-debt ledger size {len(identities)} != pin {KNOWN_DEBT_LEDGER_SIZE}; "
+    raised = {
+        identity: (counts[identity], seed_counts[identity])
+        for identity in ledger_ids
+        if counts[identity] > seed_counts[identity]
+    }
+    assert not raised, f"ledger counts exceed the frozen seed (enrollment attempt): {raised}"
+    total = sum(counts.values())
+    assert total == KNOWN_DEBT_FINDING_TOTAL, (
+        f"known-debt finding total {total} != pin {KNOWN_DEBT_FINDING_TOTAL}; "
         "legitimate shrink: prune the ledger AND lower this pin in the same PR; "
         "growth is never allowed (fix the finding instead)"
     )
@@ -808,10 +903,10 @@ def test_known_debt_ledger_is_frozen_seed_and_only_shrinks():
     assert spec and spec.loader
     scanner = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(scanner)
-    live = set(scanner._current_counts(scanner.scan_tests(ROOT / "tests"), ROOT))
-    assert (
-        identities <= live
-    ), f"stale ledger entries (debt moved/fixed): {sorted(identities - live)}"
+    live = scanner._current_counts(scanner.scan_tests(ROOT / "tests"), ROOT)
+    assert all(counts[identity] <= live.get(identity, 0) for identity in ledger_ids), (
+        f"stale ledger entries (debt moved/fixed): {sorted(ledger_ids - set(live))}"
+    )
 
 
 def test_every_selectable_pr_suite_has_a_workflow_consumer():
@@ -844,35 +939,32 @@ def test_every_selectable_pr_suite_has_a_workflow_consumer():
 
         return _json.dumps(job)
 
+    import re as _re
+
     for suite in sorted(pr_suites):
         key = suite.replace("-", "_")
         executed = False
         for job in workflow["jobs"].values():
-            if (
-                job is None
-                or "runs" not in job_text(job)
-                and "run" not in str(job.get("steps", []))
-            ):
-                pass
             text = job_text(job)
-            runs_suite = f"run {suite}" in text or (
-                "${{ matrix.suite }}" in text
-                and any(
-                    inc.get("suite") == suite
-                    for inc in job.get("strategy", {}).get("matrix", {}).get("include", [])
-                )
+            # Word-boundary match so a suite that prefixes another cannot
+            # cross-match ("python-min" vs a hypothetical "python-minimal").
+            runs_suite = _re.search(rf"ci\.py run {_re.escape(suite)}\b", text) is not None
+            in_matrix = "${{ matrix.suite }}" in text and any(
+                inc.get("suite") == suite
+                for inc in job.get("strategy", {}).get("matrix", {}).get("include", [])
             )
-            if not runs_suite:
+            if not runs_suite and not in_matrix:
                 continue
             gated = f"outputs.{key}" in text
             step_gated = any(f"outputs.{key}" in str(s.get("if", "")) for s in job.get("steps", []))
             job_gated = f"outputs.{key}" in str(job.get("if", ""))
             if gated or job_gated or step_gated:
-                executed = True  # arm (i)
-            elif "${{ matrix.suite }}" in text:
-                continue  # matrix job: gating checked per suite below
-            else:
-                executed = True  # arm (ii): runs regardless of selection
+                executed = True  # arm (i): selection-gated execution
+            elif not in_matrix:
+                executed = True  # arm (ii): always-run execution (e.g. package in build)
+            # A matrix lane counts ONLY when the output key gates the job
+            # somewhere (job- or step-level `if`) — an ungated matrix lane is
+            # fail-closed: not counted here.
         assert executed, (
             f"suite {suite} is selectable but no ci.yml job executes it through "
             "either the selection-gated or always-run arm (orphan suite)"
@@ -894,9 +986,9 @@ def test_false_positive_scan_lane_is_gate_consumed():
         if "ci.py run false-positive-scan" in str(job)
     )
     gate = workflow["jobs"]["pr-gate"]
-    assert (
-        scan_job in gate["needs"]
-    ), f"job {scan_job} executes the scanner but is absent from pr-gate needs"
+    assert scan_job in gate["needs"], (
+        f"job {scan_job} executes the scanner but is absent from pr-gate needs"
+    )
     validate_step = next(s for s in gate["steps"] if "Validate required" in str(s.get("name", "")))
     snippet = str(validate_step["run"])
     assert "SCAN" in validate_step["env"], "pr-gate must map the scanner result to SCAN"

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -54,9 +54,28 @@ def test_docs_only_change_selects_no_runtime_suite():
 def test_backend_change_selects_production_python_suite():
     assert ci.select_pr_suites(["app/services/auth_service.py"]) == [
         "default-collection",
+        "false-positive-scan",
         "python-core",
         "python-min",
     ]
+
+
+def test_every_non_docs_change_selects_false_positive_scan():
+    """#3186 Phase A: the scanner lane rides on every non-docs change.
+
+    The docs promise "每个非文档改动都跑" is now literally what the selector
+    implements — a tests-only change, a product-code change, a scanner-script
+    change, and an empty-changes push all select it; only docs-only does not.
+    """
+    for changed in (
+        ["tests/unit/test_example.py"],  # plain test change / new test
+        ["app/services/auth_service.py"],  # product code
+        ["scripts/scan_test_false_positives.py"],  # the scanner itself
+        ["ci/false-positive-ledger.json"],  # ledger edit (also policy)
+        [],  # empty change set
+    ):
+        assert "false-positive-scan" in ci.select_pr_suites(changed), changed
+    assert "false-positive-scan" not in ci.select_pr_suites(["README.md"])
 
 
 def test_min_supported_python_runs_the_full_unit_suite():
@@ -82,15 +101,15 @@ def test_min_supported_python_runs_the_full_unit_suite():
     suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
     commands = suites["python-min"]["commands"]
     flat = [tuple(c) for c in commands]
-    assert any(
-        c[:3] == ("{python}", "-m", "compileall") for c in flat
-    ), "python-min must compileall"
+    assert any(c[:3] == ("{python}", "-m", "compileall") for c in flat), (
+        "python-min must compileall"
+    )
     pytest_cmd = next((c for c in flat if c[:3] == ("{python}", "-m", "pytest")), None)
     assert pytest_cmd is not None, "python-min must run pytest"
     # The WHOLE unit tree, not a hand-picked subset — that is the #2868 fix.
-    assert (
-        "tests/unit/" in pytest_cmd
-    ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
+    assert "tests/unit/" in pytest_cmd, (
+        f"python-min must run the full tests/unit/, got {pytest_cmd}"
+    )
 
 
 def test_python_min_timeout_budget_absorbs_runner_variance():
@@ -358,3 +377,570 @@ def test_changed_files_includes_committed_and_local_worktree_changes(monkeypatch
             text=True,
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Known-debt ledger contract (#3186 Phase A)
+# ---------------------------------------------------------------------------
+
+KNOWN_DEBT_FROZEN_SEED = (
+    (
+        "erroneous_skip",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_batch_session_termination",
+    ),
+    (
+        "no_assertion",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_batch_session_termination",
+    ),
+    (
+        "erroneous_skip",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_deregister_with_active_session",
+    ),
+    (
+        "no_assertion",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_deregister_with_active_session",
+    ),
+    (
+        "erroneous_skip",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_full_deregistration_flow",
+    ),
+    (
+        "no_assertion",
+        "tests/e2e/remote/test_deregister_e2e.py",
+        "TestDeregisterE2E.test_full_deregistration_flow",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestErrorHandlingIntegration.test_degraded_status_on_partial_failure",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestErrorHandlingIntegration.test_idempotent_collection",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestPerformanceIntegration.test_100_users_performance",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestPerformanceIntegration.test_large_file_handling",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestPermission700Collection.test_message_count_correct",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestPermission700Collection.test_two_users_permission_700_collected",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestPermission700Collection.test_user_id_mapping_correct",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestSecurityIntegration.test_symlink_attack_blocked",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_fetch_wrapper_integration_2543.py",
+        "TestSecurityIntegration.test_web_service_cannot_read_other_users",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_coverage_data_in_result",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_coverage_data_in_result",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_multi_user_session_collection",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_multi_user_session_collection",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_session_data_persistence",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_session_data_persistence",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_single_user_session_collection",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_single_user_session_collection",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_tenant_attribution",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_tenant_attribution",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_user_id_resolution",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_multiuser_qwen_collection_2735.py",
+        "TestMultiUserQwenCollection.test_user_id_resolution",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_agent_sessions_user_id_filled",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_agent_sessions_user_id_filled",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_daily_messages_user_id_filled",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_daily_messages_user_id_filled",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_tenant_isolation_in_aggregation",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestTenantAttribution.test_tenant_summary_includes_qwen_data",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_by_username",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_by_username",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_returns_correct_id",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_qwen_user_attribution_2735.py",
+        "TestUserIdResolution.test_resolve_user_id_returns_none_for_unknown",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_system_user_sync_2735.py",
+        "TestSystemUserSync.test_sync_failure_logging",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_system_user_sync_2735.py",
+        "TestSystemUserSync.test_sync_failure_logging",
+    ),
+    (
+        "erroneous_skip",
+        "tests/integration/test_system_user_sync_2735.py",
+        "TestSystemUserSync.test_sync_system_users_creates_users",
+    ),
+    (
+        "no_assertion",
+        "tests/integration/test_system_user_sync_2735.py",
+        "TestSystemUserSync.test_sync_system_users_creates_users",
+    ),
+    (
+        "erroneous_skip",
+        "tests/performance/test_qwen_performance_2735.py",
+        "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+    ),
+    (
+        "no_assertion",
+        "tests/performance/test_qwen_performance_2735.py",
+        "TestPerformanceWithDatabase.test_100_session_files_with_db_performance",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_agent_transport.py",
+        "test_shutdown_on_an_already_dead_process_does_not_raise",
+    ),
+    ("no_assertion", "tests/unit/test_analytics_routes.py", "TestParseDateRange.test_route"),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestAuditLogging.test_audit_log_created",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestAuditLogging.test_username_sanitized",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestFileSizeLimits.test_large_file_rejected",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestIntegration.test_degraded_status_on_partial_failure",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestIntegration.test_multi_user_collection_with_permission_700",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestParameterValidation.test_exact_match_valid_params",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestUserIdentityMapping.test_no_match_returns_none",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestUserIdentityMapping.test_resolve_user_id_by_system_account",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_fetch_wrapper_2543.py",
+        "TestUserIdentityMapping.test_resolve_user_id_by_username",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_issue_wrong_repo_3075.py",
+        "TestIssueRepoFallback.test_fallback_raises_githubopserror",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_new_project_local_repo_init_2963.py",
+        "TestValidateProjectPath.test_pass_if_valid_git_repository",
+    ),
+    ("no_assertion", "tests/unit/test_openace_gh_wrapper.py", "test_admin_merge_is_config_gated"),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_gh_wrapper.py",
+        "test_current_github_ops_gh_shapes_are_allowed",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_gh_wrapper.py",
+        "test_dangerous_gh_shapes_are_denied",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_gh_wrapper.py",
+        "test_version_and_help_are_only_standalone_passthrough",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_current_github_ops_git_shapes_are_allowed",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_forbidden_global_options_and_configs_are_denied",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_git_commands_require_hardening_globals",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_mutating_branches_are_limited_to_workflow_branches",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_relative_path_operands_cannot_escape_worktree",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_show_tree_paths_allow_real_filenames_but_not_escapes",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_openace_git_wrapper.py",
+        "test_version_and_help_are_only_standalone_passthrough",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_client.py",
+        "test_delete_sandbox_treats_404_as_success",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_policy.py",
+        "test_a_cni_tier_accepts_any_public_proxy_host",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_policy.py",
+        "test_an_allowlisted_proxy_url_passes",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_provider.py",
+        "test_destroy_attribution_never_raises",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_wiring.py",
+        "test_sweep_survives_a_provider_failure_on_one_row",
+    ),
+    (
+        "no_assertion",
+        "tests/unit/test_opensandbox_workspace.py",
+        "test_apply_deleting_a_missing_path_is_not_an_error",
+    ),
+)
+
+KNOWN_DEBT_LEDGER_SIZE = 77
+
+
+def _ledger_identities() -> set[tuple[str, str, str]]:
+    import json
+
+    data = json.loads((ROOT / "ci" / "false-positive-ledger.json").read_text())
+    return {(e["pattern"], e["file"], e.get("function") or "<module>") for e in data["entries"]}
+
+
+def test_known_debt_ledger_is_frozen_seed_and_only_shrinks():
+    """#3186: the known-debt ledger starts EXACTLY as the frozen seed and only shrinks.
+
+    Three properties, all load-bearing:
+    1. entries ⊆ KNOWN_DEBT_FROZEN_SEED — substitution is programmatically red:
+       "fix A, introduce B, hand-edit the ledger to add B" fails here because
+       B is not in the frozen seed. Enrollment is impossible via --prune-ledger
+       (removal-only by design).
+    2. len == KNOWN_DEBT_LEDGER_SIZE — the EXACT size pin is the only guard
+       against RE-enrolling an identity that was already paid down but still
+       sits in the frozen seed (⊆ passes, size red). Do NOT relax this to <=.
+       A legitimate paydown (Phase B) shrinks the ledger AND edits this pin
+       in the same PR — that visible pin edit is the audit trail.
+    3. every ledger entry still matches a live finding — a stale entry means
+       someone moved/renamed debt without pruning; the CI scanner job fails
+       on stale entries too, this keeps the unit lane honest as well.
+    """
+    identities = _ledger_identities()
+    assert identities <= set(KNOWN_DEBT_FROZEN_SEED), (
+        "ledger contains identities outside the frozen seed (substitution or "
+        "enrollment attempt): "
+        f"{sorted(identities - set(KNOWN_DEBT_FROZEN_SEED))}"
+    )
+    assert len(identities) == KNOWN_DEBT_LEDGER_SIZE, (
+        f"known-debt ledger size {len(identities)} != pin {KNOWN_DEBT_LEDGER_SIZE}; "
+        "legitimate shrink: prune the ledger AND lower this pin in the same PR; "
+        "growth is never allowed (fix the finding instead)"
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "scan_fp", ROOT / "scripts" / "scan_test_false_positives.py"
+    )
+    assert spec and spec.loader
+    scanner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scanner)
+    live = set(scanner._current_counts(scanner.scan_tests(ROOT / "tests"), ROOT))
+    assert identities <= live, (
+        f"stale ledger entries (debt moved/fixed): {sorted(identities - live)}"
+    )
+
+
+def test_every_selectable_pr_suite_has_a_workflow_consumer():
+    """#3186 Phase A req 4: no selectable suite may be a workflow orphan.
+
+    For every suite the selector can pick (pr_suites), the ci.yml `changes`
+    job must expose its output key, and some job must actually execute the
+    suite, via either arm:
+      (i) selection-gated: a job/step `if` references outputs.<key> and the
+          job runs `ci.py run <suite>` (matrix entries resolve to their
+          `ci.py run ${{ matrix.suite }}` job); or
+      (ii) always-run: a step runs `ci.py run <suite>` with no `if` gating on
+          that suite's output (e.g. `package` inside `build`).
+    A registered-but-never-executed suite (the pre-#3186 false-positive-scan
+    situation) fails here.
+    """
+    import json
+
+    pr_suites = json.loads((ROOT / "ci" / "suites.json").read_text())["pr_suites"]
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+
+    changes_outputs = set(workflow["jobs"]["changes"]["outputs"])
+    # Every suite name's snake_case key must be exposed by the changes job.
+    for suite in pr_suites:
+        key = suite.replace("-", "_")
+        assert key in changes_outputs, f"suite {suite}: changes job does not expose {key}"
+
+    def job_text(job: dict) -> str:
+        import json as _json
+
+        return _json.dumps(job)
+
+    for suite in sorted(pr_suites):
+        key = suite.replace("-", "_")
+        executed = False
+        for job in workflow["jobs"].values():
+            if (
+                job is None
+                or "runs" not in job_text(job)
+                and "run" not in str(job.get("steps", []))
+            ):
+                pass
+            text = job_text(job)
+            runs_suite = f"run {suite}" in text or (
+                "${{ matrix.suite }}" in text
+                and any(
+                    inc.get("suite") == suite
+                    for inc in job.get("strategy", {}).get("matrix", {}).get("include", [])
+                )
+            )
+            if not runs_suite:
+                continue
+            gated = f"outputs.{key}" in text
+            step_gated = any(f"outputs.{key}" in str(s.get("if", "")) for s in job.get("steps", []))
+            job_gated = f"outputs.{key}" in str(job.get("if", ""))
+            if gated or job_gated or step_gated:
+                executed = True  # arm (i)
+            elif "${{ matrix.suite }}" in text:
+                continue  # matrix job: gating checked per suite below
+            else:
+                executed = True  # arm (ii): runs regardless of selection
+        assert executed, (
+            f"suite {suite} is selectable but no ci.yml job executes it through "
+            "either the selection-gated or always-run arm (orphan suite)"
+        )
+
+
+def test_false_positive_scan_lane_is_gate_consumed():
+    """#3186 Phase A req 3: the scanner lane's result must feed PR Gate.
+
+    Executing is not enough — an advisory job would pass the consumer test
+    above. The job that runs `ci.py run false-positive-scan` must be in
+    pr-gate's `needs` AND its result variable must appear in the validation
+    snippet, so a red scanner blocks merge.
+    """
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    scan_job = next(
+        name
+        for name, job in workflow["jobs"].items()
+        if "ci.py run false-positive-scan" in str(job)
+    )
+    gate = workflow["jobs"]["pr-gate"]
+    assert scan_job in gate["needs"], (
+        f"job {scan_job} executes the scanner but is absent from pr-gate needs"
+    )
+    validate_step = next(s for s in gate["steps"] if "Validate required" in str(s.get("name", "")))
+    snippet = str(validate_step["run"])
+    assert "SCAN" in validate_step["env"], "pr-gate must map the scanner result to SCAN"
+    assert '"SCAN"' in snippet, "the pr-gate validation dict must consume SCAN"
+
+
+def test_workflow_suite_references_resolve():
+    """Every `ci.py run <name>` and changes output key in ci.yml is a real suite."""
+    import json
+    import re
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    run_texts = [
+        str(step.get("run", ""))
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if isinstance(step, dict)
+    ]
+    for run_text in run_texts:
+        for name in re.findall(r"ci\.py run ([a-z][a-z0-9-]*[a-z0-9])", run_text):
+            assert name in suites, f"ci.yml runs unknown suite {name!r}"
+    for key in workflow["jobs"]["changes"]["outputs"]:
+        if key == "selected":
+            continue
+        assert key.replace("_", "-") in suites, f"changes output {key!r} has no suite"
+
+
+def test_false_positive_scan_suite_command_shape():
+    """The scanner suite must scan the whole tests/ tree against the ledger.
+
+    Narrowing the scan via suites.json (--exclude-dirs/--pattern/another
+    target) is the only remaining way to hide new debt without touching the
+    ledger; this pin makes any such narrowing a visible contract change.
+    """
+    import json
+
+    suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
+    assert suites["false-positive-scan"]["commands"] == [
+        [
+            "{python}",
+            "scripts/scan_test_false_positives.py",
+            "tests",
+            "--ledger",
+            "ci/false-positive-ledger.json",
+        ]
+    ], suites["false-positive-scan"]["commands"]

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -101,15 +101,15 @@ def test_min_supported_python_runs_the_full_unit_suite():
     suites = json.loads((ROOT / "ci" / "suites.json").read_text())["suites"]
     commands = suites["python-min"]["commands"]
     flat = [tuple(c) for c in commands]
-    assert any(c[:3] == ("{python}", "-m", "compileall") for c in flat), (
-        "python-min must compileall"
-    )
+    assert any(
+        c[:3] == ("{python}", "-m", "compileall") for c in flat
+    ), "python-min must compileall"
     pytest_cmd = next((c for c in flat if c[:3] == ("{python}", "-m", "pytest")), None)
     assert pytest_cmd is not None, "python-min must run pytest"
     # The WHOLE unit tree, not a hand-picked subset — that is the #2868 fix.
-    assert "tests/unit/" in pytest_cmd, (
-        f"python-min must run the full tests/unit/, got {pytest_cmd}"
-    )
+    assert (
+        "tests/unit/" in pytest_cmd
+    ), f"python-min must run the full tests/unit/, got {pytest_cmd}"
 
 
 def test_python_min_timeout_budget_absorbs_runner_variance():
@@ -904,9 +904,9 @@ def test_known_debt_ledger_is_frozen_seed_and_only_shrinks():
     scanner = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(scanner)
     live = scanner._current_counts(scanner.scan_tests(ROOT / "tests"), ROOT)
-    assert all(counts[identity] <= live.get(identity, 0) for identity in ledger_ids), (
-        f"stale ledger entries (debt moved/fixed): {sorted(ledger_ids - set(live))}"
-    )
+    assert all(
+        counts[identity] <= live.get(identity, 0) for identity in ledger_ids
+    ), f"stale ledger entries (debt moved/fixed): {sorted(ledger_ids - set(live))}"
 
 
 def test_every_selectable_pr_suite_has_a_workflow_consumer():
@@ -986,9 +986,9 @@ def test_false_positive_scan_lane_is_gate_consumed():
         if "ci.py run false-positive-scan" in str(job)
     )
     gate = workflow["jobs"]["pr-gate"]
-    assert scan_job in gate["needs"], (
-        f"job {scan_job} executes the scanner but is absent from pr-gate needs"
-    )
+    assert (
+        scan_job in gate["needs"]
+    ), f"job {scan_job} executes the scanner but is absent from pr-gate needs"
     validate_step = next(s for s in gate["steps"] if "Validate required" in str(s.get("name", "")))
     snippet = str(validate_step["run"])
     assert "SCAN" in validate_step["env"], "pr-gate must map the scanner result to SCAN"

--- a/tests/unit/test_scan_false_positives.py
+++ b/tests/unit/test_scan_false_positives.py
@@ -333,3 +333,200 @@ def test_annotation_template_validation() -> None:
 
     # Unknown pattern type
     assert not validate_annotation_content("any reason", "unknown-pattern")
+
+
+# ---- known-debt ledger mode (#3186 Phase A) ----
+#
+# The ledger compares per-finding IDENTITIES (pattern + file + class-qualified
+# function) count-exactly, so new debt is red, fixed debt must be pruned, and
+# pruning can never enroll anything.
+
+
+def _run_ledger(tmp_path: Path, *extra: str, scan: str | None = None):
+    return subprocess.run(
+        [sys.executable, str(SCANNER), str(tmp_path if scan is None else scan), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _entry(tmp_path: Path, rel: str, pattern: str, function: str, count: int = 1) -> dict:
+    return {
+        "pattern": pattern,
+        "file": str(tmp_path / rel),
+        "function": function,
+        "count": count,
+    }
+
+
+def _write_ledger(tmp_path: Path, entries: list[dict]) -> Path:
+    import json
+
+    ledger = tmp_path / "ledger.json"
+    ledger.write_text(json.dumps({"version": 1, "entries": entries}, indent=2))
+    return ledger
+
+
+TWO_CLASS_SAME_NAME = """\
+class TestA:
+    def test_foo(self):
+        do_thing()
+
+class TestB:
+    def test_foo(self):
+        do_other()
+"""
+
+MODULE_LEVEL_SWALLOW = """\
+try:
+    setup()
+except Exception:
+    pass
+
+def test_ok():
+    assert setup() is not None
+"""
+
+
+def test_ledger_green_when_exact(tmp_path: Path) -> None:
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(tmp_path, [_entry(tmp_path, "test_x.py", "no_assertion", "test_b")])
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "mirrors reality" in proc.stdout
+
+
+def test_ledger_green_covers_known_p0_debt(tmp_path: Path) -> None:
+    """The known P0s must pass under the ledger (early return before the P0 rule)."""
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(tmp_path, [_entry(tmp_path, "test_x.py", "no_assertion", "test_b")])
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_ledger_fails_on_unknown_finding(tmp_path: Path) -> None:
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(tmp_path, [])
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "unknown finding" in proc.stdout
+
+
+def test_ledger_fails_on_stale_entry(tmp_path: Path) -> None:
+    """A fixed finding without ledger pruning is red (ledger mirrors reality)."""
+    ledger = _write_ledger(tmp_path, [_entry(tmp_path, "test_x.py", "no_assertion", "test_b")])
+    _write(tmp_path, "test_clean.py", "def test_ok():\n    assert True\n")
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "stale ledger entry" in proc.stdout
+
+
+def test_ledger_count_exact_same_identity(tmp_path: Path) -> None:
+    """Two hits under one identity need count 2; a second silent hit is red."""
+    two_swallows = (
+        "def test_double():\n"
+        "    try:\n        a()\n    except Exception:\n        pass\n"
+        "    try:\n        b()\n    except Exception:\n        pass\n"
+        "    assert True\n"
+    )
+    _write(tmp_path, "test_double.py", two_swallows)
+    short = _write_ledger(
+        tmp_path, [_entry(tmp_path, "test_double.py", "broad_except_swallow", "test_double", 1)]
+    )
+    proc = _run_ledger(tmp_path, "--ledger", str(short))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    exact = _write_ledger(
+        tmp_path, [_entry(tmp_path, "test_double.py", "broad_except_swallow", "test_double", 2)]
+    )
+    proc = _run_ledger(tmp_path, "--ledger", str(exact))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_ledger_identity_is_class_qualified(tmp_path: Path) -> None:
+    """Same-named methods in different classes are distinct identities."""
+    _write(tmp_path, "test_cls.py", TWO_CLASS_SAME_NAME)
+    half = _write_ledger(
+        tmp_path, [_entry(tmp_path, "test_cls.py", "no_assertion", "TestA.test_foo")]
+    )
+    proc = _run_ledger(tmp_path, "--ledger", str(half))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "TestB.test_foo" in proc.stdout
+    full = _write_ledger(
+        tmp_path,
+        [
+            _entry(tmp_path, "test_cls.py", "no_assertion", "TestA.test_foo"),
+            _entry(tmp_path, "test_cls.py", "no_assertion", "TestB.test_foo"),
+        ],
+    )
+    proc = _run_ledger(tmp_path, "--ledger", str(full))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_ledger_module_level_identity(tmp_path: Path) -> None:
+    _write(tmp_path, "test_mod.py", MODULE_LEVEL_SWALLOW)
+    ledger = _write_ledger(
+        tmp_path, [_entry(tmp_path, "test_mod.py", "broad_except_swallow", "<module>")]
+    )
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_prune_removes_stale_entries(tmp_path: Path) -> None:
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(
+        tmp_path,
+        [
+            _entry(tmp_path, "test_x.py", "no_assertion", "test_b"),
+            _entry(tmp_path, "test_gone.py", "no_assertion", "test_b"),
+        ],
+    )
+    proc = _run_ledger(tmp_path, "--prune-ledger", str(ledger))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    import json
+
+    data = json.loads(ledger.read_text())
+    assert [e["function"] for e in data["entries"]] == ["test_b"]
+    assert "removed (fixed)" in proc.stdout
+
+
+def test_prune_refuses_unknown_finding(tmp_path: Path) -> None:
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(tmp_path, [])
+    proc = _run_ledger(tmp_path, "--prune-ledger", str(ledger))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "cannot enroll" in proc.stdout
+    import json
+
+    assert json.loads(ledger.read_text())["entries"] == []
+
+
+def test_prune_refuses_count_increase(tmp_path: Path) -> None:
+    module_two = (
+        "try:\n    a()\nexcept Exception:\n    pass\n"
+        "try:\n    b()\nexcept Exception:\n    pass\n"
+        "def test_ok():\n    assert True\n"
+    )
+    _write(tmp_path, "test_mod2.py", module_two)
+    ledger = _write_ledger(
+        tmp_path, [_entry(tmp_path, "test_mod2.py", "broad_except_swallow", "<module>", 1)]
+    )
+    proc = _run_ledger(tmp_path, "--prune-ledger", str(ledger))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "cannot raise counts" in proc.stdout
+
+
+def test_prune_noop_when_mirroring(tmp_path: Path) -> None:
+    _write(tmp_path, "test_x.py", NO_ASSERT)
+    ledger = _write_ledger(tmp_path, [_entry(tmp_path, "test_x.py", "no_assertion", "test_b")])
+    before = ledger.read_text()
+    proc = _run_ledger(tmp_path, "--prune-ledger", str(ledger))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert ledger.read_text() == before
+    assert "no changes" in proc.stdout
+
+
+def test_ledger_and_prune_are_mutually_exclusive(tmp_path: Path) -> None:
+    ledger = _write_ledger(tmp_path, [])
+    proc = _run_ledger(tmp_path, "--ledger", str(ledger), "--prune-ledger", str(ledger))
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "mutually exclusive" in proc.stdout


### PR DESCRIPTION
Implements #3186 Phase A (plan + two independent review rounds: plan comment, rev1, rev2 verdict CLEAN, rev3 fold-ins — all on the issue).

## What was broken
`false-positive-scan` was registered in `ci/suites.json` + listed in `pr_suites` + documented as "runs on every non-docs change" — but no ci.yml job ever executed it, pr-gate never saw it, and the count-only baseline could not stop fix-A-introduce-B substitution. While unwired, **8 new no_assertion P0s merged through green required CI** (69 → 77 findings), from the opensandbox cluster (#3205/#2023), test_agent_transport (d02c0113), test_analytics_routes (dd2399d0).

## Changes
1. **Precise known-debt ledger** `ci/false-positive-ledger.json`: the 77 current findings by exact identity — `pattern + repo-relative file + class-qualified function` (`Class.test_foo`; `<module>` fallback). Count-based `.false-positive-baseline.json` retired (refs updated in `ci/suites.json`, `ci/ci-health-policy.json` ×4 lists; scanner script added to contract_paths).
2. **Scanner ledger modes** (detection rules untouched; `Finding` gains a class-qualified `function` field):
   - `--ledger`: count-exact identity compare — unknown finding → exit 1; stale entry (fixed but not pruned) → exit 1; all-known P0s → exit 0 (early return before the P0 rule).
   - `--prune-ledger`: **removal-only** — refuses unknown identities and count increases; pruning can never enroll debt; no-op leaves the file untouched.
3. **Selector**: `false-positive-scan` in the default set for every non-docs change + the empty-changes path — the documented promise, now literal.
4. **ci.yml**: `changes` exposes `false_positive_scan`; new `false-positive-scan` job (checkout + setup-python, stdlib-only so no pip install) runs `python scripts/ci.py run false-positive-scan` — same runner/contract as local; **PR Gate** adds it to `needs` and consumes `SCAN` (success|skipped). No advisory, no continue-on-error, no skip label.
5. **Contracts** (`tests/unit/test_ci_runner.py`):
   - `FROZEN_SEED` pin: ledger ⊆ 77-entry frozen seed + exact size — substitution (B ∉ seed) and re-enrollment (size grows back) are programmatically red; legitimate Phase B paydown edits the pin in the same PR (that edit is the audit trail).
   - Generic no-orphan-suite test: every `pr_suites` entry must have a workflow consumer (selection-gated arm incl. matrix resolution, or always-run arm like `package` in `build`).
   - Scanner lane is pr-gate-consumed (job in `needs`, `SCAN` in the validation dict) — guards against silent demotion to advisory.
   - Workflow suite references resolve; suite command shape pinned (whole `tests/` tree, ledger path — the only remaining hiding vector, now a visible contract change).
6. **Ledger-mode unit tests** (13): unknown/stale/count-exact/class-qualified identity/module-level/mutual-exclusion/refusal paths/no-op prune byte-stability.
7. **docs/TEST_LAYERS.md**: real trigger scope + shrink-only rule.

## Local verification
- `pytest tests/unit/test_ci_runner.py tests/unit/test_scan_false_positives.py` → **63 passed** (incl. new contracts).
- Collateral suites.json consumers: `test_acceptance_verifier_hardening_2431.py`, `test_ci_health_metrics.py`, `test_scheduled_workflow_contracts.py`, `test_extended_workflow_contracts.py` → 104 passed; default collection 12384 tests.
- `python scripts/ci.py run false-positive-scan` → green (77/77 known debt) in 1.7s; `ci.py detect` selects it for a policy change.
- Negative controls executed: synthetic no-assert file → `--ledger` exit 1 + `--prune-ledger` refusal, ledger byte-unchanged; removing the ci.yml job → both consumer contract tests red, restored → green.

## After merge (per plan)
Real negative evidence on a throwaway branch: synthetic finding → scanner job + PR Gate red on Actions, record URL/SHA, delete branch. Then Phase B burn-down starts with the 8 new regressions.