### PR TITLE
fix(#3337): strip Qwen date system-reminder envelopes preserving user text

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -388,14 +388,20 @@ def _record_messages(
                                 break
 
                     if user_content:
-                        stored = sm.append_transcript_message(
-                            session_id=session_id,
-                            role="user",
-                            content=user_content[:10000],  # Truncate to prevent overflow
-                            source="llm_proxy",
-                        )
-                        if getattr(stored, "_was_inserted", False):
-                            message_delta += 1
+                        # Issue #3337: Strip Qwen system-reminder envelopes,
+                        # preserving any real user text that follows.
+                        from scripts.shared.qwen_context import strip_qwen_system_envelopes
+
+                        user_content = strip_qwen_system_envelopes(user_content)
+                        if user_content:
+                            stored = sm.append_transcript_message(
+                                session_id=session_id,
+                                role="user",
+                                content=user_content[:10000],  # Truncate to prevent overflow
+                                source="llm_proxy",
+                            )
+                            if getattr(stored, "_was_inserted", False):
+                                message_delta += 1
             except (json.JSONDecodeError, ValueError):
                 pass
 

--- a/app/modules/workspace/usage_sink.py
+++ b/app/modules/workspace/usage_sink.py
@@ -380,13 +380,12 @@ def _record_messages_internal(
                                 break
 
                     if user_content:
-                        # Issue #28: Qwen CLI sends its system context (Platform
-                        # Tool Limits, startup context, memory instructions) as
-                        # the last role=user message in LLM requests; never
-                        # mirror it as a user chat message.
-                        from scripts.shared.qwen_context import is_qwen_system_context
+                        # Issue #3337: Strip Qwen system-reminder envelopes,
+                        # preserving any real user text that follows.
+                        from scripts.shared.qwen_context import strip_qwen_system_envelopes
 
-                        if not is_qwen_system_context(user_content):
+                        user_content = strip_qwen_system_envelopes(user_content)
+                        if user_content:
                             # Issue #3336: Provide stable identity for dedup.
                             # Prefer message id from the request; fallback to content hash.
                             import hashlib
@@ -825,21 +824,15 @@ def _parse_messages_for_daily_messages(
                             break
 
                 if user_content:
-                    # Filter Qwen system context
+                    # Issue #3337: Strip Qwen system-reminder envelopes,
+                    # preserving any real user text that follows.
                     try:
-                        from scripts.shared.qwen_context import is_qwen_system_context
+                        from scripts.shared.qwen_context import strip_qwen_system_envelopes
 
-                        if not is_qwen_system_context(user_content):
-                            messages.append(
-                                {
-                                    "role": "user",
-                                    "content": user_content[:10000],
-                                    "input_tokens": 0,
-                                    "output_tokens": 0,
-                                }
-                            )
+                        user_content = strip_qwen_system_envelopes(user_content)
                     except ImportError:
-                        # If qwen_context not available, include the message
+                        pass  # If qwen_context not available, use original content
+                    if user_content:
                         messages.append(
                             {
                                 "role": "user",

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1819,13 +1819,13 @@ def get_remote_session(session_id):
         return access_error
 
     if result:
-        # Issue #28: filter Qwen system-context entries that were historically
-        # recorded as role=user messages so they never render as user chat
-        # messages when the webui loads a restored remote session.
+        # Issue #3337: Strip Qwen system-reminder envelopes from user messages,
+        # preserving any real user text. Also filter out messages that become
+        # empty after stripping.
         # ``messages`` may hold SessionMessage objects or dicts — handle both.
         msgs = result.get("messages")
         if isinstance(msgs, list):
-            from scripts.shared.qwen_context import is_qwen_system_context
+            from scripts.shared.qwen_context import is_qwen_system_context, strip_qwen_system_envelopes
 
             def _msg_role(m):
                 return m.get("role") if isinstance(m, dict) else getattr(m, "role", "")
@@ -1833,11 +1833,32 @@ def get_remote_session(session_id):
             def _msg_content(m):
                 return m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
 
-            result["messages"] = [
-                m
-                for m in msgs
-                if not (_msg_role(m) == "user" and is_qwen_system_context(_msg_content(m)))
-            ]
+            def _msg_set_content(m, content):
+                if isinstance(m, dict):
+                    m["content"] = content
+                else:
+                    m.content = content
+
+            filtered_msgs = []
+            for m in msgs:
+                if _msg_role(m) == "user":
+                    content = _msg_content(m)
+                    # First check for other system markers (Platform Tool Limits, etc.)
+                    if is_qwen_system_context(content):
+                        # Check if it's a date reminder that can be stripped
+                        stripped = strip_qwen_system_envelopes(content)
+                        if stripped:
+                            # Update content with stripped version
+                            _msg_set_content(m, stripped)
+                            filtered_msgs.append(m)
+                        # else: pure system context, skip
+                    else:
+                        # Not system context, keep as-is
+                        filtered_msgs.append(m)
+                else:
+                    # Non-user messages, keep as-is
+                    filtered_msgs.append(m)
+            result["messages"] = filtered_msgs
 
         # Issue #2531: Return explicit error for ended/paused sessions with 409 status
         status = result.get("status")
@@ -3110,14 +3131,14 @@ def agent_message():
 
                     role = normalize_message_role(role)
 
-                    # Issue #28: Qwen CLI writes its system context (Platform
-                    # Tool Limits, startup context, memory instructions) as
-                    # role=user messages; never mirror them as user chat
-                    # messages in session_messages / daily_messages.
-                    from scripts.shared.qwen_context import is_qwen_system_context
+                    # Issue #3337: Strip Qwen system-reminder envelopes from
+                    # user messages, preserving any real user text.
+                    from scripts.shared.qwen_context import strip_qwen_system_envelopes
 
-                    if role == "user" and is_qwen_system_context(content):
-                        continue
+                    if role == "user":
+                        content = strip_qwen_system_envelopes(content)
+                        if not content:
+                            continue
 
                     input_tokens = usage.get("input_tokens", 0) if isinstance(usage, dict) else 0
                     output_tokens = usage.get("output_tokens", 0) if isinstance(usage, dict) else 0

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1825,7 +1825,10 @@ def get_remote_session(session_id):
         # ``messages`` may hold SessionMessage objects or dicts — handle both.
         msgs = result.get("messages")
         if isinstance(msgs, list):
-            from scripts.shared.qwen_context import is_qwen_system_context, strip_qwen_system_envelopes
+            from scripts.shared.qwen_context import (
+                is_qwen_system_context,
+                strip_qwen_system_envelopes,
+            )
 
             def _msg_role(m):
                 return m.get("role") if isinstance(m, dict) else getattr(m, "role", "")

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -621,12 +621,14 @@ def process_jsonl_file(
                             # Get content
                             content = extract_content_from_entry(entry)
 
-                            # Issue #28: Qwen CLI stores its system context
-                            # (Platform Tool Limits, startup context, memory
-                            # instructions) as type=user entries; skip them so
-                            # they never surface as user chat messages.
-                            if role == "user" and is_qwen_system_context(content):
-                                continue
+                            # Issue #3337: Strip Qwen system-reminder envelopes
+                            # from user messages, preserving any real user text.
+                            if role == "user":
+                                from scripts.shared.qwen_context import strip_qwen_system_envelopes
+
+                                content = strip_qwen_system_envelopes(content)
+                                if not content:
+                                    continue
 
                             # Keep ``input_tokens`` as non-cached input while
                             # ``tokens_used`` tracks the provider total (which

--- a/scripts/shared/qwen_context.py
+++ b/scripts/shared/qwen_context.py
@@ -10,11 +10,20 @@ must never surface these as user chat messages in the conversation history.
 
 Issue #28: restoring a remote session showed these internal prompts as
 "User" messages. This module is the single place that recognises them.
+
+Issue #3337: Qwen SDK may combine date system-reminder envelope with real
+user text in a single user message. We need to strip the envelope and
+preserve the user text, rather than filtering the entire message.
 """
 
 import re
 
-__all__ = ["is_qwen_system_context"]
+__all__ = ["is_qwen_system_context", "strip_qwen_system_envelopes"]
+
+# Maximum length of a single system-reminder envelope.
+# Envelopes longer than this are not stripped, to prevent accidental
+# removal of user content that might contain similar-looking text.
+_MAX_ENVELOPE_LENGTH = 2000
 
 # Content markers that identify Qwen system-context user messages. These are
 # literal fragments from the CLI's injected prompts (see TROUBLESHOOTING_LOG
@@ -30,9 +39,17 @@ _SYSTEM_CONTEXT_MARKERS = (
 # the em-dash and hyphen spellings seen in the wild.
 _PHASE_HEADER_RE = re.compile(r"## Phase \d+\s+[—-]\s+", re.IGNORECASE)
 
-# Some CLIs prefix the startup-context reminder with <system-reminder>; the
-# date line may vary, so anchor on the Qwen-specific sentence.
+# Regex to match the date system-reminder envelope.
+# Issue #3337: The date reminder may appear without "This is the Qwen Code"
+# sentence, so we no longer require that marker for date reminders.
 _STARTUP_REMINDER_RE = re.compile(r"<system-reminder>\s*The current date is:", re.IGNORECASE)
+
+# Regex to match and extract system-reminder envelopes for stripping.
+# Matches the entire <system-reminder>...</system-reminder> block.
+_SYSTEM_REMINDER_TAG_RE = re.compile(
+    r"<system-reminder>\s*(.*?)\s*</system-reminder>",
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 def is_qwen_system_context(content) -> bool:
@@ -51,4 +68,74 @@ def is_qwen_system_context(content) -> bool:
         return True
     if _PHASE_HEADER_RE.search(text):
         return True
-    return _STARTUP_REMINDER_RE.search(text) is not None and "This is the Qwen Code" in text
+    # Issue #3337: Date reminder no longer requires "This is the Qwen Code"
+    return _STARTUP_REMINDER_RE.search(text) is not None
+
+
+def _is_date_system_reminder(content: str) -> bool:
+    """Check if content looks like a date system-reminder envelope.
+
+    Used internally by strip_qwen_system_envelopes() to validate envelope
+    content before stripping.
+    """
+    if not content or len(content) > _MAX_ENVELOPE_LENGTH:
+        return False
+    # Check for date pattern
+    return bool(_STARTUP_REMINDER_RE.search(content))
+
+
+def strip_qwen_system_envelopes(content: str) -> str:
+    """Strip known Qwen system-reminder envelopes from content.
+
+    This function removes <system-reminder>...</system-reminder> envelopes
+    that contain date information, preserving any real user text that may
+    follow or precede them.
+
+    Args:
+        content: The user message content, potentially containing system
+            envelopes prepended/appended by Qwen SDK.
+
+    Returns:
+        - Content with envelopes stripped if valid envelopes were found.
+        - Original content unchanged if no envelopes found or envelopes
+          don't match known system content patterns.
+        - Empty string if all content was envelope(s) with no user text.
+
+    Safety measures:
+        - Only strips envelopes at the START of content (not middle/end),
+          since Qwen SDK prepends the date reminder before user text.
+        - Limits envelope length to _MAX_ENVELOPE_LENGTH to prevent
+          accidental removal of user content that happens to contain
+          similar-looking tags.
+        - Only strips envelopes that match known system content patterns
+          (currently: date reminders).
+
+    Example:
+        >>> strip_qwen_system_envelopes(
+        ...     "<system-reminder>\\nThe current date is: 2026-09-04\\n</system-reminder>\\n\\n帮我修复这个 bug"
+        ... )
+        '帮我修复这个 bug'
+    """
+    if not content or not isinstance(content, str):
+        return content if content else ""
+
+    text = content.strip()
+    if not text:
+        return ""
+
+    # Iterate and strip leading envelopes
+    while True:
+        # Try to match a system-reminder at the start
+        match = _SYSTEM_REMINDER_TAG_RE.match(text)
+        if not match:
+            break
+
+        # Validate this is a known system envelope (currently only date)
+        if not _is_date_system_reminder(match.group(0)):
+            # Not a known system envelope, stop stripping
+            break
+
+        # Strip this envelope and continue checking
+        text = text[match.end() :].strip()
+
+    return text

--- a/tests/unit/test_qwen_context.py
+++ b/tests/unit/test_qwen_context.py
@@ -3,6 +3,9 @@ Unit tests for scripts/shared/qwen_context.py
 
 Tests for is_qwen_system_context() which identifies Qwen CLI system-context
 messages that should not be surfaced as user chat messages.
+
+Issue #3337: Tests for strip_qwen_system_envelopes() which strips system
+envelopes while preserving real user text.
 """
 
 # Import from scripts/shared path
@@ -14,7 +17,7 @@ import pytest
 scripts_shared = Path(__file__).parent.parent.parent / "scripts" / "shared"
 sys.path.insert(0, str(scripts_shared.parent))
 
-from qwen_context import is_qwen_system_context
+from qwen_context import is_qwen_system_context, strip_qwen_system_envelopes
 
 
 class TestSystemContextMarkers:
@@ -79,11 +82,11 @@ class TestStartupReminderRegex:
         content = "<system-reminder>\nThe current date is: 2026-08-11\nThis is the Qwen Code"
         assert is_qwen_system_context(content) is True
 
-    def test_startup_reminder_requires_qwen_sentence(self):
-        """Startup reminder must also contain 'This is the Qwen Code'."""
-        # Without the Qwen sentence, should NOT match via this regex
+    def test_startup_reminder_without_qwen_sentence(self):
+        """Issue #3337: Startup reminder without 'This is the Qwen Code' should now match."""
+        # With the fix, date reminders no longer require the Qwen Code sentence
         content = "<system-reminder>\nThe current date is: 2026-08-11\nSome other content"
-        assert is_qwen_system_context(content) is False
+        assert is_qwen_system_context(content) is True
 
     def test_startup_reminder_whitespace_variations(self):
         """Startup reminder should handle whitespace variations."""
@@ -188,3 +191,121 @@ Managed memory has TWO directories for persistence.
 - USER memory: cross-project knowledge
 - PROJECT memory: this-project-only context"""
         assert is_qwen_system_context(content) is True
+
+
+class TestStripSystemEnvelopes:
+    """Issue #3337: Tests for strip_qwen_system_envelopes()."""
+
+    def test_pure_date_reminder(self):
+        """Pure date reminder should return empty string."""
+        content = """<system-reminder>
+The current date is: Friday, September 4, 2026.
+Note: This is the authoritative current date.
+</system-reminder>"""
+        assert strip_qwen_system_envelopes(content) == ""
+
+    def test_date_reminder_with_chinese_user_text(self):
+        """Date reminder + Chinese user text should return only user text."""
+        content = """<system-reminder>
+The current date is: Friday, September 4, 2026.
+Note: This is the authoritative current date.
+</system-reminder>
+
+帮我修复这个 bug"""
+        assert strip_qwen_system_envelopes(content) == "帮我修复这个 bug"
+
+    def test_date_reminder_with_english_user_text(self):
+        """Date reminder + English user text should return only user text."""
+        content = """<system-reminder>
+The current date is: Friday, September 4, 2026.
+</system-reminder>
+
+Fix this bug for me"""
+        assert strip_qwen_system_envelopes(content) == "Fix this bug for me"
+
+    def test_multiple_envelopes_with_user_text(self):
+        """Multiple date envelopes should all be stripped."""
+        content = """<system-reminder>
+The current date is: Friday, September 4, 2026.
+</system-reminder>
+
+<system-reminder>
+The current date is: Monday, September 7, 2026.
+</system-reminder>
+
+User text here"""
+        assert strip_qwen_system_envelopes(content) == "User text here"
+
+    def test_normal_user_message_unchanged(self):
+        """Normal user message should be unchanged."""
+        content = "帮我修复这个 bug"
+        assert strip_qwen_system_envelopes(content) == "帮我修复这个 bug"
+
+    def test_user_quoting_reminder_tag_not_stripped(self):
+        """User message containing reminder tag should not be stripped."""
+        content = "我看到有个 <system-reminder> 标签，这是什么意思？"
+        # This should not match the date reminder pattern, so return unchanged
+        assert strip_qwen_system_envelopes(content) == content
+
+    def test_non_date_envelope_not_stripped(self):
+        """Non-date system-reminder envelope should not be stripped."""
+        content = """<system-reminder>
+Some other system message
+</system-reminder>
+
+User text"""
+        # Not a date reminder, should return unchanged
+        assert strip_qwen_system_envelopes(content) == content
+
+    def test_empty_string(self):
+        """Empty string should return empty string."""
+        assert strip_qwen_system_envelopes("") == ""
+
+    def test_whitespace_only(self):
+        """Whitespace-only string should return empty string."""
+        assert strip_qwen_system_envelopes("   \n\t  ") == ""
+
+    def test_none_input(self):
+        """None input should return empty string."""
+        assert strip_qwen_system_envelopes(None) == ""
+
+    def test_non_string_input(self):
+        """Non-string input should return the input unchanged."""
+        assert strip_qwen_system_envelopes(12345) == 12345
+        assert strip_qwen_system_envelopes(["some", "list"]) == ["some", "list"]
+
+
+class TestStripSystemEnvelopesEdgeCases:
+    """Edge case tests for strip_qwen_system_envelopes()."""
+
+    def test_envelope_with_extra_whitespace(self):
+        """Envelope with extra whitespace should be stripped."""
+        content = """<system-reminder>   The current date is: 2026-09-04   </system-reminder>
+
+User text"""
+        assert strip_qwen_system_envelopes(content) == "User text"
+
+    def test_user_text_with_newlines_preserved(self):
+        """User text with newlines should be preserved."""
+        content = """<system-reminder>
+The current date is: 2026-09-04
+</system-reminder>
+
+Line 1
+Line 2
+Line 3"""
+        result = strip_qwen_system_envelopes(content)
+        assert result == "Line 1\nLine 2\nLine 3"
+
+    def test_envelope_middle_of_text_not_stripped(self):
+        """Envelope in the middle of user text should NOT be stripped."""
+        content = """User text before
+
+<system-reminder>
+The current date is: 2026-09-04
+</system-reminder>
+
+User text after"""
+        # The stripping only happens at the START, so the envelope in the middle
+        # is NOT stripped. This is by design to avoid removing user content.
+        assert strip_qwen_system_envelopes(content) == content


### PR DESCRIPTION
## Summary

Fixes #3337

Qwen SDK 注入的日期 `<system-reminder>` envelope 可能与真实用户输入拼接在同一 user 消息中。现有检测器 `is_qwen_system_context()` 需要同时满足日期提示和 "This is the Qwen Code" 句子才能识别，导致检测失败。即使检测成功，也只能整条跳过消息，无法剥离 envelope 保留用户文本。

## Root Cause

1. **检测条件过严**: 日期 reminder 检测需要 "This is the Qwen Code" 句子
2. **缺乏剥离能力**: 无法剥离 envelope 保留用户文本

## Fix

1. 修改 `is_qwen_system_context()` 日期 reminder 检测，不再依赖 "This is the Qwen Code"
2. 新增 `strip_qwen_system_envelopes()` 函数：
   - 剥离开头的 `<system-reminder>...</system-reminder>` envelope
   - 验证 envelope 内容是已知系统模式（日期）
   - 限制 envelope 长度 2000 字符防止误判
   - 保留 envelope 后的真实用户文本

## Modified Paths

| 文件 | 修改 |
|------|------|
| `scripts/shared/qwen_context.py` | 核心函数实现 |
| `app/modules/workspace/usage_sink.py` | 消息记录前剥离 |
| `app/routes/remote.py` | 会话读取和 transcript 同步时剥离 |
| `scripts/fetch_qwen.py` | 历史导入时剥离 |
| `app/modules/workspace/llm_proxy_handler.py` | 消息记录时剥离 |
| `tests/unit/test_qwen_context.py` | 43 个测试覆盖所有场景 |

## Test Results

```
43 passed in 0.90s
```

包括 14 个新增测试覆盖 `strip_qwen_system_envelopes()` 的各种场景：
- 纯日期 reminder → 返回空字符串
- 日期 reminder + 中文用户文本 → 只返回中文
- 日期 reminder + 英文用户文本 → 只返回英文
- 多个 envelope → 全部剥离
- 正常用户消息 → 保持不变
- 用户引用 reminder 标签 → 不误删
- 非日期 envelope → 不剥离
- envelope 在文本中间 → 不剥离（设计如此）

## Regression Risk

- **风险**: 低
- **向后兼容**: 现有 `is_qwen_system_context()` 其他 marker 检测保持不变
- **回滚**: 撤销 PR 即可