### PR TITLE
fix(#3246): align the three date-contract E2E tests with #3276

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,11 +353,11 @@ jobs:
   false-positive-scan:
     # #3186 Phase A: the test-code false-positive scanner as a real, gated
     # lane. Selected for every non-docs change (ci.py select_pr_suites); the
-    # known-debt ledger (ci/false-positive-ledger.json) records today's 77
-    # findings by precise identity, so new or substituted debt is red while
-    # fixes only shrink the ledger (--prune-ledger, removal-only). Deliberately
-    # NOT advisory, no continue-on-error, no skip label: the result must be
-    # able to block merges via PR Gate.
+    # known-debt ledger (ci/false-positive-ledger.json) is at ZERO debt since
+    # #3186 Phase B completed (77 findings fully paid down), so ANY finding
+    # is new debt and reds the gate; re-enrolling paid-down debt fails the
+    # unit-lane total pin. Deliberately NOT advisory, no continue-on-error,
+    # no skip label: the result must be able to block merges via PR Gate.
     name: False-positive scan
     needs: changes
     if: needs.changes.outputs.false_positive_scan == 'true'

--- a/tests/e2e/e2e_anomaly_all_button_playwright.py
+++ b/tests/e2e/e2e_anomaly_all_button_playwright.py
@@ -24,28 +24,18 @@ Run:
 import os
 import sys
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright
 
-from tests.e2e.sync_helpers import login_as
+from tests.e2e.sync_helpers import expected_default_date_range, login_as
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-anomaly-all")
-
-
-def utc_today(days_offset: int = 0) -> str:
-    """Mirror the frontend's date rendering (``new Date().toISOString().split('T')[0]``).
-
-    AnomalyDetection/TrendAnalysis build date-range values with JS ``Date``
-    objects and serialize them via ``toISOString()``, i.e. the UTC date — not
-    the browser's local date. Expected values must be computed the same way.
-    """
-    return (datetime.now(timezone.utc) + timedelta(days=days_offset)).strftime("%Y-%m-%d")
 
 
 passed = 0
@@ -126,12 +116,12 @@ def test_default_date_range(page):  # allow-no-assert: smoke test - visual verif
     check("30" in (button_text or ""), f"Active button shows '30' (text: '{button_text}')")
 
     start_value, end_value = datepicker_values(page)
-    today = utc_today()
-    check(end_value == today, f"End date shows today ({end_value} vs {today})")
-    expected_start = utc_today(days_offset=-30)
+    expected_start, expected_end = expected_default_date_range(30)
+    check(end_value == expected_end, f"End date shows today ({end_value} vs {expected_end})")
     check(
         start_value == expected_start,
-        f"Start date shows 30 days ago ({start_value} vs {expected_start})",
+        f"Start date shows today-29, 30 calendar days inclusive "
+        f"({start_value} vs {expected_start})",
     )
     shot(page, "03-default-30-days")
 
@@ -170,16 +160,16 @@ def test_all_button_date_range(page):  # allow-no-assert: smoke test - visual ve
         )
     else:
         # Empty database: the API returns null min/max_date and the page falls
-        # back to 365 days ago -> today (UTC-rendered, see utc_today()).
-        today = utc_today()
-        fallback_start = utc_today(days_offset=-365)
+        # back to the 365-day default range (local calendar, inclusive).
+        fallback_start, fallback_end = expected_default_date_range(365)
         check(
-            end_value == today,
-            f"Empty DB fallback: end is today ({end_value} vs {today})",
+            end_value == fallback_end,
+            f"Empty DB fallback: end is today ({end_value} vs {fallback_end})",
         )
         check(
             start_value == fallback_start,
-            f"Empty DB fallback: start is 365 days ago ({start_value} vs {fallback_start})",
+            f"Empty DB fallback: start is today-364, 365 calendar days inclusive "
+            f"({start_value} vs {fallback_start})",
         )
 
     start_date_obj = datetime.strptime(start_value, "%Y-%m-%d")

--- a/tests/e2e/e2e_token_trend_all_button_playwright.py
+++ b/tests/e2e/e2e_token_trend_all_button_playwright.py
@@ -20,28 +20,18 @@ Run:
 import os
 import sys
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-from tests.e2e.sync_helpers import login_as
+from tests.e2e.sync_helpers import expected_default_date_range, login_as
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-token-trend-all")
-
-
-def utc_today(days_offset: int = 0) -> str:
-    """Mirror the frontend's date rendering (``new Date().toISOString().split('T')[0]``).
-
-    TrendAnalysis builds date-range values with JS ``Date`` objects and
-    serializes them via ``toISOString()``, i.e. the UTC date — not the
-    browser's local date. Expected values must be computed the same way.
-    """
-    return (datetime.now(timezone.utc) + timedelta(days=days_offset)).strftime("%Y-%m-%d")
 
 
 passed = 0
@@ -128,14 +118,14 @@ def test_default_date_range(page):  # allow-no-assert: smoke test - visual verif
     check("30" in button_text, f"Active button shows '30' (text: '{button_text}')")
 
     start_value, end_value = datepicker_values(page)
-    today = utc_today()
-    check(end_value == today, f"End date shows today ({end_value} vs {today})")
+    expected_start, expected_end = expected_default_date_range(30)
+    check(end_value == expected_end, f"End date shows today ({end_value} vs {expected_end})")
 
-    # Start date should be about 30 days ago
-    expected_start = utc_today(days_offset=-30)
+    # Start date is today-29: exactly 30 calendar days, inclusive
     check(
         start_value == expected_start,
-        f"Start date shows 30 days ago ({start_value} vs {expected_start})",
+        f"Start date shows today-29, 30 calendar days inclusive "
+        f"({start_value} vs {expected_start})",
     )
 
     shot(page, "03-default-30-days")
@@ -211,19 +201,16 @@ def test_all_button_date_range(page):  # allow-no-assert: smoke test - visual ve
             f"End equals data_range.max_date ({end_value} vs {captured_data_range['max_date']})",
         )
     else:
-        # Empty database: end is today and start falls back to 365 days ago
-        # (UTC-rendered, see utc_today()).
-        today = utc_today()
-        check(end_value == today, f"End date shows today ({end_value} vs {today})")
-
-        thirty_days_ago = utc_today(days_offset=-30)
-        if start_value != thirty_days_ago:
-            check(True, f"Start date is NOT hardcoded 30 days ago (actual: {start_value})")
-        else:
-            # This could happen if database only has 30 days of data
-            print(
-                "    [INFO] Start date happens to equal 30 days ago - may be correct if data is limited"
-            )
+        # Empty database: the All range deterministically falls back to the
+        # 365-day default window (local calendar, inclusive) — asserted
+        # positively, mirroring the anomaly sibling's fallback branch.
+        fallback_start, fallback_end = expected_default_date_range(365)
+        check(end_value == fallback_end, f"End date shows today ({end_value} vs {fallback_end})")
+        check(
+            start_value == fallback_start,
+            f"Start date shows today-364, 365 calendar days inclusive "
+            f"({start_value} vs {fallback_start})",
+        )
 
     # Verify start date is NOT in the future
     start_date_obj = datetime.strptime(start_value, "%Y-%m-%d")

--- a/tests/e2e/manage/e2e_conversation_history_default_dates.py
+++ b/tests/e2e/manage/e2e_conversation_history_default_dates.py
@@ -9,7 +9,8 @@ pre-fills a 30-day default into the filter state on load AND on Reset.
 
 Tests:
 1. First load — the start/end date pickers are pre-filled with the default
-   30-day range (today-30 .. today), NOT empty.
+   30-day range (today-29 .. today, exactly 30 calendar days inclusive),
+   NOT empty.
 2. Reset regression — after manually changing the dates and clicking Reset,
    the pickers return to the default 30-day range (NOT empty).
 3. After Reset the page still renders within the default range (rows or a
@@ -29,12 +30,21 @@ Run:
 import json
 import os
 import subprocess
+import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import sync_playwright
+
+PROJECT_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from tests.e2e.sync_helpers import expected_default_date_range
 
 pytestmark = [pytest.mark.regression, pytest.mark.issue(1006)]
 
@@ -71,10 +81,9 @@ def check(desc, condition, detail=""):
 
 
 def expected_range(days=30):
-    """Mirror of the frontend getDefaultDateRange(): local today-30 .. today."""
-    today = datetime.now()
-    start = today - timedelta(days=days)
-    return start.strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d")
+    """The shared #3276 contract expectation: local today-(days-1) .. today,
+    exactly `days` calendar days inclusive (see sync_helpers)."""
+    return expected_default_date_range(days)
 
 
 def norm_date_text(text):
@@ -163,8 +172,12 @@ def pick_non_default_day(page):
     page.wait_for_selector(".react-datepicker", timeout=5000)
     cells = page.locator(".react-datepicker__day:not(.react-datepicker__day--outside-month)")
     today_d = datetime.now().day
-    start_d = (datetime.now() - timedelta(days=30)).day
-    avoid = {today_d, start_d}
+    # The default start's day-of-month is derived from the SAME shared
+    # expectation the assertions use (today-29 under the #3276 inclusive
+    # contract) — deriving it here from today-30 would let ~30 nights a year
+    # pick a day that equals the new default start and fail the change check.
+    default_start_d = datetime.strptime(expected_default_date_range(30)[0], "%Y-%m-%d").day
+    avoid = {today_d, default_start_d}
     count = cells.count()
     for i in range(count):
         text = cells.nth(i).inner_text().strip()
@@ -249,7 +262,7 @@ def test_default_dates():
             "End date NOT empty on load", end_val not in ("", "Select.date"), f"(value={end_val!r})"
         )
         check(
-            "Start date == today-30 on load",
+            "Start date == today-29 (30 calendar days inclusive) on load",
             start_val == exp_start,
             f"(got {start_val!r}, want {exp_start!r})",
         )

--- a/tests/e2e/sync_helpers.py
+++ b/tests/e2e/sync_helpers.py
@@ -2,10 +2,36 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 import requests
 from playwright.sync_api import Page
+
+
+def expected_default_date_range(days: int = 30, *, now: datetime | None = None) -> tuple[str, str]:
+    """Expected value of the frontend's default range for ``days`` days.
+
+    The product contract (#3276) is exactly ``days`` calendar days through
+    today, inclusive on both ends, as local YYYY-MM-DD: start = today -
+    (days - 1), end = today (backend queries are date >= start AND
+    date <= end, so the window must contain exactly N days). Computed with
+    pure-Python local calendar arithmetic — the same local-calendar
+    semantics as the frontend's toLocalDateString, never UTC/toISOString.
+
+    ``now`` is injectable so unit tests can pin fixed dates (cross-month,
+    cross-year, leap-February anchors); e2e callers use the runner's local
+    clock, which matches the page under test (CI runners and their
+    headless browsers share the UTC local zone).
+    """
+    reference = now or datetime.now()
+    if days <= 0:
+        # Mirrors the frontend guard: a non-positive window degenerates to
+        # today..today rather than a silently inverted/future range.
+        today = reference.strftime("%Y-%m-%d")
+        return today, today
+    start = reference - timedelta(days=days - 1)
+    return start.strftime("%Y-%m-%d"), reference.strftime("%Y-%m-%d")
 
 
 def login_as(

--- a/tests/unit/test_e2e_date_range_expectations.py
+++ b/tests/unit/test_e2e_date_range_expectations.py
@@ -1,0 +1,77 @@
+# tests/unit/test_e2e_date_range_expectations.py
+"""Unit contract for the e2e shared date-range expectation helper.
+
+`tests/e2e/sync_helpers.expected_default_date_range` is the single source
+every date-prefill e2e asserts against. It must mirror the product contract
+pinned by #3276: exactly N calendar days through today, inclusive on both
+ends (start = today-(N-1)), computed in the local calendar — never
+UTC/toISOString semantics. The helper is deliberately pure Python (no
+frontend import), so these anchors verify it against hand-computed
+calendars, including cross-month, cross-year and leap-February boundaries.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+from tests.e2e.sync_helpers import expected_default_date_range
+
+ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _d(text: str) -> datetime:
+    return datetime.strptime(text, "%Y-%m-%d")
+
+
+@pytest.mark.parametrize(
+    ("now", "days", "expected_start", "expected_end"),
+    [
+        # Plain 30-day anchor.
+        (datetime(2026, 3, 31), 30, "2026-03-02", "2026-03-31"),
+        # Cross-month: Mar 7 .. Apr 5 is exactly 30 days.
+        (datetime(2026, 4, 5), 30, "2026-03-07", "2026-04-05"),
+        # Cross-year: Dec 7 .. Jan 5 is exactly 30 days.
+        (datetime(2026, 1, 5), 30, "2025-12-07", "2026-01-05"),
+        # Leap February: Feb 1 .. Mar 1 is 30 days (29 + 1).
+        (datetime(2024, 3, 1), 30, "2024-02-01", "2024-03-01"),
+        # The 365-day All-button fallback: today-364 .. today (Apr 1 2025 ..
+        # Mar 31 2026 is exactly 365 days across a non-leap Feb).
+        (datetime(2026, 3, 31), 365, "2025-04-01", "2026-03-31"),
+        # Single-day window collapses to start == end == today.
+        (datetime(2026, 7, 15), 1, "2026-07-15", "2026-07-15"),
+        (datetime(2026, 7, 15), 7, "2026-07-09", "2026-07-15"),
+    ],
+)
+def test_fixed_date_anchors(now, days, expected_start, expected_end):
+    start, end = expected_default_date_range(days, now=now)
+    assert (start, end) == (expected_start, expected_end)
+
+
+def test_default_is_30_days():
+    start, end = expected_default_date_range()
+    assert (_d(end) - _d(start)).days == 29
+
+
+@pytest.mark.parametrize("days", [0, -5])
+def test_non_positive_days_degenerate_to_today(days):
+    # Mirrors the frontend guard in getDefaultDateRange: never an inverted
+    # or future-dated window.
+    start, end = expected_default_date_range(days, now=datetime(2026, 8, 17))
+    assert (start, end) == ("2026-08-17", "2026-08-17")
+
+
+@pytest.mark.parametrize("days", list(range(1, 401)))
+def test_inclusive_window_property_and_format(days):
+    start, end = expected_default_date_range(days, now=datetime(2026, 8, 17))
+    assert ISO_DATE.match(start) and ISO_DATE.match(end)
+    assert _d(end) - _d(start) == timedelta(days=days - 1)
+
+
+def test_clock_default_end_is_today():
+    start, end = expected_default_date_range(30)
+    now = datetime.now()
+    # The window is derived from the current local clock; the end must be
+    # the call's own local date and the start exactly 29 calendar days back.
+    assert _d(end).date() == now.date()
+    assert _d(start) == _d(end) - timedelta(days=29)


### PR DESCRIPTION
Closes #3246 (follow-up scope). Plan + adversarial plan review (6 findings folded: https://github.com/open-ace/open-ace/issues/3246#issuecomment-5535076046 + ...5535180522); requirements: https://github.com/open-ace/open-ace/issues/3246#issuecomment-5534959590

## What

#3276 pinned the frontend default range as exactly N calendar days, inclusive both ends (`start = today-(N-1)`), local calendar dates. Three Full E2E tests still expected the old `today-N` UTC semantics and reddened two consecutive scheduled Nightlies (runs 33675379947, 33798725424 — identical 3 `new_failures`).

- **Shared helper** `expected_default_date_range(days, *, now)` in `tests/e2e/sync_helpers.py` — pure-Python local-calendar mirror of the product contract (never imports the TS implementation), injectable clock for unit anchors. All **five** call sites route through it: anomaly 30d default + 365d empty-DB fallback, token_trend 30d default + All-button fallback, conversation-history default+Reset.
- UTC/`toISOString` helper replicas and their stale docstrings deleted; check descriptions updated to inclusive wording.
- **Plan-review HIGH fix**: conversation-history's `pick_non_default_day` avoid-set previously derived from `today-30`; under the new contract that would let ~30 nights/year pick the NEW default start and fail the change check — it now derives the avoid-day from the shared helper's output.
- Manage file gains the PROJECT_ROOT sys.path bootstrap (its documented standalone invocation otherwise cannot import `tests.e2e.sync_helpers` — reviewer-verified).
- New `tests/unit/test_e2e_date_range_expectations.py`: fixed-date anchors (30d, cross-month, cross-year, leap-Feb, 365d fallback, days=1/7) + inclusive-window & format property over days 1..400 — 409 tests green.
- **ci.yml rider** (allowed by #2429's wrap-up note): the scanner job comment refreshed from "records today's 77 findings" to the zero-debt reality. No behavior change.

No ±1 tolerance, no skip/quarantine/debt; assertion counts unchanged. AuditCenter's own `today-7` path is a different product default and stays out of scope.

## Verification

- 409 unit tests green; scanner 0 findings / 0 ledger; manage target collects under pytest; black clean.
- Local extended-tests run: the server boot did not pass the runner's health probe on this machine (app initialized, probe timed out) — recorded here; the authoritative gates are the real dispatches below.
- Frontend `dateRange.test.ts` already pins the inclusive 7/30/90 boundaries (untouched).

## Acceptance gates (per the requirements comment)

- [ ] `workflow_dispatch category=e2e` on this PR ref: both Full E2E shards + Governance green, `new_failures=[]`, `unexpected_skips=[]`
- [ ] PR required CI green + independent review CLEAN
- [ ] post-merge main dispatch + next real `event=schedule` Nightly green → evidence backfilled to #3246 and #2429