### PR TITLE
fix(#3364): add browser-compatible UUID generation

### DIFF
--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -5,6 +5,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { remoteApi } from '@/api';
 import type { StoreApiKeyRequest, UpdateApiKeyRequest, CreateRemoteSessionRequest } from '@/api';
+import { generateUUID } from '@/utils/uuid';
 
 // ==================== Machine Hooks ====================
 
@@ -180,7 +181,8 @@ export function useCreateRemoteSession() {
   return useMutation({
     mutationFn: (data: CreateRemoteSessionRequest) => {
       // Issue #3206: Generate idempotency key for deduplication
-      const idempotencyKey = crypto.randomUUID();
+      // Issue #3364: Use generateUUID for browser compatibility
+      const idempotencyKey = generateUUID();
       return remoteApi.createSession(data, idempotencyKey);
     },
     onSuccess: () => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -59,6 +59,9 @@ export { copyToClipboard } from './clipboard';
 
 export { downloadBlob } from './download';
 
+// UUID generation utilities
+export { generateUUID } from './uuid';
+
 // Project path utilities
 export { decodeProjectName, encodeProjectPath } from './project';
 

--- a/frontend/src/utils/uuid.test.ts
+++ b/frontend/src/utils/uuid.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { generateUUID } from './uuid';
+
+// UUID v4 格式正则：xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+// y 必须是 8, 9, a, 或 b
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('generateUUID', () => {
+  const originalCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    // 恢复原始 crypto
+    Object.defineProperty(globalThis, 'crypto', {
+      value: originalCrypto,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('should generate valid UUID v4 format', () => {
+    const uuid = generateUUID();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('should generate unique UUIDs', () => {
+    const uuids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      uuids.add(generateUUID());
+    }
+    expect(uuids.size).toBe(1000);
+  });
+
+  it('should use crypto.randomUUID when available', () => {
+    const mockRandomUUID = vi.fn().mockReturnValue('12345678-1234-4000-8000-123456789abc');
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { randomUUID: mockRandomUUID },
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+    expect(mockRandomUUID).toHaveBeenCalled();
+    expect(uuid).toBe('12345678-1234-4000-8000-123456789abc');
+  });
+
+  it('should fallback to crypto.getRandomValues when randomUUID is not available', () => {
+    // Mock crypto without randomUUID but with getRandomValues
+    const mockGetRandomValues = vi.fn((arr: Uint8Array) => {
+      // 填充伪随机值
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = i;
+      }
+      return arr;
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues: mockGetRandomValues },
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+    expect(mockGetRandomValues).toHaveBeenCalled();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('should fallback to Math.random when crypto is not available', () => {
+    // 移除 crypto
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('should fallback to getRandomValues when randomUUID throws', () => {
+    const mockRandomUUID = vi.fn().mockImplementation(() => {
+      throw new Error('Not available in non-secure context');
+    });
+    const mockGetRandomValues = vi.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = Math.floor(Math.random() * 256);
+      }
+      return arr;
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        randomUUID: mockRandomUUID,
+        getRandomValues: mockGetRandomValues,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+    expect(mockRandomUUID).toHaveBeenCalled();
+    expect(mockGetRandomValues).toHaveBeenCalled();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('should set correct version and variant bits when using getRandomValues', () => {
+    // 使用固定值测试版本位和变体位设置
+    const mockGetRandomValues = vi.fn((arr: Uint8Array) => {
+      // 所有字节设为 0
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = 0x00;
+      }
+      return arr;
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues: mockGetRandomValues },
+      writable: true,
+      configurable: true,
+    });
+
+    const uuid = generateUUID();
+
+    // 解析 UUID 验证版本位和变体位
+    const parts = uuid.split('-');
+
+    // 第 7 字节（时间高位）的高 4 位应为版本号 4
+    const versionByte = parseInt(parts[2].slice(0, 2), 16);
+    expect((versionByte >> 4) & 0xf).toBe(4);
+
+    // 第 9 字节（时钟序列）的高 2 位应为 10（变体 RFC 4122）
+    const variantByte = parseInt(parts[3].slice(0, 2), 16);
+    expect((variantByte >> 6) & 0x3).toBe(0b10);
+  });
+});

--- a/frontend/src/utils/uuid.ts
+++ b/frontend/src/utils/uuid.ts
@@ -1,0 +1,48 @@
+/**
+ * 生成兼容性 UUID v4
+ *
+ * 按以下优先级生成 UUID：
+ * 1. crypto.randomUUID() - 现代浏览器原生支持
+ * 2. crypto.getRandomValues() - 手动生成，兼容性好
+ * 3. Math.random() - 最终 fallback，仅在不支持 crypto 的环境使用
+ *
+ * 解决 Issue #3364: crypto.randomUUID is not a function
+ * 原因：旧版浏览器或非 HTTPS 环境下 crypto.randomUUID() 不可用
+ */
+export function generateUUID(): string {
+  // 优先使用 crypto.randomUUID()
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // 某些环境下可能抛出异常（如非安全上下文），继续尝试 fallback
+    }
+  }
+
+  // 使用 crypto.getRandomValues() 手动生成
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    try {
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      // 设置 UUID v4 版本位 (第 6 字节高 4 位为 0100)
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      // 设置 UUID 变体位 (第 8 字节高 2 位为 10)
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      // 转换为 UUID 格式字符串
+      const hex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+    } catch {
+      // 继续尝试 fallback
+    }
+  }
+
+  // 最终 fallback：Math.random()
+  // 注意：Math.random() 不是加密安全的随机数生成器
+  // 但对于幂等键生成场景足够使用
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}


### PR DESCRIPTION
## 问题描述

Fixes #3364

创建 Linux 远程会话时报错 `crypto.randomUUID is not a function`。

### 根因

- 代码位置：`frontend/src/hooks/useRemote.ts:183`
- 直接调用 `crypto.randomUUID()` 而没有兼容性处理
- 该 API 在旧版浏览器或非 HTTPS 环境下不可用

### 浏览器兼容性

| 浏览器 | 最低支持版本 |
|--------|-------------|
| Chrome | 92+ |
| Firefox | 95+ |
| Safari | 15.4+ |
| HTTP 环境 | 不支持 |

## 修复方案

创建兼容性 UUID 生成工具函数 `generateUUID()`，按以下优先级：

1. `crypto.randomUUID()` - 现代浏览器原生支持
2. `crypto.getRandomValues()` - 手动生成，兼容性好
3. `Math.random()` - 最终 fallback

## 变更内容

| 文件 | 操作 |
|------|------|
| `frontend/src/utils/uuid.ts` | 新增 |
| `frontend/src/utils/uuid.test.ts` | 新增 |
| `frontend/src/hooks/useRemote.ts` | 修改（使用 generateUUID） |
| `frontend/src/utils/index.ts` | 修改（导出 generateUUID） |

## 测试证据

- ✅ 7 个单元测试全部通过
- ✅ TypeScript 类型检查通过
- ✅ ESLint 检查通过（新增文件无错误）

## 风险与回滚

- 风险低：仅修改一行调用代码，新增工具函数
- 回滚方式：直接 revert PR

## Issue 关联

- 根因分析报告：https://github.com/open-ace/open-ace/issues/3364#issuecomment-5578218890
- 根因评估报告：https://github.com/open-ace/open-ace/issues/3364#issuecomment-5578236416
- 修复方案：https://github.com/open-ace/open-ace/issues/3364#issuecomment-5578241790
- 方案评估报告：https://github.com/open-ace/open-ace/issues/3364#issuecomment-5578257091