### PR TITLE
fix(#3368): replace $n placeholders with %s in PostgreSQL UPSERT

### DIFF
--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -1241,7 +1241,7 @@ class SessionManager:
                     INSERT INTO session_daily_usage
                         (session_id, user_id, tenant_id, date, tokens, requests,
                          input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (session_id, date) DO UPDATE SET
                         tokens = session_daily_usage.tokens + EXCLUDED.tokens,
                         requests = session_daily_usage.requests + EXCLUDED.requests,
@@ -1270,7 +1270,7 @@ class SessionManager:
                     INSERT INTO session_daily_usage
                         (session_id, user_id, tenant_id, date, tokens, requests,
                          input_tokens, output_tokens)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (session_id, date) DO UPDATE SET
                         tokens = session_daily_usage.tokens + EXCLUDED.tokens,
                         requests = session_daily_usage.requests + EXCLUDED.requests,

--- a/tests/unit/test_session_daily_usage.py
+++ b/tests/unit/test_session_daily_usage.py
@@ -378,3 +378,38 @@ class TestQuotaManagerPriority:
         # Should return session_daily_usage values
         assert result["tokens"] == 300
         assert result["requests"] == 3
+
+
+class TestPostgreSQLParameterFormat:
+    """Tests for Issue #3368: PostgreSQL parameter placeholder format."""
+
+    def test_upsert_daily_usage_uses_percent_s_not_dollar_n(self):
+        """PostgreSQL branch must use %s placeholders, not $1, $2, etc.
+
+        psycopg2 requires %s format for parameterized queries. Using $n format
+        causes 'there is no parameter $1' errors at runtime.
+        """
+        import inspect
+        from app.modules.workspace.session_manager import SessionManager
+
+        source = inspect.getsource(SessionManager._upsert_daily_usage)
+
+        # Should NOT contain $n placeholders in SQL VALUES clauses
+        import re
+        dollar_placeholders = re.findall(r'VALUES\s*\([^)]*\$[0-9]+', source, re.IGNORECASE)
+        assert len(dollar_placeholders) == 0, (
+            f"Found $n placeholders in _upsert_daily_usage: {dollar_placeholders}. "
+            "PostgreSQL branch must use %s format for psycopg2 compatibility."
+        )
+
+    def test_upsert_daily_usage_postgresql_branch_has_percent_s(self):
+        """Verify PostgreSQL branch uses %s placeholders."""
+        import inspect
+        from app.modules.workspace.session_manager import SessionManager
+
+        source = inspect.getsource(SessionManager._upsert_daily_usage)
+
+        # Should contain %s placeholders for PostgreSQL
+        assert "%s" in source, (
+            "_upsert_daily_usage should use %s placeholders for PostgreSQL compatibility"
+        )

--- a/tests/unit/test_session_daily_usage.py
+++ b/tests/unit/test_session_daily_usage.py
@@ -390,13 +390,15 @@ class TestPostgreSQLParameterFormat:
         causes 'there is no parameter $1' errors at runtime.
         """
         import inspect
+
         from app.modules.workspace.session_manager import SessionManager
 
         source = inspect.getsource(SessionManager._upsert_daily_usage)
 
         # Should NOT contain $n placeholders in SQL VALUES clauses
         import re
-        dollar_placeholders = re.findall(r'VALUES\s*\([^)]*\$[0-9]+', source, re.IGNORECASE)
+
+        dollar_placeholders = re.findall(r"VALUES\s*\([^)]*\$[0-9]+", source, re.IGNORECASE)
         assert len(dollar_placeholders) == 0, (
             f"Found $n placeholders in _upsert_daily_usage: {dollar_placeholders}. "
             "PostgreSQL branch must use %s format for psycopg2 compatibility."
@@ -405,11 +407,12 @@ class TestPostgreSQLParameterFormat:
     def test_upsert_daily_usage_postgresql_branch_has_percent_s(self):
         """Verify PostgreSQL branch uses %s placeholders."""
         import inspect
+
         from app.modules.workspace.session_manager import SessionManager
 
         source = inspect.getsource(SessionManager._upsert_daily_usage)
 
         # Should contain %s placeholders for PostgreSQL
-        assert "%s" in source, (
-            "_upsert_daily_usage should use %s placeholders for PostgreSQL compatibility"
-        )
+        assert (
+            "%s" in source
+        ), "_upsert_daily_usage should use %s placeholders for PostgreSQL compatibility"


### PR DESCRIPTION
## Root Cause

`SessionManager._upsert_daily_usage()` PostgreSQL branch used asyncpg-style `$1..$10` placeholders, but the project uses psycopg2 which requires `%s` format.

This caused `there is no parameter $1` errors on every model request, making `session_daily_usage` writes silently fail and Work page show 0/0 for daily token/request counts.

## Fix

- Replace `$1..$10` with 10x `%s` (with cache columns)
- Replace `$1..$8` with 8x `%s` (without cache columns)
- Add regression test ensuring no `$n` placeholders remain in the method

## Changes

| File | Change |
|------|--------|
| `app/modules/workspace/session_manager.py` | Fix PostgreSQL parameter placeholders |
| `tests/unit/test_session_daily_usage.py` | Add `TestPostgreSQLParameterFormat` regression tests |

## Tests

- 23 passed, 1 skipped
- New tests verify `$n` placeholders are not present and `%s` is used

## Verification

- Agent b (root cause review): ✅ Agreed - confirmed all evidence, ruled out alternative causes
- All existing tests continue to pass
- No other `$n` placeholders found in `app/` directory

Closes #3368