### PR TITLE
test: pay down the 8 scanner-unwired regressions with real assertions (#3186 Phase B batch 1)

### DIFF
--- a/ci/false-positive-ledger.json
+++ b/ci/false-positive-ledger.json
@@ -285,18 +285,6 @@
     },
     {
       "pattern": "no_assertion",
-      "file": "tests/unit/test_agent_transport.py",
-      "function": "test_shutdown_on_an_already_dead_process_does_not_raise",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_analytics_routes.py",
-      "function": "TestParseDateRange.test_route",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
       "file": "tests/unit/test_fetch_wrapper_2543.py",
       "function": "TestAuditLogging.test_audit_log_created",
       "count": 1
@@ -425,42 +413,6 @@
       "pattern": "no_assertion",
       "file": "tests/unit/test_openace_git_wrapper.py",
       "function": "test_version_and_help_are_only_standalone_passthrough",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_client.py",
-      "function": "test_delete_sandbox_treats_404_as_success",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_policy.py",
-      "function": "test_a_cni_tier_accepts_any_public_proxy_host",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_policy.py",
-      "function": "test_an_allowlisted_proxy_url_passes",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_provider.py",
-      "function": "test_destroy_attribution_never_raises",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_wiring.py",
-      "function": "test_sweep_survives_a_provider_failure_on_one_row",
-      "count": 1
-    },
-    {
-      "pattern": "no_assertion",
-      "file": "tests/unit/test_opensandbox_workspace.py",
-      "function": "test_apply_deleting_a_missing_path_is_not_an_error",
       "count": 1
     }
   ]

--- a/tests/unit/test_agent_transport.py
+++ b/tests/unit/test_agent_transport.py
@@ -104,7 +104,7 @@ def test_shutdown_escalates_sigterm_then_sigkill_on_the_process_group():
     # Reproduces today's teardown exactly: SIGTERM, wait, then SIGKILL. The
     # child ignores SIGTERM, so only the escalation ends it.
     process = _spawn(
-        "import signal, time\n" "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n" "time.sleep(60)"
+        "import signal, time\nsignal.signal(signal.SIGTERM, signal.SIG_IGN)\ntime.sleep(60)"
     )
     transport = LocalProcessTransport(process)
     started = time.monotonic()
@@ -117,7 +117,8 @@ def test_shutdown_on_an_already_dead_process_does_not_raise():
     process = _spawn("pass")
     transport = LocalProcessTransport(process)
     transport.wait(timeout=5)
-    transport.shutdown(grace=0.5)
+    assert process.poll() is not None  # premise: dead AND reaped by wait()
+    assert transport.shutdown(grace=0.5) is None
 
 
 def test_local_transport_satisfies_the_protocol():

--- a/tests/unit/test_analytics_routes.py
+++ b/tests/unit/test_analytics_routes.py
@@ -86,7 +86,9 @@ class TestParseDateRange:
         app.config["TESTING"] = True
 
         @app.route("/test")
-        def test_route():
+        def _parse_route():
+            # Not a test: a Flask view registered only so this helper's
+            # request context can exercise parse_date_range() directly.
             return parse_date_range()
 
         return app

--- a/tests/unit/test_ci_runner.py
+++ b/tests/unit/test_ci_runner.py
@@ -843,7 +843,7 @@ KNOWN_DEBT_FROZEN_SEED = (
     ),
 )
 
-KNOWN_DEBT_FINDING_TOTAL = 77  # total findings across all seed entries
+KNOWN_DEBT_FINDING_TOTAL = 69  # total findings across all seed entries (#3186 batch 1: 77 -> 69)
 
 
 def _ledger_counts() -> dict[tuple[str, str, str], int]:

--- a/tests/unit/test_opensandbox_client.py
+++ b/tests/unit/test_opensandbox_client.py
@@ -146,6 +146,8 @@ def test_delete_sandbox_treats_404_as_success():
     # destroy() must be idempotent per the #2022 contract.
     session = _Session([_Response(404, {"code": "NOT_FOUND", "message": "gone"})])
     _api(session).delete_sandbox("sb-1")
+    # The 404 was consumed by exactly one DELETE: no retry, no other traffic.
+    assert [c["method"] for c in session.calls] == ["DELETE"]
 
 
 def test_get_sandbox_returns_none_on_404():
@@ -666,11 +668,7 @@ def test_a_truncated_tail_is_dropped_in_the_BARE_shape_too():
 
 def test_corruption_mid_stream_is_still_surfaced_in_the_bare_shape():
     """Only the FINAL event may be dropped — a lost middle event is a real signal."""
-    body = (
-        b'{"type":"stdout","text":"a"}\n\n'
-        b"{TRUNCATED-MIDDLE\n\n"
-        b'{"type":"execution_complete"}\n\n'
-    )
+    body = b'{"type":"stdout","text":"a"}\n\n{TRUNCATED-MIDDLE\n\n{"type":"execution_complete"}\n\n'
     types = [e["type"] for e in iter_sse_events(_Response(200, content=body))]
     assert types == ["stdout", "error", "execution_complete"], types
 

--- a/tests/unit/test_opensandbox_policy.py
+++ b/tests/unit/test_opensandbox_policy.py
@@ -790,7 +790,10 @@ def test_an_allowlisted_proxy_url_passes():
     from app.modules.workspace.autonomous.sandbox.opensandbox.policy import assert_proxy_reachable
 
     cfg = _cfg()
-    assert_proxy_reachable({"ANTHROPIC_BASE_URL": "https://api.anthropic.com/v1"}, _endpoint(cfg))
+    endpoint = _endpoint(cfg)
+    # The host is admitted BY THE ALLOWLIST, not by skipping the check.
+    assert "api.anthropic.com" in endpoint.egress_allow_hosts
+    assert_proxy_reachable({"ANTHROPIC_BASE_URL": "https://api.anthropic.com/v1"}, endpoint)
 
 
 def test_a_cni_tier_accepts_any_public_proxy_host():
@@ -802,6 +805,8 @@ def test_a_cni_tier_accepts_any_public_proxy_host():
     from app.modules.workspace.autonomous.sandbox.opensandbox.policy import assert_proxy_reachable
 
     endpoint = _endpoint(_cni_cfg())
+    # Premise: this tier genuinely has no allowlist to consult.
+    assert endpoint.egress_allow_hosts == ()
     assert_proxy_reachable({"ANTHROPIC_BASE_URL": "https://proxy.example.com/api"}, endpoint)
 
 

--- a/tests/unit/test_opensandbox_provider.py
+++ b/tests/unit/test_opensandbox_provider.py
@@ -624,8 +624,12 @@ def test_destroy_attribution_works_without_a_live_handle():
 
 
 def test_destroy_attribution_never_raises():
-    provider, _ = _provider()
+    provider, api = _provider()
     provider.destroy_attribution("sb-unknown", None)
+    # Locate-before-delete: an unknown attribution is a reporting no-op — a
+    # blind DELETE whose 404 counts as success would be indistinguishable
+    # from destroying the wrong server's sandbox.
+    assert api.deleted == set()
 
 
 def test_reconcile_orphans_destroys_only_unclaimed_sandboxes():

--- a/tests/unit/test_opensandbox_wiring.py
+++ b/tests/unit/test_opensandbox_wiring.py
@@ -126,8 +126,10 @@ def test_sweep_survives_a_provider_failure_on_one_row(api, monkeypatch):
         "sandbox_id": "sb-1",
         "sandbox_remote_session_id": None,
     }
-    # One bad row must never abort a sweep that walks many.
-    _destroy_orphan_sandbox(wf, remote_session_manager=None)
+    # One bad row must never abort a sweep that walks many — and the caller
+    # must LEARN the teardown failed (False) so it keeps the persisted ids
+    # for a retry instead of stranding a live sandbox.
+    assert _destroy_orphan_sandbox(wf, remote_session_manager=None) is False
 
 
 # ── agent-runner wiring (spec §6.5, §6.6) ─────────────────────────────
@@ -264,8 +266,7 @@ def test_select_sandbox_provider_returns_the_injected_one_without_config(monkeyp
 
     monkeypatch.delenv("OPENACE_SANDBOX_BACKENDS", raising=False)
     monkeypatch.setattr(
-        "app.modules.workspace.autonomous.sandbox.opensandbox.config."
-        "DEFAULT_BACKEND_CONFIG_PATH",
+        "app.modules.workspace.autonomous.sandbox.opensandbox.config.DEFAULT_BACKEND_CONFIG_PATH",
         str(tmp_path / "etc.json"),
     )
     monkeypatch.setattr(
@@ -785,6 +786,6 @@ def test_a_failing_destroy_does_not_replace_the_original_error(api, tmp_path, mo
 
     result = _run_local_against(_DestroyRaises(inner), worktree, monkeypatch)
     assert result.success is False
-    assert "upgrade refused" in (
-        result.error or ""
-    ), f"the destroy failure replaced the original error: {result.error!r}"
+    assert "upgrade refused" in (result.error or ""), (
+        f"the destroy failure replaced the original error: {result.error!r}"
+    )

--- a/tests/unit/test_opensandbox_wiring.py
+++ b/tests/unit/test_opensandbox_wiring.py
@@ -786,6 +786,6 @@ def test_a_failing_destroy_does_not_replace_the_original_error(api, tmp_path, mo
 
     result = _run_local_against(_DestroyRaises(inner), worktree, monkeypatch)
     assert result.success is False
-    assert "upgrade refused" in (result.error or ""), (
-        f"the destroy failure replaced the original error: {result.error!r}"
-    )
+    assert "upgrade refused" in (
+        result.error or ""
+    ), f"the destroy failure replaced the original error: {result.error!r}"

--- a/tests/unit/test_opensandbox_workspace.py
+++ b/tests/unit/test_opensandbox_workspace.py
@@ -272,8 +272,14 @@ def test_apply_sets_the_declared_mode(tmp_path):
 
 def test_apply_deleting_a_missing_path_is_not_an_error(tmp_path):
     apply_changeset(
-        [], root=str(tmp_path), limits=_limits(), fetch=lambda p: b"", deleted=["nope.py"]
+        [ChangeSetEntry(path="real.py", mode=0o644, size=3)],
+        root=str(tmp_path),
+        limits=_limits(),
+        fetch=lambda path: b"new",
+        deleted=["nope.py"],
     )
+    # The tolerated missing deletion must not poison the rest of the changeset.
+    assert (tmp_path / "real.py").read_text(encoding="utf-8") == "new"
 
 
 # ── apply verifies delivered bytes, not the manifest's self-report (B6) ──


### PR DESCRIPTION
#3186 Phase B batch 1 — clears the 8 no_assertion P0s that merged while the scanner was unwired (69→77 in the Phase A audit). Disposition plan independently reviewed to **CLEAN** first pass ([plan](https://github.com/open-ace/open-ace/issues/3186#issuecomment-5497501926), [review](https://github.com/open-ace/open-ace/issues/3186) — the reviewer simulated all 8 fixes end-to-end and proved 77→69 before implementation began).

## Per-item final assertions (as implemented)
1. **agent_transport** `test_shutdown_on_an_already_dead_process_does_not_raise` — premise `assert process.poll() is not None` (dead AND reaped by `wait()`), return contract `assert transport.shutdown(grace=0.5) is None` (SUT `transport.py:126-147` has no return path).
2. **analytics_routes** — inner Flask view `test_route` → `_parse_route` (not a collected test; collided with the scanner's `test_*` heuristic; repo precedent `api_test_route`; zero consumers of the old name; URL/bodies untouched).
3. **opensandbox_client** `test_delete_sandbox_treats_404_as_success` — `assert [c["method"] for c in session.calls] == ["DELETE"]`: the 404 was consumed by exactly one DELETE, no retry, no other traffic.
4. **opensandbox_policy** allowlisted — premise proof `assert "api.anthropic.com" in endpoint.egress_allow_hosts` (admitted BY the allowlist, not by skipping the check).
5. **opensandbox_policy** CNI tier — premise proof `assert endpoint.egress_allow_hosts == ()` (the tier genuinely has no allowlist; config makes non-empty + CNI a parse error).
6. **opensandbox_provider** `test_destroy_attribution_never_raises` — `assert api.deleted == set()`: locate-before-delete makes an unknown attribution a reporting no-op (a blind DELETE masked by 404-as-success would be indistinguishable from destroying the wrong server's sandbox).
7. **opensandbox_wiring** `test_sweep_survives_a_provider_failure_on_one_row` — `assert _destroy_orphan_sandbox(...) is False`: the docstring contract (teardown attempted and failed ⇒ report False so the caller keeps persisted ids for retry) was never actually checked.
8. **opensandbox_workspace** missing-deletion — applies a real entry (`ChangeSetEntry(path="real.py", mode=0o644, size=3)`, `fetch` bytes == declared size) alongside `deleted=["nope.py"]` and asserts the file landed: the tolerated deletion must not poison the rest of the changeset.

## Ledger accounting (shrink-only)
`--prune-ledger` removed exactly the 8 identities (removal-only, list printed in the log); `KNOWN_DEBT_FINDING_TOTAL` 77 → **69** edited in the same PR; FROZEN_SEED untouched (`ledger ⊆ seed` still proves no substitution); scanner `--ledger` green with 69/69 known debt.

## Verification
- 318 tests across the 7 touched files green; `tests/unit/test_scan_false_positives.py` 33 green; `tests/unit/test_ci_runner.py` 32 green (incl. the frozen-seed pin at 69).
- `python scripts/ci.py run false-positive-scan` → green ("69 finding identities ... mirrors reality exactly").
- ruff clean. No assertions weakened — pure additions plus one non-collected-helper rename.