### PR TITLE
fix(#3321): resume codex across autonomous milestones

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -2920,6 +2920,8 @@ class AutonomousAgentRunner:
                 system_account=system_account,
                 user_id=user_id,
                 runtime_python_command=runtime_python_command,
+                resume=resume,
+                resume_session_id=resume_session_id,
             )
 
         # Build env vars with LLM proxy auth so the agent authenticates through
@@ -3949,6 +3951,53 @@ class AutonomousAgentRunner:
 
         return event_log, response_text.strip(), input_tokens, output_tokens, tool_calls
 
+    @staticmethod
+    def _extract_thread_started_id(stdout_text: str) -> str:
+        """Return codex's minted thread_id from the first ``thread.started`` event.
+
+        ``codex exec --json`` emits ``{"type":"thread.started","thread_id":...}``
+        as its first event; the id names the rollout file and is what
+        ``codex exec resume <id>`` accepts (#3321). Empty string when absent
+        (e.g. openclaw, which emits no such event).
+        """
+        for raw in (stdout_text or "").splitlines():
+            line = raw.strip()
+            if not line or '"thread.started"' not in line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(parsed, dict) and parsed.get("type") == "thread.started":
+                thread_id = str(parsed.get("thread_id") or "").strip()
+                if thread_id:
+                    return thread_id
+        return ""
+
+    def _persist_single_shot_resume_id(self, session_id: str, stdout_text: str) -> None:
+        """Write the CLI-minted resume id to ``agent_sessions.cli_session_id`` (#3321).
+
+        Explicit, additive write — the single-shot path never runs the
+        claude-only sidebar sync that populates the column for streaming tools.
+        Best-effort: a DB hiccup degrades the next milestone to a cold start,
+        it never fails the completed milestone. Writes only when an id was
+        found, so a no-``thread.started`` run (openclaw) records nothing.
+        """
+        session_manager = getattr(self, "session_manager", None)
+        if not session_manager:
+            return
+        thread_id = self._extract_thread_started_id(stdout_text)
+        if not thread_id:
+            return
+        try:
+            session_manager.update_session_fields(
+                session_id, {"cli_session_id": thread_id}, require_tenant=False
+            )
+        except Exception as exc:  # noqa: BLE001 - never fail a finished milestone
+            logger.warning(
+                "Failed to persist single-shot resume id for %s: %s", session_id[:8], exc
+            )
+
     def _run_single_shot(
         self,
         session_id: str,
@@ -3962,11 +4011,17 @@ class AutonomousAgentRunner:
         system_account: str | None = None,
         user_id: int | None = None,
         runtime_python_command: list[str] | None = None,
+        resume: bool = False,
+        resume_session_id: str = "",
     ) -> AgentTaskResult:
         """Run a CLI tool in single-shot mode for tools without stdin protocol.
 
         Uses ``adapter.build_single_shot_args`` to produce a self-contained
         command (e.g. ``codex exec --json "<prompt>"``) and captures output.
+
+        ``resume`` / ``resume_session_id`` (#3321) let codex continue a prior
+        milestone via ``codex exec resume <id>``; the adapter ignores them for
+        tools that cannot resume non-interactively (openclaw).
         """
         import sys
 
@@ -3990,7 +4045,9 @@ class AutonomousAgentRunner:
                 error=f"CLI tool '{exe_name}' not found",
             )
 
-        args = adapter.build_single_shot_args(prompt, project_path, model)
+        args = adapter.build_single_shot_args(
+            prompt, project_path, model, resume=resume, resume_session_id=resume_session_id
+        )
         cmd = [executable] + (args[1:] if len(args) > 1 and args[0] == exe_name else args)
         env = (
             self._build_agent_env(
@@ -4077,6 +4134,12 @@ class AutonomousAgentRunner:
             self._parse_single_shot_stdout(proc.stdout or "", cli_tool)
         )
         total_tokens = input_tokens + output_tokens
+
+        # #3321: persist the CLI-minted resume id so the next milestone can
+        # `--resume` it. Explicit write here — the single-shot path never enters
+        # the claude-only sidebar sync that populates cli_session_id for the
+        # streaming tools.
+        self._persist_single_shot_resume_id(session_id, proc.stdout or "")
 
         stderr_text = (proc.stderr or "").strip()
         success = proc.returncode == 0

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2140,6 +2140,13 @@ SESSION_LINE_FIELDS = {
     "verification": "verification_session_id",  # #2335 acceptance verifier
 }
 
+# Tools whose CLI mints its own session id, so a line's stable tracking id must
+# be mapped to the real ``cli_session_id`` before it can be resumed. For these,
+# resuming the tracking id itself would target a session the CLI never created.
+# claude-code captures its id from the SDK stream; codex (#3321) from the
+# ``thread.started`` event. Tools absent here resume the tracking id directly.
+_RESUME_ID_MAPPED_TOOLS = frozenset({"claude-code", "codex"})
+
 # Agent intro/closing text patterns for _clean_agent_text().
 # These match common Chinese agent narration phrases that should not
 # appear in GitHub comments.
@@ -7225,9 +7232,11 @@ class AutonomousOrchestrator:
             existing = (fresh.get(field) or "").strip()
         if existing:
             resume_target = existing
-            if (wf or {}).get("cli_tool") == "claude-code" and getattr(
-                self._runner, "session_manager", None
-            ) is not None:
+            cli_tool = (wf or {}).get("cli_tool") or ""
+            if (
+                cli_tool in _RESUME_ID_MAPPED_TOOLS
+                and getattr(self._runner, "session_manager", None) is not None
+            ):
                 try:
                     session_row = self._runner.session_manager.get_session(existing) or {}
                     # get_session returns an AgentSession (column on the object)
@@ -7248,19 +7257,30 @@ class AutonomousOrchestrator:
                     if cli_session_id:
                         resume_target = cli_session_id
                     else:
-                        # Mapping lost: keep this SAME session line stable and
+                        # No mapping yet: keep this SAME session line stable and
                         # re-probe/rebind the real CLI id onto it on the next
                         # run, rather than creating a new wrapper line or faking
-                        # a resume with the tracking id.
-                        logger.warning(
-                            "Claude session line %s has no cli_session_id mapping "
-                            "(tracking=%s); starting fresh on the same line",
-                            session_line,
-                            existing[:8],
-                        )
+                        # a resume with the tracking id. For claude this means a
+                        # lost mapping (anomalous → warn); for codex it is simply
+                        # the first turn, before any id is captured (expected).
+                        if cli_tool == "claude-code":
+                            logger.warning(
+                                "Claude session line %s has no cli_session_id mapping "
+                                "(tracking=%s); starting fresh on the same line",
+                                session_line,
+                                existing[:8],
+                            )
+                        else:
+                            logger.debug(
+                                "%s session line %s has no cli_session_id yet "
+                                "(tracking=%s); starting fresh on the same line",
+                                cli_tool,
+                                session_line,
+                                existing[:8],
+                            )
                         return existing, None, False
                 except Exception:
-                    logger.warning("Failed to resolve Claude resume target", exc_info=True)
+                    logger.warning("Failed to resolve %s resume target", cli_tool, exc_info=True)
                     return existing, None, False
             return existing, resume_target, True
         return str(uuid.uuid4()), None, False

--- a/docs/dev-notes/3321-codex-resume-plan.md
+++ b/docs/dev-notes/3321-codex-resume-plan.md
@@ -1,0 +1,178 @@
+# #3321 — resume `codex` in autonomous single-shot runs
+
+Plan, for review before implementation. Revised after independent review found
+the first draft's carry channel did not exist for codex. Claims verified
+against source and the live CLI on 2026-09-02 (see "Verification").
+
+## The gating question is settled: `codex exec` can resume
+
+The issue says: *"Can `codex exec` resume a session? Determine this first. Do
+not implement against an assumed flag."* It can.
+
+`codex exec resume [OPTIONS] <SESSION_ID> [PROMPT]` is a real non-interactive
+subcommand (codex-cli 0.152.1). Verified live, with a three-way identity match
+that closes any doubt about which id to use:
+
+* `codex exec --json` emits `{"type":"thread.started","thread_id":"<uuid>"}` as
+  its **first** event.
+* That same `<uuid>` names the rollout file:
+  `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` (`$CODEX_HOME`
+  defaults to `~/.codex`), matching `scripts/fetch_codex.py:8`.
+* `codex exec resume --json <uuid> "<prompt>"` resolves that rollout — an
+  **unknown** id fails distinctly with *"no rollout found for thread id
+  <uuid>"*, so a wrong id is a loud error, not a silent cold start.
+
+So this is the **plumbing** case, implemented — not the design-change case, not
+closed with a finding.
+
+Two live caveats, carried forward as risks rather than assumptions:
+
+* Resuming an id whose writer is still open fails with *"thread … already has
+  an active writer"*. In production, milestone *N*'s codex process exits before
+  milestone *N+1* starts, releasing the writer, so sequential milestones should
+  not hit this — **but a test/first real run must confirm it**, because if it
+  does bite it converts resume into a hard failure.
+* `codex exec resume` **rejects `--sandbox` and `--cd`** (confirmed by running
+  them). Sandbox policy is preserved with `-c sandbox_mode="read-only"` — a
+  config override the subcommand accepts and `--strict-config` recognises as a
+  real key (a bogus key is rejected, so this is not silently ignored). Working
+  directory comes from the subprocess `cwd` the runner already sets.
+
+## The blocking defect the first draft missed: the resume id is claude-only
+
+Carrying nothing on disk is fine — the rollout persists for free (see below).
+The hard part is the **id**, and the first draft's "surface it as the result's
+session id" does not work, because the resume id is resolved claude-only in
+three places, none reached by codex:
+
+1. **Capture → persist.** The claude `cli_session_id` writers
+   (`_capture_cli_session_id` at `:1285`, `_sync_sidebar_session_totals` at
+   `:2239`) run **only from the streaming `_read_stdout` loop**
+   (`:5071`/`:5109`/`:5143`/`:5176`). `_run_single_shot` (`:3952-4116`) — the
+   codex path — never calls them and never touches `session_manager`, so
+   codex's id is never written to the column. This is **not** fixed by
+   flipping `_uses_sidebar_session_source` (that predicate gates 14
+   claude-sidebar-specific sites, e.g. the `AGENT_STATE_CARRIED` refusal at
+   `:2715`, and would misfire for codex); it needs a new explicit write.
+2. **Resolve.** `_resolve_session_line` maps a line's tracking id to the real
+   `cli_session_id` **only when `cli_tool == "claude-code"`**
+   (`orchestrator.py:7228`); for every other tool it returns
+   `(existing, existing, True)` — resume target == tracking id
+   (`orchestrator.py:7265`).
+
+Net: without a change, codex is launched with `codex exec resume <tracking-id>`
+while the rollout is named `<thread_id>` → *"no rollout found"* every time. The
+fix must (a) capture `thread_id` into `cli_session_id`, (b) extend the resolve
+branch to codex, and (c) keep `tracking_session_id == task_id` so the per-task
+HOME does not rotate.
+
+## Why the rollout persists across milestones without a carry
+
+`task_id == session_id` throughout the runner (`:2935`, `:3218`), and the
+per-line `session_id` is the stable `wf["main_session_id"]` reused by
+`_resolve_session_line`, so the per-task HOME
+(`/run/openace-agent-tasks/<session_id>/home`, `_resolve_home_dir:1197`) is the
+**same directory** across a line's milestones; `ensure_task_runtime_dirs` uses
+`mkdir(exist_ok=True)` and never wipes it (`task_isolation.py`). `~/.codex`
+lives under that HOME, so the rollout written on milestone 1 is still there on
+milestone 2. This is the same mechanism claude-code already resumes on locally.
+Only the **id** needs carrying, and that is what §"blocking defect" above adds.
+(Codex also never gets a sandbox — it is refused under production isolation and
+otherwise runs local — so #3237 does not apply.)
+
+## openclaw: deferred (confirmed with the user)
+
+`openclaw` reaches the same `_run_single_shot` path, but its resume is **not**
+in scope for this issue. Correcting the first draft: openclaw *does* have a
+documented on-disk layout — `scripts/fetch_openclaw.py:67-96` documents
+`~/.openclaw/agents/main/sessions/<uuid>.jsonl`. What it lacks is a *verified*
+non-interactive resume: its adapter captures no id and emits no resume flag
+(`build_single_shot_args`, `openclaw.py:86`), and no live test was run against
+the openclaw CLI. Wiring it would be implementing against an assumed flag, which
+the issue forbids. Decision: **fix codex; defer openclaw**, recorded in code so
+it is not a silent second case, and tracked for a separate issue if wanted.
+
+## Changes
+
+1. `build_single_shot_args` — add `resume: bool = False` and
+   `resume_session_id: str = ""` to **base *and every override***: `base.py:162`,
+   `codex_cli.py:138`, **and `openclaw.py:86`**. The overrides do not inherit a
+   widened base signature, and only codex/openclaw reach `_run_single_shot`, so
+   leaving openclaw's 3-arg override in place would still `TypeError` on the
+   shared call at `agent_runner.py:3993`. openclaw accepts-and-ignores; codex
+   uses them.
+2. `codex_cli.build_single_shot_args` — when resuming, emit
+   `codex exec resume --json -c sandbox_mode="read-only" <id> <prompt>`;
+   otherwise byte-identical to today
+   (`codex exec --json --sandbox read-only <prompt>`).
+3. `_run_single_shot` — add `resume`/`resume_session_id` params and pass them to
+   `build_single_shot_args`; the dispatch (`agent_runner.py:2910`) passes them
+   through, mirroring the ZCode branch.
+4. Capture — parse the first `--json` `thread.started.thread_id` in the
+   single-shot stdout path and surface it as the result's captured session id.
+   (`_extract_stream_session_id` only knows `session_id`/`sessionId`/`uuid`, so
+   `thread_id` is codex-specific and must be added, not assumed generic.)
+5. Persist + resolve — the load-bearing change; items 1–4 are inert without it:
+   * **Persist** the captured `thread_id` with a **new explicit
+     `self.session_manager.update_session_fields(session_id, {"cli_session_id":
+     thread_id, …}, require_tenant=False)` inside `_run_single_shot`'s result
+     path.** The codex wrapper `agent_sessions` row already exists before
+     dispatch (`:2390-2403`, since codex is not in `_APPSERVER_TOOLS`), so the
+     target row is present. Do **not** modify `_uses_sidebar_session_source` or
+     route codex through the claude sidebar/host-mtime functions.
+   * **Resolve** by extending the `_resolve_session_line` mapping branch
+     (`orchestrator.py:7228`) from claude-only to also cover codex, keeping
+     `tracking_session_id == task_id` (safe: the "mapping lost" arm returns a
+     clean fresh start and nothing else assumes the branch is claude-only).
+6. openclaw — a code comment at the adapter and the single-shot dispatch
+   recording the deferral and why, plus the accept-and-ignore signature widening
+   from Change #1 (so the shared call never raises for it).
+
+## Acceptance
+
+1. A two-turn regression driven through `_run_agent` → `_resolve_session_line`
+   (not `_run_single_shot` in isolation): turn 1's `thread_id` is persisted to
+   `cli_session_id`; turn 2 resolves that id and its argv is
+   `codex exec resume … <thread_id>`. It must fail if **either** the capture/
+   persist **or** the `_resolve_session_line` extension is removed — a test that
+   hand-feeds `resume_session_id` into `_run_single_shot` would pass with the
+   real carry deleted, which is exactly how the issue warns this gap hides.
+2. The first-milestone (non-resume) codex argv is unchanged:
+   `codex exec --json --sandbox read-only <prompt>`.
+3. A resumed codex turn still runs read-only: its argv carries
+   `-c sandbox_mode="read-only"` (since `--sandbox` is rejected on resume), so
+   turn 2 is not less sandboxed than turn 1.
+4. openclaw's argv and behaviour are unchanged, and passing `resume=…` to any
+   adapter's `build_single_shot_args` does not raise.
+5. An absent `thread_id` (capture failed) degrades to a cold, non-resume next
+   turn — never `codex exec resume` with an empty id.
+
+## Forward note (check at implementation, not a resume-correctness issue)
+
+Populating `agent_sessions.cli_session_id` for codex means any UI/timeline/
+transcript code that assumes a non-empty `cli_session_id` implies a Claude
+`~/.claude/projects/<id>.jsonl` file would look in the wrong place for codex
+(whose rollout lives under `~/.codex/sessions/...`). Grep the readers of
+`cli_session_id` during implementation and guard on `cli_tool` where one assumes
+the Claude layout. This is display-only; resume correctness does not depend on
+it. The same applies to #3319 (qwen).
+
+## Verification (2026-09-02)
+
+* `codex exec resume --help` (0.152.1): `resume [OPTIONS] [SESSION_ID]
+  [PROMPT]`; `--sandbox`/`--cd` rejected on the subcommand.
+* `codex exec --json` first event `thread.started.thread_id`; rollout at
+  `$CODEX_HOME/sessions/2026/09/02/rollout-…-<thread_id>.jsonl`; the event id ==
+  the rollout filename id.
+* resume `<known-id>` → "already has an active writer"; `<unknown-id>` → "no
+  rollout found for thread id …"; `-c sandbox_mode="read-only"` accepted, and
+  `--strict-config` accepts `sandbox_mode` while rejecting `not_a_real_key`.
+* Source: `_run_single_shot` lacks resume params (`agent_runner.py:3952`) and
+  never touches `session_manager`/`cli_session_id` (`:3952-4116`); dispatch
+  (`:2910`), shared `build_single_shot_args` call (`:3993`), overrides at
+  `codex_cli.py:138`/`openclaw.py:86`; `task_id==session_id` (`:2935`,`:3218`),
+  per-task HOME (`:1197`); claude `cli_session_id` writers run only from
+  `_read_stdout` (`:5071`/`:5109`/`:5143`/`:5176`); codex wrapper row created
+  early (`:2390-2403`); resolve branch (`orchestrator.py:7228`,`:7265`);
+  `_uses_sidebar_session_source` (`:824-826`) gates 14 sites incl. `:2715`;
+  `codex_cli.py:127,161`; `scripts/fetch_openclaw.py:67`.

--- a/remote-agent/cli_adapters/base.py
+++ b/remote-agent/cli_adapters/base.py
@@ -160,7 +160,18 @@ class BaseCLIAdapter(abc.ABC):
         return False
 
     def build_single_shot_args(
-        self, prompt: str, project_path: str, model: str | None = None
+        self,
+        prompt: str,
+        project_path: str,
+        model: str | None = None,
+        resume: bool = False,
+        resume_session_id: str = "",
     ) -> list[str]:
-        """Build args for a single-shot prompt execution (used when stdin is not supported)."""
+        """Build args for a single-shot prompt execution (used when stdin is not supported).
+
+        ``resume`` / ``resume_session_id`` let a tool continue a prior session
+        (#3321). Adapters that cannot resume non-interactively ignore them; the
+        parameters live on the base signature so ``_run_single_shot`` can pass
+        them uniformly without a per-tool ``TypeError``.
+        """
         return [self.get_executable_name(), prompt]

--- a/remote-agent/cli_adapters/codex_cli.py
+++ b/remote-agent/cli_adapters/codex_cli.py
@@ -136,14 +136,41 @@ class CodexCLIAdapter(BaseCLIAdapter):
         return args
 
     def build_single_shot_args(
-        self, prompt: str, project_path: str, model: str | None = None
+        self,
+        prompt: str,
+        project_path: str,
+        model: str | None = None,
+        resume: bool = False,
+        resume_session_id: str = "",
     ) -> list[str]:
         """
         Build args for a single-shot prompt execution.
 
-        Uses ``codex exec --json`` for machine-parseable output with a
-        read-only sandbox as the default safety boundary.
+        Cold turn: ``codex exec --json --sandbox read-only`` for
+        machine-parseable output with a read-only sandbox as the safety
+        boundary.
+
+        Resume turn (#3321): ``codex exec resume --json <id>``. The ``resume``
+        subcommand rejects ``--sandbox`` and ``--cd``, so the read-only policy
+        is carried by a ``-c sandbox_mode=read-only`` config override (verified
+        against ``--strict-config``) and the working directory comes from the
+        subprocess ``cwd`` the runner already sets. Falls back to the cold form
+        when no id is available so we never emit ``resume`` with an empty id.
         """
+        if resume and resume_session_id:
+            args = [
+                self.EXECUTABLE,
+                "exec",
+                "resume",
+                "--json",
+                "-c",
+                "sandbox_mode=read-only",
+            ]
+            if model:
+                args.extend(["--model", model])
+            args.extend([resume_session_id, prompt])
+            return args
+
         args = [
             self.EXECUTABLE,
             "exec",

--- a/remote-agent/cli_adapters/openclaw.py
+++ b/remote-agent/cli_adapters/openclaw.py
@@ -84,12 +84,21 @@ class OpenClawAdapter(BaseCLIAdapter):
         return args
 
     def build_single_shot_args(
-        self, prompt: str, project_path: str, model: str | None = None
+        self,
+        prompt: str,
+        project_path: str,
+        model: str | None = None,
+        resume: bool = False,
+        resume_session_id: str = "",
     ) -> list[str]:
         """Build args for a single-shot OpenClaw execution.
 
         Mirrors build_start_args but appends the prompt as the final
         positional argument, matching OpenClaw's agent-mode CLI contract.
+
+        ``resume`` / ``resume_session_id`` are accepted (so the shared
+        ``_run_single_shot`` call site never raises) but **ignored**: openclaw's
+        non-interactive resume is unverified and deliberately deferred (#3321).
         """
         args = [
             self.EXECUTABLE,

--- a/tests/unit/test_codex_resume_3321.py
+++ b/tests/unit/test_codex_resume_3321.py
@@ -1,0 +1,121 @@
+"""Regression tests for #3321: codex autonomous runs must resume.
+
+Before #3321 the single-shot dispatch dropped ``resume`` entirely, so every
+milestone was a cold ``codex exec`` with no prior context. These tests pin the
+adapter-level argv construction; the orchestrator-level capture/persist/resolve
+round-trip is covered by ``test_codex_resume_carry_3321.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REMOTE_AGENT_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "remote-agent")
+)
+if REMOTE_AGENT_DIR not in sys.path:
+    sys.path.insert(0, REMOTE_AGENT_DIR)
+
+
+def _codex_adapter():
+    from cli_adapters import ADAPTERS
+
+    return ADAPTERS["codex"]()
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3321)
+def test_codex_single_shot_resume_emits_exec_resume_with_id():
+    """A resume single-shot run targets ``codex exec resume <id>``.
+
+    Fails before #3321 because ``build_single_shot_args`` has no ``resume``
+    parameter and always builds a cold ``codex exec``.
+    """
+    adapter = _codex_adapter()
+
+    args = adapter.build_single_shot_args(
+        "continue the work",
+        project_path="/workspace",
+        model="o3",
+        resume=True,
+        resume_session_id="01a062a7-6e97-7c20-a694-2ebd922ea386",
+    )
+
+    assert args[:3] == ["codex", "exec", "resume"], args
+    assert "01a062a7-6e97-7c20-a694-2ebd922ea386" in args, args
+    assert "--json" in args, args
+    # The prompt is still delivered.
+    assert "continue the work" in args, args
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3321)
+def test_codex_resume_keeps_read_only_sandbox_via_config_override():
+    """Resume preserves the read-only sandbox despite ``--sandbox`` being rejected.
+
+    ``codex exec resume`` rejects ``--sandbox``; the policy is carried by
+    ``-c sandbox_mode=read-only`` instead. Without this a resumed turn would run
+    under codex's default (more permissive) sandbox — less isolated than turn 1.
+    """
+    adapter = _codex_adapter()
+
+    args = adapter.build_single_shot_args(
+        "continue",
+        project_path="/workspace",
+        model="o3",
+        resume=True,
+        resume_session_id="tid-1",
+    )
+
+    assert "--sandbox" not in args, f"resume rejects --sandbox: {args}"
+    assert "-c" in args, args
+    ci = args.index("-c")
+    assert args[ci + 1] == "sandbox_mode=read-only", args
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3321)
+def test_codex_non_resume_single_shot_argv_unchanged():
+    """The first-milestone (cold) argv is byte-for-byte what it was pre-#3321."""
+    adapter = _codex_adapter()
+
+    args = adapter.build_single_shot_args("do the task", project_path="/workspace", model="o3")
+
+    assert args == [
+        "codex",
+        "exec",
+        "--json",
+        "--sandbox",
+        "read-only",
+        "--model",
+        "o3",
+        "do the task",
+    ], args
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3321)
+def test_openclaw_single_shot_ignores_resume_kwargs_without_raising():
+    """openclaw shares the single-shot call site; passing resume kwargs must not raise.
+
+    ``_run_single_shot`` calls ``adapter.build_single_shot_args`` for both codex
+    and openclaw. openclaw is deferred (#3321), so it accepts-and-ignores the new
+    kwargs rather than growing resume behaviour or a ``TypeError``.
+    """
+    from cli_adapters import ADAPTERS
+
+    adapter = ADAPTERS["openclaw"]()
+
+    base = adapter.build_single_shot_args("task", project_path="/workspace", model="o3")
+    with_kwargs = adapter.build_single_shot_args(
+        "task",
+        project_path="/workspace",
+        model="o3",
+        resume=True,
+        resume_session_id="ignored",
+    )
+
+    assert base == with_kwargs, "openclaw must ignore resume kwargs, not act on them"

--- a/tests/unit/test_codex_resume_carry_3321.py
+++ b/tests/unit/test_codex_resume_carry_3321.py
@@ -1,0 +1,290 @@
+"""#3321: codex's minted thread_id must round-trip capture → persist → resolve.
+
+The adapter-level argv is covered by ``test_codex_resume_3321.py``. These tests
+pin the orchestrator/runner carry: extending the claude-only
+``_resolve_session_line`` mapping branch to codex, and persisting the captured
+``thread_id`` into ``agent_sessions.cli_session_id`` from ``_run_single_shot``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3321)]
+
+
+def _patch_codex_adapter():
+    """Patch cli_adapters.get_adapter so _run_single_shot finds a codex executable."""
+    adapter = MagicMock()
+    adapter.get_executable_name.return_value = "codex"
+    adapter.build_single_shot_args.return_value = ["codex", "exec", "--json", "prompt"]
+    mod = MagicMock()
+    mod.get_adapter.return_value = adapter
+    return adapter, (
+        patch.dict("sys.modules", {"cli_adapters": mod}),
+        patch("shutil.which", return_value="/usr/bin/codex"),
+    )
+
+
+def _make_orchestrator(db_state):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    repo = MagicMock()
+    repo.get_workflow = MagicMock(return_value=dict(db_state))
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = str(uuid.uuid4())
+    orch.repo = repo
+    orch._session_lock = MagicMock()
+    orch._current_session_id = None
+    orch._runner = MagicMock()
+    orch._runner.session_manager = MagicMock()
+    return orch
+
+
+def test_resolve_session_line_maps_codex_cli_session_id():
+    """A codex line resumes the captured thread_id, not the tracking id.
+
+    Fails before #3321: the mapping branch is gated ``cli_tool == "claude-code"``,
+    so codex falls through to ``(existing, existing, True)`` and resumes the
+    tracking id — which names no rollout, so ``codex exec resume`` cold-starts.
+    """
+    from app.modules.workspace.session_manager import AgentSession
+
+    db_state = {"main_session_id": "wf-main-track", "cli_tool": "codex"}
+    orch = _make_orchestrator(db_state)
+    orch._runner.session_manager.get_session.return_value = AgentSession(
+        session_id="wf-main-track",
+        cli_session_id="01a062a7-6e97-7c20-a694-2ebd922ea386",
+    )
+
+    sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
+
+    assert resume is True
+    assert sid == "wf-main-track", "tracking id must stay stable (HOME must not rotate)"
+    assert resume_sid == "01a062a7-6e97-7c20-a694-2ebd922ea386"
+
+
+def test_resolve_session_line_codex_first_turn_starts_fresh():
+    """Turn 1 codex has no captured id yet → cold start, not a fake resume.
+
+    The tracking id is set from workflow creation, but ``cli_session_id`` is
+    empty until turn 1 records it. Resuming the tracking id would hit
+    "no rollout found"; return resume=False so turn 1 runs cold.
+    """
+    from app.modules.workspace.session_manager import AgentSession
+
+    db_state = {"main_session_id": "wf-main-track", "cli_tool": "codex"}
+    orch = _make_orchestrator(db_state)
+    orch._runner.session_manager.get_session.return_value = AgentSession(
+        session_id="wf-main-track", cli_session_id=""
+    )
+
+    sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
+
+    assert resume is False
+    assert resume_sid is None
+    assert sid == "wf-main-track"
+
+
+def test_run_single_shot_threads_resume_into_adapter():
+    """A resume single-shot call passes resume/resume_session_id to the adapter.
+
+    Fails before #3321: ``_run_single_shot`` has no ``resume`` parameter, so the
+    dispatch could not carry it even if it wanted to.
+    """
+    runner = AutonomousAgentRunner()
+    proc = MagicMock(returncode=0, stdout="", stderr="")
+    adapter, (mod_patch, which_patch) = _patch_codex_adapter()
+
+    with mod_patch, which_patch, patch("subprocess.run", return_value=proc):
+        runner._run_single_shot(
+            session_id="s1",
+            cli_tool="codex",
+            model="m",
+            project_path="/tmp/p",
+            prompt="do it",
+            timeout=5,
+            workflow_id="wf1",
+            resume=True,
+            resume_session_id="01a062a7-tid",
+        )
+
+    _, kwargs = adapter.build_single_shot_args.call_args
+    assert kwargs.get("resume") is True, adapter.build_single_shot_args.call_args
+    assert kwargs.get("resume_session_id") == "01a062a7-tid"
+
+
+def test_run_single_shot_captures_and_persists_codex_thread_id():
+    """codex's first ``thread.started`` id is written to cli_session_id.
+
+    This is the capture+persist half of the carry. Without it, the next
+    milestone's ``_resolve_session_line`` reads an empty column and cold-starts.
+    """
+    runner = AutonomousAgentRunner()
+    runner.session_manager = MagicMock()
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "01a062a7-6e97-7c20-real"}),
+            json.dumps({"type": "turn.started"}),
+            json.dumps(
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}}
+            ),
+        ]
+    )
+    proc = MagicMock(returncode=0, stdout=stdout, stderr="")
+    _adapter, (mod_patch, which_patch) = _patch_codex_adapter()
+
+    with mod_patch, which_patch, patch("subprocess.run", return_value=proc):
+        runner._run_single_shot(
+            session_id="s1",
+            cli_tool="codex",
+            model="m",
+            project_path="/tmp/p",
+            prompt="do it",
+            timeout=5,
+            workflow_id="wf1",
+        )
+
+    runner.session_manager.update_session_fields.assert_called_once()
+    call = runner.session_manager.update_session_fields.call_args
+    assert call.args[0] == "s1", call
+    assert call.args[1].get("cli_session_id") == "01a062a7-6e97-7c20-real", call
+
+
+def test_run_single_shot_no_thread_id_persists_nothing():
+    """A run with no thread.started (e.g. openclaw) records no cli_session_id."""
+    runner = AutonomousAgentRunner()
+    runner.session_manager = MagicMock()
+    stdout = json.dumps(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+    )
+    proc = MagicMock(returncode=0, stdout=stdout, stderr="")
+    _adapter, (mod_patch, which_patch) = _patch_codex_adapter()
+
+    with mod_patch, which_patch, patch("subprocess.run", return_value=proc):
+        runner._run_single_shot(
+            session_id="s1",
+            cli_tool="openclaw",
+            model="m",
+            project_path="/tmp/p",
+            prompt="do it",
+            timeout=5,
+            workflow_id="wf1",
+        )
+
+    runner.session_manager.update_session_fields.assert_not_called()
+
+
+def test_run_local_dispatch_forwards_resume_to_single_shot():
+    """`_run_local` must hand resume/resume_session_id to `_run_single_shot`.
+
+    This is the dispatch line the issue warns about: a codex run whose dispatch
+    drops resume would silently cold-start even with every other piece working.
+    """
+    runner = AutonomousAgentRunner()
+    sentinel = MagicMock(name="AgentTaskResult")
+
+    with (
+        patch.object(runner, "_run_single_shot", return_value=sentinel) as mock_ss,
+        patch.object(runner, "_ensure_project_dir"),
+    ):
+        out = runner._run_local(
+            session_id="s1",
+            cli_tool="codex",
+            model="m",
+            project_path="/tmp/p",
+            prompt="do it",
+            permission_mode="auto",
+            timeout=5,
+            workflow_id="wf1",
+            user_id=None,
+            workspace_type="local",
+            resume=True,
+            resume_session_id="01a062a7-tid",
+            tenant_id=0,  # skip _resolve_tenant_for_isolation
+        )
+
+    assert out is sentinel
+    mock_ss.assert_called_once()
+    kwargs = mock_ss.call_args.kwargs
+    assert kwargs.get("resume") is True, mock_ss.call_args
+    assert kwargs.get("resume_session_id") == "01a062a7-tid"
+
+
+class _FakeSessionStore:
+    """Minimal session_manager that actually round-trips cli_session_id."""
+
+    def __init__(self):
+        self.rows: dict[str, dict] = {}
+
+    def update_session_fields(self, session_id, fields, require_tenant=True):
+        self.rows.setdefault(session_id, {}).update(fields)
+
+    def get_session(self, session_id):
+        from app.modules.workspace.session_manager import AgentSession
+
+        row = self.rows.get(session_id)
+        if row is None:
+            return {}
+        return AgentSession(session_id=session_id, cli_session_id=row.get("cli_session_id", ""))
+
+
+def test_two_turn_codex_resume_round_trip():
+    """AC1: turn 1 captures+persists the thread_id; turn 2 resolves it and the
+    real codex adapter builds ``codex exec resume <thread_id>``.
+
+    Fails if the capture/persist OR the ``_resolve_session_line`` extension is
+    removed — the two halves of the carry.
+    """
+    from cli_adapters import ADAPTERS
+
+    store = _FakeSessionStore()
+
+    # --- Turn 1: codex runs cold, mints a thread id; the runner persists it ---
+    runner = AutonomousAgentRunner()
+    runner.session_manager = store
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "01a0-turn1"}),
+            json.dumps(
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}}
+            ),
+        ]
+    )
+    proc = MagicMock(returncode=0, stdout=stdout, stderr="")
+    _adapter, (mod_patch, which_patch) = _patch_codex_adapter()
+    with mod_patch, which_patch, patch("subprocess.run", return_value=proc):
+        runner._run_single_shot(
+            session_id="wf-main-track",
+            cli_tool="codex",
+            model="o3",
+            project_path="/workspace",
+            prompt="start",
+            timeout=5,
+            workflow_id="wf1",
+        )
+    assert store.rows["wf-main-track"]["cli_session_id"] == "01a0-turn1"
+
+    # --- Turn 2: the orchestrator resolves the line to the persisted id ---
+    orch = _make_orchestrator({"main_session_id": "wf-main-track", "cli_tool": "codex"})
+    orch._runner.session_manager = store
+    sid, resume_sid, resume = orch._resolve_session_line(
+        {"main_session_id": "wf-main-track", "cli_tool": "codex"}, "main"
+    )
+    assert resume is True
+    assert sid == "wf-main-track"
+    assert resume_sid == "01a0-turn1"
+
+    # --- The real codex adapter turns that into a resume invocation ---
+    argv = ADAPTERS["codex"]().build_single_shot_args(
+        "continue", "/workspace", "o3", resume=resume, resume_session_id=resume_sid
+    )
+    assert argv[:3] == ["codex", "exec", "resume"]
+    assert "01a0-turn1" in argv


### PR DESCRIPTION
## What & why

Every codex milestone was a cold `codex exec` — the single-shot dispatch dropped `resume` entirely, and there was no way to point a non-interactive run at a prior session. So the session-line design (`main` over six milestones, `review` over two) silently did not apply to codex. Fixes #3321.

The issue's gating question — *can `codex exec` resume?* — is **yes** (verified live, codex-cli 0.152.1): `codex exec --json` emits `{"type":"thread.started","thread_id":<uuid>}` as its first event; that id names the rollout file (`~/.codex/sessions/.../rollout-*-<id>.jsonl`) and is what `codex exec resume <id>` accepts. An unknown id fails loudly ("no rollout found"), so a wrong id never silently cold-starts.

## The fix (the claude pattern, made tool-general)

The resume **id** — not the transcript — is the hard part. The rollout persists for free because `task_id == session_id` keeps the per-task HOME stable across a line's milestones. But the id was resolved claude-only, so codex resumed its *tracking* id (which names no rollout). Three legs, all previously claude-only:

- **Capture + persist** — parse `thread_id` from the first `--json` event; write it to `agent_sessions.cli_session_id` with an explicit `update_session_fields` in `_run_single_shot`'s result path (the single-shot path never runs the claude sidebar sync). Best-effort: a DB hiccup degrades to a cold next turn, never fails the finished milestone.
- **Resolve** — extend `_resolve_session_line`'s mapping branch from claude-only to codex via `_RESUME_ID_MAPPED_TOOLS`, keeping `tracking_session_id == task_id` so the HOME (and rollout under it) does not rotate.
- **Argv** — `_run_single_shot` + the dispatch gain `resume`/`resume_session_id`; the adapter emits `codex exec resume --json -c sandbox_mode=read-only <id> <prompt>` (resume rejects `--sandbox`, so the read-only policy rides a `-c` override verified against `--strict-config`).

`build_single_shot_args` gains the kwargs on the **base and both overrides** (codex, openclaw) — the shared call reaches both and openclaw's 3-arg override would otherwise `TypeError`. **openclaw is deferred**: it accepts-and-ignores the kwargs (its non-interactive resume is unverified).

## Tests (TDD, mutation-verified)

- Adapter: resume argv, sandbox override preserved, cold-path argv unchanged, openclaw ignores kwargs.
- Orchestrator: codex resolve maps the captured id; first-turn cold start.
- Runner: captures+persists `thread_id`; persists nothing without one; dispatch forwards `resume`.
- Integration: two-turn capture→persist→resolve→argv round trip.

Each new gate was confirmed to fail when its production line is reverted. Full affected suites (261 tests) green; false-positive scanner clean.

## Scope note

Populating `cli_session_id` for codex could mislead UI/timeline code that assumes it implies a Claude transcript layout — display-only, flagged in the plan for a follow-up check. Plan: `docs/dev-notes/3321-codex-resume-plan.md` (reviewed to zero findings by an independent agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)