### PR TITLE
fix(#3319): carry the CLI transcript for qwen-code-cli

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1317,7 +1317,8 @@ class AutonomousAgentRunner:
         if cli_session_id != session.cli_session_id:
             session.cli_session_id = cli_session_id
             logger.info(
-                "Captured Claude session_id from %s (workflow=%s tracking=%s cli=%s)",
+                "Captured %s session_id from %s (workflow=%s tracking=%s cli=%s)",
+                session.cli_tool,
                 source,
                 session.workflow_id,
                 (session.session_id or "")[:8],
@@ -3338,10 +3339,10 @@ class AutonomousAgentRunner:
             # `resume=True` with a falsy `cli_session_id`, and
             # `_resolve_session_line` never returns that shape — it yields
             # `(id, None, False)` when the mapping is missing and `(id, id,
-            # True)` for non-Claude tools. Kept because the alternative failure
-            # is silent (the line simply stops carrying history), and because
-            # the stream capture is gated on `_uses_sidebar_session_source`,
-            # which is a condition this code does not control.
+            # True)` for a tool it does not map. Kept because the alternative
+            # failure is silent (the line simply stops carrying history), and
+            # because stream capture is gated (claude-code and qwen-code-cli
+            # only), a condition this code does not control.
             captured = getattr(session, "cli_session_id", "") or resumed_with
             try:
                 blob = provider.export_agent_state(

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -160,6 +160,13 @@ COMPLETION_POLL_INTERVAL = 5.0
 # remote-agent/executor.py::_APPSERVER_TOOLS.
 _APPSERVER_TOOLS = frozenset({"zcode", "zcode-code"})
 
+# Tools whose transcript a `carried` provider (OpenSandbox) knows how to export
+# and import across an ephemeral HOME (#3237/#3319): both take the stream-json
+# path, emit their session_id on stdout, and have a provider transcript layout.
+# A `carried`-provider resume for any other tool is refused rather than run into
+# an empty HOME.
+_CARRIED_STATE_TOOLS = frozenset({"claude-code", "qwen-code-cli"})
+
 # Path to the cross-user agent launcher (Issue #1395). The service runs as
 # `openace` but agent CLIs (claude-code/qwen-code/openclaw) infer the project
 # root from cwd and have no --cwd flag, so they must launch with cwd=project.
@@ -1288,8 +1295,19 @@ class AutonomousAgentRunner:
         parsed: dict[str, Any],
         source: str,
     ) -> str:
-        """Persist the authoritative Claude session_id when the stream exposes it."""
-        if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
+        """Capture the CLI's own session_id from the stream onto the session.
+
+        For claude-code this is the sidebar/resume id (its long-standing use).
+        For qwen-code-cli (#3319) it is the id needed to name the carried
+        transcript — qwen emits ``session_id`` on the same stream-json stdout.
+        The gate widens for qwen HERE only; ``_uses_sidebar_session_source`` and
+        its sidebar-linkage call sites are untouched, so qwen's sidebar
+        behaviour does not change.
+        """
+        if (
+            not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type)
+            and session.cli_tool != "qwen-code-cli"
+        ):
             return ""
 
         cli_session_id = self._extract_stream_session_id(parsed)
@@ -2692,35 +2710,31 @@ class AutonomousAgentRunner:
 
         mode = agent_state_persistence(provider)
         # A carrying provider still only carries the tools it knows how to
-        # address. OpenSandbox writes and reads `.claude/projects/-workspace`,
-        # and `_capture_cli_session_id` only yields an id for claude-code — so
-        # for qwen-code-cli the export got an empty id, discarded the slot, and
-        # the next turn found nothing and started cold. That is the silent
-        # continuity loss this whole change exists to remove, surviving for a
-        # tool the sandbox genuinely supports. Refuse instead: the turn costs
-        # nothing yet, and a stated refusal is recoverable where a silent cold
-        # start is not.
+        # address. OpenSandbox reads/writes each tool's own transcript layout —
+        # `.claude/projects/-workspace/<id>.jsonl` for claude-code,
+        # `.qwen/projects/-workspace/chats/<id>.jsonl` for qwen-code-cli (#3319)
+        # — and `_capture_cli_session_id` yields the id for both from the
+        # stream. A tool with neither a captured id nor a provider path would get
+        # an empty id, discard the slot, and cold-start the next turn: silent
+        # continuity loss. Refuse instead — the turn costs nothing yet, and a
+        # stated refusal is recoverable where a silent cold start is not.
         #
-        # INTERIM, and the reason is scope rather than feasibility — #3319
-        # implements the real carry. Qwen supports `--resume`, its directory
-        # encoding is the same one Claude uses, and its session id is already
-        # on the wire; the only genuine unknown is that its transcript may sit
-        # at either `<encoded>/chats/<id>.jsonl` or `<encoded>/<id>.jsonl`, and
-        # that is discoverable by probing on export rather than guessing.
-        #
-        # qwen-code-cli is the ONLY other tool this can reach: ZCode and the
+        # claude-code and qwen-code-cli (#3319) are the tools this seam can
+        # carry: both take the stream-json path, emit their session_id on stdout,
+        # and the provider knows their transcript layout. ZCode and the
         # single-shot tools (codex, openclaw) return from _run_local before
-        # `_select_sandbox_provider` and spawn locally, so they have no
-        # ephemeral HOME to carry anything across.
-        if mode == AGENT_STATE_CARRIED and not self._uses_sidebar_session_source(cli_tool, "local"):
+        # `_select_sandbox_provider` and spawn locally, so they never reach here;
+        # any future stream-json tool without a provider path must refuse rather
+        # than resume into an empty HOME.
+        if mode == AGENT_STATE_CARRIED and cli_tool not in _CARRIED_STATE_TOOLS:
             return _AgentStatePlan(
                 resume=False,
                 refuse=True,
                 reason_code="agent_state_unavailable",
                 detail=(
-                    f"{type(provider).__name__} does not yet carry agent state for "
+                    f"{type(provider).__name__} does not carry agent state for "
                     f"{cli_tool!r}: its transcript location and session-id capture are "
-                    "claude-code specific (see #3319). Refusing rather than resuming "
+                    "not wired for this tool. Refusing rather than resuming "
                     "into an empty HOME."
                 ),
             )
@@ -3113,6 +3127,7 @@ class AutonomousAgentRunner:
                         sandbox_handle,
                         cli_session_id=resume_target,
                         blob=state_plan.blob,
+                        cli_tool=cli_tool,
                     )
                     resumed_with = resume_target
                 except Exception as exc:  # noqa: BLE001 - degrade, never fail the turn
@@ -3329,9 +3344,16 @@ class AutonomousAgentRunner:
             # which is a condition this code does not control.
             captured = getattr(session, "cli_session_id", "") or resumed_with
             try:
-                blob = provider.export_agent_state(sandbox_handle, cli_session_id=captured)
+                blob = provider.export_agent_state(
+                    sandbox_handle, cli_session_id=captured, cli_tool=cli_tool
+                )
                 if blob is not None:
                     self._agent_state_store.put(workflow_id, session_id, blob)
+                    # #3319: persist the captured id so the NEXT milestone's
+                    # `_resolve_session_line` can map the tracking id to it. The
+                    # streaming tools' claude-only sidebar sync never runs for
+                    # qwen, so this is an explicit, best-effort write here.
+                    self._persist_carried_resume_id(session, cli_tool, captured)
                 else:
                     self._agent_state_store.discard(workflow_id, session_id)
             except Exception as exc:  # noqa: BLE001 - never discard finished work
@@ -3950,6 +3972,33 @@ class AutonomousAgentRunner:
                     output_tokens += usage["output"]
 
         return event_log, response_text.strip(), input_tokens, output_tokens, tool_calls
+
+    def _persist_carried_resume_id(
+        self, session: _LocalSession, cli_tool: str, cli_session_id: str
+    ) -> None:
+        """Write a carried tool's stream session id to ``cli_session_id`` (#3319).
+
+        For claude-code the sidebar sync already persists this during streaming;
+        qwen-code-cli's does not (it is gated claude-only), so its export-time id
+        needs an explicit write here so the next milestone's
+        ``_resolve_session_line`` can map the tracking id to it. Best-effort — a
+        DB error degrades the next turn to a cold start, never fails this one.
+        """
+        if cli_tool != "qwen-code-cli" or not cli_session_id:
+            return
+        session_manager = getattr(self, "session_manager", None)
+        if not session_manager:
+            return
+        try:
+            session_manager.update_session_fields(
+                session.session_id, {"cli_session_id": cli_session_id}, require_tenant=False
+            )
+        except Exception as exc:  # noqa: BLE001 - never fail a finished milestone
+            logger.warning(
+                "Failed to persist carried resume id for %s: %s",
+                (session.session_id or "")[:8],
+                exc,
+            )
 
     @staticmethod
     def _extract_thread_started_id(stdout_text: str) -> str:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2144,8 +2144,9 @@ SESSION_LINE_FIELDS = {
 # be mapped to the real ``cli_session_id`` before it can be resumed. For these,
 # resuming the tracking id itself would target a session the CLI never created.
 # claude-code captures its id from the SDK stream; codex (#3321) from the
-# ``thread.started`` event. Tools absent here resume the tracking id directly.
-_RESUME_ID_MAPPED_TOOLS = frozenset({"claude-code", "codex"})
+# ``thread.started`` event; qwen-code-cli (#3319) emits ``session_id`` on the
+# same stream-json stdout. Tools absent here resume the tracking id directly.
+_RESUME_ID_MAPPED_TOOLS = frozenset({"claude-code", "codex", "qwen-code-cli"})
 
 # Agent intro/closing text patterns for _clean_agent_text().
 # These match common Chinese agent narration phrases that should not

--- a/app/modules/workspace/autonomous/sandbox/opensandbox/provider.py
+++ b/app/modules/workspace/autonomous/sandbox/opensandbox/provider.py
@@ -164,8 +164,14 @@ _SAFE_DIR = f"-c safe.directory={_WORKSPACE}"
 # so they cannot drift apart.
 _AGENT_STATE_DIR = "/home/agent/.claude/projects/-workspace"
 
+# qwen (#3319) shares the same fixed cwd (/workspace -> -workspace) but keeps its
+# transcript under ~/.qwen and one level deeper, in a chats/ subdir. Both dirs
+# are constants for the pinned sandbox image, not host-derived, and are covered
+# by tests that pin the layout so it cannot drift.
+_QWEN_AGENT_STATE_DIR = "/home/agent/.qwen/projects/-workspace/chats"
 
-def _agent_state_path(cli_session_id: str) -> str | None:
+
+def _agent_state_path(cli_session_id: str, cli_tool: str = "claude-code") -> str | None:
     """The transcript path for *cli_session_id*, or ``None`` if unusable.
 
     The id is NOT trusted. It reaches here from ``agent_sessions.cli_session_id``,
@@ -186,7 +192,8 @@ def _agent_state_path(cli_session_id: str) -> str | None:
     """
     if not _SAFE_SESSION_ID.match(str(cli_session_id or "")):
         return None
-    return f"{_AGENT_STATE_DIR}/{cli_session_id}.jsonl"
+    base = _QWEN_AGENT_STATE_DIR if cli_tool == "qwen-code-cli" else _AGENT_STATE_DIR
+    return f"{base}/{cli_session_id}.jsonl"
 
 
 # Session ids are uuids in practice; this is deliberately a little wider so a
@@ -536,15 +543,21 @@ class OpenSandboxProvider:
         )
         self._emit("changeset_applied", {"sandbox_id": handle.sandbox_id})
 
-    def export_agent_state(self, handle: SandboxHandle, *, cli_session_id: str) -> bytes | None:
+    def export_agent_state(
+        self, handle: SandboxHandle, *, cli_session_id: str, cli_tool: str = "claude-code"
+    ) -> bytes | None:
         """Read the CLI transcript out before the sandbox is destroyed (#3237).
 
         Returns ``None`` when there is nothing to carry — no session id (the
         stream never yielded one) or no transcript at that path (the turn never
         started a conversation). Neither is an error, and neither should cost
         the caller a completed milestone.
+
+        ``cli_tool`` selects the transcript layout: claude-code under
+        ``.claude/projects/-workspace``, qwen-code-cli under
+        ``.qwen/projects/-workspace/chats`` (#3319).
         """
-        path = _agent_state_path(cli_session_id)
+        path = _agent_state_path(cli_session_id, cli_tool)
         if path is None:
             # Emitted, not silently dropped. This is the FIRST place a hostile
             # id surfaces: the sandbox prints it during its own turn and the
@@ -601,7 +614,12 @@ class OpenSandboxProvider:
         return blob
 
     def import_agent_state(
-        self, handle: SandboxHandle, *, cli_session_id: str, blob: bytes
+        self,
+        handle: SandboxHandle,
+        *,
+        cli_session_id: str,
+        blob: bytes,
+        cli_tool: str = "claude-code",
     ) -> None:
         """Place the transcript where ``--resume`` will look for it (#3237).
 
@@ -610,9 +628,10 @@ class OpenSandboxProvider:
         and a credential must not round-trip through the control plane.
         Verified against a real CLI that restoring this file alone into an
         otherwise empty HOME is sufficient for ``--resume`` to resolve, with
-        the original session id preserved.
+        the original session id preserved. ``cli_tool`` selects the layout
+        (#3319), same as :meth:`export_agent_state`.
         """
-        path = _agent_state_path(cli_session_id)
+        path = _agent_state_path(cli_session_id, cli_tool)
         if path is None:
             raise self._refuse(
                 f"agent state id {cli_session_id!r} is not a plain path component; "

--- a/docs/dev-notes/3319-qwen-transcript-carry-plan.md
+++ b/docs/dev-notes/3319-qwen-transcript-carry-plan.md
@@ -1,0 +1,178 @@
+# #3319 — carry the CLI transcript for `qwen-code-cli`
+
+Plan, for review before implementation. Revised after independent review found
+the first draft's carry channel (store the transcript's on-disk path) both
+insufficient (the resume id never reaches the CLI) and unsafe (a stored path
+bypasses the traversal guard). Claims verified 2026-09-02 (see "Verification").
+
+## Problem
+
+`qwen-code-cli` runs on the OpenSandbox backend and shares claude-code's
+stream-json path through `_run_local`, so it reaches the #3237 agent-state seam.
+Before #3263 a sandboxed qwen resume was a silent no-op; #3263 made it an
+explicit refusal (`agent_state_unavailable`). This issue replaces the refusal
+with a working carry.
+
+`qwen-code-cli` is the only tool that needs this here. ZCode returns to
+`_run_zcode_appserver` and codex/openclaw to `_run_single_shot`, both before
+`_select_sandbox_provider` (`agent_runner.py:2711-2714`). See #3321 and #3323.
+
+## The blocking defect the first draft missed: resume id, not just the file
+
+Carrying the transcript bytes to the right path is necessary but **not
+sufficient**. Qwen mints its **own** session id and the runner never tells the
+CLI to use ours:
+
+* Turn 1 runs fresh (no `--resume`; qwen has no `--session-id` flag —
+  `qwen_code.py:56-113`) and mints uuid **Q1**, writing
+  `~/.qwen/projects/<encoded>/chats/Q1.jsonl`.
+* The resume id is resolved **claude-only**. `_resolve_session_line` maps a
+  line's tracking id to the real `cli_session_id` only when `cli_tool ==
+  "claude-code"` (`orchestrator.py:7228`); otherwise it returns
+  `(existing, existing, True)` — resume target == tracking id
+  (`orchestrator.py:7265`). And the write that populates `cli_session_id` is
+  itself gated claude-only (`_ensure_sidebar_session`, `agent_runner.py:2137`→
+  `:2198`, behind `_uses_sidebar_session_source`).
+
+So even with the bytes restored perfectly, turn 2's argv is `--resume
+<tracking-id>` while the file is `chats/Q1.jsonl` → qwen finds nothing → silent
+cold start. The first draft's "capture `stream_session_id` for carry only, do
+not touch the resolve path" cannot work.
+
+## Design: the minted id is the single source of truth
+
+One id flows through capture → persist → resolve → import, so the file the CLI
+looks for and the file we restore are named by the *same* id. This replaces the
+first draft's sidecar `<line>.meta.json` (which the review showed leaks past
+`reap`/`discard`, is written non-atomically with the blob, and — by storing an
+absolute path the import trusts — removes the `_SAFE_SESSION_ID` traversal guard
+the current code depends on).
+
+**Export discovers the id from the sandbox** (it cannot be known before the turn
+— qwen mints it): list `.qwen/projects/*/chats/*.jsonl` in the sandbox, pick the
+newest by mtime (the file this turn wrote or appended), read its `sessionId`
+field, and return `(blob, discovered_id)`. Reading `sessionId` from the file
+content — not the basename — matches how `scripts/fetch_qwen.py:645` identifies
+sessions and is robust to any rename. Picking the newest *after* the turn means
+a resumed turn carries this turn's transcript, not the stale one imported at its
+start (the failure the first draft used to reject an alternative while sharing
+it).
+
+**Persist** the discovered id with a **dedicated, explicit write at export
+time** — not by touching the claude sidebar machinery. The claude path writes
+`cli_session_id` inside `_ensure_sidebar_session` (`agent_runner.py:2137`→`:2198`),
+which is gated claude-only, fires *during* streaming (before qwen's id is even
+discovered), and falls back to `_find_latest_claude_session_id` — a **host-side**
+`.claude` mtime glob that would look on the control plane, not inside the pod.
+None of that fits qwen. Instead, the export block (`agent_runner.py:~3328`),
+which is where `discovered_id` first exists, calls
+`session_manager.update_session_fields(session.session_id, {"cli_session_id":
+discovered_id, …}, require_tenant=False)` directly for qwen. `tracking_session_id`
+stays `task_id`; nothing rotates.
+
+**Resolve** by extending the `_resolve_session_line` mapping branch
+(`orchestrator.py:7228`) from claude-only to also cover qwen-code-cli, so turn 2
+reads back the persisted `cli_session_id` as its resume target. (Confirmed safe:
+the branch's "mapping lost" arm returns `(existing, None, False)` — a clean fresh
+start — and nothing else assumes it is claude-only.)
+
+This is why `_uses_sidebar_session_source` is **not** touched (below): the
+sidebar-linkage functions it gates stay claude-only, and qwen's carry-id persist
+is a separate, explicit code path that never enters them.
+
+**Import rebuilds the path from the validated id** — never from a stored string.
+Turn 2 resolves resume target = Q1, argv `--resume Q1`; import writes the blob to
+`.qwen/projects/-workspace/chats/<Q1>.jsonl`, where `<Q1>` is validated by
+`_SAFE_SESSION_ID` before the path is built (identical to today's guard) and
+`-workspace` is the encoded sandbox project dir (see Encoding). No path is
+carried, so the traversal guard is intact.
+
+### On-disk layout and encoding (verified, and why no path is carried)
+
+* **Layout.** qwen 0.21.5 on this machine writes `chats/<sessionId>.jsonl`
+  exclusively (1127 transcripts, zero flat). The flat form
+  (`<encoded>/<id>.jsonl`) is a legacy layout `fetch_qwen.py` still tolerates
+  (probes `<encoded>/chats/*.jsonl` at `:787` and `<encoded>/*.jsonl` at `:782`).
+  The sandbox image pins the qwen version, so import targets `chats/` and a test
+  pins it; if the image's qwen ever changed layout, this constant changes with
+  it.
+* **Encoding.** The two repo encoders differ in general —
+  `encode_project_path_legacy` = `re.sub(r"[/\\:._]","-")`
+  (`app/routes/workspace.py`) vs the runner's `_encode_project_path` =
+  `re.sub(r"[^A-Za-z0-9]","-")` (`agent_runner.py:1746`) — but both map
+  `/workspace` → `-workspace` (only the leading slash is touched). Export
+  **globs** `.qwen/projects/*/chats/` so discovery does not depend on the exact
+  encoding; import uses `-workspace`, pinned by a test, and confirmed against a
+  real sandbox run during implementation.
+
+## Changes
+
+1. `provider.py` — `export_agent_state` for qwen discovers the newest
+   `chats/*.jsonl`, reads its `sessionId`, returns `(blob, discovered_id)`;
+   `import_agent_state` writes to `chats/<validated_id>.jsonl` under the encoded
+   project dir. `_SAFE_SESSION_ID` still validates the id before any path is
+   built. claude-code keeps its fixed `-workspace/.claude` path unchanged.
+2. `agent_runner.py` — thread `cli_tool` into the provider export/import; in the
+   export block (`~:3328`), where `discovered_id` first exists, persist it to
+   `agent_sessions.cli_session_id` via a direct
+   `session_manager.update_session_fields(..., require_tenant=False)` for qwen —
+   **not** by extending `_ensure_sidebar_session` (`:2137`→`:2198`) or the other
+   claude-only sidebar functions (they fire during streaming, before the id
+   exists, and fall back to a host-side `.claude` mtime glob); remove the
+   `_plan_agent_state` refusal for qwen-code-cli. The persist write goes in its
+   own `try/except` (a DB hiccup degrades to a cold start, never loses the
+   completed milestone — matching the log-only philosophy at `:3293`) and fires
+   only when `blob is not None`, so a no-transcript turn records no id.
+3. `orchestrator.py` — extend the `_resolve_session_line` mapping branch
+   (`:7228`) to qwen-code-cli so its resume target is the minted
+   `cli_session_id`, not the tracking id.
+4. `docs/sandbox-backends.md` — drop the "claude-code only" note; describe the
+   discover-persist-resolve-import flow.
+
+Deliberately **not** changed: `_uses_sidebar_session_source` (its 12 call sites
+drive sidebar linkage — a separate concern — and qwen's carry-id persist is a
+distinct explicit write that never enters them); and no sidecar file is added.
+
+## Acceptance
+
+1. A two-turn qwen regression through `_run_agent` → `_resolve_session_line`
+   (not the provider in isolation): turn 1's discovered `sessionId` is persisted
+   to `cli_session_id` and the blob uploaded to `chats/<id>.jsonl`; turn 2
+   resolves that id, its argv carries `--resume <same id>`, **and** the blob is
+   imported to that path. It must fail if **either** the persist/resolve
+   extension **or** the import is removed — asserting only that `--resume` is in
+   argv would pass with the carry deleted (the argv is built independently of
+   the import block at `agent_runner.py:2996`), the exact round-1 defect.
+2. Export picks the transcript written by *this* turn (newest by mtime), not a
+   stale one imported at turn start.
+3. Claude-code carry is unchanged; its stored state needs no discovery step and
+   its existing tests pass untouched.
+4. Only the transcript round-trips — no `.qwen` credential/settings file — as an
+   invariant asserted at the provider's written-path set (mirroring
+   `test_no_credential_file_is_ever_carried`). Noted as an invariant, not as
+   proof the feature works.
+5. A hostile qwen id is refused by `_SAFE_SESSION_ID` before any import path is
+   built.
+6. The `_plan_agent_state` refusal no longer fires for qwen-code-cli; a
+   synthetic uncarryable tool still triggers it (qwen was the only real tool
+   reaching that seam, so the negative case needs a synthetic tool — stated, not
+   pretended).
+
+## Verification (2026-09-02)
+
+* qwen 0.21.5: `-r/--resume <ID>` real (live `qwen --help`); adapter emits
+  `--resume <session_id>` (`qwen_code.py:87`); on-disk `chats/<sessionId>.jsonl`
+  only, `sessionId` both the basename and an in-file field (`fetch_qwen.py:645`
+  reads the field, not the basename).
+* Claude-only resume id path: persist gate `agent_runner.py:2242`; resolve
+  branch `orchestrator.py:7228`/`:7265`; `_extract_stream_session_id` generic
+  but Claude-shaped and only called on Claude SDK event types (`:1156`).
+* Encoders `app/routes/workspace.py` (legacy) vs `agent_runner.py:1746`
+  (runner); both `/workspace`→`-workspace`. `_SAFE_SESSION_ID` at
+  `provider.py:187`; hostile-id test `tests/unit/test_opensandbox_agent_state.py`.
+
+## Out of scope
+
+Deployment topology is unchanged: the shared state-root contract from #3237
+(`docs/sandbox-backends.md`) applies as-is — this changes what is carried and
+how the id is threaded, not where state rests.

--- a/docs/dev-notes/3319-qwen-transcript-carry-plan.md
+++ b/docs/dev-notes/3319-qwen-transcript-carry-plan.md
@@ -39,46 +39,57 @@ So even with the bytes restored perfectly, turn 2's argv is `--resume
 cold start. The first draft's "capture `stream_session_id` for carry only, do
 not touch the resolve path" cannot work.
 
+## Verified finding that simplifies the design (2026-09-03)
+
+The reviews' one open question was whether qwen's session id is on the **stdout
+stream** or must be recovered from disk. Tested against the installed qwen
+(0.21.5): it **is** on the stream. Every stream-json event carries
+`"session_id"`, starting with the very first `{"type":"system","subtype":"init",
+"session_id":"<uuid>", …}` — *before* any model call — and that id equals the
+transcript filename basename (`chats/<uuid>.jsonl`, confirmed on disk).
+
+This is exactly claude's shape, so the carry is the **claude pattern**: capture
+the id from the stream *during* the turn, then export/import a fixed
+`chats/<id>.jsonl` path. It also removes the need for disk discovery — which was
+never feasible anyway: the OpenSandbox API exposes only `download_file` /
+`upload_file` / `run_command`, no file listing, so "list `chats/*.jsonl` and pick
+the newest" would have required an extra exec during teardown. Stream capture
+needs neither, and it is what this plan now implements. (The sidecar
+`<line>.meta.json` the first draft proposed is still dropped, for the same
+traversal/leak reasons the review raised.)
+
 ## Design: the minted id is the single source of truth
 
 One id flows through capture → persist → resolve → import, so the file the CLI
-looks for and the file we restore are named by the *same* id. This replaces the
-first draft's sidecar `<line>.meta.json` (which the review showed leaks past
-`reap`/`discard`, is written non-atomically with the blob, and — by storing an
-absolute path the import trusts — removes the `_SAFE_SESSION_ID` traversal guard
-the current code depends on).
+looks for and the file we restore are named by the *same* id.
 
-**Export discovers the id from the sandbox** (it cannot be known before the turn
-— qwen mints it): list `.qwen/projects/*/chats/*.jsonl` in the sandbox, pick the
-newest by mtime (the file this turn wrote or appended), read its `sessionId`
-field, and return `(blob, discovered_id)`. Reading `sessionId` from the file
-content — not the basename — matches how `scripts/fetch_qwen.py:645` identifies
-sessions and is robust to any rename. Picking the newest *after* the turn means
-a resumed turn carries this turn's transcript, not the stale one imported at its
-start (the failure the first draft used to reject an alternative while sharing
-it).
+**Capture from the stream.** qwen reaches the generic stream-json path in
+`_run_local`, which already calls `_capture_cli_session_id` on its stream events
+(including the terminal `result` event, which qwen emits carrying `session_id`).
+Widen that helper's internal gate to admit qwen so it sets
+`session.cli_session_id` from the stream — the change is confined to that one
+helper; `_uses_sidebar_session_source` and its twelve sidebar-linkage call sites
+are left exactly as they are, so qwen's sidebar behaviour does not change, and
+claude's capture is byte-for-byte unchanged.
 
-**Persist** the discovered id with a **dedicated, explicit write at export
-time** — not by touching the claude sidebar machinery. The claude path writes
+**Persist** the captured id with a **dedicated, explicit write at export time** —
+not by touching the claude sidebar machinery. The claude path writes
 `cli_session_id` inside `_ensure_sidebar_session` (`agent_runner.py:2137`→`:2198`),
-which is gated claude-only, fires *during* streaming (before qwen's id is even
-discovered), and falls back to `_find_latest_claude_session_id` — a **host-side**
-`.claude` mtime glob that would look on the control plane, not inside the pod.
-None of that fits qwen. Instead, the export block (`agent_runner.py:~3328`),
-which is where `discovered_id` first exists, calls
+which is gated claude-only and falls back to `_find_latest_claude_session_id` — a
+**host-side** `.claude` mtime glob that would look on the control plane, not
+inside the pod. None of that fits qwen. Instead the export block
+(`agent_runner.py:~3330`, inside `_run_local`, where `cli_tool`, `session` and the
+captured id are all in scope) calls
 `session_manager.update_session_fields(session.session_id, {"cli_session_id":
-discovered_id, …}, require_tenant=False)` directly for qwen. `tracking_session_id`
-stays `task_id`; nothing rotates.
+<id>}, require_tenant=False)` directly for qwen, in its own `try/except` and only
+when a blob was actually carried. `tracking_session_id` stays `task_id`; nothing
+rotates. (This mirrors the codex persist landed in #3321.)
 
-**Resolve** by extending the `_resolve_session_line` mapping branch
-(`orchestrator.py:7228`) from claude-only to also cover qwen-code-cli, so turn 2
-reads back the persisted `cli_session_id` as its resume target. (Confirmed safe:
-the branch's "mapping lost" arm returns `(existing, None, False)` — a clean fresh
-start — and nothing else assumes it is claude-only.)
-
-This is why `_uses_sidebar_session_source` is **not** touched (below): the
-sidebar-linkage functions it gates stay claude-only, and qwen's carry-id persist
-is a separate, explicit code path that never enters them.
+**Resolve** by adding `qwen-code-cli` to `_RESUME_ID_MAPPED_TOOLS`
+(`orchestrator.py`, the shared frozenset #3321 introduced), so turn 2 reads back
+the persisted `cli_session_id` as its resume target. Confirmed safe: the branch's
+"no mapping yet" arm returns `(existing, None, False)` — a clean fresh start for
+turn 1 — and nothing else assumes it is claude-only.
 
 **Import rebuilds the path from the validated id** — never from a stored string.
 Turn 2 resolves resume target = Q1, argv `--resume Q1`; import writes the blob to
@@ -87,66 +98,67 @@ Turn 2 resolves resume target = Q1, argv `--resume Q1`; import writes the blob t
 `-workspace` is the encoded sandbox project dir (see Encoding). No path is
 carried, so the traversal guard is intact.
 
-### On-disk layout and encoding (verified, and why no path is carried)
+### On-disk layout and encoding (verified)
 
-* **Layout.** qwen 0.21.5 on this machine writes `chats/<sessionId>.jsonl`
-  exclusively (1127 transcripts, zero flat). The flat form
-  (`<encoded>/<id>.jsonl`) is a legacy layout `fetch_qwen.py` still tolerates
-  (probes `<encoded>/chats/*.jsonl` at `:787` and `<encoded>/*.jsonl` at `:782`).
-  The sandbox image pins the qwen version, so import targets `chats/` and a test
-  pins it; if the image's qwen ever changed layout, this constant changes with
-  it.
+* **Layout.** qwen 0.21.5 writes `chats/<sessionId>.jsonl` exclusively (1127
+  transcripts on this machine, zero flat). The flat form (`<encoded>/<id>.jsonl`)
+  is a legacy layout `fetch_qwen.py` still tolerates. The sandbox image pins the
+  qwen version, so the provider addresses a fixed
+  `.qwen/projects/-workspace/chats/<id>.jsonl` (analogous to claude's fixed
+  `.claude/projects/-workspace/<id>.jsonl`), pinned by a test; if the image's
+  qwen ever changed layout, this constant changes with it.
 * **Encoding.** The two repo encoders differ in general —
   `encode_project_path_legacy` = `re.sub(r"[/\\:._]","-")`
   (`app/routes/workspace.py`) vs the runner's `_encode_project_path` =
   `re.sub(r"[^A-Za-z0-9]","-")` (`agent_runner.py:1746`) — but both map
-  `/workspace` → `-workspace` (only the leading slash is touched). Export
-  **globs** `.qwen/projects/*/chats/` so discovery does not depend on the exact
-  encoding; import uses `-workspace`, pinned by a test, and confirmed against a
-  real sandbox run during implementation.
+  `/workspace` → `-workspace` (only the leading slash is touched), the sandbox's
+  fixed cwd. Verified locally that qwen encodes cwd with the same `/`→`-` scheme.
+  `-workspace` is pinned by a test and confirmed against a real sandbox run
+  during implementation, the same way claude's constant already is.
 
 ## Changes
 
-1. `provider.py` — `export_agent_state` for qwen discovers the newest
-   `chats/*.jsonl`, reads its `sessionId`, returns `(blob, discovered_id)`;
-   `import_agent_state` writes to `chats/<validated_id>.jsonl` under the encoded
-   project dir. `_SAFE_SESSION_ID` still validates the id before any path is
-   built. claude-code keeps its fixed `-workspace/.claude` path unchanged.
-2. `agent_runner.py` — thread `cli_tool` into the provider export/import; in the
-   export block (`~:3328`), where `discovered_id` first exists, persist it to
-   `agent_sessions.cli_session_id` via a direct
-   `session_manager.update_session_fields(..., require_tenant=False)` for qwen —
-   **not** by extending `_ensure_sidebar_session` (`:2137`→`:2198`) or the other
-   claude-only sidebar functions (they fire during streaming, before the id
-   exists, and fall back to a host-side `.claude` mtime glob); remove the
-   `_plan_agent_state` refusal for qwen-code-cli. The persist write goes in its
-   own `try/except` (a DB hiccup degrades to a cold start, never loses the
-   completed milestone — matching the log-only philosophy at `:3293`) and fires
-   only when `blob is not None`, so a no-transcript turn records no id.
-3. `orchestrator.py` — extend the `_resolve_session_line` mapping branch
-   (`:7228`) to qwen-code-cli so its resume target is the minted
-   `cli_session_id`, not the tracking id.
+1. `provider.py` — `_agent_state_path(cli_session_id, cli_tool)` becomes
+   tool-aware: claude keeps `.claude/projects/-workspace/<id>.jsonl`, qwen gets
+   `.qwen/projects/-workspace/chats/<id>.jsonl`. `export_agent_state` /
+   `import_agent_state` gain `cli_tool="claude-code"` and pass it through.
+   `_SAFE_SESSION_ID` still validates the id before any path is built, so the
+   traversal guard is unchanged and no path string is ever stored.
+2. `agent_runner.py` —
+   * **Capture**: widen `_capture_cli_session_id`'s internal gate to admit qwen
+     (that one helper only — not `_uses_sidebar_session_source`), so its existing
+     stream-event calls set `session.cli_session_id` for qwen too.
+   * **Export/import**: thread `cli_tool` into both provider calls.
+   * **Persist**: in the export block (`~:3330`, inside `_run_local`, where
+     `cli_tool`/`session`/the captured id are in scope), an explicit
+     `session_manager.update_session_fields(session.session_id, {"cli_session_id":
+     <id>}, require_tenant=False)` for qwen — **not** via `_ensure_sidebar_session`
+     (`:2137`→`:2198`) or the other claude-only sidebar functions. Own
+     `try/except` (a DB hiccup degrades to a cold start, never loses the
+     milestone) and only when `blob is not None`.
+   * **Refusal**: `_plan_agent_state` (`:2715`) no longer refuses qwen; the
+     refusal fires only for a tool that is neither claude-code nor qwen-code-cli.
+3. `orchestrator.py` — add `qwen-code-cli` to `_RESUME_ID_MAPPED_TOOLS` so
+   `_resolve_session_line` maps qwen's tracking id to its captured
+   `cli_session_id` (the shared frozenset #3321 introduced).
 4. `docs/sandbox-backends.md` — drop the "claude-code only" note; describe the
-   discover-persist-resolve-import flow.
+   capture-persist-resolve-import flow.
 
 Deliberately **not** changed: `_uses_sidebar_session_source` (its 12 call sites
-drive sidebar linkage — a separate concern — and qwen's carry-id persist is a
-distinct explicit write that never enters them); and no sidecar file is added.
+drive sidebar linkage — a separate concern; only `_capture_cli_session_id`'s own
+gate widens); and no sidecar file is added.
 
 ## Acceptance
 
-1. A two-turn qwen regression through `_run_agent` → `_resolve_session_line`
-   (not the provider in isolation): turn 1's discovered `sessionId` is persisted
-   to `cli_session_id` and the blob uploaded to `chats/<id>.jsonl`; turn 2
-   resolves that id, its argv carries `--resume <same id>`, **and** the blob is
-   imported to that path. It must fail if **either** the persist/resolve
-   extension **or** the import is removed — asserting only that `--resume` is in
-   argv would pass with the carry deleted (the argv is built independently of
-   the import block at `agent_runner.py:2996`), the exact round-1 defect.
-2. Export picks the transcript written by *this* turn (newest by mtime), not a
-   stale one imported at turn start.
-3. Claude-code carry is unchanged; its stored state needs no discovery step and
-   its existing tests pass untouched.
+1. A two-turn qwen regression covering capture → persist → resolve → import:
+   turn 1 captures `sessionId` from the stream into `cli_session_id` and the
+   provider writes the blob to `.qwen/projects/-workspace/chats/<id>.jsonl`;
+   turn 2 resolves that id and imports the blob to that same path. It must fail
+   if **either** the persist/resolve extension **or** the import is removed.
+2. Capture: a qwen `system/init` (or any) event's `session_id` lands in
+   `session.cli_session_id`; claude's capture timing is unchanged.
+3. Claude-code carry is unchanged; the tool-aware path leaves claude's fixed
+   `.claude` path and its existing tests untouched.
 4. Only the transcript round-trips — no `.qwen` credential/settings file — as an
    invariant asserted at the provider's written-path set (mirroring
    `test_no_credential_file_is_ever_carried`). Noted as an invariant, not as

--- a/docs/sandbox-backends.md
+++ b/docs/sandbox-backends.md
@@ -435,20 +435,22 @@ than by Open ACE.
 **Multi-turn `--resume` carries the CLI transcript, and nothing else.** Each
 turn gets a fresh sandbox with an empty `HOME`, so the transcript `--resume`
 reads is exported before the sandbox is destroyed and imported into the next
-one (#3237). Exactly one file moves —
-`$HOME/.claude/projects/-workspace/<id>.jsonl` — never `.claude.json`,
-`.credentials.json` or settings: the sandbox environment is constructed, never
-inherited, and a credential must not round-trip through the control plane. A
-real CLI confirms that this one file is sufficient for `--resume` to resolve,
-with the original session id preserved.
+one (#3237). Exactly one file moves, under each tool's own layout —
+`$HOME/.claude/projects/-workspace/<id>.jsonl` for claude-code,
+`$HOME/.qwen/projects/-workspace/chats/<id>.jsonl` for qwen-code-cli (#3319) —
+never `.claude.json`, `.credentials.json` or settings: the sandbox environment
+is constructed, never inherited, and a credential must not round-trip through
+the control plane. A real CLI confirms that this one file is sufficient for
+`--resume` to resolve, with the original session id preserved.
 
-**Carry is claude-code only today.** The transcript path above and the
-session-id capture that feeds it are both claude-code specific, so a resuming
-`qwen-code-cli` turn is *refused* with `agent_state_unavailable` before the
-sandbox is created rather than allowed to start cold and silently lose its
-history. That is an interim state — #3319 implements the real Qwen carry — and
-it is a scoping decision, not a limitation: Qwen supports `--resume`, shares
-Claude's directory encoding, and already puts its session id on the wire.
+**Both stream-json tools carry (#3319).** claude-code and qwen-code-cli both
+emit their `session_id` on stdout, so the runner captures it during the turn,
+persists it to `agent_sessions.cli_session_id`, and the next milestone's
+`_resolve_session_line` maps the line's tracking id to it — resuming the real
+CLI session, not the tracking id. A resuming turn for any *other* tool (a future
+stream-json CLI with no provider transcript path) is still *refused* with
+`agent_state_unavailable` before the sandbox is created, rather than allowed to
+start cold and silently lose its history.
 
 No other tool is affected, because no other tool reaches this path. ZCode
 speaks its own app-server protocol and the single-shot tools (codex, openclaw)

--- a/tests/unit/test_agent_state_persistence.py
+++ b/tests/unit/test_agent_state_persistence.py
@@ -314,16 +314,37 @@ def test_recovery_returns_empty_without_ids(tmp_path):
 
 
 def test_a_resume_for_a_tool_the_provider_cannot_carry_is_refused():
-    """qwen-code-cli runs on OpenSandbox, but its transcript is not `.claude`.
+    """A stream-json tool the provider has no transcript layout for is refused.
 
-    `_AGENT_STATE_DIR` is claude-code specific and `_capture_cli_session_id`
-    only yields an id for claude-code, so on Qwen the export received an empty
-    id and discarded the slot, and the next turn found nothing and started
-    cold. Silent continuity loss for a tool the sandbox genuinely supports —
-    the exact defect this change exists to remove. Refusing costs nothing at
-    this point: no sandbox has been created and no tokens spent.
+    qwen-code-cli used to be this case, but #3319 wired its capture and
+    transcript path, so it now carries (see
+    ``test_qwen_transcript_carry_3319`` and ``test_qwen_carries`` below). A
+    genuinely uncarryable tool — one not in ``_CARRIED_STATE_TOOLS`` — must
+    still refuse rather than resume into an empty HOME. Refusing costs nothing
+    here: no sandbox created, no tokens spent.
     """
     plan = _runner()._plan_agent_state(
+        _Carried(),
+        workflow_id="wf-1",
+        tracking_session_id="s-1",
+        resume=True,
+        cli_tool="some-future-stream-tool",
+    )
+
+    assert plan.refuse, "an uncarryable resume was allowed to proceed into an empty HOME"
+    assert plan.resume is False
+    assert plan.reason_code == "agent_state_unavailable"
+    assert "some-future-stream-tool" in plan.detail
+
+
+def test_qwen_carries(tmp_path):
+    """#3319: qwen-code-cli is now a carried tool, not a refusal."""
+    from app.modules.workspace.autonomous.sandbox.agent_state_store import AgentStateStore
+
+    runner = _runner(tmp_path)
+    AgentStateStore(root=str(tmp_path)).put("wf-1", "s-1", b"QWEN\n")
+
+    plan = runner._plan_agent_state(
         _Carried(),
         workflow_id="wf-1",
         tracking_session_id="s-1",
@@ -331,10 +352,9 @@ def test_a_resume_for_a_tool_the_provider_cannot_carry_is_refused():
         cli_tool="qwen-code-cli",
     )
 
-    assert plan.refuse, "a Qwen resume was allowed to proceed into an empty HOME"
-    assert plan.resume is False
-    assert plan.reason_code == "agent_state_unavailable"
-    assert "qwen-code-cli" in plan.detail
+    assert plan.refuse is False
+    assert plan.resume is True
+    assert plan.blob == b"QWEN\n"
 
 
 def test_claude_code_still_carries(tmp_path):

--- a/tests/unit/test_opensandbox_agent_state.py
+++ b/tests/unit/test_opensandbox_agent_state.py
@@ -92,6 +92,46 @@ def test_a_round_trip_preserves_the_bytes(sandbox):
     assert provider.export_agent_state(handle, cli_session_id=_SID) == blob
 
 
+# ── #3319: qwen carries under a different on-disk layout ──────────────
+
+_QWEN_DIR = "/home/agent/.qwen/projects/-workspace/chats"
+
+
+@pytest.mark.issue(3319)
+def test_qwen_export_reads_the_chats_path(sandbox):
+    """qwen's transcript lives under .qwen/.../chats/, not .claude/."""
+    provider, api, handle = sandbox
+    api.uploaded[handle.sandbox_id][f"{_QWEN_DIR}/{_SID}.jsonl"] = b"QWEN\n"
+
+    assert (
+        provider.export_agent_state(handle, cli_session_id=_SID, cli_tool="qwen-code-cli")
+        == b"QWEN\n"
+    )
+    # And the claude path is NOT where qwen looks.
+    assert provider.export_agent_state(handle, cli_session_id=_SID) is None
+
+
+@pytest.mark.issue(3319)
+def test_qwen_import_writes_to_the_chats_path(sandbox):
+    provider, api, handle = sandbox
+    provider.import_agent_state(
+        handle, cli_session_id=_SID, blob=b"QWEN\n", cli_tool="qwen-code-cli"
+    )
+
+    assert api.uploaded[handle.sandbox_id][f"{_QWEN_DIR}/{_SID}.jsonl"] == b"QWEN\n"
+
+
+@pytest.mark.issue(3319)
+def test_qwen_round_trip_preserves_bytes(sandbox):
+    provider, _api, handle = sandbox
+    blob = b'{"sessionId":"' + _SID.encode() + b'","type":"user"}\n'
+    provider.import_agent_state(handle, cli_session_id=_SID, blob=blob, cli_tool="qwen-code-cli")
+
+    assert (
+        provider.export_agent_state(handle, cli_session_id=_SID, cli_tool="qwen-code-cli") == blob
+    )
+
+
 def test_no_credential_file_is_ever_carried(sandbox):
     """Only the transcript moves.
 

--- a/tests/unit/test_opensandbox_wiring.py
+++ b/tests/unit/test_opensandbox_wiring.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import threading
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -386,6 +387,7 @@ def _run_local_against(
     session_id="s-1",
     uses_sidebar=False,
     runner_spy=None,
+    cli_tool="claude-code",
 ):
     """Invoke the REAL _run_local with *provider* selected by the gate.
 
@@ -448,7 +450,7 @@ def _run_local_against(
         runner_spy(runner)
     return runner._run_local(
         session_id=session_id,
-        cli_tool="claude-code",
+        cli_tool=cli_tool,
         model="claude-sonnet-4",
         project_path=str(worktree),
         prompt="do the thing",
@@ -887,7 +889,7 @@ def test_run_local_exports_the_transcript_before_destroy(api, tmp_path, monkeypa
     real_export = provider.export_agent_state
     real_destroy = provider.destroy
 
-    def _export(handle, *, cli_session_id):
+    def _export(handle, *, cli_session_id, cli_tool="claude-code"):
         order.append("export")
         # Stand in for the CLI having written its transcript during the turn.
         provider.import_agent_state(
@@ -922,6 +924,62 @@ def test_run_local_exports_the_transcript_before_destroy(api, tmp_path, monkeypa
     )
 
 
+@pytest.mark.issue(3319)
+def test_run_local_carries_qwen_transcript_and_persists_the_id(api, tmp_path, monkeypatch):
+    """#3319 turn 1: qwen captures its stream id, exports under the qwen layout,
+    stores the transcript, and persists the id for the next milestone's resolve.
+
+    Fails if any of the three runner wiring changes is dropped: without the
+    export ``cli_tool`` the provider reads the wrong (claude) path and the store
+    stays empty; without the capture there is no id to export or persist; without
+    the explicit persist the next milestone's ``_resolve_session_line`` reads an
+    empty column and cold-starts.
+    """
+    worktree = _worktree_at(tmp_path)
+    provider = _provider_for(api, worktree, _ScriptedPtyConnection(_turn_frames("qwen-sid-1")))
+    store = _agent_state_store(tmp_path)
+
+    export_tool: list[str] = []
+    real_export = provider.export_agent_state
+
+    def _export(handle, *, cli_session_id, cli_tool="claude-code"):
+        export_tool.append(cli_tool)
+        # Stand in for qwen having written its transcript under the qwen layout
+        # during the turn — import with the SAME cli_tool so export finds it.
+        provider.import_agent_state(
+            handle, cli_session_id=cli_session_id, blob=b"QWEN-T1\n", cli_tool=cli_tool
+        )
+        return real_export(handle, cli_session_id=cli_session_id, cli_tool=cli_tool)
+
+    monkeypatch.setattr(provider, "export_agent_state", _export)
+
+    session_manager = MagicMock()
+
+    def _inject_sm(runner):
+        runner.session_manager = session_manager
+
+    result = _run_local_against(
+        provider,
+        worktree,
+        monkeypatch,
+        agent_state_store=store,
+        session_id="wf-main-track",
+        cli_tool="qwen-code-cli",
+        runner_spy=_inject_sm,
+    )
+
+    assert result.success, result.error
+    # The export addressed the qwen transcript layout, not claude's.
+    assert export_tool == ["qwen-code-cli"], export_tool
+    # The transcript reached the control-plane store.
+    assert store.get("wf-1", "wf-main-track") == b"QWEN-T1\n"
+    # The captured stream id was persisted so the next milestone can resolve it.
+    session_manager.update_session_fields.assert_called_once()
+    call = session_manager.update_session_fields.call_args
+    assert call.args[0] == "wf-main-track", call
+    assert call.args[1].get("cli_session_id") == "qwen-sid-1", call
+
+
 def test_run_local_imports_the_transcript_and_emits_resume(api, tmp_path, monkeypatch):
     """Turn 2: the stored transcript is placed, and --resume goes into argv.
 
@@ -936,7 +994,7 @@ def test_run_local_imports_the_transcript_and_emits_resume(api, tmp_path, monkey
     imported: list = []
     real_import = provider.import_agent_state
 
-    def _import(handle, *, cli_session_id, blob):
+    def _import(handle, *, cli_session_id, blob, cli_tool="claude-code"):
         imported.append((cli_session_id, blob))
         return real_import(handle, cli_session_id=cli_session_id, blob=blob)
 
@@ -1137,7 +1195,7 @@ def test_two_turns_on_one_line_carry_the_conversation(api, tmp_path, monkeypatch
     p1 = _provider_for(api, wt1, _ScriptedPtyConnection(_turn_frames("cli-1")))
     real_export = p1.export_agent_state
 
-    def _export(handle, *, cli_session_id):
+    def _export(handle, *, cli_session_id, cli_tool="claude-code"):
         p1.import_agent_state(handle, cli_session_id=cli_session_id, blob=b"HISTORY\n")
         return real_export(handle, cli_session_id=cli_session_id)
 
@@ -1152,7 +1210,7 @@ def test_two_turns_on_one_line_carry_the_conversation(api, tmp_path, monkeypatch
     placed: list = []
     real_import = p2.import_agent_state
 
-    def _import(handle, *, cli_session_id, blob):
+    def _import(handle, *, cli_session_id, blob, cli_tool="claude-code"):
         placed.append(blob)
         return real_import(handle, cli_session_id=cli_session_id, blob=blob)
 

--- a/tests/unit/test_qwen_transcript_carry_3319.py
+++ b/tests/unit/test_qwen_transcript_carry_3319.py
@@ -1,0 +1,197 @@
+"""#3319: carry the qwen-code-cli transcript across ephemeral sandboxes.
+
+qwen shares claude's stream-json path and emits its ``session_id`` on stdout
+(verified against qwen 0.21.5), so the carry is the claude pattern: capture the
+id from the stream, then export/import a fixed
+``.qwen/projects/-workspace/chats/<id>.jsonl``. These tests pin each leg —
+tool-aware provider path, stream capture, the ``_plan_agent_state`` refusal
+removal, and the ``_resolve_session_line`` extension.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3319)]
+
+
+# ── provider path is tool-aware ───────────────────────────────────────
+
+
+def test_agent_state_path_qwen_uses_chats_subdir():
+    """qwen's transcript path is ``.qwen/projects/-workspace/chats/<id>.jsonl``.
+
+    Fails before #3319: ``_agent_state_path`` hardcodes the claude
+    ``.claude/projects/-workspace`` dir for every tool.
+    """
+    from app.modules.workspace.autonomous.sandbox.opensandbox.provider import _agent_state_path
+
+    path = _agent_state_path("1dce24ac-4388-45fa-b663-3eebf55f4b73", cli_tool="qwen-code-cli")
+
+    assert (
+        path
+        == "/home/agent/.qwen/projects/-workspace/chats/1dce24ac-4388-45fa-b663-3eebf55f4b73.jsonl"
+    )
+
+
+def test_agent_state_path_claude_default_unchanged():
+    """claude-code keeps its fixed .claude path (default arg, no behaviour change)."""
+    from app.modules.workspace.autonomous.sandbox.opensandbox.provider import _agent_state_path
+
+    assert _agent_state_path("abc123") == "/home/agent/.claude/projects/-workspace/abc123.jsonl"
+    assert (
+        _agent_state_path("abc123", cli_tool="claude-code")
+        == "/home/agent/.claude/projects/-workspace/abc123.jsonl"
+    )
+
+
+def test_agent_state_path_hostile_id_refused_for_qwen_too():
+    """The traversal guard applies to qwen exactly as to claude."""
+    from app.modules.workspace.autonomous.sandbox.opensandbox.provider import _agent_state_path
+
+    assert _agent_state_path("../../etc/passwd", cli_tool="qwen-code-cli") is None
+    assert _agent_state_path("bad\nid", cli_tool="qwen-code-cli") is None
+    assert _agent_state_path("", cli_tool="qwen-code-cli") is None
+
+
+# ── stream capture (qwen emits session_id on stdout) ──────────────────
+
+
+def _qwen_session():
+    from app.modules.workspace.autonomous.agent_runner import _LocalSession
+
+    return _LocalSession(
+        session_id="wf-main-track",
+        process=None,
+        cli_tool="qwen-code-cli",
+        workspace_type="remote",
+        project_path="/workspace",
+        encoded_project_path="-workspace",
+        workflow_id="wf1",
+    )
+
+
+def test_capture_cli_session_id_captures_for_qwen_stream():
+    """qwen's stream ``session_id`` lands in ``session.cli_session_id``.
+
+    Fails before #3319: ``_capture_cli_session_id`` early-returns for any tool
+    that is not claude-code local, so qwen's id was never captured.
+    """
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+    runner = AutonomousAgentRunner()
+    session = _qwen_session()
+    parsed = {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "1dce24ac-4388-45fa-b663-3eebf55f4b73",
+    }
+
+    runner._capture_cli_session_id(session, parsed, "system")
+
+    assert session.cli_session_id == "1dce24ac-4388-45fa-b663-3eebf55f4b73"
+
+
+def test_capture_cli_session_id_ignores_non_stream_tool():
+    """A tool that is neither claude nor qwen still captures nothing here."""
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+
+    runner = AutonomousAgentRunner()
+    session = _LocalSession(session_id="s1", process=None, cli_tool="codex", workspace_type="local")
+    runner._capture_cli_session_id(session, {"session_id": "x"}, "system")
+    assert session.cli_session_id == ""
+
+
+# ── the refusal is lifted for qwen, kept for genuinely uncarryable tools ──
+
+
+class _Carried:
+    from app.modules.workspace.autonomous.sandbox.provider import AGENT_STATE_CARRIED
+
+    agent_state_persistence = AGENT_STATE_CARRIED
+
+
+def _runner_with_store(tmp_path):
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+    from app.modules.workspace.autonomous.sandbox.agent_state_store import AgentStateStore
+
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._agent_state_store = AgentStateStore(root=str(tmp_path))
+    return runner
+
+
+def test_plan_agent_state_no_longer_refuses_qwen(tmp_path):
+    """A carried provider with stored qwen state plans to resume, not refuse.
+
+    Fails before #3319: ``_plan_agent_state`` refuses every non-claude tool
+    under AGENT_STATE_CARRIED.
+    """
+    runner = _runner_with_store(tmp_path)
+    runner._agent_state_store.put("wf-1", "sid-1", b"QWEN TRANSCRIPT\n")
+
+    plan = runner._plan_agent_state(
+        _Carried(),
+        workflow_id="wf-1",
+        tracking_session_id="sid-1",
+        resume=True,
+        cli_tool="qwen-code-cli",
+    )
+
+    assert plan.refuse is False
+    assert plan.resume is True
+    assert plan.blob == b"QWEN TRANSCRIPT\n"
+
+
+def test_plan_agent_state_still_refuses_an_uncarryable_tool(tmp_path):
+    """A tool the sandbox cannot address is still refused, not silently cold."""
+    runner = _runner_with_store(tmp_path)
+    runner._agent_state_store.put("wf-1", "sid-1", b"X\n")
+
+    plan = runner._plan_agent_state(
+        _Carried(),
+        workflow_id="wf-1",
+        tracking_session_id="sid-1",
+        resume=True,
+        cli_tool="some-future-tool",
+    )
+
+    assert plan.refuse is True
+    assert plan.reason_code == "agent_state_unavailable"
+
+
+# ── resolve maps qwen's tracking id to the captured cli_session_id ────
+
+
+def _make_orchestrator(db_state):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    repo = MagicMock()
+    repo.get_workflow = MagicMock(return_value=dict(db_state))
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = str(uuid.uuid4())
+    orch.repo = repo
+    orch._session_lock = MagicMock()
+    orch._current_session_id = None
+    orch._runner = MagicMock()
+    orch._runner.session_manager = MagicMock()
+    return orch
+
+
+def test_resolve_session_line_maps_qwen_cli_session_id():
+    """A qwen line resumes the captured sessionId, not the tracking id."""
+    from app.modules.workspace.session_manager import AgentSession
+
+    db_state = {"main_session_id": "wf-main-track", "cli_tool": "qwen-code-cli"}
+    orch = _make_orchestrator(db_state)
+    orch._runner.session_manager.get_session.return_value = AgentSession(
+        session_id="wf-main-track", cli_session_id="1dce24ac-real"
+    )
+
+    sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
+
+    assert resume is True
+    assert sid == "wf-main-track"
+    assert resume_sid == "1dce24ac-real"


### PR DESCRIPTION
## What & why

`qwen-code-cli` runs on OpenSandbox and shares claude's stream-json path, so it reaches the #3237 agent-state seam — but the carry was claude-specific, and a resuming qwen turn was *refused* (`agent_state_unavailable`) rather than resumed. Every milestone started cold. Fixes #3319.

## The verified finding that shaped the design

Tested against the installed qwen (0.21.5): qwen emits its own `session_id` on **stdout** — the `system/init` event onward — and it equals the transcript filename `chats/<sessionId>.jsonl`. So the carry is the **claude pattern** (capture the id from the stream during the turn, then export/import a fixed path), not the disk-discovery the plan first assumed — which was infeasible anyway, since the OpenSandbox API exposes only `download_file`/`upload_file`/`run_command`, no file listing.

## The fix

- **Capture** — widen `_capture_cli_session_id`'s internal gate to admit qwen, so its existing stream-event calls set `session.cli_session_id`. That one helper only; `_uses_sidebar_session_source` and its 12 sidebar-linkage sites are untouched, so qwen's sidebar behaviour and claude's capture are unchanged.
- **Provider** — `_agent_state_path`/`export_agent_state`/`import_agent_state` gain `cli_tool`; qwen addresses `.qwen/projects/-workspace/chats/<id>.jsonl`, claude keeps its `.claude` path. `_SAFE_SESSION_ID` still validates the id before any path is built (traversal guard intact; no path string is ever stored).
- **Persist** — an explicit best-effort `update_session_fields` at export time writes the captured id to `agent_sessions.cli_session_id` (the claude-only sidebar sync never runs for qwen), only when a blob was carried.
- **Resolve** — add `qwen-code-cli` to `_RESUME_ID_MAPPED_TOOLS`, so the next milestone maps the tracking id to the captured id (tracking id stays `task_id`; the HOME does not rotate). This is the shared frozenset #3321 introduced.
- **Refuse** — `_plan_agent_state` now refuses only a tool that is neither claude-code nor qwen-code-cli (a future stream-json CLI with no provider path), via `_CARRIED_STATE_TOOLS`.

## Tests (TDD, mutation-verified)

Tool-aware provider path + hostile-id guard; qwen stream capture; refusal lifted for qwen but kept for an uncarryable tool; resolve maps qwen; wire-level qwen round trip; and a full `_run_local` integration that captures, exports under the qwen layout, stores the blob, and persists the id. Each gate was confirmed to fail when its production line is reverted (including: reverting the capture-gate widening breaks the integration test; the top-of-loop early-capture was dropped because the `result`-event capture already covers it and the extra call was untested). 1054 tests across the affected areas green; false-positive scanner clean.

Plan: `docs/dev-notes/3319-qwen-transcript-carry-plan.md` (reviewed to zero findings by an independent agent). Builds on #3321's `_RESUME_ID_MAPPED_TOOLS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)