### PR TITLE
perf(#3287): clone pg_db from a session template — PG lane budget restored

### DIFF
--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -51,6 +51,11 @@ POSTGRES_PATTERNS = (
     "migrations/**",
     "schema/**",
     "tests/integration/*_pg.py",
+    # The integration conftest owns the pg_db fixture (the per-test database
+    # + schema wiring every *_pg.py file consumes) — a conftest-only diff
+    # must select this lane too, or it rides the lane only when some policy
+    # file happens to change (#3287 follow-up review finding).
+    "tests/integration/conftest.py",
 )
 E2E_PATTERNS = (
     "app/auth/**",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,8 +71,9 @@ def _create_sqlite_tables(db):
     Previously aggregated 10 modules' get_ddl_statements() plus ~17 hand-written
     CREATE TABLE statements — the same shadow-schema drift #1276 fixed for
     production. Now a single call to load_schema_from_file builds the full
-    authoritative schema (68 tables), so integration tests exercise the SAME
-    schema the app starts with, and drift can't silently re-emerge here.
+    authoritative schema (101 tables at #3287 review time), so integration
+    tests exercise the SAME schema the app starts with, and drift can't
+    silently re-emerge here.
     """
     from app.repositories.schema_init import load_schema_from_file
 
@@ -170,31 +171,97 @@ def _create_pg_tables(db):
     _create_tenant_keywords_tables(db, dialect="postgresql")
 
 
-@pytest.fixture
-def pg_db():
-    """Create a temporary PostgreSQL database for integration testing.
+@pytest.fixture(scope="session")
+def _pg_template_db():
+    """Session-scoped template database with the schema loaded ONCE.
 
-    Creates an isolated test database (ace_test_<uuid>), initializes the schema,
-    and drops it after tests complete.  Does NOT touch the production 'ace' database.
+    ``pg_db`` clones this per test via ``CREATE DATABASE ... TEMPLATE`` —
+    a file-level copy (measured 0.1-0.6s) instead of re-running the full
+    schema DDL per test (measured 3.5-9.7s each — the #3287 budget-erosion
+    bottleneck). Isolation is unchanged: every test still gets its own
+    disposable database cloned from a template that no test ever writes.
+
+    Skip semantics (#3287 review): unreachability is only skippable HERE,
+    at build time (parity with PG-less environments); per-test clone
+    failures in pg_db must ERROR, never skip — an all-skipped run reads
+    as green and hides exactly the regression this lane exists to catch.
     """
     psycopg2 = pytest.importorskip("psycopg2")
     from psycopg2 import pool as pg_pool
-    from psycopg2.extras import RealDictCursor
+
+    base_url = _get_pg_base_url()
+    template_name = f"ace_tpl_{uuid.uuid4().hex[:8]}"
+
+    try:
+        conn = psycopg2.connect(base_url, connect_timeout=2)
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"PostgreSQL server not reachable at {base_url}: {exc}")
+    conn.autocommit = True
+    try:
+        conn.cursor().execute(f'CREATE DATABASE "{template_name}"')
+    finally:
+        conn.close()
+
+    template_url = base_url.rsplit("/", 1)[0] + "/" + template_name
+
+    try:
+        # The schema loader routes connections through the module-level pool /
+        # get_database_url (not the db_url argument), so point the global pool
+        # at the template exactly like pg_db does for each test database.
+        previous_pool = getattr(db_mod, "_pg_pool", None)
+        db_mod._pg_pool = pg_pool.ThreadedConnectionPool(1, 10, template_url)
+        try:
+            template_db = Database(db_url=template_url)
+            _create_pg_tables(template_db)
+        finally:
+            # closeall() is load-bearing: CREATE DATABASE ... TEMPLATE requires
+            # zero other connections to the source, and this yield-style
+            # fixture keeps local references alive for the whole session —
+            # relying on garbage collection would fail every clone.
+            try:
+                db_mod._pg_pool.closeall()
+            except Exception:
+                pass
+            db_mod._pg_pool = previous_pool
+
+        yield template_name
+    finally:
+        # Covers both session end AND a failed schema build: either way the
+        # template database must not outlive the fixture on a shared server.
+        conn = psycopg2.connect(base_url)
+        conn.autocommit = True
+        try:
+            conn.cursor().execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = %s",
+                (template_name,),
+            )
+            conn.cursor().execute(f'DROP DATABASE IF EXISTS "{template_name}"')
+        finally:
+            conn.close()
+
+
+@pytest.fixture
+def pg_db(_pg_template_db):
+    """Create a temporary PostgreSQL database for integration testing.
+
+    Each test gets its own disposable database cloned from the
+    session-scoped template (_pg_template_db) — a fast file-level copy of
+    the fully-initialized schema — initialized and dropped per test. Does
+    NOT touch the production 'ace' database and shares no state across
+    tests.
+    """
+    psycopg2 = pytest.importorskip("psycopg2")
+    from psycopg2 import pool as pg_pool
 
     base_url = _get_pg_base_url()
     test_db_name = f"ace_test_{uuid.uuid4().hex[:8]}"
 
-    # Create test database
-    try:
-        conn = psycopg2.connect(base_url, connect_timeout=2)
-    except psycopg2.OperationalError as exc:
-        # Skip cleanly when no live PostgreSQL server is reachable instead of
-        # erroring every test. These integration tests require a running Postgres;
-        # environments without one (local sandbox, CI without a DB service) skip.
-        pytest.skip(f"PostgreSQL server not reachable at {base_url}: {exc}")
+    # Clone the template. The template was built this session, so the
+    # server WAS reachable: any failure here must ERROR, not skip.
+    conn = psycopg2.connect(base_url, connect_timeout=2)
     conn.autocommit = True
     try:
-        conn.cursor().execute(f'CREATE DATABASE "{test_db_name}"')
+        conn.cursor().execute(f'CREATE DATABASE "{test_db_name}" TEMPLATE "{_pg_template_db}"')
     finally:
         conn.close()
 
@@ -207,7 +274,6 @@ def pg_db():
 
     try:
         db = Database(db_url=test_url)
-        _create_pg_tables(db)
 
         # Patch global functions so repo code's is_postgresql() and get_database_url()
         # point to our test database instead of the production config.


### PR DESCRIPTION
Closes #3287 (follow-up scope). Measurement + plan + adversarial plan review (1 HIGH + 2 MEDIUM folded): https://github.com/open-ace/open-ace/issues/3287#issuecomment-5535428273 and https://github.com/open-ace/open-ace/issues/3287#issuecomment-5535532025

## What

The postgres lane's 480s budget was being eaten by **per-test schema initialization**: `pg_db` ran the full authoritative schema DDL after every `CREATE DATABASE`. Measured: top-25 durations were ALL setup-phase (3.5-9.7s each); 101 tests = **313.49s local serial** ≈ 840s on the CI runner — exactly why run 33641020557 died at 479s / 57% with zero assertion failures.

**Fix = amortize initialization (the requirements' option 1), not sharding, not a budget raise:**

1. **Session-scoped `_pg_template_db`**: builds ONE template per session via the same `_create_pg_tables` path. The module-level `_pg_pool` is pointed at it exactly like `pg_db` does (the schema loader routes through the global pool / `DATABASE_URL`, not the `db_url` argument — plan-review finding), then **explicitly `closeall()`d** before yielding: `CREATE DATABASE ... TEMPLATE` requires zero source connections, and a yield fixture holds references all session.
2. **`pg_db` clones the template per test** (file-level copy). **Per-test isolation unchanged**: each test still gets its own disposable database, own pool, own patches, per-test terminate+DROP; the template is only connected during build and never written by tests. Clone-completeness was verified against a live PG (101 tables / 417 indexes / object counts (indexes, constraints, sequences) identical between clone / template / fresh-load; nothing lives outside the database).
3. **Skip semantics pinned** (plan-review finding): unreachable PG skips only at template-build time (PG-less environments); per-test clone failures **ERROR** — an all-skipped run reads green and hides exactly this lane's historical regression.
4. **`POSTGRES_PATTERNS` gains `tests/integration/conftest.py`** (plan-review HIGH finding): a conftest-only diff previously selected neither the PR nor the main-push postgres lane (`*_pg.py` fnmatch doesn't cover conftest) — the follow-up's own two-real-runs acceptance would have been unexecutable. Verified: `ci.py detect tests/integration/conftest.py` → postgres selected; `scripts/ci.py` ∈ POLICY_PATTERNS so this PR selects all suites on both runs.

## Measured evidence (same selection/marker/env as the GitHub lane)

| | before | after |
|---|---|---|
| pytest tests/integration -m postgres (local, serial) | 101 passed, **313.49s** | 101 passed, **31.21s** |
| `ci.py run postgres` (suite contract) | — | 101 passed, **17.09s** (17.9s wall) |
| top setup per test | 3.5-9.7s | 0.2-0.5s (+ one-time template build ~6.8s) |
| leftover `ace_test_*`/`ace_tpl_*` DBs after run | — | none |

**Budget 480s kept** (no raise): projected CI ≈ 50-120s → >4x headroom, far under the 75% erosion warning (360s, `SUITE_BUDGET_WARNING_FRACTION`). Single-test `--timeout 300 --timeout-method thread` and the exact selection expression unchanged. If real CI lands above 360s the decision returns to #3287 (deterministic-sharding tracker) — never a silent raise.

## Gates

- [ ] PR CI with postgres lane REALLY selected (it is — conftest+ci.py changed): 101 passed / 0 failed / 0 skipped, job URL + durations backfilled
- [ ] independent review CLEAN / zero findings
- [ ] post-merge main-push run with the lane selected, green, with wall-clock + slowest-items summary