### PR TITLE
fix: preserve CI reports when GitHub retry queue timestamps are reversed (#3358)

### DIFF
--- a/ci/ci-health-policy.json
+++ b/ci/ci-health-policy.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "derivation_version": 1,
+  "derivation_version": 2,
   "window_days": 30,
   "pr_contract_epoch": "2026-08-09T12:23:45Z",
   "sample_cap": 25,

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -144,6 +144,25 @@ CI 所需的测试、检查、构建及审计工具统一保留在
 收集成功只证明测试“存在且能导入”，不证明断言是绿的。只有 required lane
 中的测试才能作为合并门禁。
 
+## CI Health Metrics 计时有效性
+
+`ci-health-metrics.yml` 在 GitHub 定时采集，也支持默认分支手动 dispatch。
+采集器按 `ci/ci-health-policy.json` 限制时间窗口、样本量与 API 请求预算；
+报告中的同契约样本不足时，p95 必须标记 `insufficient_data`，不得据此将
+Critical E2E 从 advisory 提升为 required。
+
+报告 schema/计时推导版本 2（#3358）将 GitHub workflow/attempt 的负排队
+时间单独标记为不可用：`seconds=null`，保留原始差值、两端时间戳及原因。
+它不会被夹成 0 秒，也不会导致丢弃整个 run/attempt 或其 success/failure/
+cancelled 结论。JSON `workflow_queue_anomalies` 和 Markdown 提供 run/attempt
+定位信息；queue 分位数只使用有效值，p95 最小样本数按有有效 queue 的独立
+run 数判断，不能用多次重跑或已排除样本凑足。读取报告的消费者须先检查
+`schema_version`；版本 1/2 的 queue 统计不可直接混合。
+
+此容错仅适用于 workflow queue 的源数据时序异常。缺失或格式错误时间戳
+仍报错；job queue、job execution、attempt wall 等保留既有的 fail-closed
+校验与最多 2 秒的小幅时钟偏差规则，inherited/skipped job 规则不变。
+
 ## Legacy issue 测试迁移（已完成并退役）
 
 #2429 分批把 `tests/issues/` 迁入规范目录（unit-like → integration →

--- a/scripts/ci/github_actions_metrics.py
+++ b/scripts/ci/github_actions_metrics.py
@@ -60,6 +60,26 @@ def measured_delta(start: str | None, end: str | None, field: str) -> dict[str, 
     }
 
 
+def measured_workflow_queue(start: str | None, end: str | None) -> dict[str, Any]:
+    """Keep inconsistent API queue timestamps observable, never invent a zero.
+
+    GitHub retry metadata can put run_started_at before attempt.created_at
+    (#3358). This makes only the queue sample unavailable, not the run's
+    conclusion or execution timings. Malformed/missing timestamps still fail.
+    """
+    raw = (
+        parse_time(end, "workflow.queue.end") - parse_time(start, "workflow.queue.start")
+    ).total_seconds()
+    return {
+        "seconds": raw if raw >= 0 else None,
+        "raw_seconds": raw,
+        "timestamp_skew_clamped": False,
+        "created_at": start,
+        "run_started_at": end,
+        "unavailable_reason": "negative_timestamp_delta" if raw < 0 else None,
+    }
+
+
 def validate_conclusion(value: Any, field: str) -> str:
     if value not in CONCLUSION_KEYS:
         raise MetricsError(f"invalid completed conclusion {field}: {value!r}")
@@ -683,8 +703,8 @@ def collect_attempts(
             {
                 "attempt": number,
                 "conclusion": attempt_conclusion,
-                "queue": measured_delta(
-                    meta.get("created_at"), meta.get("run_started_at"), "workflow.queue"
+                "queue": measured_workflow_queue(
+                    meta.get("created_at"), meta.get("run_started_at")
                 ),
                 "wall": measured_delta(
                     meta.get("run_started_at"), meta.get("updated_at"), "attempt.wall"
@@ -738,14 +758,29 @@ def aggregate_contract(runs: list[dict[str, Any]], min_samples: int) -> dict[str
     first_walls = [run["first_attempt_wall"]["seconds"] for run in runs]
     eventual_latencies = [run["eventual_resolution"]["seconds"] for run in runs]
     workflow_queue: list[float] = []
+    workflow_queue_eligible_runs = 0
+    workflow_queue_anomalies = []
     job_queue: list[float] = []
     job_execution: list[float] = []
     slow_jobs = []
     inherited_job_count = 0
     skipped_job_count = 0
     for run in runs:
+        has_valid_workflow_queue = False
         for attempt in run["attempts"]:
-            workflow_queue.append(attempt["queue"]["seconds"])
+            queue = attempt["queue"]
+            if queue["seconds"] is None:
+                workflow_queue_anomalies.append(
+                    {
+                        "run_id": run["run_id"],
+                        "attempt": attempt["attempt"],
+                        "url": run.get("url"),
+                        **queue,
+                    }
+                )
+            else:
+                workflow_queue.append(queue["seconds"])
+                has_valid_workflow_queue = True
             for job in attempt["jobs"]:
                 if job["timing_state"] == "inherited_snapshot":
                     inherited_job_count += 1
@@ -764,6 +799,7 @@ def aggregate_contract(runs: list[dict[str, Any]], min_samples: int) -> dict[str
                         "seconds": job["execution"]["seconds"],
                     }
                 )
+        workflow_queue_eligible_runs += int(has_valid_workflow_queue)
     sample_count = len(runs)
     first_conclusions = {key: first.get(key, 0) for key in CONCLUSION_KEYS}
     eventual_conclusions = {key: eventual.get(key, 0) for key in CONCLUSION_KEYS}
@@ -789,9 +825,14 @@ def aggregate_contract(runs: list[dict[str, Any]], min_samples: int) -> dict[str
         "eventual_resolution": summarize_values(
             eventual_latencies, min_samples, cohort_samples=sample_count
         ),
-        "workflow_queue": summarize_values(
-            workflow_queue, min_samples, cohort_samples=sample_count
-        ),
+        "workflow_queue": {
+            **summarize_values(
+                workflow_queue, min_samples, cohort_samples=workflow_queue_eligible_runs
+            ),
+            "eligible_run_count": workflow_queue_eligible_runs,
+            "excluded_count": len(workflow_queue_anomalies),
+        },
+        "workflow_queue_anomalies": workflow_queue_anomalies,
         "job_queue": summarize_values(job_queue, min_samples, cohort_samples=sample_count),
         "job_execution": summarize_values(job_execution, min_samples, cohort_samples=sample_count),
         "slow_jobs": sorted(slow_jobs, key=lambda item: item["seconds"], reverse=True)[:10],
@@ -842,8 +883,18 @@ def render_markdown(report: dict[str, Any]) -> str:
                     f"- retry recoveries: {contract['retry_recovery_count']}",
                     f"- inherited job snapshots: {contract['inherited_job_snapshot_count']}",
                     f"- skipped jobs (never executed): {contract['skipped_job_no_execution_count']}",
+                    f"- unavailable workflow queue samples: {contract['workflow_queue']['excluded_count']} "
+                    f"(valid runs: {contract['workflow_queue']['eligible_run_count']}; "
+                    f"p95: {contract['workflow_queue']['p95_status']})",
                 ]
             )
+            for anomaly in contract["workflow_queue_anomalies"]:
+                lines.append(
+                    f"- workflow queue unavailable: run {anomaly['run_id']} / "
+                    f"attempt {anomaly['attempt']}; {anomaly['unavailable_reason']}; "
+                    f"raw={anomaly['raw_seconds']}s; created_at={anomaly['created_at']}; "
+                    f"run_started_at={anomaly['run_started_at']}"
+                )
     lines.extend(
         [
             "",
@@ -1023,7 +1074,7 @@ def collect(
         )
 
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "report_contract": hashlib.sha256(
             json.dumps(policy, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest(),

--- a/tests/unit/test_ci_health_metrics.py
+++ b/tests/unit/test_ci_health_metrics.py
@@ -269,6 +269,34 @@ def test_timestamp_skew_below_tolerance_is_invalid():
         metrics.measured_delta("2026-08-11T00:00:03Z", "2026-08-11T00:00:00Z", "test")
 
 
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+@pytest.mark.parametrize("raw", [-3600, -3, -2, -1, 0, 3])
+def test_workflow_queue_excludes_negative_samples_instead_of_clamping(raw):
+    start = datetime(2026, 9, 6, tzinfo=timezone.utc)
+    end = start + timedelta(seconds=raw)
+    measured = metrics.measured_workflow_queue(start.isoformat(), end.isoformat())
+    assert measured == {
+        "seconds": None if raw < 0 else raw,
+        "raw_seconds": raw,
+        "timestamp_skew_clamped": False,
+        "created_at": start.isoformat(),
+        "run_started_at": end.isoformat(),
+        "unavailable_reason": "negative_timestamp_delta" if raw < 0 else None,
+    }
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+@pytest.mark.parametrize("bad", [None, "invalid-timestamp"])
+@pytest.mark.parametrize("field", ["start", "end"])
+def test_workflow_queue_missing_or_malformed_timestamps_still_fail_closed(bad, field):
+    start = bad if field == "start" else "2026-09-06T03:40:28Z"
+    end = bad if field == "end" else "2026-09-06T03:40:25Z"
+    with pytest.raises(metrics.MetricsError, match="timestamp"):
+        metrics.measured_workflow_queue(start, end)
+
+
 def test_nearest_rank_and_minimum_sample_contract():
     values = list(range(1, 26))
     assert metrics.nearest_rank(values, 0.95) == 24
@@ -485,6 +513,114 @@ def _job(job_id, conclusion, created, started, completed):
         "started_at": started,
         "completed_at": completed,
     }
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+def test_real_negative_retry_queue_preserves_cancelled_run_and_valid_timings():
+    # GitHub API run 34009579058, attempts 1/2, caused collector 34068124975
+    # to abort. Keep literal source timestamps/conclusions, not a made-up clamp.
+    repo = "open-ace/open-ace"
+    run_id = 34009579058
+    base = f"/repos/{repo}/actions/runs/{run_id}/attempts"
+    responses = {
+        f"{base}/1": _attempt_meta(
+            1,
+            "action_required",
+            "2026-09-06T03:40:19Z",
+            "2026-09-06T03:40:19Z",
+            "2026-09-06T03:40:19Z",
+        ),
+        f"{base}/1/jobs?per_page=100": {"total_count": 0, "jobs": []},
+        f"{base}/2": _attempt_meta(
+            2,
+            "cancelled",
+            "2026-09-06T03:40:28Z",
+            "2026-09-06T03:40:25Z",
+            "2026-09-06T03:44:03Z",
+        ),
+        f"{base}/2/jobs?per_page=100": {
+            "total_count": 1,
+            "jobs": [
+                {
+                    **_job(
+                        101422983775,
+                        "success",
+                        "2026-09-06T03:40:53Z",
+                        "2026-09-06T03:40:55Z",
+                        "2026-09-06T03:41:02Z",
+                    ),
+                    "name": "Select suites",
+                }
+            ],
+        },
+    }
+    run = {"id": run_id, "run_attempt": 2, "created_at": "2026-09-06T03:40:19Z"}
+    attempts = metrics.collect_attempts(AttemptClient(responses), repo, run, 100)
+    normalized = metrics.normalize_run(run, "contract", {}, attempts)
+    aggregate = metrics.aggregate_contract([normalized], min_samples=20)
+    assert attempts[1]["queue"]["raw_seconds"] == -3
+    assert attempts[1]["queue"]["seconds"] is None
+    assert attempts[1]["wall"]["seconds"] == 218
+    assert aggregate["sample_count"] == 1
+    assert aggregate["first_conclusions"]["action_required"] == 1
+    assert aggregate["eventual_conclusions"]["cancelled"] == 1
+    assert aggregate["eventual_pass_rate"] == 0
+    assert aggregate["retry_recovery_count"] == 0
+    assert aggregate["workflow_queue"]["count"] == 1
+    assert aggregate["workflow_queue"]["excluded_count"] == 1
+    assert aggregate["job_queue"]["p50_seconds"] == 2
+    assert aggregate["job_execution"]["p50_seconds"] == 7
+    assert aggregate["workflow_queue_anomalies"] == [
+        {
+            "run_id": run_id,
+            "attempt": 2,
+            "url": None,
+            "seconds": None,
+            "raw_seconds": -3,
+            "timestamp_skew_clamped": False,
+            "created_at": "2026-09-06T03:40:28Z",
+            "run_started_at": "2026-09-06T03:40:25Z",
+            "unavailable_reason": "negative_timestamp_delta",
+        }
+    ]
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+@pytest.mark.parametrize("valid_run_count", [0, 19, 20])
+def test_workflow_queue_p95_needs_valid_distinct_runs_not_retries(valid_run_count):
+    runs = []
+    duration = {"seconds": 10}
+    for run_id in range(25):
+        valid = run_id < valid_run_count
+        queue = metrics.measured_workflow_queue(
+            "2026-09-06T03:40:28Z",
+            "2026-09-06T03:40:29Z" if valid else "2026-09-06T03:40:25Z",
+        )
+        runs.append(
+            {
+                "run_id": run_id,
+                "first_conclusion": "success",
+                "eventual_conclusion": "success",
+                "recovered_on_retry": False,
+                "first_attempt_wall": duration,
+                "eventual_resolution": duration,
+                "attempts": [{"attempt": number, "queue": queue, "jobs": []} for number in (1, 2)],
+            }
+        )
+    aggregate = metrics.aggregate_contract(runs, min_samples=20)
+    queue_summary = aggregate["workflow_queue"]
+    assert aggregate["sample_count"] == 25
+    assert aggregate["first_pass_rate"] == 1
+    assert queue_summary["count"] == 2 * valid_run_count
+    assert queue_summary["eligible_run_count"] == valid_run_count
+    assert queue_summary["excluded_count"] == 2 * (25 - valid_run_count)
+    assert queue_summary["p50_seconds"] == (1 if valid_run_count else None)
+    assert queue_summary["p95_seconds"] == (1 if valid_run_count >= 20 else None)
+    assert queue_summary["p95_status"] == (
+        "observed" if valid_run_count >= 20 else "insufficient_data"
+    )
 
 
 def _runtime_fixture(*, payload_link=True, bad_parents=False):
@@ -976,6 +1112,93 @@ def test_collect_end_to_end_records_pre_epoch_skip_and_writes_reports(
     assert "Out-of-contract runs skipped (ci-pull-request): pre_contract_epoch=1" in markdown
 
 
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+def test_collector_writes_reports_with_unavailable_queue_and_visible_diagnostics(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(metrics, "datetime", _FrozenDateTime)
+    payload = _e2e_fixture(break_contract=False)
+    for response in payload["responses"]:
+        if response["path"].endswith("/actions/runs/501/attempts/1"):
+            response["json"]["created_at"] = "2026-08-26T09:41:33Z"
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps(payload), encoding="utf-8")
+    out_json = tmp_path / "report.json"
+    out_md = tmp_path / "report.md"
+    rc = metrics.main(
+        [
+            "--repo",
+            "open-ace/open-ace",
+            "--policy",
+            str(_e2e_policy(tmp_path)),
+            "--input",
+            str(fixture),
+            "--output-json",
+            str(out_json),
+            "--output-markdown",
+            str(out_md),
+        ]
+    )
+    assert rc == 0
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["schema_version"] == 2
+    cohort = report["cohorts"][0]
+    assert cohort["sampled_count"] == 1
+    assert cohort["runs"][0]["eventual_conclusion"] == "success"
+    contract = next(iter(cohort["contracts"].values()))
+    assert contract["workflow_queue"]["count"] == 0
+    assert contract["workflow_queue"]["excluded_count"] == 1
+    assert contract["workflow_queue"]["p95_seconds"] is None
+    assert contract["workflow_queue"]["p95_status"] == "insufficient_data"
+    markdown = out_md.read_text(encoding="utf-8")
+    assert (
+        "unavailable workflow queue samples: 1 (valid runs: 0; p95: insufficient_data)" in markdown
+    )
+    assert "run 501 / attempt 1; negative_timestamp_delta; raw=-3.0s" in markdown
+    assert "created_at=2026-08-26T09:41:33Z; run_started_at=2026-08-26T09:41:30Z" in markdown
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+@pytest.mark.parametrize("field", ["attempt.wall", "job.execution", "job.queue"])
+def test_unavailable_workflow_queue_does_not_hide_other_invalid_timings(tmp_path, field):
+    payload = _e2e_fixture(break_contract=False)
+    responses = {}
+    for response in payload["responses"]:
+        if "json" not in response:
+            continue
+        path = response["path"]
+        data = response["json"]
+        if path.endswith("/actions/runs/501/attempts/1"):
+            data["created_at"] = "2026-08-26T09:41:33Z"
+            if field == "attempt.wall":
+                data["updated_at"] = "2026-08-26T09:41:27Z"
+        if path.endswith("/actions/runs/501/attempts/1/jobs"):
+            job = data["jobs"][0]
+            if field == "job.execution":
+                job["completed_at"] = "2026-08-26T09:41:29Z"
+            elif field == "job.queue":
+                job["created_at"] = "2026-08-26T09:41:35Z"
+        responses[metrics.canonical_request(path, response.get("params"))] = data
+    with pytest.raises(metrics.MetricsError, match=f"timestamp order invalid for {field}"):
+        metrics.collect_attempts(
+            AttemptClient(responses), "open-ace/open-ace", {"id": 501, "run_attempt": 1}, 100
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.issue(3358)
+def test_queue_derivation_contract_does_not_mix_with_v1():
+    policy = metrics.load_policy(ROOT / "ci" / "ci-health-policy.json")
+    assert policy["derivation_version"] == 2
+    run = {"head_sha": "head"}
+    cohort = {"id": "ci-main-push", "event": "push", "contract_paths": []}
+    current, _ = metrics.contract_hash(run, cohort, {"head": {}}, policy["derivation_version"])
+    previous, _ = metrics.contract_hash(run, cohort, {"head": {}}, 1)
+    assert current != previous
+
+
 def test_collect_end_to_end_contract_break_fails_closed_without_reports(
     tmp_path, monkeypatch, capsys
 ):
@@ -1110,8 +1333,8 @@ def test_attempts_keep_first_failure_and_retry_recovery_separate():
     normalized = metrics.normalize_run(run, "contract", {}, attempts)
     aggregate = metrics.aggregate_contract([normalized], min_samples=20)
 
-    assert attempts[1]["queue"]["seconds"] == 0
-    assert attempts[1]["queue"]["timestamp_skew_clamped"] is True
+    assert attempts[1]["queue"]["seconds"] is None
+    assert attempts[1]["queue"]["timestamp_skew_clamped"] is False
     assert normalized["recovered_on_retry"] is True
     assert aggregate["first_conclusions"]["failure"] == 1
     assert aggregate["first_conclusions"]["success"] == 0
@@ -1122,7 +1345,7 @@ def test_attempts_keep_first_failure_and_retry_recovery_separate():
     # The attempt-1 skipped job never executed: no queue sample, counted in
     # skipped_job_no_execution_count instead.
     assert aggregate["skipped_job_no_execution_count"] == 1
-    assert aggregate["workflow_queue"]["count"] == 2
+    assert aggregate["workflow_queue"]["count"] == 1
     assert aggregate["job_queue"]["count"] == 3
     assert attempts[1]["jobs"][1]["inherited_from_job_id"] == 3
     assert attempts[1]["jobs"][2]["inherited_from_job_id"] == 4


### PR DESCRIPTION
## Summary

- Treat negative GitHub workflow/attempt queue deltas as unavailable, with null seconds, raw timestamps/delta and explicit diagnostics. Do not clamp to invented zero or discard the run/conclusion.
- Exclude only those queue samples from percentiles; p95 sufficiency counts distinct runs contributing valid queue data, not retries or excluded samples.
- Keep missing/malformed timestamps and existing non-queue timing validation fail-closed. Preserve inherited/skipped-job semantics. Version schema and derivation to 2 and document the consumer contract.

Fixes #3358. Related #2429/#2493.

## Evidence and tests

- Source: run34009579058 attempt2 has created_at03:40:28Z vs run_started_at03:40:25Z on2026-09-06, cancelled; real job timings remain ordered. This aborted scheduled collector34068124975.
- RED: literal source fixture fails on base72e59be8 with `workflow.queue: -3.0s`.
- GREEN: 72 Metrics tests passed on Python3.12 and fresh locked Python3.11. Includes report JSON/Markdown generation, all-unavailable samples, 19/20 valid-run boundary, retry counts, and other invalid timing hard failures.
- Scanner: 0 findings / 0 ledger entries. Scoped hooks pass.
- Independent Agent plan review CLEAN; independent code review97131301 CLEAN, suite independently rerun72 passed.
- Local full-suite check caught old worktree-only ignored tests/issues pyc residue (no source changes); archived those cached files and rerunning unified CI. GitHub clean checkout is separately required.
- Pending: GitHub PR gates and post-merge default-branch collector dispatch artifacts; no claim of scheduled recovery yet. Critical E2E remains advisory.
