### PR TITLE
fix(#3317): reject the fetch wrapper's -- argument-separator bypass

### DIFF
--- a/scripts/openace-fetch-wrapper
+++ b/scripts/openace-fetch-wrapper
@@ -22,6 +22,8 @@
 #
 # Issue #2543: 本地工作区会话数据采集权限修复
 # Issue #3249: 参数校验下划线修复和安全加固
+# Issue #3317: 关闭 `--` 参数分离旁路（post-`--` 曾绕过全部校验进入
+#              审计日志与 fetch 脚本 argv）
 
 set -euo pipefail
 
@@ -126,15 +128,14 @@ sanitize_username() {
 # 结果。终止性：脱敏产物含 '*'，不满足 [a-zA-Z0-9_-]+ 段匹配，不会再
 # 次命中；对已脱敏输入幂等。
 # 覆盖边界（如实声明）：参数白名单（validate_config_path 等）只放行单层
-# home 形状，本函数对这类形状保证脱敏。但 validate_args 对 `--` 之后的
-# 参数不做校验（既有行为，独立跟进），post-`--` 内容可绕过白名单进入
-# details——对其中不匹配 ^/home|/Users/<name>/ 形状的用户名（无尾斜杠、
-# 含非法字符、嵌套段、超过 guard 上限的多次出现）本函数不保证脱敏。
+# home 形状，本函数对这类形状保证脱敏。`--` 参数分离旁路已被 #3317 关闭
+# （validate_args 不再接受 `--`，一切参数经 case 白名单校验后方可进入
+# details）；对不匹配 ^/home|/Users/<name>/ 形状的用户名（无尾斜杠、含
+# 非法字符、嵌套段）本函数不保证脱敏。
 sanitize_details() {
     local details="$1"
     local re='(/(home|Users)/)([a-zA-Z0-9_-]+)/'
-    # 防御性上限：校验过的参数面（单个 --config、拒绝重复）远小于 20 段；
-    # post-`--` 内容可人为超过（见上），届时 20 名之后的段保持原样
+    # 防御性上限：校验过的参数面（单个 --config、拒绝重复）远小于 20 段
     local guard=0
     while [[ "$details" =~ $re && $guard -lt 20 ]]; do
         local prefix="${BASH_REMATCH[1]}"
@@ -493,10 +494,11 @@ validate_args() {
                 # 标志参数，无值
                 shift
                 ;;
-            --)
-                # 参数分隔符，停止解析
-                break
-                ;;
+            # Issue #3317: no `--)` separator case. It let everything after
+            # it skip validation into the audit log and the fetch script's
+            # argv; nothing legitimately needs it (fixed-grammar internal
+            # RPC; validate_arg_value already rejects '-'-leading values),
+            # so `--` falls through to the unknown-argument rejection.
             *)
                 echo "ERROR: Unknown argument: $1" >&2
                 return 1

--- a/tests/unit/test_fetch_wrapper_2543.py
+++ b/tests/unit/test_fetch_wrapper_2543.py
@@ -810,6 +810,55 @@ class TestParameterValidation:
         assert result.returncode != 0
         assert "Unknown argument" in result.stderr or "ERROR" in result.stderr
 
+    def test_dashdash_separator_bypass_rejected(self, wrapper_path, tmp_path, monkeypatch):
+        """`--` no longer stops validation (#3317).
+
+        The separator case let everything after it skip the whitelist
+        verbatim into the audit log (forging `| caller=... | action=...`
+        fields) and the fetch script's argv. It must now fall into the
+        unknown-argument rejection, and the rejection must happen BEFORE
+        the first log_audit call — the forged fields reach no output and
+        no audit line is written at all.
+        """
+        if not os.path.exists(wrapper_path):
+            pytest.skip("Wrapper not installed")
+
+        audit_log = tmp_path / "audit.log"
+        monkeypatch.setenv("AUDIT_LOG", str(audit_log))
+        result = subprocess.run(
+            [
+                "bash",
+                wrapper_path,
+                "fetch_qwen",
+                "--days",
+                "1",
+                "--",
+                "| caller=root | action=forged | injected=yes",
+                "dir=/home/alice",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Unknown argument: --" in result.stderr
+        assert "caller=root" not in result.stderr
+        # Rejection precedes fetch_start: no audit line may exist, or the
+        # forged pipe-fields would be back in a consumer-parsed log.
+        assert not audit_log.exists()
+
+    def test_bare_dashdash_rejected(self, wrapper_path):
+        """A bare `--` is rejected like any other unknown argument (#3317)."""
+        if not os.path.exists(wrapper_path):
+            pytest.skip("Wrapper not installed")
+
+        result = subprocess.run(
+            ["bash", wrapper_path, "fetch_qwen", "--"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Unknown argument: --" in result.stderr
+
     def test_reject_extra_args(self, wrapper_path):
         """Test that extra arguments are rejected."""
         if not os.path.exists(wrapper_path):


### PR DESCRIPTION
Closes #3317. Plan + adversarial plan review (3 findings, all folded): https://github.com/open-ace/open-ace/issues/3317#issuecomment-5509197016 and https://github.com/open-ace/open-ace/issues/3317#issuecomment-5509503958

## What

`validate_args` broke on `--`, letting everything after it skip the duplicate/format/path validation and land verbatim in the audit log (forging `| caller=... | action=... |` fields — reproduced live during the #3310 review) and in the fetch script's argv. Deletion is the chosen disposition because:

- **No caller uses it**: all five product invocation sites use the fixed grammar (`--days/--multi-user/--recent/--config`); the scheduler only checks the wrapper's existence; the sibling wrappers have no `--` case (no shared convention); the smoke and every test invoke fixed grammar.
- **It protects nothing**: `validate_arg_value` already rejects `-`-leading values — the separator was the only way to smuggle them.
- Fail-closed matches the wrapper's stated contract (exact-match whitelist).

## Changes

- `scripts/openace-fetch-wrapper`: the `--)` case is removed — `--` now falls into the unknown-argument rejection, which happens BEFORE the first `log_audit` call (a bypassed invocation writes no audit line at all). The #3292-era `sanitize_details` boundary comments documenting the post-`--` exception are updated to the closed state, and the header issue list gains #3317.
- `tests/unit/test_fetch_wrapper_2543.py`: `test_dashdash_separator_bypass_rejected` (forged pipe-fields after `--` → rc≠0, `Unknown argument: --` on stderr, forged fields absent, and **no audit file created** — locking rejection-before-audit ordering against future reorders) and `test_bare_dashdash_rejected`.

## Verification

- 67/67 in the wrapper file (bash 5), symlink integration green (closure extraction unaffected), `bash -n` clean, black clean, scanner 0 findings (ledger untouched).
- Mutation: restoring the `--)` case makes both new tests fail — they discriminate the fix (independently confirmed by the plan reviewer's probe as well).
- No behavior change for any legitimate invocation shape (plan reviewer ran all five tools' fixed grammar against the edited wrapper: rc 0, normal fetch_start/fetch_end audit pairs).

## Recorded out-of-scope observation

`scripts/generate-sudoers.sh:161`'s argument-less `Cmnd_Alias FETCH_WRAPPER` contradicts its adjacent "不限制参数" comment (matches only no-argument invocations) — pre-existing inconsistency noted on the issue for a possible follow-up.