### PR TITLE
fix(analytics): use full report period for daily averages

### DIFF
--- a/app/modules/analytics/usage_analytics.py
+++ b/app/modules/analytics/usage_analytics.py
@@ -191,7 +191,7 @@ class UsageAnalytics:
         usage_data = self._get_usage_data(start_date, end_date)
 
         # Calculate summary statistics
-        summary = self._calculate_summary(usage_data)
+        summary = self._calculate_summary(usage_data, start_date, end_date)
 
         # Create report
         report = UsageReport(period_start=start_date, period_end=end_date, **summary)
@@ -228,8 +228,23 @@ class UsageAnalytics:
         """
         return self.db.fetch_all(query, (start_date, end_date))
 
-    def _calculate_summary(self, usage_data: list[dict]) -> dict[str, Any]:
-        """Calculate summary statistics from usage data in a single pass."""
+    def _calculate_summary(
+        self,
+        usage_data: list[dict],
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Calculate summary statistics from usage data in a single pass.
+
+        Args:
+            usage_data: List of usage records from the database.
+            start_date: Optional start date (YYYY-MM-DD) for period calculation.
+            end_date: Optional end date (YYYY-MM-DD) for period calculation.
+
+        Returns:
+            Dictionary with summary statistics including daily averages calculated
+            over the full report period (not just active days).
+        """
         if not usage_data:
             return {
                 "total_tokens": 0,
@@ -274,8 +289,18 @@ class UsageAnalytics:
                     date = date.strftime("%Y-%m-%d")
                 daily_totals[date] = daily_totals.get(date, 0) + d.get("tokens", 0)
 
-        # Calculate averages
-        num_days = len(daily_totals) if daily_totals else 1
+        # Calculate number of days in the report period for daily averages
+        # Use the full period (start_date to end_date inclusive) rather than
+        # just the active days with data. This ensures missing days are treated
+        # as zero usage, giving accurate daily averages.
+        if start_date and end_date:
+            start = datetime.strptime(start_date, "%Y-%m-%d")
+            end = datetime.strptime(end_date, "%Y-%m-%d")
+            num_days = (end - start).days + 1
+        else:
+            # Fallback to active days if dates not provided
+            num_days = len(daily_totals) if daily_totals else 1
+
         daily_avg_tokens = total_tokens / num_days
         daily_avg_requests = total_requests / num_days
 

--- a/tests/unit/test_usage_analytics.py
+++ b/tests/unit/test_usage_analytics.py
@@ -94,6 +94,62 @@ class TestUsageAnalytics:
         assert result["peak_day"] == "2026-01-01"
         assert isinstance(result["peak_day"], str)
 
+    def test_calculate_summary_with_missing_days(self):
+        """Daily averages should use full period, not just active days.
+
+        Issue #3256: When a 31-day period has only 19 active days,
+        the average should be total / 31, not total / 19.
+        """
+        analytics, _, _ = self._make_analytics()
+        # 19 days of data in a 31-day period (2026-01-01 to 2026-01-31)
+        data = [
+            {
+                "date": f"2026-01-{i:02d}",
+                "tool_name": "qwen",
+                "host_name": "h1",
+                "tokens": 1000,
+                "input_tokens": 800,
+                "output_tokens": 200,
+                "requests": 10,
+            }
+            for i in range(1, 20)  # Days 1-19 (19 active days)
+        ]
+        total_tokens = 19 * 1000  # 19000 tokens total
+
+        # Without date parameters: should use active days (19)
+        result_no_dates = analytics._calculate_summary(data)
+        assert result_no_dates["daily_average_tokens"] == total_tokens / 19
+
+        # With date parameters: should use full period (31 days)
+        result_with_dates = analytics._calculate_summary(
+            data, start_date="2026-01-01", end_date="2026-01-31"
+        )
+        assert result_with_dates["daily_average_tokens"] == total_tokens / 31
+
+    def test_calculate_summary_single_day_period(self):
+        """Single day period should give same result regardless of method."""
+        analytics, _, _ = self._make_analytics()
+        data = [
+            {
+                "date": "2026-01-15",
+                "tool_name": "qwen",
+                "host_name": "h1",
+                "tokens": 1000,
+                "input_tokens": 800,
+                "output_tokens": 200,
+                "requests": 10,
+            }
+        ]
+
+        # Both methods should give same result for single day
+        result_no_dates = analytics._calculate_summary(data)
+        result_with_dates = analytics._calculate_summary(
+            data, start_date="2026-01-15", end_date="2026-01-15"
+        )
+
+        assert result_no_dates["daily_average_tokens"] == 1000
+        assert result_with_dates["daily_average_tokens"] == 1000
+
     def test_generate_report_no_data(self):
         analytics, mock_db, _ = self._make_analytics()
         mock_db.fetch_all.return_value = []


### PR DESCRIPTION
## Summary

Fixes #3256: Enterprise Report daily averages were calculated using active days (days with data) as the denominator instead of the full report period.

## Root Cause

`_calculate_summary()` in `app/modules/analytics/usage_analytics.py` used `len(daily_totals)` as the denominator, where `daily_totals` only contains dates with recorded data. This caused significant overestimation when there were days without usage data.

## Solution

Modified `_calculate_summary()` to accept `start_date` and `end_date` parameters. Daily averages now use the full report period (inclusive of start and end dates) as the denominator. Missing days are effectively treated as zero usage.

## Changes

- Modified `_calculate_summary()` signature to accept optional `start_date` and `end_date` parameters
- Updated `generate_report()` to pass date parameters to `_calculate_summary()`
- Added test cases for missing days scenario and single-day period

## Example

- 31-day period with 19 active days (total 19,000 tokens)
- **Before**: 19,000 / 19 = 1,000 tokens/day (incorrect)
- **After**: 19,000 / 31 = 612.9 tokens/day (correct)

## Test Plan

- [x] Unit tests pass: `test_calculate_summary_with_missing_days`
- [x] Unit tests pass: `test_calculate_summary_single_day_period`
- [x] All existing `test_usage_analytics.py` tests pass (42 tests)
- [ ] CI checks pass

## Impact

- **Behavior Change**: Daily averages will be lower (more accurate) when there are missing days
- **No Data Migration**: Only calculation logic change, no database changes
- **Backward Compatible**: No breaking API changes