### PR TITLE
fix: restore standalone Qwen fetch CLI and add subprocess regression (#3357)

### DIFF
--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -171,7 +171,7 @@ if shared_dir not in sys.path:
     sys.path.insert(0, script_dir)
 from shared import db
 from shared.file_change_parser import append_file_change_blocks, extract_file_changes  # Issue #8
-from shared.qwen_context import is_qwen_system_context  # Issue #28
+from shared.qwen_context import is_qwen_system_context, strip_qwen_system_envelopes
 from shared.utils import update_session_last_seen, warn_if_skipped_message_has_text
 
 
@@ -624,8 +624,6 @@ def process_jsonl_file(
                             # Issue #3337: Strip Qwen system-reminder envelopes
                             # from user messages, preserving any real user text.
                             if role == "user":
-                                from scripts.shared.qwen_context import strip_qwen_system_envelopes
-
                                 content = strip_qwen_system_envelopes(content)
                                 if not content:
                                     continue

--- a/tests/integration/subprocess/test_fetch_qwen_entrypoint.py
+++ b/tests/integration/subprocess/test_fetch_qwen_entrypoint.py
@@ -1,0 +1,73 @@
+"""Exercise the deployed Qwen script without pytest's import-path setup."""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.regression, pytest.mark.issue(3357)]
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_direct_script_persists_user_text_without_system_envelopes(tmp_path):
+    home_dir = tmp_path / "home"
+    project = home_dir / ".qwen" / "projects" / "fixture-project"
+    project.mkdir(parents=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    envelope = "<system-reminder>The current date is: 2026-09-07</system-reminder>"
+    entries = [
+        {
+            "type": "user",
+            "uuid": message_id,
+            "parentUuid": None,
+            "sessionId": "qwen-entrypoint-fixture",
+            "timestamp": timestamp,
+            "message": {"role": "user", "parts": [{"text": content}]},
+        }
+        for message_id, content in [
+            ("mixed", envelope + "\nKeep this real user request."),
+            ("system-only", envelope),
+            ("plain", "Another real user request."),
+        ]
+    ]
+    (project / "session.jsonl").write_text(
+        "\n".join(json.dumps(entry) for entry in entries) + "\n", encoding="utf-8"
+    )
+    database = tmp_path / "usage.db"
+    # Deliberately do not inherit PYTHONPATH, DB_*, config, or real-user HOME.
+    env = {
+        "HOME": str(home_dir),
+        "USERPROFILE": str(home_dir),
+        "PATH": os.defpath,
+        "DATABASE_URL": f"sqlite:///{database}",
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "fetch_qwen.py"),
+            "--project",
+            str(project),
+            "--hostname",
+            "entrypoint-test",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    with sqlite3.connect(database) as connection:
+        rows = connection.execute(
+            "SELECT message_id, role, content FROM daily_messages ORDER BY message_id"
+        ).fetchall()
+    assert rows == [
+        ("mixed", "user", "Keep this real user request."),
+        ("plain", "user", "Another real user request."),
+    ]


### PR DESCRIPTION
## Summary

- Fix the standalone `python scripts/fetch_qwen.py` entrypoint by importing the envelope helper through the existing `shared.qwen_context` path. No PYTHONPATH workaround or filtering behavior change.
- Add an isolated real-process integration regression that ingests JSONL and checks exact persisted user text and removal of system-only messages. This runs in existing python-core PR coverage; full Docker multi-user smoke remains main-push-only.

Fixes #3357. Related #2429, #3337.

## Verification

- RED: new test failed on base72e59be8 with the same `ModuleNotFoundError: No module named 'scripts'` as Docker run34086133272/job101631701761.
- GREEN: 67 related Qwen tests passed (Python3.12, 0.70s).
- Full false-positive scanner: 0 findings / 0 ledger entries. Commit hooks passed.
- Independent Agent plan review: CLEAN. Independent code review at da1bf2ee: CLEAN, targeted test independently passed.
- Pending: GitHub PR required checks, then merged-main Docker deployment smoke; results will be linked to #3357/#2429, not inferred from local pytest.
