### PR TITLE
fix: display error instead of empty state when efficiency API fails

### DIFF
--- a/frontend/src/components/features/analysis/EnterpriseReport.test.tsx
+++ b/frontend/src/components/features/analysis/EnterpriseReport.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { EnterpriseReport } from './EnterpriseReport';
@@ -45,6 +46,8 @@ vi.mock('@/hooks', async (importOriginal) => {
     useEfficiencyMetrics: vi.fn(() => ({
       data: null,
       isLoading: false,
+      isError: false,
+      error: null,
       refetch: vi.fn(),
     })),
     useAuth: vi.fn(() => ({
@@ -173,6 +176,8 @@ describe('EnterpriseReport Component', () => {
         input_output_ratio: 1.0,
       },
       isLoading: false,
+      isError: false,
+      error: null,
       refetch: vi.fn(),
     } as ReturnType<typeof useEfficiencyMetrics>);
 
@@ -227,6 +232,8 @@ describe('EnterpriseReport Component', () => {
     vi.mocked(useEfficiencyMetrics).mockReturnValue({
       data: { efficiency_available: false },
       isLoading: false,
+      isError: false,
+      error: null,
       refetch: vi.fn(),
     } as any);
 
@@ -270,6 +277,8 @@ describe('EnterpriseReport Component', () => {
     vi.mocked(useEfficiencyMetrics).mockReturnValue({
       data: { efficiency_available: false },
       isLoading: false,
+      isError: false,
+      error: null,
       refetch: vi.fn(),
     } as any);
 
@@ -313,6 +322,8 @@ describe('EnterpriseReport Component', () => {
     vi.mocked(useEfficiencyMetrics).mockReturnValue({
       data: { efficiency_available: false },
       isLoading: false,
+      isError: false,
+      error: null,
       refetch: vi.fn(),
     } as any);
 
@@ -359,6 +370,8 @@ describe('EnterpriseReport Component', () => {
       vi.mocked(useEfficiencyMetrics).mockReturnValue({
         data: { efficiency_available: false },
         isLoading: false,
+        isError: false,
+        error: null,
         refetch: vi.fn(),
       } as any);
 
@@ -408,6 +421,8 @@ describe('EnterpriseReport Component', () => {
       vi.mocked(useEfficiencyMetrics).mockReturnValue({
         data: { efficiency_available: false },
         isLoading: false,
+        isError: false,
+        error: null,
         refetch: vi.fn(),
       } as any);
 
@@ -422,6 +437,111 @@ describe('EnterpriseReport Component', () => {
 
       // Should NOT display peak tokens subtitle
       expect(screen.queryByText(/峰值 Tokens:/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Efficiency Metrics Error Handling', () => {
+    it('displays error when efficiency metrics API fails', async () => {
+      const mockReportData = {
+        period: { start: '2024-01-01', end: '2024-01-31' },
+        summary: {
+          total_tokens: 100000,
+          total_input_tokens: 50000,
+          total_output_tokens: 50000,
+          total_requests: 1000,
+          unique_tools: 10,
+          unique_hosts: 5,
+          daily_average_tokens: 3333,
+          daily_average_requests: 33,
+          peak_day: null,
+          peak_tokens: 0,
+        },
+        trends: [],
+        anomalies: [],
+        breakdown_by_tool: {},
+        breakdown_by_host: {},
+      };
+
+      const { useEnterpriseReport, useEfficiencyMetrics } = await import('@/hooks');
+      vi.mocked(useEnterpriseReport).mockReturnValue({
+        data: mockReportData,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      vi.mocked(useEfficiencyMetrics).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('Efficiency API Error'),
+        refetch: vi.fn(),
+      } as any);
+
+      render(<EnterpriseReport />, { wrapper: createWrapper() });
+
+      // Wait for main report to load
+      await waitFor(() => {
+        expect(screen.getByText('总 Tokens')).toBeInTheDocument();
+      });
+
+      // Should display error for efficiency metrics
+      expect(screen.getByText('Efficiency API Error')).toBeInTheDocument();
+      expect(screen.getByText('Retry')).toBeInTheDocument();
+    });
+
+    it('retries efficiency metrics when retry button is clicked', async () => {
+      const refetchMock = vi.fn();
+      const mockReportData = {
+        period: { start: '2024-01-01', end: '2024-01-31' },
+        summary: {
+          total_tokens: 100000,
+          total_input_tokens: 50000,
+          total_output_tokens: 50000,
+          total_requests: 1000,
+          unique_tools: 10,
+          unique_hosts: 5,
+          daily_average_tokens: 3333,
+          daily_average_requests: 33,
+          peak_day: null,
+          peak_tokens: 0,
+        },
+        trends: [],
+        anomalies: [],
+        breakdown_by_tool: {},
+        breakdown_by_host: {},
+      };
+
+      const { useEnterpriseReport, useEfficiencyMetrics } = await import('@/hooks');
+      vi.mocked(useEnterpriseReport).mockReturnValue({
+        data: mockReportData,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      vi.mocked(useEfficiencyMetrics).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('API Error'),
+        refetch: refetchMock,
+      } as any);
+
+      render(<EnterpriseReport />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText('总 Tokens')).toBeInTheDocument();
+      });
+
+      // Click retry button
+      const retryButton = screen.getByText('Retry');
+      await userEvent.click(retryButton);
+
+      // Verify refetch was called
+      expect(refetchMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/components/features/analysis/EnterpriseReport.test.tsx
+++ b/frontend/src/components/features/analysis/EnterpriseReport.test.tsx
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { EnterpriseReport } from './EnterpriseReport';
@@ -538,7 +537,7 @@ describe('EnterpriseReport Component', () => {
 
       // Click retry button
       const retryButton = screen.getByText('Retry');
-      await userEvent.click(retryButton);
+      fireEvent.click(retryButton);
 
       // Verify refetch was called
       expect(refetchMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/features/analysis/EnterpriseReport.tsx
+++ b/frontend/src/components/features/analysis/EnterpriseReport.tsx
@@ -256,12 +256,22 @@ const SummaryCards: React.FC<SummaryCardsProps> = ({ summary, language }) => (
 
 // Efficiency Cards Component
 interface EfficiencyCardsProps {
-  efficiency: EfficiencyMetricsResponse;
+  efficiency: EfficiencyMetricsResponse | undefined;
   isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
   language: Language;
+  onRetry: () => void;
 }
 
-const EfficiencyCards: React.FC<EfficiencyCardsProps> = ({ efficiency, isLoading, language }) => {
+const EfficiencyCards: React.FC<EfficiencyCardsProps> = ({
+  efficiency,
+  isLoading,
+  isError,
+  error,
+  language,
+  onRetry,
+}) => {
   if (isLoading) {
     return (
       <Card title={t('efficiencyMetrics', language)} className="mb-4">
@@ -270,7 +280,15 @@ const EfficiencyCards: React.FC<EfficiencyCardsProps> = ({ efficiency, isLoading
     );
   }
 
-  if (!efficiency.efficiency_available) {
+  if (isError) {
+    return (
+      <Card title={t('efficiencyMetrics', language)} className="mb-4">
+        <Error message={error?.message || t('error', language)} onRetry={onRetry} />
+      </Card>
+    );
+  }
+
+  if (!efficiency || !efficiency.efficiency_available) {
     return (
       <Card title={t('efficiencyMetrics', language)} className="mb-4">
         <EmptyState icon="bi-speedometer" title={t('noEfficiencyData', language)} />
@@ -603,6 +621,8 @@ export const EnterpriseReport: React.FC = () => {
   const {
     data: efficiencyData,
     isLoading: isEfficiencyLoading,
+    isError: isEfficiencyError,
+    error: efficiencyError,
     refetch: refetchEfficiency,
   } = useEfficiencyMetrics(startDate, endDate);
 
@@ -783,9 +803,12 @@ export const EnterpriseReport: React.FC = () => {
 
       {/* Efficiency Cards */}
       <EfficiencyCards
-        efficiency={efficiencyData ?? { efficiency_available: false }}
+        efficiency={efficiencyData}
         isLoading={isEfficiencyLoading}
+        isError={isEfficiencyError}
+        error={efficiencyError}
         language={language}
+        onRetry={refetchEfficiency}
       />
 
       {/* Trends Table */}

--- a/frontend/src/components/features/analysis/EnterpriseReport.tsx
+++ b/frontend/src/components/features/analysis/EnterpriseReport.tsx
@@ -283,12 +283,12 @@ const EfficiencyCards: React.FC<EfficiencyCardsProps> = ({
   if (isError) {
     return (
       <Card title={t('efficiencyMetrics', language)} className="mb-4">
-        <Error message={error?.message || t('error', language)} onRetry={onRetry} />
+        <Error message={error?.message ?? t('error', language)} onRetry={onRetry} />
       </Card>
     );
   }
 
-  if (!efficiency || !efficiency.efficiency_available) {
+  if (!efficiency?.efficiency_available) {
     return (
       <Card title={t('efficiencyMetrics', language)} className="mb-4">
         <EmptyState icon="bi-speedometer" title={t('noEfficiencyData', language)} />


### PR DESCRIPTION
## Issue
Fixes #3260

## Problem
When the efficiency metrics API fails, the Enterprise Report page displays "No efficiency data available" instead of showing the actual error. This masks network errors, server 500 errors, and permission issues.

## Root Cause
The main component only destructures `data` and `isLoading` from `useEfficiencyMetrics`, missing `isError` and `error` fields. When the request fails, `efficiencyData` is `undefined`, and the fallback `{ efficiency_available: false }` triggers the EmptyState component.

## Solution
1. Destructure `isError` and `error` from `useEfficiencyMetrics` hook
2. Add `isError`, `error`, and `onRetry` props to `EfficiencyCards` component
3. Render Error component with retry button when API fails
4. Show EmptyState only when `efficiency_available: false` (successful response with no data)

## Changes
- `frontend/src/components/features/analysis/EnterpriseReport.tsx`
  - Updated hook destructuring to include error state
  - Updated `EfficiencyCardsProps` interface
  - Updated `EfficiencyCards` component to handle error state
  - Updated component call site to pass new props

- `frontend/src/components/features/analysis/EnterpriseReport.test.tsx`
  - Updated all `useEfficiencyMetrics` mocks to include `isError` and `error`
  - Added test for displaying error when efficiency API fails
  - Added test for retry button functionality

## Testing
- [x] Unit tests pass locally
- [x] Error state displays correctly when API fails
- [x] Retry button triggers refetch
- [x] EmptyState still displays when `efficiency_available: false`
- [x] Normal flow unchanged when API succeeds

## Screenshots
N/A - UI change follows existing Error component style