### PR TITLE
refactor(#79): remove redundant config.json fields

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -235,7 +235,6 @@ def cmd_config(action: str) -> None:
                     "claude": {"enabled": True},
                     "qwen": {"enabled": True},
                 },
-                "cron": {"enabled": True, "run_time": "00:30"},
             }
             with open(config_path, "w") as f:
                 json.dump(default_config, f, indent=2)

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -6,7 +6,7 @@
 
 | 参数 | 说明 | 示例值 |
 |------|------|--------|
-| `host_name` | 主机名标识，用于区分不同机器的数据 | `localhost`, `server-01` |
+| `host_name` | 主机名标识，用于区分不同机器的数据。这是**唯一**的主机名字段，所有工具的数据都以它归属；请勿在 `tools.*` 下重复配置主机名。 | `localhost`, `server-01` |
 | `server.upload_auth_key` | 上传认证密钥，用于验证远程机器上传的数据 | 随机字符串 |
 | `server.server_url` | 服务器地址，远程机器需要配置此地址 | `http://192.168.1.100:19888` |
 | `server.web_port` | Web 服务端口 | `19888` |
@@ -114,12 +114,6 @@
 | `tools.openclaw.gateway_url` | OpenClaw Gateway 地址 | `http://localhost:18789` |
 | `tools.claude.enabled` | 是否启用 Claude | `true` |
 | `tools.qwen.enabled` | 是否启用 Qwen | `true` |
-
-#### 定时任务
-| 参数 | 说明 | 默认值 |
-|------|------|--------|
-| `cron.enabled` | 是否启用定时任务 | `true` |
-| `cron.run_time` | 每日运行时间（HH:MM 格式） | `00:30` |
 
 #### 飞书集成（可选）
 

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -41,21 +41,14 @@
     "openclaw": {
       "enabled": true,
       "token_env": "OPENCLAW_TOKEN",
-      "gateway_url": "http://localhost:18789",
-      "hostname": "<HOST_NAME>"
+      "gateway_url": "http://localhost:18789"
     },
     "claude": {
-      "enabled": true,
-      "hostname": "<HOST_NAME>"
+      "enabled": true
     },
     "qwen": {
-      "enabled": true,
-      "hostname": "<HOST_NAME>"
+      "enabled": true
     }
-  },
-  "cron": {
-    "enabled": true,
-    "run_time": "00:30"
   },
   "feishu": {
     "app_id": "<FEISHU_APP_ID>",
@@ -71,13 +64,6 @@
     "org_sync_tenant_id": 1,
     "org_sync_interval_minutes": 60,
     "org_sync_root_dept_id": "1"
-  },
-  "auth": {
-    "auth_type": "openai",
-    "env": {
-      "OPENAI_API_KEY": "<YOUR_API_KEY>",
-      "OPENAI_BASE_URL": "https://api.openai.com/v1"
-    }
   },
   "insights": {
     "temperature": 0.3,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -886,32 +886,18 @@ generate_default_config() {
     "openclaw": {
       "enabled": true,
       "token_env": "OPENCLAW_TOKEN",
-      "gateway_url": "http://${SERVER_IP}:18789",
-      "hostname": "$HOST_NAME"
+      "gateway_url": "http://${SERVER_IP}:18789"
     },
     "claude": {
-      "enabled": true,
-      "hostname": "$HOST_NAME"
+      "enabled": true
     },
     "qwen": {
-      "enabled": true,
-      "hostname": "$HOST_NAME"
+      "enabled": true
     }
-  },
-  "cron": {
-    "enabled": true,
-    "run_time": "00:30"
   },
   "feishu": {
     "app_id": "",
     "app_secret": ""
-  },
-  "auth": {
-    "auth_type": "openai",
-    "env": {
-      "OPENAI_API_KEY": "",
-      "OPENAI_BASE_URL": "https://api.openai.com/v1"
-    }
   },
   "insights": {
     "temperature": 0.3,

--- a/docs/dev-notes/79-config-json-cleanup-plan.md
+++ b/docs/dev-notes/79-config-json-cleanup-plan.md
@@ -1,0 +1,101 @@
+# Issue #79 — Optimize config.json structure (remove redundant fields)
+
+## Goal
+
+Remove fields from `config.json` (and every generator/reader of them) that the
+**current** code no longer consumes, so the config schema has a single source of
+truth and stops advertising settings that silently do nothing. Scope was verified
+field-by-field against the live code, not against the issue text or docs. Issue
+points #2 (`token_secret` generation) and #3 (`webui_path` npm pollution) were
+already fixed in commit `3431627`.
+
+## Redundant field-sets (each verified to have ZERO readers in current code)
+
+1. **`tools.<tool>.hostname`** (issue #79's named target). All fetchers read the
+   top-level `config.get("host_name", "localhost")`
+   (`fetch_qwen.py:1304`, `fetch_claude.py:1199`, `fetch_zcode.py`, `fetch_codex.py`,
+   `fetch_openclaw.py`). The only code touching `tools.*.hostname` is a dead
+   placeholder-cleanup loop in two copies of `load_config()`
+   (`scripts/shared/utils.py:82-88`, `scripts/upload-to-central/shared/utils.py:81-87`)
+   that mutates the dict in memory and is never saved or read.
+2. **`auth` section** (`auth.auth_type`, `auth.env.OPENAI_API_KEY`,
+   `auth.env.OPENAI_BASE_URL`). Dead by design: `WorkspaceConfig` was refactored to
+   drop the `auth_type`/`auth_env` fields and `WebUIManager._load_config()` explicitly
+   ignores the `auth` section (regression-guarded by
+   `tests/unit/test_webui_manager.py::test_no_auth_type_field` /
+   `test_load_config_from_file_without_auth`). `OPENAI_API_KEY` at runtime comes from
+   the API-key proxy/store and `os.environ`, never from config `auth.env`. No
+   `get_config_value("auth", …)` / `config.get("auth")` reader exists.
+3. **`cron` section** (`cron.enabled`, `cron.run_time`). The daily fetch is driven by
+   `app/services/data_fetch_scheduler.py`, which reads the `data_fetch` section
+   (`get_data_fetch_interval` / `is_data_fetch_enabled`), not `cron`. No
+   `get_config_value("cron", …)` / `config.get("cron")` reader exists. `cli.py:238`
+   and the docker generators write it, but nothing consumes it.
+
+Generators are already drifting/inconsistent (`cli.py` omits `hostname` and `auth`;
+`manage.py` omits `cron`/`auth`), which corroborates all three as cruft.
+
+## Naming standardization (issue point #4): host_name vs hostname
+
+The only real divergence is the legacy `scripts/upload-to-central/` uploader, which
+reads a flat top-level `config.get("hostname", …)`
+(`upload_to_server.py:396,459`; `deploy.sh:395,424`) and generates a flat
+`"hostname"` (`deploy.sh:123-131`). Standardize on `host_name` **backward-compatibly**:
+prefer `host_name`, fall back to the old `hostname`, so existing flat configs keep
+working; update `deploy.sh` to emit `host_name`.
+
+## Changes
+
+### Remove `tools.*.hostname`
+1. `config/config.json.sample` — drop the three `"hostname"` lines; fix the orphaned
+   trailing comma on whichever key becomes last in each tool entry
+   (openclaw→`gateway_url`, claude→`enabled`, qwen→`enabled`).
+2. `scripts/manage.py:143-145` — drop `"hostname": "localhost"` from the three tools.
+3. `docker-entrypoint.sh:889-899` — drop the three `"hostname": "$HOST_NAME"` lines +
+   comma fixes.
+4. `scripts/install-central/docker-method/install.sh:3229-3243` — same.
+5. `scripts/install-central/docker-method/quick-install-mac.sh:200-215` — same.
+6. `scripts/shared/utils.py` — remove the dead tools-hostname cleanup loop in
+   `load_config()` (keep the top-level `host_name` placeholder cleanup).
+7. `scripts/upload-to-central/shared/utils.py` — remove the same dead loop.
+
+### Remove dead `auth` section
+8. `config/config.json.sample` — drop the `auth` block (lines 75-81).
+9. `docker-entrypoint.sh:909-915` — drop the generated `auth` block.
+
+### Remove dead `cron` section
+10. `config/config.json.sample` — drop the `cron` block (lines 56-59).
+11. `docker-entrypoint.sh:901-904` — drop the generated `cron` block.
+12. `cli.py:238` — drop the `"cron"` entry from the default-config dict.
+13. `scripts/install-central/docker-method/install.sh:3245-3248` — drop generated `cron`.
+14. `config/CONFIG_GUIDE.md` — remove the now-inaccurate `定时任务` (cron) table
+    (lines 118-122).
+
+### Naming standardization (#4)
+15. `scripts/upload-to-central/upload_to_server.py:396,459` — read
+    `config.get("host_name") or config.get("hostname", os.uname().nodename)`.
+16. `scripts/upload-to-central/deploy.sh` — emit `host_name` and read
+    `config.get('host_name') or config.get('hostname', …)`.
+
+### Docs
+17. `config/CONFIG_GUIDE.md` — add a one-line note that top-level `host_name` is the
+    single machine-identity key (tools inherit it); remove the cron table (item 14).
+
+## Explicitly NOT touched (with rationale)
+- Top-level `secret_key` — **kept**, it IS read (`events_ingest.py:74`,
+  `scripts/shared/config.py:277`) as an events-ingest signing fallback.
+- `insights` section — **kept**, read by `insights_service.py:171`.
+- `data_fetch` / `quota_enforcement` — read by code but absent from the sample; that
+  is a *missing* (not redundant) key, out of scope for this cleanup.
+
+## Backward compatibility
+Removing keys is safe for existing user configs: `json.load` keeps any stale
+`tools.*.hostname` / `auth` / `cron` keys in the dict and every reader either uses
+`.get(...)` with a default or never looks at them — no `KeyError`, no migration.
+
+## Verification
+- `python -m json.tool config/config.json.sample` — valid JSON.
+- `bash -n docker-entrypoint.sh scripts/install-central/docker-method/install.sh scripts/install-central/docker-method/quick-install-mac.sh scripts/upload-to-central/deploy.sh` — parse OK; spot-check each generated `config.json` heredoc renders valid JSON (no dangling comma).
+- `python -m ruff check` on every edited `.py`.
+- `python -m pytest -q tests/unit/test_webui_manager.py tests/unit/test_webui_manager_42.py tests/unit/test_insights.py tests/unit/test_insights_service.py tests/unit/test_fetch_openclaw_dingtalk.py` (sample-validity + config-load guards).
+- Post-change grep: `grep -rn '"hostname"' config/ scripts/manage.py cli.py docker-entrypoint.sh scripts/install-central/docker-method/` returns nothing in tool blocks; `grep -rn '"auth"\|"cron"' config/config.json.sample docker-entrypoint.sh cli.py` returns nothing.

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -3230,21 +3230,14 @@ $workspace_config,
     "openclaw": {
       "enabled": $OPENCLAW_ENABLED,
       "token_env": "OPENCLAW_TOKEN",
-      "gateway_url": "$openclaw_url_config",
-      "hostname": "$HOST_NAME"
+      "gateway_url": "$openclaw_url_config"
     },
     "claude": {
-      "enabled": $CLAUDE_ENABLED,
-      "hostname": "$HOST_NAME"
+      "enabled": $CLAUDE_ENABLED
     },
     "qwen": {
-      "enabled": $QWEN_ENABLED,
-      "hostname": "$HOST_NAME"
+      "enabled": $QWEN_ENABLED
     }
-  },
-  "cron": {
-    "enabled": true,
-    "run_time": "00:30"
   },
   "insights": {
     "model": "glm-5",

--- a/scripts/install-central/docker-method/quick-install-mac.sh
+++ b/scripts/install-central/docker-method/quick-install-mac.sh
@@ -201,16 +201,13 @@ cat > "$DEPLOY_DIR/config/config.json" << EOF
     "openclaw": {
       "enabled": false,
       "token_env": "OPENCLAW_TOKEN",
-      "gateway_url": "",
-      "hostname": "$(hostname)"
+      "gateway_url": ""
     },
     "claude": {
-      "enabled": true,
-      "hostname": "$(hostname)"
+      "enabled": true
     },
     "qwen": {
-      "enabled": true,
-      "hostname": "$(hostname)"
+      "enabled": true
     }
   }
 }

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -140,9 +140,9 @@ def init_config():
                     "web_host": WEB_HOST,
                 },
                 "tools": {
-                    "openclaw": {"enabled": True, "hostname": "localhost"},
-                    "claude": {"enabled": True, "hostname": "localhost"},
-                    "qwen": {"enabled": True, "hostname": "localhost"},
+                    "openclaw": {"enabled": True},
+                    "claude": {"enabled": True},
+                    "qwen": {"enabled": True},
                 },
             }
             with open(config_file, "w") as f:

--- a/scripts/shared/utils.py
+++ b/scripts/shared/utils.py
@@ -78,14 +78,6 @@ def load_config(config_path: str | None = None) -> dict:
     if not host_name or _is_placeholder(host_name):
         config["host_name"] = platform.node()
 
-    # Also clean up placeholder hostnames in tools config
-    tools = config.get("tools", {})
-    for tool_name, tool_cfg in tools.items():
-        if isinstance(tool_cfg, dict):
-            hostname = tool_cfg.get("hostname")
-            if hostname and _is_placeholder(hostname):
-                tool_cfg["hostname"] = platform.node()
-
     return config
 
 

--- a/scripts/upload-to-central/deploy.sh
+++ b/scripts/upload-to-central/deploy.sh
@@ -124,7 +124,7 @@ cat > "$INSTALL_DIR/config.json" << EOF
 {
     "server_url": "$SERVER_URL",
     "auth_key": "$AUTH_KEY",
-    "hostname": "$HOSTNAME",
+    "host_name": "$HOSTNAME",
     "interval": $INTERVAL,
     "days": 1
 }
@@ -392,7 +392,7 @@ def run_daemon(server_url=None, auth_key=None, hostname=None, interval=300, days
     config = load_config()
     server_url = server_url or config.get('server_url')
     auth_key = auth_key or config.get('auth_key')
-    hostname = hostname or config.get('hostname', os.uname().nodename)
+    hostname = hostname or config.get('host_name') or config.get('hostname') or os.uname().nodename
     interval = interval or config.get('interval', 300)
     if not server_url or not auth_key:
         print("Error: server_url and auth_key required")
@@ -421,7 +421,7 @@ if __name__ == '__main__':
         config = load_config(args.config)
         server_url = args.server or config.get('server_url')
         auth_key = args.auth_key or config.get('auth_key')
-        hostname = args.hostname or config.get('hostname', os.uname().nodename)
+        hostname = args.hostname or config.get('host_name') or config.get('hostname') or os.uname().nodename
         if not server_url or not auth_key:
             print("Error: --server and --auth-key required")
             sys.exit(1)

--- a/scripts/upload-to-central/shared/utils.py
+++ b/scripts/upload-to-central/shared/utils.py
@@ -77,14 +77,6 @@ def load_config(config_path: str | None = None) -> dict:
     if not host_name or _is_placeholder(host_name):
         config["host_name"] = platform.node()
 
-    # Also clean up placeholder hostnames in tools config
-    tools = config.get("tools", {})
-    for tool_name, tool_cfg in tools.items():
-        if isinstance(tool_cfg, dict):
-            hostname = tool_cfg.get("hostname")
-            if hostname and _is_placeholder(hostname):
-                tool_cfg["hostname"] = platform.node()
-
     return config
 
 

--- a/scripts/upload-to-central/upload_to_server.py
+++ b/scripts/upload-to-central/upload_to_server.py
@@ -393,7 +393,9 @@ def run_daemon(
     if auth_key is None:
         auth_key = config.get("auth_key")
     if hostname is None:
-        hostname = config.get("hostname", os.uname().nodename)
+        # Prefer the standardized "host_name" key; fall back to the legacy
+        # "hostname" for backward compatibility with older config files.
+        hostname = config.get("host_name") or config.get("hostname") or os.uname().nodename
     if interval is None:
         interval = config.get("interval", 300)
     if days is None:
@@ -456,7 +458,12 @@ if __name__ == "__main__":
         config = load_config(args.config)
         server_url = args.server or config.get("server_url")
         auth_key = args.auth_key or config.get("auth_key")
-        hostname = args.hostname or config.get("hostname", os.uname().nodename)
+        hostname = (
+            args.hostname
+            or config.get("host_name")
+            or config.get("hostname")
+            or os.uname().nodename
+        )
 
         if not server_url or not auth_key:
             print("Error: --server and --auth-key are required (or set in config.json)")


### PR DESCRIPTION
## Summary
Optimizes `config.json` by removing field-sets that the **current** code no longer reads — verified field-by-field against the live codebase (not just the issue text/docs). Addresses issue #79 points #1 (redundant `tools.*.hostname`) and #4 (host_name vs hostname naming); points #2/#3 were already fixed in `3431627`.

### Removed (each verified to have zero readers)
- **`tools.<tool>.hostname`** — all fetchers read top-level `host_name`; the only toucher was a dead in-memory placeholder-cleanup loop in the two `load_config()` copies.
- **`auth` section** — `WorkspaceConfig` was refactored to drop `auth_type`/`auth_env` and `WebUIManager._load_config()` explicitly ignores it (regression-guarded by `test_webui_manager.py`); `OPENAI_*` come from env / the API-key proxy, never from config `auth.env`.
- **`cron` section** — the daily fetch is driven by `data_fetch_scheduler` (reads the `data_fetch` section), not `cron`.

Removed from the sample and every generator: `docker-entrypoint.sh`, `docker-method/install.sh`, `docker-method/quick-install-mac.sh`, `scripts/manage.py`, `cli.py`, plus the dead cleanup loops in `scripts/shared/utils.py` and `scripts/upload-to-central/shared/utils.py`.

### Naming standardization (#4)
The only real `host_name`/`hostname` divergence is the legacy `scripts/upload-to-central/` uploader (flat `hostname` key). Standardized on `host_name` **backward-compatibly**: prefer `host_name`, fall back to the old `hostname`; `deploy.sh` now emits `host_name`.

### Docs
`config/CONFIG_GUIDE.md`: removed the now-inaccurate cron (定时任务) table; noted that top-level `host_name` is the single machine-identity key.

### Kept (still read — explicitly not removed)
- top-level `secret_key` (events-ingest signing fallback), `insights` section.

## Backward compatibility
Removing keys is safe for existing configs: `json.load` keeps any stale keys and every reader uses `.get(...)` defaults or never looks at them — no `KeyError`, no migration.

## Verification
- `python -m json.tool config/config.json.sample` — valid.
- Rendered each generator's heredoc with dummy vars → all produce valid JSON.
- `bash -n` on all edited shell scripts; `py_compile` on all edited Python (incl. `deploy.sh`'s embedded uploader).
- `ruff` clean; `pytest tests/unit/test_webui_manager*.py tests/unit/test_insights*.py tests/unit/test_fetch_openclaw_dingtalk.py` → 108 passed.
- `load_config()` still resolves the top-level `host_name` placeholder.

Plan + reasoning: `docs/dev-notes/79-config-json-cleanup-plan.md`.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)