### PR TITLE
fix(ci): fail early on unsupported Bash toolchains (#3366)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,9 @@ What actually happened.
 
 - Python 3.10+
 - pip
+- Bash >= 4 on PATH for `python-core` / `python-min` (macOS's bundled Bash 3.2
+  is insufficient). See [local shell prerequisites](docs/TEST_LAYERS.md#local-shell-prerequisites)
+  for setup and the Linux/macOS validation boundary.
 
 ### Setup
 

--- a/ci/suites.json
+++ b/ci/suites.json
@@ -9,6 +9,7 @@
       "3.14"
     ],
     "node": "20",
+    "bash_min_major": 4,
     "runner": "ubuntu-24.04"
   },
   "pr_suites": [
@@ -109,6 +110,7 @@
       ]
     },
     "python-core": {
+      "requires_bash": true,
       "description": "Required deterministic Python suite on the production runtime",
       "timeout_seconds": 1200,
       "commands": [
@@ -155,6 +157,7 @@
       ]
     },
     "python-min": {
+      "requires_bash": true,
       "description": "compileall + full unit suite on the minimum supported Python (catches version-specific regressions on the oldest interpreter; #2868)",
       "timeout_seconds": 1200,
       "commands": [

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -85,11 +85,19 @@ macOS 的 `/bin/bash` 3.2 不满足要求。可安装独立现代 Bash，并仅�
 ```bash
 brew install bash
 export PATH="$(brew --prefix)/bin:$PATH"
+# 再激活装有 requirements-ci.lock 的环境，避免 Homebrew python3 抢先
+source venv/bin/activate
 command -v bash
 bash --version
+command -v python python3
 python scripts/ci.py doctor --strict
 python scripts/ci.py run default-collection python-core
 ```
+
+保留 Docker Compose CLI 等已有依赖所在的 PATH 目录；不要为选择 Bash
+而用一份缩减 PATH 覆盖它们。相关脚本测试会调用 `python3` 和
+`docker compose version`，仅用 venv Python 的绝对路径启动入口并不足以
+保证这些子进程也使用同一套依赖。
 
 探测和 suite 子进程统一移除 `BASH_ENV` / `ENV`，避免开发者启动脚本注入
 影响 CI；父进程环境不变。PATH 保持原顺序，相对/空目录项按调用时工作目录

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -84,9 +84,10 @@ macOS 的 `/bin/bash` 3.2 不满足要求。可安装独立现代 Bash，并仅�
 
 ```bash
 brew install bash
-export PATH="$(brew --prefix)/bin:$PATH"
-# 再激活装有 requirements-ci.lock 的环境，避免 Homebrew python3 抢先
+# 先激活装有 requirements-ci.lock 的环境（重复激活会恢复旧 PATH）
 source venv/bin/activate
+# 保持 venv Python 第一、现代 Bash 随后，不丢弃其余 CLI 路径
+export PATH="$VIRTUAL_ENV/bin:$(brew --prefix)/bin:$PATH"
 command -v bash
 bash --version
 command -v python python3

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -66,6 +66,42 @@ pytest --issue=2429
 python scripts/run_extended_tests.py --category e2e --isolated-home
 ```
 
+## Local shell prerequisites
+
+`ci/suites.json` 声明 Bash 最低主版本为 4；`python-core` 和 `python-min`
+包含 fetch wrapper 的真实子进程测试，需要 Bash associative arrays。
+`python scripts/ci.py doctor` 报告 PATH 实际选中的 Bash 路径、版本和能力；
+`doctor --strict` 对缺失、不兼容或探测失败返回非零。严格 doctor 同时检查
+生产 Python 3.11 / Node 20；它不是 Python 3.10 最低版本 lane 的启动条件。
+
+`run` / `pr` 在任何选中 suite 开始前检查整个执行计划的 Bash 前置条件，
+避免先花数分钟跑 collection 或测试再暴露环境问题。单独扫描、`list`、
+`detect` 不要求 Bash；直接运行 `pytest` 会绕过这个入口前置检查，但不改变
+测试自身的要求或通过标准。
+
+macOS 的 `/bin/bash` 3.2 不满足要求。可安装独立现代 Bash，并仅为当前终端
+调整 PATH；不需要替换系统 Bash、修改默认登录 shell 或 wrapper shebang：
+
+```bash
+brew install bash
+export PATH="$(brew --prefix)/bin:$PATH"
+command -v bash
+bash --version
+python scripts/ci.py doctor --strict
+python scripts/ci.py run default-collection python-core
+```
+
+探测和 suite 子进程统一移除 `BASH_ENV` / `ENV`，避免开发者启动脚本注入
+影响 CI；父进程环境不变。PATH 保持原顺序，相对/空目录项按调用时工作目录
+转为绝对路径，避免 suite 切换工作目录后选中另一个 Bash。不要依赖个人
+shell 启动脚本提供 CI 依赖，应显式准备 PATH 和锁定依赖环境。
+
+现代 Bash 是必要条件，并不代表 macOS 已获得全量 Linux CI 等价保证。
+规范执行环境仍是 `ci/suites.json` 的 Ubuntu 24.04、对应 lane 的 Python、
+锁定依赖及所需服务。跨平台验收应分别记录操作系统、Python/Bash 实际版本、
+相同 suite 命令、测试结果和 GitHub run 链接；不能把前置检查通过或定向测试
+通过写成全量通过。本改动不新增耗时 macOS PR lane，不跳过 wrapper 回归。
+
 ## CI 保证
 
 目录本身不构成保证，CI 的消费关系才构成保证：

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -280,9 +280,11 @@ def shell_environment() -> dict[str, str]:
     for name in ("BASH_ENV", "ENV"):
         env.pop(name, None)
     # Anchor relative (including empty) entries before commands change cwd.
-    # Preserve PATH ordering and the user's interpreter choice.
+    # Do not collapse symlink/..: preserve filesystem traversal and ordering.
+    cwd = os.getcwd()
     env["PATH"] = os.pathsep.join(
-        os.path.abspath(entry) for entry in env.get("PATH", os.defpath).split(os.pathsep)
+        os.path.join(cwd, entry) if entry else cwd
+        for entry in env.get("PATH", os.defpath).split(os.pathsep)
     )
     return env
 

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -10,6 +10,7 @@ import json
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -273,8 +274,21 @@ def changed_files(base: str) -> list[str]:
     return sorted(changed)
 
 
-def isolated_environment(home: str, preserve_database_environment: bool = False) -> dict[str, str]:
+def shell_environment() -> dict[str, str]:
+    """Use the same noninteractive startup policy for probes and CI commands."""
     env = os.environ.copy()
+    for name in ("BASH_ENV", "ENV"):
+        env.pop(name, None)
+    # Anchor relative (including empty) entries before commands change cwd.
+    # Preserve PATH ordering and the user's interpreter choice.
+    env["PATH"] = os.pathsep.join(
+        os.path.abspath(entry) for entry in env.get("PATH", os.defpath).split(os.pathsep)
+    )
+    return env
+
+
+def isolated_environment(home: str, preserve_database_environment: bool = False) -> dict[str, str]:
+    env = shell_environment()
     env.update(
         {
             "CI": "true",
@@ -660,6 +674,62 @@ def write_github_outputs(selected: list[str]) -> None:
         handle.write(f"selected={','.join(selected)}\n")
 
 
+def check_bash(config: dict[str, Any]) -> None:
+    """Check PATH-selected Bash, including the feature the fetch wrapper uses."""
+    minimum = config["toolchain"]["bash_min_major"]
+    if not isinstance(minimum, int) or isinstance(minimum, bool) or minimum < 4:
+        raise CIError("Invalid bash_min_major: expected an integer >= 4")
+    env = shell_environment()
+    executable = shutil.which("bash", path=env.get("PATH", os.defpath))
+    version = "missing"
+    detail = "not found on PATH"
+    if executable:
+        try:
+            result = subprocess.run(
+                [
+                    executable,
+                    "--noprofile",
+                    "--norc",
+                    "-c",
+                    'set -eu; printf "%s\\n" "$BASH_VERSION"; '
+                    "declare -A openace_probe; openace_probe[check]=assoc-ok; "
+                    'printf "%s\\n" "${openace_probe[check]}"',
+                ],
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            lines = result.stdout.strip().splitlines()
+            version = lines[0] if lines else "unknown"
+            match = re.fullmatch(r"(\d+)\.\d+(?:\.\d+)?(?:\(\d+\)-release)?", version)
+            if (
+                result.returncode == 0
+                and match
+                and int(match[1]) >= minimum
+                and lines[1:] == ["assoc-ok"]
+            ):
+                print(
+                    f"Bash:   {version} ({executable}; required >= {minimum}, associative arrays OK)"
+                )
+                return
+            detail = f"probe exited {result.returncode}; version or associative-array capability unsuitable"
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            detail = f"probe failed: {type(exc).__name__}"
+    raise CIError(
+        f"Bash: {version} ({executable or 'missing'}; required >= {minimum}): {detail}. "
+        "Install a supported Bash and put its bin directory first on PATH, then run "
+        "python scripts/ci.py doctor --strict. See docs/TEST_LAYERS.md#local-shell-prerequisites."
+    )
+
+
+def check_suite_prerequisites(names: list[str], config: dict[str, Any]) -> None:
+    """Check the entire plan before an earlier suite can spend its budget."""
+    if any(config["suites"].get(name, {}).get("requires_bash", False) for name in names):
+        check_bash(config)
+
+
 def check_toolchain(config: dict[str, Any], strict: bool = False) -> bool:
     """Report whether local runtimes match the canonical PR toolchain."""
     expected_python = config["toolchain"]["production_python"]
@@ -680,7 +750,13 @@ def check_toolchain(config: dict[str, Any], strict: bool = False) -> bool:
     print(f"Python: {actual_python} (PR runtime {expected_python})")
     print(f"Node:   {actual_node} (PR runtime {expected_node}.x)")
     print(f"Runner: local (GitHub {config['toolchain']['runner']})")
-    matches = python_matches and node_matches
+    bash_matches = True
+    try:
+        check_bash(config)
+    except CIError as exc:
+        bash_matches = False
+        print(str(exc))
+    matches = python_matches and node_matches and bash_matches
     if not matches:
         message = "Local toolchain differs from the canonical PR toolchain"
         if strict:
@@ -738,6 +814,12 @@ def execute_suites(
             )
 
     primary: Exception | None = None
+    preflight_error = None
+    try:
+        check_suite_prerequisites(names, config)
+    except Exception as exc:
+        primary = exc
+        preflight_error = str(exc)
     for name in names:
         if primary is not None:
             outcomes[name] = "not_started_due_to_previous_failure"
@@ -775,6 +857,7 @@ def execute_suites(
             completed_at=utc_now(),
             duration_seconds=round(time.monotonic() - invocation_started, 6),
             outcome=invocation_outcome,
+            **({"preflight_error": preflight_error} if preflight_error else {}),
         )
     metrics.close()
     if primary is not None:

--- a/tests/integration/subprocess/test_ci_bash_preflight.py
+++ b/tests/integration/subprocess/test_ci_bash_preflight.py
@@ -211,3 +211,18 @@ def test_relative_path_keeps_same_bash_when_suite_changes_directory(checkout):
     result = _invoke(checkout, "run", "python-core", extra_env={"PATH": "bin"})
     assert result.returncode == 0, result.stdout + result.stderr
     assert "assoc-ok" in result.stdout
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_path_symlink_parent_semantics_are_preserved(checkout, absolute):
+    _shell(checkout, "5.2.0")
+    (checkout / "nested/inner").mkdir(parents=True)
+    (checkout / "link").symlink_to(checkout / "nested/inner", target_is_directory=True)
+    # link/../bin denotes nested/bin (missing), not checkout/bin (suitable).
+    path = "link/../bin"
+    if absolute:
+        path = str(checkout / path)
+    result = _invoke(checkout, "run", "python-core", extra_env={"PATH": path})
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not found on PATH" in result.stderr
+    assert not list(checkout.glob("*.ran"))

--- a/tests/integration/subprocess/test_ci_bash_preflight.py
+++ b/tests/integration/subprocess/test_ci_bash_preflight.py
@@ -1,0 +1,213 @@
+"""CI must reject an unsuitable shell before starting any selected command."""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.regression, pytest.mark.issue(3366)]
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def checkout(tmp_path):
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "ci").mkdir()
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "home").mkdir()
+    shutil.copyfile(ROOT / "scripts/ci.py", tmp_path / "scripts/ci.py")
+    config = json.loads((ROOT / "ci/suites.json").read_text())
+    # Keep the real manifest's prerequisites and selection semantics, but
+    # substitute cheap observable commands for expensive test/dependency work.
+    for name, suite in config["suites"].items():
+        suite.pop("collection_target", None)
+        suite.pop("working_directory", None)
+        suite["commands"] = [
+            [
+                sys.executable,
+                "-c",
+                "from pathlib import Path; "
+                f"Path({str(tmp_path / (name + '.ran'))!r}).write_text('executed')",
+            ]
+        ]
+    (tmp_path / "ci/suites.json").write_text(json.dumps(config))
+    return tmp_path
+
+
+def _env(checkout):
+    return {
+        "PATH": str(checkout / "bin"),
+        "HOME": str(checkout / "home"),
+        "OPENACE_CI_METRICS_FILE": str(checkout / "metrics.jsonl"),
+    }
+
+
+def _invoke(checkout, *args, extra_env=None):
+    return subprocess.run(
+        [sys.executable, str(checkout / "scripts/ci.py"), *args],
+        cwd=checkout,
+        env={**_env(checkout), **(extra_env or {})},
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+
+
+def _shell(checkout, version, *, code=0, capability="assoc-ok"):
+    # External interpreter protocol double: run as a real process. A separate
+    # test below exercises actual Bash; this permits old/missing/broken cases
+    # to run on Linux without installing additional shell versions.
+    path = checkout / "bin/bash"
+    path.write_text(
+        f"#!{sys.executable}\nimport sys\n"
+        f"print({version!r})\nprint({capability!r})\nsys.exit({code})\n"
+    )
+    path.chmod(0o755)
+    return path
+
+
+@pytest.mark.parametrize("shell", ["missing", "old", "broken", "malformed", "no-capability"])
+def test_unsuitable_bash_blocks_entire_plan_before_first_command(checkout, shell):
+    if shell != "missing":
+        _shell(
+            checkout,
+            "3.2.57" if shell == "old" else "garbage" if shell == "malformed" else "5.2.0",
+            code=7 if shell == "broken" else 0,
+            capability="" if shell == "no-capability" else "assoc-ok",
+        )
+    result = _invoke(checkout, "run", "false-positive-scan", "python-core")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Bash" in result.stdout + result.stderr
+    assert not list(checkout.glob("*.ran"))
+    records = [json.loads(line) for line in (checkout / "metrics.jsonl").read_text().splitlines()]
+    assert not any(record["record_type"] == "command_start" for record in records)
+    assert records[-1]["record_type"] == "invocation_terminal"
+    assert records[-1]["outcome"] == "failure"
+    assert {record["suite"] for record in records if record["record_type"] == "suite_terminal"} == {
+        "false-positive-scan",
+        "python-core",
+    }
+
+
+@pytest.mark.parametrize("suite", ["python-core", "python-min"])
+def test_valid_bash_allows_selected_commands(checkout, suite):
+    path = _shell(checkout, "4.0.0")
+    result = _invoke(checkout, "run", suite)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert str(path) in result.stdout
+    assert (checkout / (suite + ".ran")).read_text() == "executed"
+
+
+def test_bash_free_suite_does_not_require_shell(checkout):
+    result = _invoke(checkout, "run", "false-positive-scan")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (checkout / "false-positive-scan.ran").exists()
+
+
+def test_doctor_reports_old_shell_and_strict_rejects_it(checkout):
+    config_path = checkout / "ci/suites.json"
+    config = json.loads(config_path.read_text())
+    config["toolchain"]["production_python"] = f"{sys.version_info.major}.{sys.version_info.minor}"
+    config_path.write_text(json.dumps(config))
+    node = checkout / "bin/node"
+    node.write_text(f"#!{sys.executable}\nprint('v{config['toolchain']['node']}.0.0')\n")
+    node.chmod(0o755)
+    path = _shell(checkout, "3.2.57")
+    result = _invoke(checkout, "doctor", "--strict")
+    assert result.returncode == 1
+    assert str(path) in result.stdout + result.stderr
+    assert "3.2.57" in result.stdout + result.stderr
+    assert "Bash" in result.stdout + result.stderr
+    advisory = _invoke(checkout, "doctor")
+    assert advisory.returncode == 0
+    assert "WARNING" in advisory.stderr
+    _shell(checkout, "5.2.0")
+    strict = _invoke(checkout, "doctor", "--strict")
+    assert strict.returncode == 0, strict.stdout + strict.stderr
+
+
+def test_pr_preflights_selected_requirements(checkout):
+    git = shutil.which("git")
+    assert git, "git is required by the CI PR entrypoint"
+    (checkout / "bin/git").symlink_to(git)
+    for args in [
+        ["init"],
+        [
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "fixture",
+        ],
+    ]:
+        subprocess.run(
+            [git, *args],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            env={**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "HOME": str(checkout / "home")},
+        )
+    result = _invoke(checkout, "pr", "--base", "HEAD")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Bash" in result.stdout + result.stderr
+    assert not list(checkout.glob("*.ran"))
+
+
+@pytest.mark.parametrize("startup_path", ["absolute", "relative", "home-sensitive"])
+def test_real_bash_probe_and_commands_ignore_startup_injection(checkout, startup_path):
+    bash = shutil.which("bash")
+    assert bash, "Bash is required for this subprocess contract"
+    (checkout / "bin/bash").symlink_to(bash)
+    startup = checkout / "startup.sh"
+    startup.write_text('echo poisoned > "$HOME/startup-ran"\nexit 7\n')
+    if startup_path == "relative":
+        injection = "startup.sh"
+    elif startup_path == "home-sensitive":
+        shutil.copyfile(startup, checkout / "home/startup.sh")
+        injection = "$HOME/startup.sh"
+    else:
+        injection = str(startup)
+    config_path = checkout / "ci/suites.json"
+    config = json.loads(config_path.read_text())
+    # This test checks normalization with the actual installed interpreter,
+    # even on macOS Bash 3.2; it does not claim that interpreter meets >=4.
+    config["suites"]["false-positive-scan"]["commands"] = [
+        ["bash", "-c", 'test -z "${BASH_ENV-}${ENV-}" && echo clean-shell']
+    ]
+    config_path.write_text(json.dumps(config))
+    result = _invoke(
+        checkout, "run", "false-positive-scan", extra_env={"BASH_ENV": injection, "ENV": injection}
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "clean-shell" in result.stdout
+    assert not (checkout / "home/startup-ran").exists()
+    doctor = _invoke(checkout, "doctor", extra_env={"BASH_ENV": injection, "ENV": injection})
+    assert "Bash" in doctor.stdout
+    # Compare with an uninjected probe: Bash 3.2 itself legitimately fails
+    # capability checks, but the injected startup must not change the result.
+    clean = _invoke(checkout, "doctor")
+    assert (doctor.returncode, doctor.stdout, doctor.stderr) == (
+        clean.returncode,
+        clean.stdout,
+        clean.stderr,
+    )
+    assert not (checkout / "home/startup-ran").exists()
+
+
+def test_relative_path_keeps_same_bash_when_suite_changes_directory(checkout):
+    _shell(checkout, "5.2.0")
+    config_path = checkout / "ci/suites.json"
+    config = json.loads(config_path.read_text())
+    config["suites"]["python-core"]["working_directory"] = "scripts"
+    config["suites"]["python-core"]["commands"] = [["bash", "-c", "ignored by protocol double"]]
+    config_path.write_text(json.dumps(config))
+    result = _invoke(checkout, "run", "python-core", extra_env={"PATH": "bin"})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "assoc-ok" in result.stdout

--- a/tests/unit/test_ci_bash_preflight.py
+++ b/tests/unit/test_ci_bash_preflight.py
@@ -1,0 +1,55 @@
+"""In-process error boundaries for the shared Bash prerequisite check."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(3366)]
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("ci_bash_unit", ROOT / "scripts/ci.py")
+assert SPEC and SPEC.loader
+ci = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ci)
+
+
+@pytest.mark.parametrize("error", [OSError("unusable"), subprocess.TimeoutExpired("bash", 5)])
+def test_probe_failure_is_actionable(monkeypatch, error):
+    monkeypatch.setattr(ci.shutil, "which", lambda *args, **kwargs: "/chosen/bash")
+
+    def fail(*args, **kwargs):
+        assert kwargs["timeout"] == 5
+        raise error
+
+    monkeypatch.setattr(ci.subprocess, "run", fail)
+    with pytest.raises(ci.CIError, match=type(error).__name__) as caught:
+        ci.check_bash({"toolchain": {"bash_min_major": 4}})
+    assert "/chosen/bash" in str(caught.value)
+    assert "doctor --strict" in str(caught.value)
+
+
+def test_startup_normalization_does_not_mutate_parent(monkeypatch):
+    monkeypatch.setenv("BASH_ENV", "startup.sh")
+    monkeypatch.setenv("ENV", "startup.sh")
+    monkeypatch.setenv("PATH", "relative::/absolute")
+    child = ci.shell_environment()
+    assert "BASH_ENV" not in child and "ENV" not in child
+    assert ci.os.environ["BASH_ENV"] == ci.os.environ["ENV"] == "startup.sh"
+    assert ci.os.environ["PATH"] == "relative::/absolute"
+    assert child["PATH"].split(ci.os.pathsep) == [
+        str(Path.cwd() / "relative"),
+        str(Path.cwd()),
+        "/absolute",
+    ]
+
+
+def test_preflight_failure_survives_metrics_write_failure(monkeypatch):
+    monkeypatch.setattr(ci.shutil, "which", lambda *args, **kwargs: None)
+    recorder = ci.MetricsRecorder(None)
+    recorder.error = OSError("disk full")
+    config = {"toolchain": {"bash_min_major": 4}, "suites": {"core": {"requires_bash": True}}}
+    with pytest.raises(ci.CIError) as caught:
+        ci.execute_suites(["core"], config, action="run", metrics=recorder)
+    message = str(caught.value)
+    assert message.index("Bash: missing") < message.index("metrics_write_error: disk full")


### PR DESCRIPTION
## Summary

Closes #3366.

- Declare Bash >=4 in the shared manifest and probe the PATH-selected version plus associative-array capability.
- Preflight all selected run/pr suites before any suite starts; core/min require Bash without imposing Python 3.11 on the 3.10 lane. doctor reports actionable path/version diagnostics; strict mode rejects mismatch.
- Normalize child BASH_ENV/ENV and anchor relative PATH without changing symlink/.. traversal; preserve parent environment and metrics failure semantics.
- Document venv/Bash/CLI preparation and Linux canonical-validation boundaries. No wrapper changes, new skips, weakened assertions or expensive macOS PR lane.

## Final acceptance — 800c0293

- [x] Independent design review CLEAN, user approved.
- [x] Independent implementation/documentation review CLEAN after two findings were fixed and re-reviewed (PATH symlink traversal; repeated venv activation).
- [x] Real /bin/bash 3.2.57 rejects run default-collection python-core before collection, with path/version and preparation instructions.
- [x] Final targeted regressions: 132 passed in 10.80s, including the original failing wrapper case; scoped pre-commit and scripts/push.sh passed.
- [x] Prepared local same-suite full run completed, exit 0.
- [x] Final GitHub full PR CI completed successfully: https://github.com/open-ace/open-ace/actions/runs/34301871199

| Environment / suite | Result | Test time |
|---|---|---|
| macOS, locked Python 3.11.15, Bash 5.3.15; default-collection | 13231 tests / 826 files | collection gate passed |
| Same local environment; python-core (2 workers) | 13052 passed / 59 skipped / 5 xfailed; coverage 61% | 372.30s |
| GitHub Ubuntu, Bash 5.2.21; default-collection | 13231 tests / 826 files | 27.40s |
| GitHub python-core (3.11) | 13053 passed / 58 skipped / 5 xfailed; coverage 61% | 314.87s |
| GitHub python-min (3.10) | 11495 passed / 18 skipped / 5 xfailed | 177.52s |
| GitHub PostgreSQL | 101 passed | 20.30s |

Local command: PYTEST_XDIST_AUTO_NUM_WORKERS=2 python scripts/ci.py run default-collection python-core, with the locked venv first on PATH, Homebrew Bash next, existing Docker CLI retained, and a temporary credential-free DOCKER_CONFIG containing only the installed Compose plugin link (so isolated HOME can find it).

Earlier local failures are retained in the review comment: incorrect PATH preparation and per-user Compose plugin discovery. No tests were weakened or skipped to resolve them. Both environments selected 13116 core items, but pass/skip counts differ by one; this is not a claim of identical cross-platform skip behavior or unrestricted macOS deployment support. Ubuntu remains canonical.

Ready for user review; not merged automatically.