### PR TITLE
fix(#3290): wire RUN_PERFORMANCE_TESTS into the weekly performance lane

### DIFF
--- a/.github/workflows/weekly-quality.yml
+++ b/.github/workflows/weekly-quality.yml
@@ -87,6 +87,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     continue-on-error: true
+    env:
+      # #3290: the qwen wall-clock tests skip unless this is truthy — without
+      # the wiring the lane reported green while never executing them.
+      RUN_PERFORMANCE_TESTS: '1'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/unit/test_weekly_quality_workflow_contract.py
+++ b/tests/unit/test_weekly_quality_workflow_contract.py
@@ -7,9 +7,16 @@ alive (#3170): SECRET_KEY (the fail-closed development-mode boot contract)
 and PLAYWRIGHT_BROWSERS_PATH (browsers are installed under the real HOME;
 without an absolute cache path the HOME swap makes every browser launch
 fail with a missing executable).
+
+Also pins the performance lane's env wiring (#3290): the qwen wall-clock
+tests skip unless RUN_PERFORMANCE_TESTS is truthy, and nothing ever set
+it — the advisory lane reported green while never executing them.
 """
 
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,6 +25,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WEEKLY = REPO_ROOT / ".github" / "workflows" / "weekly-quality.yml"
 PLAYWRIGHT_CONFIG = REPO_ROOT / "frontend" / "playwright.config.ts"
+QWEN_PERF_TESTS = REPO_ROOT / "tests" / "performance" / "test_qwen_performance_2735.py"
 
 pytestmark = [pytest.mark.regression, pytest.mark.issue(3170)]
 
@@ -25,6 +33,11 @@ pytestmark = [pytest.mark.regression, pytest.mark.issue(3170)]
 def _cross_browser_job():
     workflow = yaml.load(WEEKLY.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
     return workflow["jobs"]["cross-browser-e2e"]
+
+
+def _performance_job():
+    workflow = yaml.load(WEEKLY.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    return workflow["jobs"]["performance"]
 
 
 def test_playwright_web_server_boots_the_real_server_py():
@@ -62,3 +75,65 @@ def test_cross_browser_job_timeout_covers_the_full_matrix():
     # server boot) and canceled the first real attempt (#3170).
     job = _cross_browser_job()
     assert int(job["timeout-minutes"]) >= 240
+
+
+# ── Performance lane env wiring (#3290) ─────────────────────────────
+
+
+@pytest.mark.issue(3290)
+def test_performance_job_wires_the_gate_the_perf_tests_read():
+    """Workflow side of the two-sided pin (#3287 pattern).
+
+    The performance job must set a truthy literal RUN_PERFORMANCE_TESTS at
+    job level (stricter than step level: covers every step's subprocesses,
+    including ci.py's environment isolation). A `${{ }}` template or empty
+    value would silently re-create the #3290 never-ran state.
+    """
+    env = _performance_job().get("env", {})
+    value = env.get("RUN_PERFORMANCE_TESTS")
+    assert isinstance(value, str) and value, (
+        f"performance job must set job-level RUN_PERFORMANCE_TESTS (what "
+        f"tests/performance/test_qwen_performance_2735.py gates on); got {value!r}"
+    )
+    assert not value.startswith("${{") and value != "0" and value.lower() != "false"
+
+
+@pytest.mark.issue(3290)
+def test_qwen_perf_tests_gate_lives_on_the_wired_env_name():
+    """Test side: without the env the three tests skip, citing its name.
+
+    Runs the real pytest collection/selection in a scrubbed subprocess —
+    the gate must be live (evaluating RUN_PERFORMANCE_TESTS at runtime),
+    not a copied constant. With the variable inherited from a developer
+    shell this would flip to passing, so it is stripped explicitly. The
+    skip reason is asserted as a substring; the full -rs line embeds
+    file:line positions that drift on edits.
+    """
+    scrubbed = {k: v for k, v in os.environ.items() if k != "RUN_PERFORMANCE_TESTS"}
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(QWEN_PERF_TESTS), "-q", "-rs", "--no-header"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=scrubbed,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "3 skipped" in result.stdout, result.stdout
+    assert (
+        "RUN_PERFORMANCE_TESTS" in result.stdout
+    ), "skip reason must name the env var so an unwired lane is diagnosable"
+
+
+@pytest.mark.issue(3290)
+def test_workflow_and_perf_file_pin_the_same_env_name():
+    """Textual name lock: the workflow writes exactly the name the file reads."""
+    workflow = WEEKLY.read_text(encoding="utf-8")
+    perf_file = QWEN_PERF_TESTS.read_text(encoding="utf-8")
+    assert re.search(
+        r"RUN_PERFORMANCE_TESTS:\s*'[^']*'", workflow
+    ), "weekly-quality.yml no longer writes RUN_PERFORMANCE_TESTS"
+    assert 'os.environ.get("RUN_PERFORMANCE_TESTS"' in perf_file, (
+        "the perf gate no longer reads RUN_PERFORMANCE_TESTS — update the "
+        "workflow wiring in the same change"
+    )


### PR DESCRIPTION
Closes #3290. Plan + adversarial plan review (5 findings, all folded): https://github.com/open-ace/open-ace/issues/3290#issuecomment-5507961255 and https://github.com/open-ace/open-ace/issues/3290#issuecomment-5508075391

## What

The performance suite's three qwen wall-clock tests skip unless `RUN_PERFORMANCE_TESTS` is truthy — and nothing anywhere set it. The advisory weekly lane reported green while never executing them (same "lane exists but never ran" class as #3287).

## Changes

1. **`.github/workflows/weekly-quality.yml`** — performance job gets job-level `RUN_PERFORMANCE_TESTS: '1'`. Job level is the stricter pin (covers every step's subprocesses through ci.py's environment isolation; the isolation layer only strips database vars — empirically traced). **Advisory + continue-on-error retained** per the suite's shared-runner-noise rationale and the issue's explicit allowance ("保留 advisory 但必须真跑"); the lane now actually runs what it reports on.
2. **Two-sided contract pin** (`tests/unit/test_weekly_quality_workflow_contract.py`, #3287 PG_TEST_URL pattern):
   - workflow side: job env must be a truthy literal (not `${{ }}`, not empty/0/false);
   - behavioral side: subprocess pytest on the gated file with the variable scrubbed → exactly 3 skips whose reason cites `RUN_PERFORMANCE_TESTS` (proves the gate live-evaluates the env name; an unwired lane stays diagnosable). The scrub prevents a developer's exported var from flipping the test;
   - textual name lock between the workflow writer and the file reader.

## Measured evidence (this commit, local)

| Scenario | Result |
|---|---|
| `RUN_PERFORMANCE_TESTS=1 pytest tests -m "performance and not postgres"` | **13 passed, 1 skipped** (18.9s) |
| without env (same filter, `-rs`) | **10 passed, 4 skipped** (3× `RUN_PERFORMANCE_TESTS` reason + 1× PostgreSQL-specific) |
| `RUN_PERFORMANCE_TESTS=1 python scripts/ci.py run performance` | **13 passed, 1 skipped** (env passthrough proven) |
| contract tests | 6 passed |
| mutation checks (env removed / env empty / var renamed in file / gate removed) | 4/4 caught |
| false-positive scanner | 0 findings, ledger untouched |

The 1 remaining skip is `tests/unit/test_usage_repo_increment.py::test_concurrent_increment_postgresql` (performance-marked, runtime `is_postgresql()` skip, no PG service in that job). It is deliberately **not** given `@pytest.mark.postgres`: that would exclude it from every lane statically (python-core excludes postgres+performance; the perf lane would drop it; the postgres lane collects tests/integration only) — turning a visible, accurately-reasoned skip into an invisible never-runs, the exact disease class this issue opposes. Recorded as a known observation on the issue.

## Post-merge

`workflow_dispatch` of weekly-quality on main will backfill the real runner counts (expect 13 passed / 1 skipped on the Performance job vs the pre-fix 10 passed / 4 skipped-class state).