### PR TITLE
fix(#3292): implement audit-log username pseudonymization in fetch wrapper

### DIFF
--- a/scripts/openace-fetch-wrapper
+++ b/scripts/openace-fetch-wrapper
@@ -8,7 +8,8 @@
 # 1. 参数精确匹配白名单（使用参数分离验证）
 # 2. 工具名称白名单校验（支持 fetch_* 下划线格式）
 # 3. 符号链接攻击防护（多层解析、循环检测、路径白名单）
-# 4. 审计日志记录（用户名脱敏）
+# 4. 审计日志记录（caller 恒脱敏；details 中单层 home 段脱敏——
+#    非加密保护，低熵用户名可字典逆推哈希，见 _username_hash 注释）
 # 5. 降权机制（root 读取，openace 写入）
 # 6. 路径规范化防遍历攻击（使用 readlink -f）
 # 7. 参数重复检测和参数值边界校验
@@ -69,29 +70,81 @@ declare -A TOOL_TO_DIR=(
 # 辅助函数
 # ============================================================================
 
-# 记录审计日志
+# 记录审计日志（#3292：caller 恒脱敏；details 过 sanitize_details，
+# 对白名单校验过的单层 home 形状保证脱敏——边界见该函数注释）
 log_audit() {
     local action="$1"
     local details="$2"
     local timestamp
     timestamp=$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z')
-    local caller="${SUDO_USER:-$USER}"
+    local caller
+    caller=$(sanitize_username "${SUDO_USER:-${USER:-unknown}}")
 
     # 确保日志目录存在
     mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || true
 
     # 写入审计日志
-    echo "${timestamp} | caller=${caller} | action=${action} | ${details}" >> "$AUDIT_LOG" 2>/dev/null || true
+    echo "${timestamp} | caller=${caller} | action=${action} | $(sanitize_details "$details")" >> "$AUDIT_LOG" 2>/dev/null || true
 }
 
-# 脱敏用户名（只显示首字母）
+# 用户名短哈希（sha256 前 8 位 hex）
+# 用途是关联而非加密：同一用户跨日志条目可关联，但用户名低熵、
+# 截断哈希可被字典逆推，不提供机密性保证。
+_username_hash() {
+    local name="$1"
+    local out=""
+    # 条件位置的命令替换失败不触发 errexit；sha256sum 缺失（如 macOS）回退 shasum
+    if out=$(printf '%s' "$name" | sha256sum 2>/dev/null); then
+        :
+    elif out=$(printf '%s' "$name" | shasum -a 256 2>/dev/null); then
+        :
+    else
+        out=""
+    fi
+    # 输出形如 "<64位hex>  -"，取前 8 位；工具缺失/输出异常时退化为 unknown
+    local hex="${out:0:8}"
+    if [[ ! "$hex" =~ ^[0-9a-f]{8}$ ]]; then
+        echo "unknown"
+    else
+        echo "$hex"
+    fi
+}
+
+# 脱敏用户名：首字母 + *** + 截断哈希（如 alice -> a***-<hash8>）
+# 单字符名不保留首字母（泄首字母即泄全名），只留 *** + 哈希。
 sanitize_username() {
     local username="$1"
     if [ ${#username} -le 1 ]; then
-        echo "***"
+        echo "***-$(_username_hash "$username")"
     else
-        echo "${username:0:1}***"
+        echo "${username:0:1}***-$(_username_hash "$username")"
     fi
+}
+
+# details 内 home 路径用户名段脱敏（#3292）
+# 将 /home/<name>/ 与 /Users/<name>/ 中的用户名段替换为 sanitize_username
+# 结果。终止性：脱敏产物含 '*'，不满足 [a-zA-Z0-9_-]+ 段匹配，不会再
+# 次命中；对已脱敏输入幂等。
+# 覆盖边界（如实声明）：参数白名单（validate_config_path 等）只放行单层
+# home 形状，本函数对这类形状保证脱敏。但 validate_args 对 `--` 之后的
+# 参数不做校验（既有行为，独立跟进），post-`--` 内容可绕过白名单进入
+# details——对其中不匹配 ^/home|/Users/<name>/ 形状的用户名（无尾斜杠、
+# 含非法字符、嵌套段、超过 guard 上限的多次出现）本函数不保证脱敏。
+sanitize_details() {
+    local details="$1"
+    local re='(/(home|Users)/)([a-zA-Z0-9_-]+)/'
+    # 防御性上限：校验过的参数面（单个 --config、拒绝重复）远小于 20 段；
+    # post-`--` 内容可人为超过（见上），届时 20 名之后的段保持原样
+    local guard=0
+    while [[ "$details" =~ $re && $guard -lt 20 ]]; do
+        local prefix="${BASH_REMATCH[1]}"
+        local name="${BASH_REMATCH[3]}"
+        local seg="${prefix}${name}/"
+        local rep="${prefix}$(sanitize_username "$name")/"
+        details="${details//$seg/$rep}"
+        guard=$((guard + 1))
+    done
+    printf '%s' "$details"
 }
 
 # 验证工具名称是否在白名单内

--- a/tests/integration/test_fetch_wrapper_integration_2543.py
+++ b/tests/integration/test_fetch_wrapper_integration_2543.py
@@ -178,6 +178,9 @@ class TestSecurityIntegration:
             "is_allowed_path",
             "safe_resolve_symlink",
             "log_audit",
+            "sanitize_username",
+            "sanitize_details",
+            "_username_hash",
             "validate_file",
         ]:
             m = _re.search(rf"^{fn}\(\) \{{.*?^\}}", text, _re.S | _re.M)
@@ -209,7 +212,8 @@ class TestSecurityIntegration:
             symlink.symlink_to(malicious)
 
             preflight = (
-                "for f in normalize_path is_allowed_path safe_resolve_symlink log_audit validate_file; "
+                "for f in normalize_path is_allowed_path safe_resolve_symlink log_audit "
+                "sanitize_username sanitize_details _username_hash validate_file; "
                 "do declare -F $f >/dev/null || exit 99; done; "
                 "for v in MAX_FILE_SIZE MAX_SYMLINK_DEPTH AUDIT_LOG TOOL_TO_DIR; "
                 "do declare -p $v >/dev/null || exit 99; done"
@@ -342,6 +346,15 @@ class TestAuditLoggingIntegration:
     def test_usernames_sanitized_in_log(self):
         """
         Test that usernames are sanitized in audit log.
+
+        #3292 review note: deliberately left as a deployed-box canary — it
+        skips everywhere in CI (/var/log/openace/fetch-audit.log does not
+        exist on runners). Strengthening it to assert the sanitized shape is
+        unsound: on an upgraded box where the wrapper has not run since the
+        upgrade, every existing line (including the last) predates the fix
+        and legitimately contains raw usernames. The real shape contract is
+        enforced on every PR by TestAuditLogging in
+        tests/unit/test_fetch_wrapper_2543.py.
         """
         audit_log = Path("/var/log/openace/fetch-audit.log")
 

--- a/tests/unit/test_fetch_wrapper_2543.py
+++ b/tests/unit/test_fetch_wrapper_2543.py
@@ -100,6 +100,9 @@ def _extract_closure(tmp_path: Path) -> Path:
         "is_allowed_path",
         "safe_resolve_symlink",
         "log_audit",
+        "sanitize_username",
+        "sanitize_details",
+        "_username_hash",
         "validate_file",
     ]
     text = WRAPPER.read_text(encoding="utf-8")
@@ -138,7 +141,8 @@ def _run_closure(
     import os as _os
 
     preflight = (
-        "for f in normalize_path is_allowed_path safe_resolve_symlink log_audit validate_file; "
+        "for f in normalize_path is_allowed_path safe_resolve_symlink log_audit "
+        "sanitize_username sanitize_details _username_hash validate_file; "
         'do declare -F $f >/dev/null || { echo "PREFLIGHT-MISSING: $f" >&2; exit 99; }; done; '
         "for v in MAX_FILE_SIZE MAX_SYMLINK_DEPTH AUDIT_LOG TOOL_TO_DIR; "
         'do declare -p $v >/dev/null || { echo "PREFLIGHT-MISSING: $v" >&2; exit 99; }; done'
@@ -1145,9 +1149,11 @@ class TestAuditLogging:
     def test_audit_log_created(self, tmp_path):
         """log_audit writes the documented line format to AUDIT_LOG.
 
-        The line is "<timestamp> | caller=<user> | action=<action> | <details>"
-        (fragments asserted separately — they are ` | `-separated). The
-        end-to-end fetch_start/fetch_end path is covered by
+        The line is "<timestamp> | caller=<pseudonymized> | action=<action> |
+        <details>" (fragments asserted separately — they are ` | `-separated).
+        #3292: the caller is pseudonymized (first letter + *** + 8-hex
+        truncation of sha256), never the raw username. The end-to-end
+        fetch_start/fetch_end path is covered by
         TestParameterValidation.test_exact_match_valid_params (real wrapper).
         """
         harness = _extract_closure(tmp_path)
@@ -1160,15 +1166,121 @@ class TestAuditLogging:
         assert rc.returncode == 0, rc.stderr
         assert rc.stdout.strip().endswith("0")
         line = audit.read_text().strip()
-        assert " | caller=auditprobe | " in line
+        caller = re.search(r" \| caller=([^|]*) \| ", line)
+        assert caller, f"no caller field in {line!r}"
+        # Shape only — never hardcode hash values (they are deterministic
+        # but platform-tool-dependent in derivation, sha256sum vs shasum).
+        assert re.fullmatch(r"a\*\*\*-[0-9a-f]{8}", caller.group(1)), line
+        assert "auditprobe" not in line
         assert " | action=fetch_start | " in line
         assert line.endswith("tool=fetch_qwen")
 
-    # test_username_sanitized was deleted (#3186 batch 3): sanitize_username is
-    # defined-but-never-called in the wrapper and log_audit writes the raw
-    # caller/user — the sanitization requirement was never implemented. The
-    # implement-or-remove decision is tracked in #3292 (the wrapper header's
-    # "脱敏" claim is currently false).
+    @requires_bash4
+    def test_caller_pseudonymized_under_sudo(self, tmp_path):
+        """SUDO_USER drives the caller field, pseudonymized (#3292).
+
+        Drives the real log_audit with SUDO_USER=alice: the audit line must
+        carry the a***-<hash8> pseudonym and must not contain the raw
+        username anywhere.
+        """
+        harness = _extract_closure(tmp_path)
+        audit = tmp_path / "audit.log"
+        rc = _run_closure(
+            harness,
+            'log_audit "fetch_start" "tool=fetch_qwen"; echo $?',
+            env={"AUDIT_LOG": str(audit), "SUDO_USER": "alice", "USER": "root"},
+        )
+        assert rc.returncode == 0, rc.stderr
+        line = audit.read_text().strip()
+        assert re.search(r" \| caller=a\*\*\*-[0-9a-f]{8} \| ", line), line
+        assert "alice" not in line
+
+    @requires_bash4
+    def test_hash_deterministic_for_correlation(self, tmp_path):
+        """Same user -> same hash suffix; different user -> different (#3292).
+
+        The truncation hash exists so operators can correlate audit entries
+        belonging to one user without learning the username.
+        """
+        harness = _extract_closure(tmp_path)
+        rc = _run_closure(
+            harness,
+            'echo "$(sanitize_username carol) $(sanitize_username carol) '
+            '$(sanitize_username dave)"',
+        )
+        assert rc.returncode == 0, rc.stderr
+        carol_a, carol_b, dave = rc.stdout.strip().split()
+        assert carol_a == carol_b, "same user must map to the same pseudonym"
+        assert carol_a != dave, "different users must not collide"
+        assert re.fullmatch(r"c\*\*\*-[0-9a-f]{8}", carol_a)
+        assert re.fullmatch(r"d\*\*\*-[0-9a-f]{8}", dave)
+
+    @requires_bash4
+    def test_home_path_segment_sanitized_in_details(self, tmp_path):
+        """Usernames inside --config home paths are sanitized too (#3292).
+
+        Only pseudonymizing caller= would leak the username right back via
+        args=--config /home/<user>/... — the details pass must rewrite the
+        home-directory segment.
+        """
+        harness = _extract_closure(tmp_path)
+        audit = tmp_path / "audit.log"
+        rc = _run_closure(
+            harness,
+            'log_audit "fetch_start" '
+            '"tool=fetch_qwen args=--config /home/alice/.open-ace/config.json"; echo $?',
+            env={"AUDIT_LOG": str(audit), "USER": "root"},
+        )
+        assert rc.returncode == 0, rc.stderr
+        line = audit.read_text().strip()
+        assert "/home/alice/" not in line
+        assert re.search(r"/home/a\*\*\*-[0-9a-f]{8}/\.open-ace/config\.json", line), line
+
+    @requires_bash4
+    def test_users_path_segment_sanitized_in_details(self, tmp_path):
+        """macOS-shaped /Users/<name>/ segments are sanitized as well (#3292).
+
+        Only reachable through the closure harness (the wrapper's config
+        allowlist rejects /Users paths), but sanitize_details covers both
+        home shapes.
+        """
+        harness = _extract_closure(tmp_path)
+        rc = _run_closure(
+            harness,
+            'echo "$(sanitize_details "file=/Users/bob/.qwen/sessions.json")"',
+        )
+        assert rc.returncode == 0, rc.stderr
+        out = rc.stdout.strip()
+        assert "/Users/bob/" not in out
+        assert re.search(r"/Users/b\*\*\*-[0-9a-f]{8}/\.qwen/sessions\.json", out), out
+
+    @requires_bash4
+    def test_single_char_username_hides_first_letter(self, tmp_path):
+        """A 1-char username keeps no first letter — it IS the name (#3292).
+
+        Uses the g-free details string tool=fetch_claude so the absence
+        assertion cannot trip over the literal 'g' in "args".
+        """
+        harness = _extract_closure(tmp_path)
+        audit = tmp_path / "audit.log"
+        rc = _run_closure(
+            harness,
+            'log_audit "fetch_start" "tool=fetch_claude"; echo $?',
+            env={"AUDIT_LOG": str(audit), "USER": "g"},
+        )
+        assert rc.returncode == 0, rc.stderr
+        line = audit.read_text().strip()
+        assert re.search(r" \| caller=\*\*\*-[0-9a-f]{8} \| ", line), line
+        # 'g' is outside the hex alphabet, so its absence is unambiguous.
+        assert "g" not in line
+
+    # #3292 implemented the sanitization the header always claimed: caller
+    # and home-path username segments are pseudonymized (first letter +
+    # *** + sha256[:8]; 1-char names drop the letter). The #3186 batch-3
+    # deletion note for the unit placeholder test_username_sanitized lived
+    # here; the tests above are its real replacement (the integration-side
+    # canary test_usernames_sanitized_in_log still exists by design — see
+    # its docstring).
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #3292. Plan + adversarial plan review (5 findings, all folded in): https://github.com/open-ace/open-ace/issues/3292#issuecomment-5504836528 and https://github.com/open-ace/open-ace/issues/3292#issuecomment-5504979189

## What

The fetch wrapper's header has always claimed "审计日志记录（用户名脱敏）", but `sanitize_username` was dead code and `log_audit` wrote the raw caller and raw `/home/<name>/` path segments into `/var/log/openace/fetch-audit.log`. This PR implements the sanitization (disposition option 1 from the issue; deletion/non-goal was rejected because the header's claim is the wrapper's stated security contract).

## Product change (scripts/openace-fetch-wrapper)

- `sanitize_username` activated: `first-letter***-<sha256[:8]>` (e.g. `alice` → `a***-2bd806c9`); 1-char names drop the letter (it would be the whole name). The hash suffix is pseudonymized correlation — same user, same suffix across entries — not crypto (usernames are low-entropy; stated in the code comment).
- `_username_hash` (new): `sha256sum` with `shasum -a 256` fallback (macOS test path), `unknown` when neither exists; written errexit-safe (condition-position command substitution — verified under `set -euo pipefail`).
- `sanitize_details` (new): rewrites `/home/<name>/` and `/Users/<name>/` segments. Termination: the replacement contains `*` which can never re-match `[a-zA-Z0-9_-]+`; idempotent on already-sanitized input; guard-20 cap (unreachable via the arg whitelist — one `--config`, duplicates rejected). Nested cross-shaped prefixes (`/home/Users/x/`) are rejected by the arg whitelist before logging and documented as the boundary (the chain-regex alternative was prototyped and rejected: bash ERE `+`-group semantics are not portably longest-match).
- `log_audit`: caller pseudonymized; `USER`-unset no longer aborts the wrapper under `set -u` (was an unbound-variable exit; now hashes the literal `unknown`).
- Header comment now describes the real mechanism.

## Tests

- Both closure harnesses extended with the three functions: `tests/unit/test_fetch_wrapper_2543.py` (`_extract_closure` + `_run_closure` preflight) and the second inline extraction in `tests/integration/test_fetch_wrapper_integration_2543.py::test_symlink_attack_blocked` (plan-review finding #2 — without it that harness silently degrades).
- The audit-format contract test upgraded from asserting the raw caller (`caller=auditprobe`) to the pseudonymized shape + raw-absent — a strengthening, not a relaxation.
- Five new real tests, all driving the REAL extracted closure under bash ≥4: SUDO_USER caller pseudonymization, hash determinism + non-collision, `/home/` segment sanitization in details, `/Users/` segment sanitization, 1-char hiding (g-free details string to avoid the `args=` false positive — plan-review finding #4).
- The deployed-box canary `test_usernames_sanitized_in_log` is left untouched with the reason recorded in its docstring (plan-review finding #1: pre-fix lines legitimately persist across upgrades, so shape assertions on existing logs are unsound; the test skips everywhere in CI).

## Verification

- 65 passed in tests/unit/test_fetch_wrapper_2543.py (bash 5.3, closure tests live) + TestWrapperSyntax `bash -n` + the extended integration symlink test.
- Mutation checks 5/5 caught: raw-caller restored, details pass removed, hash truncation removed, 1-char letter leaked, hash made nondeterministic — each corresponding test fails.
- `scripts/scan_test_false_positives.py --ledger ci/false-positive-ledger.json`: 0 findings; ledger untouched.
- Behavioral smoke matrix (multi-user segments, prefix-safety `alice` vs `alice-s`, idempotence, empty details, guard termination, unset SUDO_USER/USER) verified under `set -euo pipefail`.

## Out of scope (recorded on the issue)

Other `openace-*.sh` wrappers each carry their own differently-signed `log_audit` with raw `caller=$(whoami)`; `generate-sudoers.sh:262` writes raw `user=` — same-class follow-ups if wanted.